### PR TITLE
Feat: add optional dashboards for built-in stores

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,6 +65,9 @@ LAZYRAG_MILVUS_URI ?= http://milvus:19530
 LAZYRAG_OPENSEARCH_URI ?= https://opensearch:9200
 LAZYRAG_OPENSEARCH_USER ?= admin
 LAZYRAG_OPENSEARCH_PASSWORD ?= LazyRAG_OpenSearch123!
+LAZYRAG_ENABLE_STORE_DASHBOARDS ?= 0
+LAZYRAG_ENABLE_MILVUS_DASHBOARD ?= $(LAZYRAG_ENABLE_STORE_DASHBOARDS)
+LAZYRAG_ENABLE_OPENSEARCH_DASHBOARD ?= $(LAZYRAG_ENABLE_STORE_DASHBOARDS)
 
 # MinerU
 LAZYRAG_MINERU_SERVER_PORT ?= 8000
@@ -94,6 +97,7 @@ PADDLEOCR_VLM_BACKEND ?= vllm
 # Milvus / OpenSearch (when using built-in profiles)
 MILVUS_IMAGE_TAG ?= v2.6.11
 OPENSEARCH_IMAGE_TAG ?= 2.18.0
+ATTU_IMAGE_TAG ?= v2.6.3
 MINIO_ACCESS_KEY ?= minioadmin
 MINIO_SECRET_KEY ?= minioadmin
 
@@ -114,6 +118,7 @@ export LAZYRAG_DOCUMENT_PROCESSOR_URL LAZYRAG_DOCUMENT_SERVICE_URL LAZYRAG_PARSI
 export LAZYRAG_DOCUMENT_SERVER_PORT LAZYRAG_OCR_SERVER_TYPE LAZYRAG_MODEL_CONFIG_PATH LAZYRAG_OCR_SERVER_URL
 export LAZYRAG_MINERU_UPLOAD_MODE
 export LAZYRAG_MILVUS_URI LAZYRAG_OPENSEARCH_URI LAZYRAG_OPENSEARCH_USER LAZYRAG_OPENSEARCH_PASSWORD
+export LAZYRAG_ENABLE_STORE_DASHBOARDS LAZYRAG_ENABLE_MILVUS_DASHBOARD LAZYRAG_ENABLE_OPENSEARCH_DASHBOARD
 export LAZYRAG_MINERU_SERVER_PORT LAZYRAG_MINERU_VERSION LAZYRAG_MINERU_PACKAGE_VARIANT
 export LAZYRAG_MINERU_PREINSTALL_CPU_TORCH LAZYRAG_MINERU_TORCH_VERSION LAZYRAG_MINERU_TORCHVISION_VERSION
 export LAZYRAG_MINERU_NUMPY_VERSION
@@ -121,7 +126,7 @@ export LAZYRAG_MINERU_PYTORCH_INDEX_URL LAZYRAG_MINERU_PYPI_INDEX_URL LAZYRAG_MI
 export LAZYRAG_MINERU_CACHE_DIR LAZYRAG_MINERU_IMAGE_SAVE_DIR
 export LAZYRAG_DOCUMENT_SERVER_URL LAZYRAG_MAX_CONCURRENCY LAZYRAG_LLM_PRIORITY LAZYRAG_CHAT_PROMPT
 export PADDLEOCR_VLM_IMAGE_TAG PADDLEOCR_API_IMAGE_TAG PADDLEOCR_VLM_BACKEND
-export MILVUS_IMAGE_TAG OPENSEARCH_IMAGE_TAG MINIO_ACCESS_KEY MINIO_SECRET_KEY
+export MILVUS_IMAGE_TAG OPENSEARCH_IMAGE_TAG ATTU_IMAGE_TAG MINIO_ACCESS_KEY MINIO_SECRET_KEY
 export JUICEFS_MINIO_USER JUICEFS_MINIO_PASSWORD JUICEFS_ACCESS_KEY JUICEFS_SECRET_KEY
 
 # Python dirs to lint (exclude submodule algorithm/lazyllm via .flake8)
