### PR TITLE
Cz/add test2

### DIFF
--- a/tests/backend/auth-service/conftest.py
+++ b/tests/backend/auth-service/conftest.py
@@ -23,9 +23,9 @@ if _auth_svc not in sys.path:
 import pytest
 from fastapi.testclient import TestClient
 
-from main import app
-
 
 @pytest.fixture
 def client():
+    from main import app
+
     return TestClient(app)

--- a/tests/backend/auth-service/test_models.py
+++ b/tests/backend/auth-service/test_models.py
@@ -1,0 +1,214 @@
+import uuid
+import importlib
+
+import pytest
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy import create_engine
+from sqlalchemy.orm import joinedload, sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from models import (
+    Base,
+    Group,
+    GroupPermission,
+    PermissionGroup,
+    Role,
+    RolePermission,
+    User,
+    UserGroup,
+)
+
+
+def create_session():
+    engine = create_engine(
+        'sqlite:///:memory:',
+        connect_args={'check_same_thread': False},
+        poolclass=StaticPool,
+    )
+    Base.metadata.create_all(engine)
+    session = sessionmaker(bind=engine)()
+    return session
+
+
+def test_models_package_exports_expected_symbols():
+    models_pkg = importlib.import_module('models')
+
+    assert set(models_pkg.__all__) == {
+        'Base',
+        'Group',
+        'GroupPermission',
+        'PermissionGroup',
+        'Role',
+        'RolePermission',
+        'User',
+        'UserGroup',
+    }
+    assert models_pkg.User is User
+    assert models_pkg.Group is Group
+
+
+def test_base_to_json_excludes_sqlalchemy_internal_state():
+    session = create_session()
+    try:
+        role = Role(name='reader', built_in=False)
+        session.add(role)
+        session.commit()
+        session.refresh(role)
+
+        payload = role.to_json()
+
+        assert payload['name'] == 'reader'
+        assert payload['built_in'] is False
+        assert '_sa_instance_state' not in payload
+    finally:
+        session.close()
+
+
+def test_model_relationships_round_trip():
+    session = create_session()
+    try:
+        role = Role(name='member', built_in=False)
+        permission = PermissionGroup(
+            code='group.read',
+            description='Read groups',
+            module='group',
+            action='read',
+        )
+        session.add_all([role, permission])
+        session.commit()
+
+        role_permission = RolePermission(role_id=role.id, permission_group_id=permission.id)
+        session.add(role_permission)
+        session.commit()
+
+        user = User(
+            username='alice',
+            display_name='Alice',
+            password_hash='hashed',
+            role_id=role.id,
+            tenant_id='tenant-a',
+        )
+        session.add(user)
+        session.commit()
+
+        group = Group(
+            tenant_id='tenant-a',
+            group_name='dev-team',
+            remark='Developers',
+            creator_user_id=user.id,
+        )
+        session.add(group)
+        session.commit()
+
+        membership = UserGroup(
+            tenant_id='tenant-a',
+            user_id=user.id,
+            group_id=group.id,
+            role='owner',
+            creator_user_id=user.id,
+        )
+        group_permission = GroupPermission(group_id=group.id, permission_group_id=permission.id)
+        session.add_all([membership, group_permission])
+        session.commit()
+
+        loaded_user = (
+            session.query(User)
+            .options(joinedload(User.role), joinedload(User.groups).joinedload(UserGroup.group))
+            .filter_by(id=user.id)
+            .first()
+        )
+        loaded_role = (
+            session.query(Role)
+            .options(joinedload(Role.permission_groups))
+            .filter_by(id=role.id)
+            .first()
+        )
+        loaded_group = (
+            session.query(Group)
+            .options(
+                joinedload(Group.members).joinedload(UserGroup.user),
+                joinedload(Group.permission_groups),
+            )
+            .filter_by(id=group.id)
+            .first()
+        )
+        loaded_permission = (
+            session.query(PermissionGroup)
+            .options(joinedload(PermissionGroup.roles), joinedload(PermissionGroup.groups))
+            .filter_by(id=permission.id)
+            .first()
+        )
+
+        assert isinstance(loaded_user.id, uuid.UUID)
+        assert loaded_user.display_name == 'Alice'
+        assert loaded_user.disabled is False
+        assert loaded_user.source == 'platform'
+
+        assert loaded_user.role.id == role.id
+        assert loaded_user.groups[0].group.id == group.id
+        assert loaded_user.groups[0].role == 'owner'
+
+        assert loaded_role.permission_groups[0].code == 'group.read'
+        assert loaded_group.members[0].user.id == user.id
+        assert loaded_group.permission_groups[0].id == permission.id
+        assert loaded_permission.roles[0].id == role.id
+        assert loaded_permission.groups[0].id == group.id
+    finally:
+        session.close()
+
+
+def test_model_unique_constraints_are_enforced():
+    session = create_session()
+    try:
+        role = Role(name='user', built_in=True)
+        permission = PermissionGroup(code='user.read')
+        user = User(username='alice', password_hash='hashed', role=role, tenant_id='tenant-a')
+        group = Group(tenant_id='tenant-a', group_name='ops')
+        session.add_all([role, permission, user, group])
+        session.commit()
+
+        session.add(Role(name='user', built_in=False))
+        with pytest.raises(IntegrityError):
+            session.commit()
+        session.rollback()
+
+        session.add(PermissionGroup(code='user.read'))
+        with pytest.raises(IntegrityError):
+            session.commit()
+        session.rollback()
+
+        session.add(User(username='alice', password_hash='hashed-2', role_id=role.id, tenant_id='tenant-a'))
+        with pytest.raises(IntegrityError):
+            session.commit()
+        session.rollback()
+
+        session.add(Group(tenant_id='tenant-a', group_name='ops'))
+        with pytest.raises(IntegrityError):
+            session.commit()
+        session.rollback()
+
+        membership = UserGroup(tenant_id='tenant-a', user_id=user.id, group_id=group.id)
+        session.add(membership)
+        session.commit()
+
+        session.add(UserGroup(tenant_id='tenant-a', user_id=user.id, group_id=group.id))
+        with pytest.raises(IntegrityError):
+            session.commit()
+        session.rollback()
+
+        binding = GroupPermission(group_id=group.id, permission_group_id=permission.id)
+        session.add(binding)
+        session.commit()
+
+        session.add(GroupPermission(group_id=group.id, permission_group_id=permission.id))
+        with pytest.raises(IntegrityError):
+            session.commit()
+        session.rollback()
+
+        session.add(RolePermission(role_id=role.id, permission_group_id=permission.id))
+        session.commit()
+        session.add(RolePermission(role_id=role.id, permission_group_id=permission.id))
+        with pytest.raises(IntegrityError):
+            session.commit()
+    finally:
+        session.close()

--- a/tests/backend/auth-service/test_models.py
+++ b/tests/backend/auth-service/test_models.py
@@ -4,6 +4,8 @@ import importlib
 import pytest
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy import create_engine
+from sqlalchemy import event
+from sqlalchemy import text
 from sqlalchemy.orm import joinedload, sessionmaker
 from sqlalchemy.pool import StaticPool
 
