### PR TITLE
feat(chat): score-aware parent aggregation for line→block retrieval

### DIFF
--- a/algorithm/chat/components/process/__init__.py
+++ b/algorithm/chat/components/process/__init__.py
@@ -2,10 +2,12 @@ from chat.components.process.sensitive_filter import SensitiveFilter
 from chat.components.process.multiturn_query_rewriter import MultiturnQueryRewriter
 from chat.components.process.context_expansion import ContextExpansionComponent
 from chat.components.process.adaptive_topk import AdaptiveKComponent
+from chat.components.process.score_aware_aggregator import ScoreAwareParentAggregator
 
 __all__ = [
     'SensitiveFilter',
     'MultiturnQueryRewriter',
     'ContextExpansionComponent',
     'AdaptiveKComponent',
+    'ScoreAwareParentAggregator',
 ]

--- a/algorithm/chat/components/process/score_aware_aggregator.py
+++ b/algorithm/chat/components/process/score_aware_aggregator.py
@@ -1,0 +1,103 @@
+from collections import defaultdict
+from typing import List, Optional
+
+from lazyllm import LOG
+from lazyllm.tools.rag.doc_node import DocNode
+
+
+class ScoreAwareParentAggregator:
+    '''Aggregate child DocNodes to their parent group while preserving hit-density signal.
+
+    After a fine-grained retriever (e.g. group='line') returns nodes, the default
+    lazyllm find_parent path deduplicates parents via a set, discarding how many
+    children hit the same parent and what their similarity scores were. This component
+    re-implements the parent mapping so that:
+
+      aggregated_score = max(child_similarity_scores) + hit_weight * hit_count
+
+    A block that has 10 matching lines will therefore rank higher than a block with
+    only 1 matching line, even when both blocks contain the same best-scoring line.
+    '''
+
+    def __init__(self, document, target_group: str, hit_weight: float = 0.05):
+        '''
+        Args:
+            document: lazyllm Document (or UrlDocument) handle used to resolve
+                      parent nodes across the full group tree.
+            target_group: the group name to map nodes into, e.g. 'block'.
+            hit_weight: bonus added per child node hit. Default 0.05, meaning
+                        20 child hits contribute +1.0 on top of the max score.
+        '''
+        self._document = document
+        self._target_group = target_group
+        self._hit_weight = hit_weight
+
+    def __call__(self, nodes: List[DocNode]) -> List[DocNode]:
+        if not nodes:
+            return nodes
+
+        # If nodes are already in the target group, nothing to do.
+        if nodes[0]._group == self._target_group:
+            return nodes
+
+        # --- Step 1: collect per-parent-uid stats from child nodes ---
+        # parent uid -> {'hits': int, 'max_score': float}
+        # node.parent is either a DocNode object (in-process) or a uid string (remote store).
+        parent_stats: dict = defaultdict(lambda: {'hits': 0, 'max_score': 0.0})
+
+        direct_parent_group: Optional[str] = None
+
+        for node in nodes:
+            parent = node._parent
+            if parent is None:
+                continue
+
+            if isinstance(parent, DocNode):
+                uid = parent._uid
+                if direct_parent_group is None:
+                    direct_parent_group = parent._group
+            else:
+                # parent is a uid string (remote / db-backed node)
+                uid = parent
+
+            score = node.similarity_score or 0.0
+            stats = parent_stats[uid]
+            stats['hits'] += 1
+            if score > stats['max_score']:
+                stats['max_score'] = score
+
+        if not parent_stats:
+            LOG.warning(
+                '[ScoreAwareParentAggregator] No parent uids found on nodes; '
+                'falling back to original document.find() behaviour.'
+            )
+            return self._document.find(self._target_group)(nodes)
+
+        # Warn when parent group != target group (multi-level jump).
+        # Aggregation stats are still based on the direct children, which is a
+        # reasonable approximation, but semantics are less precise.
+        if direct_parent_group and direct_parent_group != self._target_group:
+            LOG.warning(
+                f'[ScoreAwareParentAggregator] Direct parent group '
+                f'"{direct_parent_group}" != target "{self._target_group}". '
+                f'Score aggregation is based on direct child nodes only.'
+            )
+
+        # --- Step 2: use lazyllm's find() to get deduplicated target nodes ---
+        target_nodes: List[DocNode] = self._document.find(self._target_group)(nodes)
+
+        if not target_nodes:
+            return target_nodes
+
+        # --- Step 3: attach aggregated score to each target node ---
+        # For direct-parent case, the target node uid IS the parent uid we tracked.
+        # For multi-level case we fall back to 0 bonus (no match in parent_stats).
+        for target_node in target_nodes:
+            stats = parent_stats.get(target_node._uid)
+            if stats:
+                target_node.similarity_score = (
+                    stats['max_score'] + self._hit_weight * stats['hits']
+                )
+            # If no direct mapping (multi-level), leave similarity_score unchanged.
+
+        return sorted(target_nodes, key=lambda n: n.similarity_score or 0.0, reverse=True)