@@ -136,6 +141,7 @@ help:
 	@echo "  make up-build   - Build images and start services"
 	@echo "  make down       - Stop services"
 	@echo "  make build      - Build compose services (mineru profile only when needed)"
+	@echo "                    Use LAZYRAG_ENABLE_STORE_DASHBOARDS=1 to add Attu/OpenSearch Dashboards for built-in stores"
 	@echo "  make lint       - Run Python flake8 and Go gofmt checks"
 	@echo "  make test       - Run project test script"
 	@echo "  make clear      - Stop services, remove volumes, clear Python cache"
@@ -176,12 +182,18 @@ test:
 # Only mineru has build:; paddleocr/milvus/opensearch use image: only, so only needed for up.
 _need_mineru := $(and $(filter mineru,$(LAZYRAG_OCR_SERVER_TYPE)),$(findstring mineru:8000,$(LAZYRAG_OCR_SERVER_URL)))
 _need_paddleocr := $(and $(filter paddleocr,$(LAZYRAG_OCR_SERVER_TYPE)),$(findstring paddleocr:8080,$(LAZYRAG_OCR_SERVER_URL)))
-# Deploy milvus/opensearch only when URI points to built-in services; external URIs = no deployment
-_need_milvus := $(findstring milvus:19530,$(LAZYRAG_MILVUS_URI))
-_need_opensearch := $(findstring opensearch:9200,$(LAZYRAG_OPENSEARCH_URI))
+# Deploy milvus/opensearch only when URI exactly matches the built-in services; external URIs = no deployment
+_builtin_milvus_uris := http://milvus:19530 http://milvus:19530/
+_builtin_opensearch_uris := https://opensearch:9200 https://opensearch:9200/
+_need_milvus := $(filter $(strip $(LAZYRAG_MILVUS_URI)),$(_builtin_milvus_uris))
+_need_opensearch := $(filter $(strip $(LAZYRAG_OPENSEARCH_URI)),$(_builtin_opensearch_uris))
+_enable_milvus_dashboard := $(filter 1 true TRUE yes YES on ON,$(LAZYRAG_ENABLE_MILVUS_DASHBOARD))
+_enable_opensearch_dashboard := $(filter 1 true TRUE yes YES on ON,$(LAZYRAG_ENABLE_OPENSEARCH_DASHBOARD))
+_need_milvus_dashboard := $(and $(_need_milvus),$(_enable_milvus_dashboard))
+_need_opensearch_dashboard := $(and $(_need_opensearch),$(_enable_opensearch_dashboard))
 
 # Shared compose profile flags for up/down/up-build
-_COMPOSE_PROFILES := $(strip $(if $(_need_mineru),--profile mineru) $(if $(_need_paddleocr),--profile paddleocr) $(if $(_need_milvus),--profile milvus) $(if $(_need_opensearch),--profile opensearch))
+_COMPOSE_PROFILES := $(strip $(if $(_need_mineru),--profile mineru) $(if $(_need_paddleocr),--profile paddleocr) $(if $(_need_milvus),--profile milvus) $(if $(_need_opensearch),--profile opensearch) $(if $(_need_milvus_dashboard),--profile milvus-dashboard) $(if $(_need_opensearch_dashboard),--profile opensearch-dashboard))
 
 # Only init submodules when not yet cloned; if already present (even with different commit), do nothing. Never recursive.
 _SUBMODULE_INIT = @git submodule status | grep -q '^-' && git submodule update --init || true

--- a/README.CN.md
+++ b/README.CN.md
@@ -63,8 +63,10 @@ db
 |-----|---------|----------|------|
 | **mineru** | `mineru` | `LAZYRAG_OCR_SERVER_TYPE=mineru` 且 URL 为 `http://mineru:8000` | MinerU PDF 解析（版面分析，安装 variant/backend 可配置） |
 | **paddleocr** + **paddleocr-vlm-server** | `paddleocr` | `LAZYRAG_OCR_SERVER_TYPE=paddleocr` 且 URL 为 `http://paddleocr:8080` | PaddleOCR-VL PDF 解析（需 GPU） |