@@ -25,6 +27,7 @@ def create_session():
         connect_args={'check_same_thread': False},
         poolclass=StaticPool,
     )
+    event.listen(engine, 'connect', lambda conn, _: conn.execute('PRAGMA foreign_keys=ON'))
     Base.metadata.create_all(engine)
     session = sessionmaker(bind=engine)()
     return session
@@ -210,5 +213,64 @@ def test_model_unique_constraints_are_enforced():
         session.add(RolePermission(role_id=role.id, permission_group_id=permission.id))
         with pytest.raises(IntegrityError):
             session.commit()
+    finally:
+        session.close()
+
+
+def test_model_foreign_key_delete_behaviors():
+    session = create_session()
+    try:
+        role_restrict = Role(name='restrict-role', built_in=False)
+        role_cascade = Role(name='cascade-role', built_in=False)
+        permission = PermissionGroup(code='group.manage')
+        session.add_all([role_restrict, role_cascade, permission])
+        session.commit()
+
+        user = User(username='carol', password_hash='hashed', role_id=role_restrict.id, tenant_id='tenant-a')
+        session.add(user)
+        session.commit()
+
+        group = Group(
+            tenant_id='tenant-a',
+            group_name='owners',
+            creator_user_id=user.id,
+        )
+        session.add(group)
+        session.commit()
+
+        session.add(
+            UserGroup(
+                tenant_id='tenant-a',
+                user_id=user.id,
+                group_id=group.id,
+                role='owner',
+                creator_user_id=user.id,
+            )
+        )
+        session.add(RolePermission(role_id=role_cascade.id, permission_group_id=permission.id))
+        session.add(GroupPermission(group_id=group.id, permission_group_id=permission.id))
+        session.commit()
+
+        session.delete(role_restrict)
+        with pytest.raises(IntegrityError):
+            session.commit()
+        session.rollback()
+
+        session.delete(role_cascade)
+        session.commit()
+        assert session.query(RolePermission).filter_by(role_id=role_cascade.id).count() == 0
+
+        session.delete(user)
+        session.commit()
+        refreshed_group = session.get(Group, group.id)
+        assert refreshed_group.creator_user_id is None
+        assert session.query(UserGroup).filter_by(group_id=group.id).count() == 0
+
+        session.delete(group)
+        session.commit()
+        assert session.query(GroupPermission).filter_by(group_id=group.id).count() == 0
+
+        fk_state = session.execute(text('PRAGMA foreign_keys')).scalar()
+        assert fk_state == 1
     finally:
         session.close()