--- a/algorithm/chat/components/process/score_aware_aggregator.py
+++ b/algorithm/chat/components/process/score_aware_aggregator.py
@@ -6,7 +6,7 @@ from lazyllm.tools.rag.doc_node import DocNode
 
 
 class ScoreAwareParentAggregator:
-    '''Aggregate child DocNodes to their parent group while preserving hit-density signal.
+    """Aggregate child DocNodes to their parent group while preserving hit-density signal.
 
     After a fine-grained retriever (e.g. group='line') returns nodes, the default
     lazyllm find_parent path deduplicates parents via a set, discarding how many
@@ -17,17 +17,17 @@ class ScoreAwareParentAggregator:
 
     A block that has 10 matching lines will therefore rank higher than a block with
     only 1 matching line, even when both blocks contain the same best-scoring line.
-    '''
+    """
 
     def __init__(self, document, target_group: str, hit_weight: float = 0.05):
-        '''
+        """
         Args:
             document: lazyllm Document (or UrlDocument) handle used to resolve
                       parent nodes across the full group tree.
             target_group: the group name to map nodes into, e.g. 'block'.
             hit_weight: bonus added per child node hit. Default 0.05, meaning
                         20 child hits contribute +1.0 on top of the max score.
-        '''
+        """
         self._document = document
         self._target_group = target_group
         self._hit_weight = hit_weight

--- a/algorithm/chat/components/process/score_aware_aggregator.py
+++ b/algorithm/chat/components/process/score_aware_aggregator.py
@@ -52,13 +52,16 @@ class ScoreAwareParentAggregator:
             if parent is None:
                 continue
 
-            if isinstance(parent, DocNode):
-                uid = parent._uid
-                if direct_parent_group is None:
-                    direct_parent_group = parent._group
-            else:
+            if isinstance(parent, str):
                 # parent is a uid string (remote / db-backed node)
                 uid = parent
+            elif hasattr(parent, '_uid'):
+                # DocNode or any object carrying _uid (tests may use SimpleNamespace)
+                uid = parent._uid
+                if direct_parent_group is None:
+                    direct_parent_group = getattr(parent, '_group', None)
+            else:
+                continue
 
             score = node.similarity_score or 0.0
             stats = parent_stats[uid]

--- a/algorithm/chat/pipelines/builders/get_retriever.py
+++ b/algorithm/chat/pipelines/builders/get_retriever.py
@@ -25,13 +25,13 @@ def get_remote_docment(url: str) -> Document:
 
 
 def _build_kb_retriever(document: Document, cfg: dict):
-    '''Build a single kb retriever step from a config dict.
+    """Build a single kb retriever step from a config dict.
 
     If the config contains a 'target' key, the retriever is wrapped in a
     ScoreAwareParentAggregator so that child-node hit density is preserved
     when mapping to the parent group. Without this, lazyllm's internal
     find_parent deduplicates via a set and discards hit-count signal.
-    '''
+    """
     cfg = deepcopy(cfg)
     target = cfg.pop('target', None)
     retriever = Retriever(document, **cfg)

--- a/algorithm/chat/pipelines/builders/get_retriever.py
+++ b/algorithm/chat/pipelines/builders/get_retriever.py
@@ -1,8 +1,10 @@
+from copy import deepcopy
 from typing import List, NamedTuple
 
 from lazyllm import Retriever, bind, pipeline, Document
 from lazyllm.tools.rag import TempDocRetriever
 
+from chat.components.process.score_aware_aggregator import ScoreAwareParentAggregator
 from chat.pipelines.builders.get_models import get_automodel
 from chat.utils.load_config import get_retrieval_settings
 from chat.config import DEFAULT_TMP_BLOCK_TOPK
@@ -22,11 +24,28 @@ def get_remote_docment(url: str) -> Document:
     return Document(url=f'{url}/_call', name=name)
 
 