-| **milvus** + **milvus-etcd** + **milvus-minio** | `milvus` | `LAZYRAG_MILVUS_URI` 含 `milvus:19530` | 向量存储（embeddings） |
-| **opensearch** | `opensearch` | `LAZYRAG_OPENSEARCH_URI` 含 `opensearch:9200` | 分段存储（文档切片） |
+| **milvus** + **milvus-etcd** + **milvus-minio** | `milvus` | `LAZYRAG_MILVUS_URI=http://milvus:19530` | 向量存储（embeddings） |
+| **attu** | `milvus-dashboard` | `LAZYRAG_ENABLE_MILVUS_DASHBOARD=1` 且 `LAZYRAG_MILVUS_URI=http://milvus:19530` | Milvus 可视化管理，用于排查 collection、schema、索引 |
+| **opensearch** | `opensearch` | `LAZYRAG_OPENSEARCH_URI=https://opensearch:9200` | 分段存储（文档切片） |
+| **opensearch-dashboards** | `opensearch-dashboard` | `LAZYRAG_ENABLE_OPENSEARCH_DASHBOARD=1` 且 `LAZYRAG_OPENSEARCH_URI=https://opensearch:9200` | OpenSearch 可视化管理，用于查看 index、mapping 与查询结果 |
 
 **parsing 存储**（使用 Processor/Worker 时必选）：
 
@@ -131,6 +133,21 @@ db
 make up
 ```
 
+**完整栈并启用内置存储 dashboard：**
+```bash
+make up LAZYRAG_ENABLE_STORE_DASHBOARDS=1
+```
+
+**只启用 Milvus dashboard（Attu）：**
+```bash
+make up LAZYRAG_ENABLE_MILVUS_DASHBOARD=1
+```
+
+**只启用 OpenSearch Dashboards：**
+```bash
+make up LAZYRAG_ENABLE_OPENSEARCH_DASHBOARD=1
+```
+
 **使用外部 Milvus/OpenSearch**（不部署 milvus/opensearch）：
 ```bash
 make up LAZYRAG_MILVUS_URI=http://your-milvus:19530 LAZYRAG_OPENSEARCH_URI=https://your-opensearch:9200
@@ -156,7 +173,14 @@ make up LAZYRAG_OCR_SERVER_TYPE=mineru LAZYRAG_MINERU_BACKEND=hybrid-auto-engine
 make up LAZYRAG_OCR_SERVER_TYPE=paddleocr
 ```
 
-Makefile 会根据环境变量自动选择 profile。也可直接运行 `docker compose up --build`；可选服务需通过 `--profile mineru`、`--profile paddleocr`、`--profile milvus`、`--profile opensearch` 显式启用。
+Makefile 会根据环境变量自动选择 profile。也可直接运行 `docker compose up --build`；可选服务需通过 `--profile mineru`、`--profile paddleocr`、`--profile milvus`、`--profile opensearch`、`--profile milvus-dashboard`、`--profile opensearch-dashboard` 显式启用。
+
+内置存储 dashboard 默认关闭。启用后仅绑定到 `127.0.0.1`，并且只有在对应内置存储仍被使用时才会拉起：
+
+- Attu（Milvus）：http://127.0.0.1:3000
+- OpenSearch Dashboards：http://127.0.0.1:5601
+- OpenSearch Dashboards 登录账号：`admin` / `LAZYRAG_OPENSEARCH_PASSWORD`
+- 若 `LAZYRAG_MILVUS_URI` 或 `LAZYRAG_OPENSEARCH_URI` 指向外部服务，即使打开开关，也不会部署对应内置 dashboard。
 
 MinerU 配置被拆成两层：
 
@@ -219,7 +243,7 @@ LazyRAG/
 | parsing         | `LAZYRAG_MILVUS_URI`、`LAZYRAG_OPENSEARCH_URI`、`LAZYRAG_OPENSEARCH_USER`、`LAZYRAG_OPENSEARCH_PASSWORD` | 向量与分段存储（必选） |
 | chat            | `DOCUMENT_SERVER_URL`、`MAX_CONCURRENCY` | 文档服务地址与并发数        |
 
-使用外部 Milvus/OpenSearch 时需覆盖上述存储变量；若 URI 不含 `milvus:19530` 或 `opensearch:9200`，则不会部署对应服务。
+使用外部 Milvus/OpenSearch 时需覆盖上述存储变量；只有当 URI 保持为 `http://milvus:19530` 与 `https://opensearch:9200` 时，才会部署内置服务。
 
 ## 代码检查
 