--- a/tests/backend/auth-service/test_repositories.py
+++ b/tests/backend/auth-service/test_repositories.py
@@ -1,0 +1,276 @@
+import uuid
+import importlib
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from models import Base
+from repositories import (
+    GroupPermissionRepository,
+    GroupRepository,
+    PermissionGroupRepository,
+    RoleRepository,
+    UserGroupRepository,
+    UserRepository,
+)
+
+
+@pytest.fixture
+def db_session():
+    engine = create_engine(
+        'sqlite:///:memory:',
+        connect_args={'check_same_thread': False},
+        poolclass=StaticPool,
+    )
+    Base.metadata.create_all(engine)
+    session = sessionmaker(bind=engine)()
+    yield session
+    session.close()
+
+
+@pytest.fixture
+def seeded_entities(db_session):
+    admin_role = RoleRepository.create(db_session, 'admin', built_in=True)
+    user_role = RoleRepository.create(db_session, 'user', built_in=False)
+    read_pg = PermissionGroupRepository.create(
+        db_session,
+        code='user.read',
+        description='Read user',
+        module='user',
+        action='read',
+    )
+    write_pg = PermissionGroupRepository.create(
+        db_session,
+        code='user.write',
+        description='Write user',
+        module='user',
+        action='write',
+    )
+    alice = UserRepository.create(
+        db_session,
+        username='alice',
+        password_hash='hash-a',
+        role_id=admin_role.id,
+        tenant_id='tenant-a',
+        email='alice@example.com',
+        display_name='Alice',
+    )
+    bob = UserRepository.create(
+        db_session,
+        username='bob',
+        password_hash='hash-b',
+        role_id=user_role.id,
+        tenant_id='tenant-b',
+        display_name='Bobby',
+    )
+    group_a = GroupRepository.create(db_session, 'tenant-a', 'alpha', 'Alpha team', alice.id)
+    group_b = GroupRepository.create(db_session, 'tenant-b', 'beta', 'Beta team', bob.id)
+    return {
+        'admin_role': admin_role,
+        'user_role': user_role,
+        'read_pg': read_pg,
+        'write_pg': write_pg,
+        'alice': alice,
+        'bob': bob,
+        'group_a': group_a,
+        'group_b': group_b,
+    }
+
+
+def test_repositories_package_exports_expected_symbols():
+    repositories_pkg = importlib.import_module('repositories')
+
+    assert set(repositories_pkg.__all__) == {
+        'GroupPermissionRepository',
+        'GroupRepository',
+        'PermissionGroupRepository',
+        'RoleRepository',
+        'UserGroupRepository',
+        'UserRepository',
+    }
+
+
+def test_permission_group_repository_create_get_and_list(db_session):
+    alpha = PermissionGroupRepository.create(
+        db_session,
+        code='document.read',
+        description='Read docs',
+        module='document',
+        action='read',
+    )
+    PermissionGroupRepository.create(
+        db_session,
+        code='auth.login',
+        description='Login',
+        module='auth',
+        action='write',
+    )
+
+    listed = PermissionGroupRepository.list_all_ordered(db_session)
+
+    assert PermissionGroupRepository.get_by_code(db_session, 'document.read').id == alpha.id
+    assert [item.code for item in listed] == ['auth.login', 'document.read']
+
+
+def test_role_repository_methods_cover_lookup_and_permission_replacement(db_session, seeded_entities):
+    admin_role = seeded_entities['admin_role']
+    read_pg = seeded_entities['read_pg']
+    write_pg = seeded_entities['write_pg']
+
+    assert RoleRepository.get_by_name(db_session, 'admin').id == admin_role.id
+    assert RoleRepository.get_by_id(db_session, admin_role.id).name == 'admin'
+    assert RoleRepository.get_names_in(db_session, ['admin', 'missing']) == {'admin'}
+    assert RoleRepository.count(db_session) == 2
+    assert [item.name for item in RoleRepository.list_all_ordered(db_session)] == ['admin', 'user']
+
+    RoleRepository.replace_permissions(db_session, admin_role.id, {read_pg.id, write_pg.id})
+    loaded = RoleRepository.get_with_permission_groups(db_session, admin_role.id)
+
+    assert {item.code for item in loaded.permission_groups} == {'user.read', 'user.write'}
+
+    RoleRepository.replace_permissions(db_session, admin_role.id, set())
+    loaded = RoleRepository.get_with_permission_groups(db_session, admin_role.id)
+    assert loaded.permission_groups == []
+
+
+def test_group_repository_list_create_get_and_delete(db_session, seeded_entities):
+    group_a = seeded_entities['group_a']
+    group_b = seeded_entities['group_b']
+
+    assert GroupRepository.get_by_id(db_session, group_a.id).group_name == 'alpha'
+    assert GroupRepository.get_by_tenant_and_name(db_session, 'tenant-b', 'beta').id == group_b.id
+
+    groups, total = GroupRepository.list_paginated(
+        db_session,
+        page=1,
+        page_size=10,
+        search='a',
+        tenant_id='tenant-a',
+    )
+    assert total == 1
+    assert [item.group_name for item in groups] == ['alpha']
+
+    GroupRepository.delete(db_session, group_b)
+    assert GroupRepository.get_by_id(db_session, group_b.id) is None
+
+
+def test_user_group_repository_add_list_update_and_remove(db_session, seeded_entities):
+    group_a = seeded_entities['group_a']
+    alice = seeded_entities['alice']
+    bob = seeded_entities['bob']
+
+    owner = UserGroupRepository.add(
+        db_session,
+        tenant_id='tenant-a',
+        user_id=alice.id,
+        group_id=group_a.id,
+        role='owner',
+        creator_user_id=alice.id,
+    )
+    member = UserGroupRepository.add(
+        db_session,
+        tenant_id='tenant-a',
+        user_id=bob.id,
+        group_id=group_a.id,
+        role='member',
+        creator_user_id=alice.id,
+    )
+
+    listed = UserGroupRepository.list_by_group_id(db_session, group_a.id)
+    pair = UserGroupRepository.get_by_group_and_user(db_session, group_a.id, bob.id, 'tenant-a')
+    batch = UserGroupRepository.get_by_group_and_users(db_session, group_a.id, [alice.id, bob.id])
+    no_rows = UserGroupRepository.get_by_group_and_users(db_session, group_a.id, [])
+
+    assert owner.role == 'owner'
+    assert member.role == 'member'
+    assert {row.user.username for row in listed} == {'alice', 'bob'}
+    assert pair.id == member.id
+    assert {row.user_id for row in batch} == {alice.id, bob.id}
+    assert no_rows == []
+
+    UserGroupRepository.set_member_role(db_session, member, 'maintainer')
+    assert UserGroupRepository.get_by_group_and_user(db_session, group_a.id, bob.id).role == 'maintainer'
+
+    UserGroupRepository.remove_by_group_and_users(db_session, group_a.id, [bob.id])
+    remaining = UserGroupRepository.list_by_group_id(db_session, group_a.id)
+    assert [row.user_id for row in remaining] == [alice.id]
+
+
+def test_group_permission_repository_replace_and_read_codes(db_session, seeded_entities):
+    group_a = seeded_entities['group_a']
+    read_pg = seeded_entities['read_pg']
+    write_pg = seeded_entities['write_pg']
+
+    GroupPermissionRepository.replace_permissions(db_session, group_a.id, {read_pg.id, write_pg.id})
+    assert set(GroupPermissionRepository.get_permission_codes(db_session, group_a.id)) == {
+        'user.read',
+        'user.write',
+    }
+
+    GroupPermissionRepository.replace_permissions(db_session, group_a.id, {write_pg.id})
+    assert GroupPermissionRepository.get_permission_codes(db_session, group_a.id) == ['user.write']
+
+    GroupPermissionRepository.replace_permissions(db_session, group_a.id, set())
+    assert GroupPermissionRepository.get_permission_codes(db_session, group_a.id) == []
+
+
+def test_user_repository_load_options_pagination_and_profile_update(db_session, seeded_entities):
+    admin_role = seeded_entities['admin_role']
+    read_pg = seeded_entities['read_pg']
+    alice = seeded_entities['alice']
+    bob = seeded_entities['bob']
+    group_a = seeded_entities['group_a']
+
+    RoleRepository.replace_permissions(db_session, admin_role.id, {read_pg.id})
+    UserGroupRepository.add(
+        db_session,
+        tenant_id='tenant-a',
+        user_id=alice.id,
+        group_id=group_a.id,
+        role='owner',
+        creator_user_id=alice.id,
+    )
+    GroupPermissionRepository.replace_permissions(db_session, group_a.id, {read_pg.id})
+
+    loaded = UserRepository.get_by_id(
+        db_session,
+        alice.id,
+        load_role=True,
+        load_permission_groups=True,
+        load_groups=True,
+        load_group_permission_groups=True,
+    )
+
+    assert loaded.role.name == 'admin'
+    assert loaded.role.permission_groups[0].code == 'user.read'
+    assert loaded.groups[0].group.permission_groups[0].code == 'user.read'
+
+    page_items, total = UserRepository.list_paginated(
+        db_session,
+        page=1,
+        page_size=1,
+        search='bo',
+        tenant_id='tenant-b',
+    )
+    assert total == 1
+    assert [item.username for item in page_items] == ['bob']
+
+    updated = UserRepository.update_profile(
+        db_session,
+        bob.id,
+        display_name='Bob',
+        email='bob@example.com',
+        phone='13800000000',
+        remark='Updated',
+    )
+    assert UserRepository.count(db_session) == 2
+    assert updated.display_name == 'Bob'
+    assert updated.email == 'bob@example.com'
+    assert updated.phone == '13800000000'
+    assert updated.remark == 'Updated'
+    assert UserRepository.update_profile(db_session, uuid.uuid4(), display_name='ghost') is None
+
+    assert UserRepository.get_by_username(db_session, 'alice').id == alice.id
+    assert UserRepository.get_by_id(db_session, uuid.uuid4()) is None