+def _build_kb_retriever(document: Document, cfg: dict):
+    '''Build a single kb retriever step from a config dict.
+
+    If the config contains a 'target' key, the retriever is wrapped in a
+    ScoreAwareParentAggregator so that child-node hit density is preserved
+    when mapping to the parent group. Without this, lazyllm's internal
+    find_parent deduplicates via a set and discards hit-count signal.
+    '''
+    cfg = deepcopy(cfg)
+    target = cfg.pop('target', None)
+    retriever = Retriever(document, **cfg)
+    if not target:
+        return retriever
+    aggregator = ScoreAwareParentAggregator(document=document, target_group=target)
+    return pipeline(retriever, aggregator)
+
+
 def get_retriever(url: str, retriever_configs: List[dict], *,
                   tmp_block_topk: int = DEFAULT_TMP_BLOCK_TOPK
                   ) -> SearchRetrievalParts:
     document = get_remote_docment(url)
-    kb_retrievers = [Retriever(document, **cfg) for cfg in retriever_configs]
+    kb_retrievers = [_build_kb_retriever(document, cfg) for cfg in retriever_configs]
 
     settings = get_retrieval_settings()
     ref_docs_retriever = TempDocRetriever(embed=get_automodel(settings.temp_doc_embed_key))

--- a/tests/algorithm/test_score_aware_aggregator.py
+++ b/tests/algorithm/test_score_aware_aggregator.py
@@ -1,0 +1,130 @@
+"""
+Unit tests for ScoreAwareParentAggregator.
+
+All tests use lightweight mock objects – no Milvus / OpenSearch / LLM needed.
+Core invariants under test:
+  - aggregated_score = max(child_scores) + hit_weight * hit_count
+  - output is sorted descending by aggregated_score
+  - edge cases: empty input, nodes already in target group, uid-string parents
+"""
+import types
+from unittest.mock import MagicMock
+
+from chat.components.process.score_aware_aggregator import ScoreAwareParentAggregator
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_node(uid, group, parent=None, score=None):
+    """Minimal stand-in for a lazyllm DocNode."""
+    node = types.SimpleNamespace()
+    node._uid = uid
+    node._group = group
+    node._parent = parent   # DocNode-like object or uid string
+    node.similarity_score = score
+    return node
+
+
+def _make_document_mock(target_nodes):
+    """Return a mock that behaves like document.find(group)(nodes)."""
+    doc = MagicMock()
+    doc.find.return_value = MagicMock(return_value=target_nodes)
+    return doc
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+def test_empty_input_returns_empty():
+    doc = _make_document_mock([])
+    agg = ScoreAwareParentAggregator(doc, target_group='block')
+    assert agg([]) == []
+
+
+def test_already_in_target_group_returns_unchanged():
+    """If the first node is already in the target group, skip aggregation."""
+    block = _make_node('b1', 'block', score=0.9)
+    doc = _make_document_mock([block])
+    agg = ScoreAwareParentAggregator(doc, target_group='block')
+    result = agg([block])
+    assert result == [block]
+    doc.find.assert_not_called()
+
+
+def test_score_formula_single_child():
+    """One child hit: aggregated = max_score + hit_weight * 1."""
+    parent = _make_node('p1', 'block')
+    child = _make_node('c1', 'line', parent=parent, score=0.8)
+
+    doc = _make_document_mock([parent])
+    agg = ScoreAwareParentAggregator(doc, target_group='block', hit_weight=0.05)
+    result = agg([child])
+
+    assert len(result) == 1
+    assert abs(result[0].similarity_score - (0.8 + 0.05 * 1)) < 1e-9
+
+
+def test_score_formula_multiple_children_same_parent():
+    """Three children -> hit_count=3, max of their scores is used."""
+    parent = _make_node('p1', 'block')
+    c1 = _make_node('c1', 'line', parent=parent, score=0.5)
+    c2 = _make_node('c2', 'line', parent=parent, score=0.9)
+    c3 = _make_node('c3', 'line', parent=parent, score=0.7)
+
+    doc = _make_document_mock([parent])
+    agg = ScoreAwareParentAggregator(doc, target_group='block', hit_weight=0.05)
+    result = agg([c1, c2, c3])
+
+    expected = 0.9 + 0.05 * 3   # max_score=0.9, hits=3
+    assert len(result) == 1
+    assert abs(result[0].similarity_score - expected) < 1e-9
+
+
+def test_sorting_descending_by_aggregated_score():
+    """Block with more hits should rank above block with a higher single score."""
+    p_many = _make_node('p_many', 'block')
+    p_single = _make_node('p_single', 'block')
+
+    # p_single: one child at 0.95 -> 0.95 + 0.05*1 = 1.00
+    # p_many: five children at 0.85 each -> max 0.85 + 0.05*5 = 1.10 (hits pull it above)
+    children = (
+        [_make_node('c_single', 'line', parent=p_single, score=0.95)]
+        + [_make_node(f'c_many_{i}', 'line', parent=p_many, score=0.85) for i in range(5)]
+    )
+
+    doc = _make_document_mock([p_many, p_single])
+    agg = ScoreAwareParentAggregator(doc, target_group='block', hit_weight=0.05)
+    result = agg(children)
+
+    assert result[0]._uid == 'p_many'
+    scores = [n.similarity_score for n in result]
+    assert scores == sorted(scores, reverse=True)
+
+
+def test_uid_string_parent_is_handled():
+    """parent can be a uid string (remote / db-backed node); must not crash."""
+    parent = _make_node('p1', 'block')
+    # child._parent is just the uid string, not a DocNode object
+    child = _make_node('c1', 'line', parent='p1', score=0.6)
+
+    doc = _make_document_mock([parent])
+    agg = ScoreAwareParentAggregator(doc, target_group='block', hit_weight=0.1)
+    result = agg([child])
+
+    assert len(result) == 1
+    assert abs(result[0].similarity_score - (0.6 + 0.1 * 1)) < 1e-9
+
+
+def test_none_similarity_score_treated_as_zero():
+    """similarity_score=None must not crash; treated as 0.0."""
+    parent = _make_node('p1', 'block')
+    child = _make_node('c1', 'line', parent=parent, score=None)
+
+    doc = _make_document_mock([parent])
+    agg = ScoreAwareParentAggregator(doc, target_group='block', hit_weight=0.05)
+    result = agg([child])
+
+    assert abs(result[0].similarity_score - (0.0 + 0.05 * 1)) < 1e-9