--- a/README.md
+++ b/README.md
@@ -63,8 +63,10 @@ db
 |---------|---------|--------------|---------|
 | **mineru** | `mineru` | `LAZYRAG_OCR_SERVER_TYPE=mineru` and URL `http://mineru:8000` | MinerU PDF parsing (layout analysis; install variant/backend configurable) |
 | **paddleocr** + **paddleocr-vlm-server** | `paddleocr` | `LAZYRAG_OCR_SERVER_TYPE=paddleocr` and URL `http://paddleocr:8080` | PaddleOCR-VL PDF parsing (GPU required) |
-| **milvus** + **milvus-etcd** + **milvus-minio** | `milvus` | `LAZYRAG_MILVUS_URI` contains `milvus:19530` | Vector store for embeddings |
-| **opensearch** | `opensearch` | `LAZYRAG_OPENSEARCH_URI` contains `opensearch:9200` | Segment store for document chunks |
+| **milvus** + **milvus-etcd** + **milvus-minio** | `milvus` | `LAZYRAG_MILVUS_URI=http://milvus:19530` | Vector store for embeddings |
+| **attu** | `milvus-dashboard` | `LAZYRAG_ENABLE_MILVUS_DASHBOARD=1` and `LAZYRAG_MILVUS_URI=http://milvus:19530` | Milvus dashboard for collections, schema, and index troubleshooting |
+| **opensearch** | `opensearch` | `LAZYRAG_OPENSEARCH_URI=https://opensearch:9200` | Segment store for document chunks |
+| **opensearch-dashboards** | `opensearch-dashboard` | `LAZYRAG_ENABLE_OPENSEARCH_DASHBOARD=1` and `LAZYRAG_OPENSEARCH_URI=https://opensearch:9200` | OpenSearch dashboard for index, mapping, and query inspection |
 
 **Store for parsing** (required when using Processor/Worker):
 
@@ -131,6 +133,21 @@ For environment-variable setup and runnable startup examples, see:
 make up
 ```
 
+**Full stack with built-in store dashboards:**
+```bash
+make up LAZYRAG_ENABLE_STORE_DASHBOARDS=1
+```
+
+**Enable only the Milvus dashboard (Attu):**
+```bash
+make up LAZYRAG_ENABLE_MILVUS_DASHBOARD=1
+```
+
+**Enable only OpenSearch Dashboards:**
+```bash
+make up LAZYRAG_ENABLE_OPENSEARCH_DASHBOARD=1
+```
+
 **With external Milvus/OpenSearch** (no deployment of milvus/opensearch):
 ```bash
 make up LAZYRAG_MILVUS_URI=http://your-milvus:19530 LAZYRAG_OPENSEARCH_URI=https://your-opensearch:9200