--- a/tests/backend/auth-service/test_schemas.py
+++ b/tests/backend/auth-service/test_schemas.py
@@ -1,0 +1,202 @@
+import importlib
+
+from pydantic import ValidationError
+
+from schemas.auth import (
+    AuthorizeBody,
+    AuthorizeResponse,
+    ChangePasswordBody,
+    HealthResponse,
+    LoginBody,
+    LoginResponse,
+    LogoutBody,
+    MeResponse,
+    RefreshBody,
+    RegisterBody,
+    RegisterResponse,
+    SuccessResponse,
+    UpdateMeBody,
+    ValidateResponse,
+)
+from schemas.group import (
+    GroupAddUsersBody,
+    GroupCreateResponse,
+    GroupCreateBody,
+    GroupDetailResponse,
+    GroupItem,
+    GroupListResponse,
+    GroupMemberRoleBody,
+    GroupMemberRoleBatchBody,
+    GroupRemoveUsersBody,
+    GroupUpdateBody,
+    GroupUserItem,
+    GroupUserListResponse,
+    OkResponse as GroupOkResponse,
+    UserGroupItem,
+    UserGroupListResponse,
+)
+from schemas.role import (
+    OkResponse as RoleOkResponse,
+    PermissionGroupItem,
+    RoleCreateBody,
+    RoleCreateResponse,
+    RoleItem,
+    RolePermissionsBody,
+    RolePermissionsResponse,
+)
+from schemas.user import (
+    CreateUserBody,
+    CreateUserResponse,
+    DisableUserBody,
+    ResetPasswordBody,
+    UserItem,
+    UserDetailResponse,
+    UserListResponse,
+    UserRoleBody,
+    UserRoleBatchBody,
+)
+
+
+def test_schemas_package_importable():
+    schemas_pkg = importlib.import_module('schemas')
+    assert schemas_pkg is not None
+
+
+def test_auth_schema_defaults_and_required_fields():
+    body = RegisterBody(username='tester', password='Aa1!aaaa', confirm_password='Aa1!aaaa')
+    update_body = UpdateMeBody()
+    success = SuccessResponse()
+    health = HealthResponse(timestamp=123.0)
+    register_response = RegisterResponse(user_id='u1', role='user')
+    login_body = LoginBody(username='tester', password='Aa1!aaaa')
+    login_response = LoginResponse(
+        access_token='access',
+        refresh_token='refresh',
+        refresh_expires_at='2026-01-01T00:00:00Z',
+        role='user',
+        expires_in=3600,
+    )
+    refresh_body = RefreshBody(refresh_token='refresh')
+    validate = ValidateResponse(sub='u1', role='user', permissions=['user.read'])
+    me = MeResponse(
+        user_id='u1',
+        username='tester',
+        status='active',
+        role='user',
+        permissions=['user.read'],
+    )
+    change_password = ChangePasswordBody(old_password='old', new_password='new')
+    logout = LogoutBody()
+    authorize_body = AuthorizeBody(method='GET', path='/api/auth')
+    authorize_response = AuthorizeResponse(allowed=True)
+
+    assert body.email is None
+    assert body.tenant_id is None
+    assert update_body.model_dump(exclude_none=True) == {}
+    assert success.success is True
+    assert health.status == 'ok'
+    assert register_response.success is True
+    assert login_body.username == 'tester'
+    assert login_response.token_type == 'bearer'
+    assert refresh_body.refresh_token == 'refresh'
+    assert validate.permissions == ['user.read']
+    assert me.display_name == ''
+    assert change_password.old_password == 'old'
+    assert logout.refresh_token is None
+    assert authorize_body.path == '/api/auth'
+    assert authorize_response.allowed is True
+
+    try:
+        RegisterBody(password='Aa1!aaaa', confirm_password='Aa1!aaaa')
+    except ValidationError as exc:
+        assert 'username' in str(exc)
+    else:
+        raise AssertionError('RegisterBody should require username')
+
+
+def test_group_schema_payload_shapes():
+    create_body = GroupCreateBody(group_name='ops')
+    update_body = GroupUpdateBody(group_name='ops-2', remark='renamed')
+    add_users = GroupAddUsersBody(user_ids=['u1', 'u2'], role='member')
+    remove_users = GroupRemoveUsersBody(user_ids=['u1'])
+    role_body = GroupMemberRoleBody(role='owner')
+    role_batch = GroupMemberRoleBatchBody(user_ids=['u1'], role='owner')
+    item = GroupItem(group_id='g1', group_name='ops')
+    response = GroupListResponse(groups=[item], total=1, page=1, page_size=20)
+    detail = GroupDetailResponse(group_id='g1', group_name='ops')
+    create_response = GroupCreateResponse(group_id='g2')
+    group_user_item = GroupUserItem(user_id='u1', username='alice', role='member')
+    user_list = GroupUserListResponse(users=[group_user_item])
+    user_group_item = UserGroupItem(user_id='u1', group_id='g1', group_name='ops')
+    user_group_list = UserGroupListResponse(groups=[user_group_item])
+
+    assert create_body.group_name == 'ops'
+    assert update_body.remark == 'renamed'
+    assert add_users.user_ids == ['u1', 'u2']
+    assert remove_users.user_ids == ['u1']
+    assert role_body.role == 'owner'
+    assert role_batch.role == 'owner'
+    assert response.groups[0].tenant_id is None
+    assert detail.group_name == 'ops'
+    assert create_response.group_id == 'g2'
+    assert user_list.users[0].username == 'alice'
+    assert user_group_list.groups[0].group_id == 'g1'
+    assert GroupOkResponse().ok is True
+
+
+def test_role_schema_payload_shapes():
+    create_body = RoleCreateBody(name='auditor')
+    permissions_body = RolePermissionsBody(permission_groups=['user.read'])
+    permission_item = PermissionGroupItem(
+        id='pg1',
+        code='user.read',
+        description='Read user',
+        module='user',
+        action='read',
+    )
+    role_item = RoleItem(id='r1', name='auditor', built_in=False)
+    create_response = RoleCreateResponse(id='r1', name='auditor', built_in=False)
+    response = RolePermissionsResponse(role_id='r1', permission_groups=['user.read'])
+
+    assert create_body.name == 'auditor'
+    assert permissions_body.permission_groups == ['user.read']
+    assert permission_item.code == 'user.read'
+    assert role_item.name == 'auditor'
+    assert create_response.id == 'r1'
+    assert response.permission_groups == ['user.read']
+    assert RoleOkResponse().ok is True
+
+
+def test_user_schema_defaults_and_collections():
+    create_body = CreateUserBody(username='alice', password='Aa1!aaaa')
+    create_response = CreateUserResponse(user_id='u1', username='alice', role_id='r1', role_name='user')
+    role_body = UserRoleBody(role_id='r1')
+    batch_body = UserRoleBatchBody(user_ids=['u1', 'u2'], role_id='r1')
+    reset_password = ResetPasswordBody(new_password='Bb2@bbbb')
+    disable_body = DisableUserBody()
+    item = UserItem(
+        user_id='u1',
+        username='alice',
+        status='active',
+        role_id='r1',
+        role_name='user',
+    )
+    detail = UserDetailResponse(
+        user_id='u1',
+        username='alice',
+        status='active',
+        role_id='r1',
+        role_name='user',
+    )
+    listing = UserListResponse(users=[], total=0, page=1, page_size=20)
+
+    assert create_body.tenant_id == ''
+    assert create_body.disabled is False
+    assert create_response.username == 'alice'
+    assert role_body.role_id == 'r1'
+    assert batch_body.user_ids == ['u1', 'u2']
+    assert reset_password.new_password == 'Bb2@bbbb'
+    assert disable_body.disabled is True
+    assert item.is_bootstrap_admin is False
+    assert detail.is_bootstrap_admin is False
+    assert listing.users == []

--- a/tests/backend/auth-service/test_schemas.py
+++ b/tests/backend/auth-service/test_schemas.py
@@ -1,5 +1,6 @@
 import importlib
 