### PR DESCRIPTION
## Summary

Adds `ScoreAwareParentAggregator` so that when a fine-grained retriever (e.g. `group='line'`) is configured with `target: 'block'`, parent `block` nodes preserve a **hit-density** signal instead of collapsing to undifferentiated parents after deduplication.

Wires the aggregator into the KB retriever path when `target` is set (see `get_retriever`).

## Motivation

In multi-path retrieval, nodes returned by the `line` retriever are mapped back to their parent `block` before RRF merges all paths. Two problems exist in the current implementation:

**Problem 1 — hit density is silently dropped by set deduplication**

Suppose a query returns the following from the `line` retriever:

    Block A  →  10 child line nodes matched
    Block B  →   1 child line node  matched

Semantically, Block A is a stronger match for this query. However, `find_parent` deduplicates parents with a `set`, so both blocks are represented by exactly **one node each** with nothing to distinguish their hit counts. In RRF, Block A and Block B receive identical rank weights from the `line` path — the hit-density signal is completely discarded.

**Problem 2 — `similarity_score` is `None` after line→block mapping**

`document.find()` only maps node references; it does not aggregate child scores onto the parent. After the mapping, every block node on the `line` path has `similarity_score = None`.

RRF's first step is to sort candidates **by score within each path** before computing ranks. With all scores `None`, the sort falls back to Python's default object ordering (hash-based, effectively arbitrary), making per-path ranks meaningless and degrading the final merged ranking.

## Approach

- Split retrieval and parent mapping: the retriever returns raw `line` nodes with scores intact, then `ScoreAwareParentAggregator` maps them to `target_group`.
- Per parent uid: track `hit_count` and `max(similarity_score)` (supports `parent` as `DocNode` or uid string).
- Still calls `document.find(target_group)(nodes)` for correct tree mapping and dedup.
- Back-fills aggregated score: `aggregated_score = max(child_scores) + hit_weight * hit_count` (default `hit_weight = 0.05`), then sorts descending for RRF.

**Trade-off:** For multi-hop targets (direct parent group ≠ target), aggregation is best-effort and a warning is logged. Current LazyRAG defaults use one-hop line→block.

## Files changed

| File | Change |
|------|--------|
| `algorithm/chat/components/process/score_aware_aggregator.py` | New — aggregator implementation |
| `algorithm/chat/pipelines/builders/get_retriever.py` | Wire aggregator when `target` is configured |
| `tests/algorithm/test_score_aware_aggregator.py` | New — unit tests (no external services) |

## Test plan

- [x] `python -m pytest tests/algorithm/test_score_aware_aggregator.py -v`
- [x] `python -m pytest tests/algorithm/ -v`