@@ -156,7 +173,14 @@ make up LAZYRAG_OCR_SERVER_TYPE=mineru LAZYRAG_MINERU_BACKEND=hybrid-auto-engine
 make up LAZYRAG_OCR_SERVER_TYPE=paddleocr
 ```
 
-The Makefile auto-selects profiles based on env vars. You can also run `docker compose up --build` directly; optional services won't start unless you pass `--profile mineru`, `--profile paddleocr`, `--profile milvus`, `--profile opensearch`.
+The Makefile auto-selects profiles based on env vars. You can also run `docker compose up --build` directly; optional services won't start unless you pass `--profile mineru`, `--profile paddleocr`, `--profile milvus`, `--profile opensearch`, `--profile milvus-dashboard`, or `--profile opensearch-dashboard`.
+
+Built-in store dashboards are disabled by default. When enabled, they bind only to `127.0.0.1` and are started only if the corresponding built-in store is still in use:
+
+- Attu (Milvus): http://127.0.0.1:3000
+- OpenSearch Dashboards: http://127.0.0.1:5601
+- OpenSearch Dashboards login: `admin` / `LAZYRAG_OPENSEARCH_PASSWORD`
+- If `LAZYRAG_MILVUS_URI` or `LAZYRAG_OPENSEARCH_URI` points to an external service, the matching built-in dashboard is not deployed even when the flag is set.
 
 MinerU configuration is split into two layers:
 
@@ -221,7 +245,7 @@ LazyRAG/
 | milvus-minio (profile) | `MINIO_ACCESS_KEY`, `MINIO_SECRET_KEY` | Override for production |
 | chat              | `DOCUMENT_SERVER_URL`, `MAX_CONCURRENCY` | Document API and concurrency    |
 
-Override store endpoints when using external Milvus/OpenSearch; if URIs do not contain `milvus:19530` or `opensearch:9200`, those services are not deployed.
+Override store endpoints when using external Milvus/OpenSearch; built-in services are deployed only when the URIs stay at `http://milvus:19530` and `https://opensearch:9200`.
 
 ## Lint
 

--- a/algorithm/common/model/utils.py
+++ b/algorithm/common/model/utils.py
@@ -1,7 +1,9 @@
+import atexit
 import functools
 import hashlib
 import os
 import re
+import shutil
 import tempfile
 from copy import deepcopy
 from dataclasses import dataclass
@@ -21,6 +23,7 @@ DEFAULT_EMBED_INDEX_KWARGS = {
     },
 }
 _ENV_PATTERN = re.compile(r'\$\{([^}:]+)(?::-([^}]*))?\}')
+_RUNTIME_AUTO_MODEL_DIR = Path(tempfile.gettempdir()) / 'lazyrag-runtime-auto-model'
 
 
 @dataclass(frozen=True)
@@ -40,17 +43,23 @@ def get_runtime_model_config_path() -> str:
     return os.getenv('LAZYRAG_MODEL_CONFIG_PATH') or str(DEFAULT_RUNTIME_MODEL_CONFIG_PATH)
 
 
+def _cleanup_runtime_auto_model_dir() -> None:
+    shutil.rmtree(_RUNTIME_AUTO_MODEL_DIR, ignore_errors=True)
+
+
+atexit.register(_cleanup_runtime_auto_model_dir)
+
+
 @functools.lru_cache(maxsize=64)
 def _write_runtime_auto_model_config(serialized_config: str) -> str:
     config = yaml.safe_load(serialized_config)
     model_name = config['model']
     digest = hashlib.sha256(serialized_config.encode('utf-8')).hexdigest()[:16]
     safe_model_name = re.sub(r'[^A-Za-z0-9_.-]+', '-', model_name).strip('-') or 'runtime-model'
-    target_dir = Path(tempfile.gettempdir()) / 'lazyrag-runtime-auto-model'
-    target_dir.mkdir(parents=True, exist_ok=True)
-    config_path = target_dir / f'{safe_model_name}-{digest}.yaml'
+    _RUNTIME_AUTO_MODEL_DIR.mkdir(parents=True, exist_ok=True)
+    config_path = _RUNTIME_AUTO_MODEL_DIR / f'{safe_model_name}-{digest}.yaml'
     temp_fd, temp_path = tempfile.mkstemp(
-        dir=target_dir,
+        dir=_RUNTIME_AUTO_MODEL_DIR,
         prefix=f'.{safe_model_name}-{digest}-',
         suffix='.yaml',
     )

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -543,6 +543,18 @@ services:
       milvus-minio:
         condition: service_started
 