+import pytest
 from pydantic import ValidationError
 
 from schemas.auth import (
@@ -200,3 +201,41 @@ def test_user_schema_defaults_and_collections():
     assert item.is_bootstrap_admin is False
     assert detail.is_bootstrap_admin is False
     assert listing.users == []
+
+
+@pytest.mark.parametrize(
+    'schema_cls,payload,missing_field',
+    [
+        (LoginBody, {'password': 'Aa1!aaaa'}, 'username'),
+        (RefreshBody, {}, 'refresh_token'),
+        (AuthorizeBody, {'method': 'GET'}, 'path'),
+        (GroupCreateBody, {}, 'group_name'),
+        (GroupAddUsersBody, {}, 'user_ids'),
+        (RoleCreateBody, {}, 'name'),
+        (RolePermissionsBody, {}, 'permission_groups'),
+        (CreateUserBody, {'username': 'alice'}, 'password'),
+        (UserRoleBatchBody, {'role_id': 'r1'}, 'user_ids'),
+    ],
+)
+def test_schema_required_fields_validation(schema_cls, payload, missing_field):
+    with pytest.raises(ValidationError) as exc_info:
+        schema_cls(**payload)
+
+    assert missing_field in str(exc_info.value)
+
+
+@pytest.mark.parametrize(
+    'schema_cls,payload,error_field',
+    [
+        (ValidateResponse, {'sub': 'u1', 'role': 'user', 'permissions': 'user.read'}, 'permissions'),
+        (GroupAddUsersBody, {'user_ids': 'u1'}, 'user_ids'),
+        (GroupMemberRoleBatchBody, {'user_ids': ['u1'], 'role': 1}, 'role'),
+        (RolePermissionsResponse, {'role_id': 'r1', 'permission_groups': 'user.read'}, 'permission_groups'),
+        (UserListResponse, {'users': [], 'total': 'abc', 'page': 1, 'page_size': 20}, 'total'),
+    ],
+)
+def test_schema_type_validation(schema_cls, payload, error_field):
+    with pytest.raises(ValidationError) as exc_info:
+        schema_cls(**payload)
+
+    assert error_field in str(exc_info.value)

--- a/tests/backend/auth-service/test_services.py
+++ b/tests/backend/auth-service/test_services.py
@@ -1,0 +1,589 @@
+import uuid
+from contextlib import contextmanager
+import importlib
+import sys
+import types
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from core.errors import AppException, AuthError
+from models import Base
+from repositories import GroupRepository, PermissionGroupRepository, RoleRepository, UserRepository
+
+try:
+    from passlib.context import CryptContext as _CryptContext
+except ModuleNotFoundError:
+    passlib_module = types.ModuleType('passlib')
+    context_module = types.ModuleType('passlib.context')
+
+    class _CryptContext:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def hash(self, password):
+            return f'fake-hash::{password}'
+
+        def verify(self, password, password_hash):
+            return password_hash == f'fake-hash::{password}'
+
+    context_module.CryptContext = _CryptContext
+    passlib_module.context = context_module
+    sys.modules['passlib'] = passlib_module
+    sys.modules['passlib.context'] = context_module
+
+from services.auth_service import AuthService
+from services.group_service import GroupService
+from services.role_service import RoleService
+from services.user_service import UserService
+
+
+@pytest.fixture
+def db_session():
+    engine = create_engine(
+        'sqlite:///:memory:',
+        connect_args={'check_same_thread': False},
+        poolclass=StaticPool,
+    )
+    Base.metadata.create_all(engine)
+    session = sessionmaker(bind=engine)()
+    yield session
+    session.close()
+
+
+@pytest.fixture
+def service_session_local(db_session):
+    @contextmanager
+    def _session_local():
+        yield db_session
+
+    return _session_local
+
+
+@pytest.fixture
+def service_modules(service_session_local, monkeypatch):
+    group_service_module = importlib.import_module('services.group_service')
+    role_service_module = importlib.import_module('services.role_service')
+    user_service_module = importlib.import_module('services.user_service')
+
+    monkeypatch.setattr(group_service_module, 'SessionLocal', service_session_local)
+    monkeypatch.setattr(role_service_module, 'SessionLocal', service_session_local)
+    monkeypatch.setattr(user_service_module, 'SessionLocal', service_session_local)
+    return group_service_module, role_service_module, user_service_module
+
+
+@pytest.fixture
+def seeded_data(db_session):
+    system_admin = RoleRepository.create(db_session, 'system-admin', built_in=True)
+    user_role = RoleRepository.create(db_session, 'user', built_in=True)
+    editor_role = RoleRepository.create(db_session, 'editor', built_in=False)
+    read_pg = PermissionGroupRepository.create(
+        db_session,
+        code='group.read',
+        description='Read group',
+        module='group',
+        action='read',
+    )
+    write_pg = PermissionGroupRepository.create(
+        db_session,
+        code='group.write',
+        description='Write group',
+        module='group',
+        action='write',
+    )
+    admin = UserRepository.create(
+        db_session,
+        username='admin',
+        password_hash='hashed-admin',
+        role_id=system_admin.id,
+        tenant_id='tenant-a',
+        source='admin',
+    )
+    bootstrap = UserRepository.create(
+        db_session,
+        username='bootstrap',
+        password_hash='hashed-bootstrap',
+        role_id=system_admin.id,
+        tenant_id='tenant-a',
+        source='init',
+    )
+    normal = UserRepository.create(
+        db_session,
+        username='normal',
+        password_hash='hashed-normal',
+        role_id=user_role.id,
+        tenant_id='tenant-a',
+        source='platform',
+    )
+    outsider = UserRepository.create(
+        db_session,
+        username='outsider',
+        password_hash='hashed-outsider',
+        role_id=user_role.id,
+        tenant_id='tenant-b',
+        source='platform',
+    )
+    team = GroupRepository.create(db_session, 'tenant-a', 'alpha-team', 'Alpha', admin.id)
+    return {
+        'system_admin': system_admin,
+        'user_role': user_role,
+        'editor_role': editor_role,
+        'read_pg': read_pg,
+        'write_pg': write_pg,
+        'admin': admin,
+        'bootstrap': bootstrap,
+        'normal': normal,
+        'outsider': outsider,
+        'team': team,
+    }
+
+
+def test_services_package_exports_instances():
+    services_pkg = importlib.import_module('services')
+
+    assert services_pkg.__all__ == ['auth_service', 'group_service', 'role_service', 'user_service']
+    assert services_pkg.auth_service is not None
+    assert services_pkg.group_service is not None
+    assert services_pkg.role_service is not None
+    assert services_pkg.user_service is not None
+
+
+def test_auth_service_validation_and_registration(db_session, seeded_data, monkeypatch):
+    service = AuthService()
+    user_role = seeded_data['user_role']
+
+    assert service.validate_username('user.name-1') is True
+    assert service.validate_username('a') is False
+    assert service.validate_username('.bad') is False
+    assert service.validate_password('Aa1!aaaa') is True
+    assert service.validate_password('weakpass') is False
+
+    created = service.register_user(
+        db=db_session,
+        username='  new_user  ',
+        password='Aa1!aaaa',
+        role_id=user_role.id,
+        tenant_id='tenant-a',
+        email='new@example.com',
+    )
+    assert created.username == 'new_user'
+    assert created.email == 'new@example.com'
+    assert service.verify_password('Aa1!aaaa', created.password_hash) is True
+
+    with pytest.raises(AuthError) as invalid_username:
+        service.register_user(db=db_session, username='*bad*', password='Aa1!aaaa', role_id=user_role.id)
+    assert invalid_username.value.code == 1000101
+
+    with pytest.raises(AuthError) as username_required:
+        service.register_user(db=db_session, username='   ', password='Aa1!aaaa', role_id=user_role.id)
+    assert username_required.value.code == 1000201
+
+    with pytest.raises(AuthError) as password_required:
+        service.register_user(db=db_session, username='valid_user2', password='', role_id=user_role.id)
+    assert password_required.value.code == 1000202
+
+    with pytest.raises(AuthError) as invalid_password:
+        service.register_user(db=db_session, username='valid_user', password='short', role_id=user_role.id)
+    assert invalid_password.value.code == 1000103
+
+    with pytest.raises(AuthError) as duplicate:
+        service.register_user(
+            db=db_session,
+            username='new_user',
+            password='Aa1!aaaa',
+            role_id=user_role.id,
+        )
+    assert duplicate.value.code == 1000102
+
+    attempts = []
+
+    class DummyLimiter:
+        def is_limited(self, user_id):
+            return user_id == created.id and len(attempts) >= 1
+
+        def record_failure(self, user_id):
+            attempts.append(user_id)
+
+    auth_service_module = importlib.import_module('services.auth_service')
+
+    monkeypatch.setattr(auth_service_module, 'login_rate_limiter', DummyLimiter())
+
+    authenticated = service.authenticate_user(db=db_session, username='new_user', password='Aa1!aaaa')
+    assert authenticated.id == created.id
+
+    with pytest.raises(AuthError) as wrong_password:
+        service.authenticate_user(db=db_session, username='new_user', password='wrong')
+    assert wrong_password.value.code == 1000105
+    assert attempts == [created.id]
+
+    with pytest.raises(AuthError) as missing_user:
+        service.authenticate_user(db=db_session, username='ghost', password='Aa1!aaaa')
+    assert missing_user.value.code == 1000105
+
+    with pytest.raises(AuthError) as locked:
+        service.authenticate_user(db=db_session, username='new_user', password='Aa1!aaaa')
+    assert locked.value.code == 1000104
+
+    created.disabled = True
+    db_session.commit()
+
+    monkeypatch.setattr(auth_service_module, 'login_rate_limiter', DummyLimiter())
+    attempts.clear()
+    with pytest.raises(AuthError) as disabled:
+        service.authenticate_user(db=db_session, username='new_user', password='Aa1!aaaa')
+    assert disabled.value.code == 1000106
+
+
+def test_role_service_crud_and_permission_management(service_modules, db_session, seeded_data):
+    _, _, _ = service_modules
+    service = RoleService()
+    editor_role = seeded_data['editor_role']
+    system_admin = seeded_data['system_admin']
+
+    listed_permissions = service.list_permission_groups()
+    assert [item['code'] for item in listed_permissions] == ['group.read', 'group.write']
+
+    listed_roles = service.list_roles()
+    assert [item['name'] for item in listed_roles] == ['editor', 'system-admin', 'user']
+
+    created = service.create_role(' auditor ')
+    assert created['name'] == 'auditor'
+    assert created['built_in'] is False
+
+    with pytest.raises(AppException) as empty_name:
+        service.create_role('   ')
+    assert empty_name.value.code == 1000408
+
+    with pytest.raises(AppException) as duplicate:
+        service.create_role('auditor')
+    assert duplicate.value.code == 1000409
+
+    service.set_role_permissions(editor_role.id, ['group.read', 'missing', 'group.write'])
+    assert set(service.get_role_permissions(editor_role.id)) == {'group.read', 'group.write'}
+
+    service.set_role_permissions(editor_role.id, [])
+    assert service.get_role_permissions(editor_role.id) == []
+
+    with pytest.raises(AppException) as role_not_found_permissions:
+        service.get_role_permissions(uuid.uuid4())
+    assert role_not_found_permissions.value.code == 1000403
+
+    with pytest.raises(AppException) as cannot_change_admin:
+        service.set_role_permissions(system_admin.id, ['group.read'])
+    assert cannot_change_admin.value.code == 1000411
+
+    with pytest.raises(AppException) as set_missing_role:
+        service.set_role_permissions(uuid.uuid4(), ['group.read'])
+    assert set_missing_role.value.code == 1000403
+
+    service.delete_role(editor_role.id)
+    assert RoleRepository.get_by_id(db_session, editor_role.id) is None
+
+    with pytest.raises(AppException) as cannot_delete_builtin:
+        service.delete_role(system_admin.id)
+    assert cannot_delete_builtin.value.code == 1000410
+
+    with pytest.raises(AppException) as delete_missing_role:
+        service.delete_role(uuid.uuid4())
+    assert delete_missing_role.value.code == 1000403
+
+
+def test_group_service_group_membership_and_permissions(service_modules, db_session, seeded_data):
+    _, _, _ = service_modules
+    service = GroupService()
+    admin = seeded_data['admin']
+    normal = seeded_data['normal']
+    outsider = seeded_data['outsider']
+    team = seeded_data['team']
+
+    created_group_id = service.create_group(
+        '  beta-team  ',
+        tenant_id='tenant-a',
+        remark='Beta',
+        creator_user_id=admin.id,
+    )
+    created_group = GroupRepository.get_by_id(db_session, uuid.UUID(created_group_id))
+    assert created_group.group_name == 'beta-team'
+
+    with pytest.raises(AppException) as empty_group_name:
+        service.create_group('   ', tenant_id='tenant-a')
+    assert empty_group_name.value.code == 1000404
+
+    with pytest.raises(AppException) as duplicate:
+        service.create_group('beta-team', tenant_id='tenant-a')
+    assert duplicate.value.code == 1000413
+
+    assert service.get_group(team.id)['group_name'] == 'alpha-team'
+    assert service.get_group(uuid.uuid4()) is None
+
+    assert service.list_groups(current_user_id=None, is_system_admin=False) == ([], 0)
+
+    with pytest.raises(AppException) as user_not_found:
+        service.list_groups(current_user_id=uuid.uuid4(), is_system_admin=False)
+    assert user_not_found.value.code == 1000401
+
+    service.add_group_users(team.id, [admin.id, normal.id], role='member', operator_id=admin.id)
+    members = service.list_group_users(team.id)
+    assert {row['username'] for row in members} == {'admin', 'normal'}
+
+    service.add_group_users(team.id, [normal.id], role='member', operator_id=admin.id)
+    assert len(service.list_group_users(team.id)) == 2
+
+    with pytest.raises(AppException) as add_missing_group:
+        service.add_group_users(uuid.uuid4(), [normal.id])
+    assert add_missing_group.value.code == 1000402
+
+    with pytest.raises(AppException) as add_missing_user:
+        service.add_group_users(team.id, [uuid.uuid4()])
+    assert add_missing_user.value.code == 1000401
+
+    user_groups = service.list_user_groups(normal.id)
+    assert user_groups[0]['group_name'] == 'alpha-team'
+
+    with pytest.raises(AppException) as missing_user_groups:
+        service.list_user_groups(uuid.uuid4())
+    assert missing_user_groups.value.code == 1000401
+
+    admin_groups, admin_total = service.list_groups(is_system_admin=True, tenant_id='tenant-a', search='team')
+    assert admin_total == 2
+    assert {item['group_name'] for item in admin_groups} == {'alpha-team', 'beta-team'}
+
+    member_groups, member_total = service.list_groups(
+        current_user_id=normal.id,
+        search='alpha',
+        tenant_id='tenant-a',
+        is_system_admin=False,
+    )
+    assert member_total == 1
+    assert member_groups[0]['group_name'] == 'alpha-team'
+
+    service.set_member_role(team.id, normal.id, ' owner ')
+    role_by_username = {row['username']: row['role'] for row in service.list_group_users(team.id)}
+    assert role_by_username['normal'] == 'owner'
+
+    with pytest.raises(AppException) as role_required:
+        service.set_member_role(team.id, normal.id, '   ')
+    assert role_required.value.code == 1000406
+
+    with pytest.raises(AppException) as membership_missing:
+        service.set_member_role(team.id, outsider.id, 'owner')
+    assert membership_missing.value.code == 1000407
+
+    service.set_member_roles_batch(team.id, [admin.id, normal.id], 'maintainer')
+    assert {row['role'] for row in service.list_group_users(team.id)} == {'maintainer'}
+
+    service.set_member_roles_batch(team.id, [], 'maintainer')
+
+    with pytest.raises(AppException) as batch_role_required:
+        service.set_member_roles_batch(team.id, [admin.id], '   ')
+    assert batch_role_required.value.code == 1000406
+
+    with pytest.raises(AppException) as missing_member:
+        service.set_member_roles_batch(team.id, [outsider.id], 'member')
+    assert missing_member.value.code == 1000407
+
+    service.set_group_permissions(team.id, ['group.read', 'group.write', 'missing'])
+    assert set(service.get_group_permissions(team.id)) == {'group.read', 'group.write'}
+
+    service.set_group_permissions(team.id, [])
+    assert service.get_group_permissions(team.id) == []
+
+    with pytest.raises(AppException) as group_permissions_missing:
+        service.get_group_permissions(uuid.uuid4())
+    assert group_permissions_missing.value.code == 1000402
+
+    with pytest.raises(AppException) as set_group_permissions_missing:
+        service.set_group_permissions(uuid.uuid4(), ['group.read'])
+    assert set_group_permissions_missing.value.code == 1000402
+
+    service.remove_group_users(team.id, [normal.id])
+    assert [row['username'] for row in service.list_group_users(team.id)] == ['admin']
+
+    service.update_group(team.id, group_name='alpha-renamed', remark='Renamed', tenant_id='tenant-x')
+    assert service.get_group(team.id) == {
+        'group_id': str(team.id),
+        'group_name': 'alpha-renamed',
+        'remark': 'Renamed',
+        'tenant_id': 'tenant-x',
+    }
+
+    service.create_group('gamma-team', tenant_id='tenant-x')
+    with pytest.raises(AppException) as group_name_empty:
+        service.update_group(team.id, group_name='   ')
+    assert group_name_empty.value.code == 1000405
+
+    with pytest.raises(AppException) as group_name_exists:
+        service.update_group(team.id, group_name='gamma-team')
+    assert group_name_exists.value.code == 1000413
+
+    with pytest.raises(AppException) as update_missing_group:
+        service.update_group(uuid.uuid4(), group_name='missing')
+    assert update_missing_group.value.code == 1000402
+
+    service.delete_group(created_group.id)
+    assert GroupRepository.get_by_id(db_session, created_group.id) is None
+
+    with pytest.raises(AppException) as delete_missing_group:
+        service.delete_group(uuid.uuid4())
+    assert delete_missing_group.value.code == 1000402
+
+
+def test_user_service_crud_role_assignment_and_password_reset(service_modules, db_session, seeded_data, monkeypatch):
+    _, _, user_service_module = service_modules
+    service = UserService()
+    user_role = seeded_data['user_role']
+    editor_role = seeded_data['editor_role']
+    bootstrap = seeded_data['bootstrap']
+    normal = seeded_data['normal']
+
+    monkeypatch.setattr(user_service_module.auth_service, 'hash_password', lambda password: f'hashed::{password}')
+    monkeypatch.setattr(
+        user_service_module.auth_service,
+        'validate_password',
+        lambda password: password.startswith('Aa1!'),
+    )
+
+    created = service.create_user(
+        username='  svc-user  ',
+        password='Aa1!service',
+        tenant_id='tenant-a',
+        email='svc@example.com',
+    )
+    assert created['username'] == 'svc-user'
+    assert created['role_name'] == 'user'
+
+    explicit = service.create_user(
+        username='editor-user',
+        password='Aa1!editor',
+        role_id=editor_role.id,
+        disabled=True,
+    )
+    explicit_user = UserRepository.get_by_id(db_session, uuid.UUID(explicit['user_id']))
+    assert explicit_user.disabled is True
+    assert explicit['role_name'] == 'editor'
+
+    assert service._is_bootstrap_admin(None) is False
+    assert service._is_bootstrap_admin(bootstrap) is True
+
+    with pytest.raises(AppException) as username_required:
+        service.create_user(username='   ', password='Aa1!service')
+    assert username_required.value.code == 1000201
+
+    with pytest.raises(AppException) as password_required:
+        service.create_user(username='missing-password', password='   ')
+    assert password_required.value.code == 1000202
+
+    with pytest.raises(AppException) as invalid_password:
+        service.create_user(username='bad-password', password='weak')
+    assert invalid_password.value.code == 1000103
+
+    with pytest.raises(AppException) as missing_role:
+        service.create_user(username='missing-role', password='Aa1!service', role_id=uuid.uuid4())
+    assert missing_role.value.code == 1000403
+
+    with pytest.raises(AppException) as duplicate:
+        service.create_user(username='svc-user', password='Aa1!service')
+    assert duplicate.value.code == 1000102
+
+    users, total = service.list_users(search='user')
+    assert total >= 2
+    assert any(item['username'] == 'svc-user' for item in users)
+
+    detail = service.get_user(normal.id)
+    assert detail['username'] == 'normal'
+    assert detail['role_name'] == 'user'
+    assert detail['is_bootstrap_admin'] is False
+
+    bootstrap_detail = service.get_user(bootstrap.id)
+    assert bootstrap_detail['is_bootstrap_admin'] is True
+
+    with pytest.raises(AppException) as get_missing_user:
+        service.get_user(uuid.uuid4())
+    assert get_missing_user.value.code == 1000401
+
+    service.set_user_role(normal.id, editor_role.id)
+    assert UserRepository.get_by_id(db_session, normal.id).role_id == editor_role.id
+
+    with pytest.raises(AppException) as set_missing_user:
+        service.set_user_role(uuid.uuid4(), editor_role.id)
+    assert set_missing_user.value.code == 1000401
+
+    with pytest.raises(AppException) as set_missing_role:
+        service.set_user_role(normal.id, uuid.uuid4())
+    assert set_missing_role.value.code == 1000403
+
+    with pytest.raises(AppException) as bootstrap_forbidden:
+        service.set_user_role(bootstrap.id, user_role.id)
+    assert bootstrap_forbidden.value.code == 1000412
+
+    service.set_user_roles_batch([normal.id, explicit_user.id], user_role.id)
+    assert UserRepository.get_by_id(db_session, normal.id).role_id == user_role.id
+    assert UserRepository.get_by_id(db_session, explicit_user.id).role_id == user_role.id
+
+    service.set_user_roles_batch([], user_role.id)
+
+    with pytest.raises(AppException) as batch_missing_role:
+        service.set_user_roles_batch([normal.id], uuid.uuid4())
+    assert batch_missing_role.value.code == 1000403
+
+    with pytest.raises(AppException) as batch_missing_user:
+        service.set_user_roles_batch([uuid.uuid4()], user_role.id)
+    assert batch_missing_user.value.code == 1000401
+
+    with pytest.raises(AppException) as batch_bootstrap_forbidden:
+        service.set_user_roles_batch([bootstrap.id], user_role.id)
+    assert batch_bootstrap_forbidden.value.code == 1000412
+
+    service.disable_user(normal.id, disabled=True)
+    assert UserRepository.get_by_id(db_session, normal.id).disabled is True
+
+    service.disable_user(normal.id, disabled=False)
+    assert UserRepository.get_by_id(db_session, normal.id).disabled is False
+
+    with pytest.raises(AppException) as disable_missing_user:
+        service.disable_user(uuid.uuid4())
+    assert disable_missing_user.value.code == 1000401
+
+    service.reset_password(normal.id, 'Aa1!reset')
+    refreshed = UserRepository.get_by_id(db_session, normal.id)
+    assert refreshed.password_hash == 'hashed::Aa1!reset'
+    assert refreshed.updated_pwd_time is not None
+
+    with pytest.raises(AppException) as reset_password_required:
+        service.reset_password(normal.id, '   ')
+    assert reset_password_required.value.code == 1000206
+
+    with pytest.raises(AppException) as invalid_password_after_reset:
+        service.reset_password(normal.id, 'bad')
+    assert invalid_password_after_reset.value.code == 1000103
+
+    with pytest.raises(AppException) as reset_missing_user:
+        service.reset_password(uuid.uuid4(), 'Aa1!reset')
+    assert reset_missing_user.value.code == 1000401
+
+
+def test_user_service_default_role_missing_raises(service_modules, db_session, monkeypatch):
+    _, _, user_service_module = service_modules
+    service = UserService()
+
+    monkeypatch.setattr(user_service_module.auth_service, 'hash_password', lambda password: f'hashed::{password}')
+    monkeypatch.setattr(user_service_module.auth_service, 'validate_password', lambda password: True)
+
+    RoleRepository.create(db_session, 'user', built_in=True)
+    role = RoleRepository.create(db_session, 'editor', built_in=False)
+    UserRepository.create(
+        db_session,
+        username='seed',
+        password_hash='hashed',
+        role_id=role.id,
+    )
+
+    user_role = RoleRepository.get_by_name(db_session, 'user')
+    db_session.delete(user_role)
+    db_session.commit()
+
+    with pytest.raises(AppException) as default_role_missing:
+        service.create_user(username='svc-user', password='Aa1!service')
+    assert default_role_missing.value.code == 1000501


### PR DESCRIPTION
# 📌 PR 内容 / PR Description

  - 为 `tests/algorithm/chat` 补充了一批单元测试，覆盖 chat 模块中的 API 路由、应用入口、核心服务、配置、工具函数以及 pipeline 相关逻辑。
  - 新增 `backend/auth-service` 四个子模块测试，覆盖模型层、仓储层、Schema 校验层与服务层的关键行为与边界场景。
  - 同时对原有 `algorithm` 测试架构进行了重构：

```text
tests/algorithm/
├── chat/
├── lazyllm/
├── parsing/
└── processor/
```

  ---

 # 🎯 问题背景 / Problem Context

  - `chat` 模块原有测试覆盖还不够完整，部分路由、配置处理、工具函数和 pipeline 构建逻辑缺少独立测试。
  - `backend/auth-service` 在模型定义、数据访问、输入输出校验与服务编排方面也存在测试覆盖空白，难以及时发现回归问题。
  - 为了降低后续重构和功能迭代带来的回归风险，需要补齐这部分测试。
  
  ---

  # ✅ 变更类型 / Type of Change

  * [ ] Bug fix
  * [x] New feature
  * [x] Refactor
  * [ ] Breaking change
  * [ ] Documentation
  * [ ] Performance optimization

  ---

  # 🧪 如何测试 / How Has This Been Tested?

  1. 运行 `tests/algorithm/chat` 目录下新增和补充的测试用例。
  2. 运行 `backend/auth-service` 四个新增测试文件，验证 models/repositories/schemas/services 的核心行为与异常分支。
  3. 确认本次改动仅涉及测试代码，不影响生产逻辑。

```bash
pytest -v tests/algorithm/chat
pytest LazyRAG/tests/backend/auth-service/test_models.py LazyRAG/tests/backend/auth-service/test_repositories.py LazyRAG/tests/backend/auth-service/test_schemas.py LazyRAG/tests/backend/auth-service/test_services.py
```
<img width="1003" height="408" alt="image" src="https://github.com/user-attachments/assets/420ac795-f7fa-4bd8-9367-46b8c61d73fe" />
<img width="1262" height="548" alt="image" src="https://github.com/user-attachments/assets/79014d0b-ed25-42f0-a1fb-d43eb900c94e" />

  ---

  # ⚠️ 注意事项 / Additional Notes

- 本次提交以测试补齐和测试结构优化为主，不包含生产代码逻辑变更。
- 目标是提升 `chat` 与 `auth-service` 关键模块测试覆盖率，为后续重构与迭代提供更稳定的回归保障。
- `auth-service` 新增测试主要聚焦：
  - 数据模型约束与行为正确性
  - 仓储层查询/持久化逻辑
  - Schema 输入输出校验与错误处理
  - 服务层业务流程编排与异常路径

  ---

  # 🧠 AI 参与情况 / AI Involvement

  - [ ] 未使用 AI / No AI used
  - [ ] 使用 AI 辅助（局部代码）/ AI-assisted (partial code)
  - [x] 使用 AI 主导（大部分代码）/ AI-led (majority of code)

  **使用工具 / Tools Used：**
  - [x] CodeX
  - [x] Cursor