+  attu:
+    profiles:
+      - milvus-dashboard
+    image: zilliz/attu:${ATTU_IMAGE_TAG:-v2.6.3}
+    ports:
+      - '127.0.0.1:3000:3000'
+    environment:
+      MILVUS_URL: milvus:19530
+    depends_on:
+      milvus:
+        condition: service_healthy
+
   # ---------- Segment store: OpenSearch single-node (profile: opensearch) ----------
   opensearch:
     profiles:
@@ -573,6 +585,20 @@ services:
       start_period: 60s
     expose:
       - '9200'
+
+  opensearch-dashboards:
+    profiles:
+      - opensearch-dashboard
+    image: opensearchproject/opensearch-dashboards:${OPENSEARCH_IMAGE_TAG:-2.18.0}
+    ports:
+      - '127.0.0.1:5601:5601'
+    expose:
+      - '5601'
+    environment:
+      OPENSEARCH_HOSTS: '["https://opensearch:9200"]'
+    depends_on:
+      opensearch:
+        condition: service_healthy
 
 volumes:
   pgdata:

--- a/tests/algorithm/test_runtime_model_config.py
+++ b/tests/algorithm/test_runtime_model_config.py
@@ -254,3 +254,15 @@ def test_get_model_uses_automodel_config_path_for_inline_entry(monkeypatch):
             'skip_auth': True,
         }]
     }
+
+
+def test_runtime_auto_model_dir_cleanup_removes_generated_files(tmp_path, monkeypatch):
+    runtime_dir = tmp_path / 'runtime-auto-model'
+    runtime_dir.mkdir()
+    generated = runtime_dir / 'foo.yaml'
+    generated.write_text('foo: bar\n', encoding='utf-8')
+    monkeypatch.setattr(model_utils, '_RUNTIME_AUTO_MODEL_DIR', runtime_dir)
+
+    model_utils._cleanup_runtime_auto_model_dir()
+
+    assert not runtime_dir.exists()


### PR DESCRIPTION
## What changed

- Added optional `attu` and `opensearch-dashboards` services to `docker-compose.yml`.
- Added `LAZYRAG_ENABLE_STORE_DASHBOARDS`, `LAZYRAG_ENABLE_MILVUS_DASHBOARD`, and `LAZYRAG_ENABLE_OPENSEARCH_DASHBOARD` to `Makefile`.
- Documented startup flags, local-only access, and dashboard URLs in `README.md` and `README.CN.md`.

## Why

LazyRAG deploys built-in Milvus and OpenSearch for local parsing flows, but there was no bundled visualization entry for debugging collections, indexes, mappings, or stored documents.

## Impact

- Default `make up` behavior stays unchanged.
- Dashboards are opt-in and bind only to `127.0.0.1`.
- Dashboards are only started when the corresponding built-in store URI is still in use, so external Milvus/OpenSearch setups do not accidentally deploy them.

## Validation

- `docker compose --profile milvus --profile milvus-dashboard --profile opensearch --profile opensearch-dashboard config`
- `make -n up LAZYRAG_ENABLE_STORE_DASHBOARDS=1`
- `make -n up LAZYRAG_ENABLE_STORE_DASHBOARDS=1 LAZYRAG_MILVUS_URI=http://external-milvus:19530 LAZYRAG_OPENSEARCH_URI=https://external-opensearch:9200`
- `make lint PYTHON=/opt/miniconda3/bin/python`

## Output

### milvus
<img width="1506" height="815" alt="image" src="https://github.com/user-attachments/assets/212b6631-ccf0-4fc6-a97b-b71c327c6d6c" />

### opensearch
<img width="1496" height="837" alt="image" src="https://github.com/user-attachments/assets/7ee4ed3e-fd50-4733-81b5-2e29d5f30a80" />

