### PR TITLE
Fitting OCR reader.

### DIFF
--- a/algorithm/parsing/build_document.py
+++ b/algorithm/parsing/build_document.py
@@ -74,6 +74,8 @@ def _build_store_config(index_kwargs):
 def _build_pdf_reader():
     ocr_type = os.getenv('LAZYRAG_OCR_SERVER_TYPE', 'none')
     ocr_url = os.getenv('LAZYRAG_OCR_SERVER_URL', 'http://localhost:8000').rstrip('/')
+    patch_applied = _parse_bool_env('LAZYRAG_OCR_PATCH_APPLIED') or False
+    service_variant = os.getenv('LAZYRAG_OCR_SERVICE_VARIANT', 'online')
     if ocr_type in ('none', None, ''):
         return PDFReader()
     if ocr_type == 'mineru':
@@ -84,11 +86,17 @@ def _build_pdf_reader():
             url=ocr_url,
             backend=os.getenv('LAZYRAG_MINERU_BACKEND', 'pipeline'),
             upload_mode=upload_mode,
-            post_func=NodeParser(),
-            timeout=3600
+            timeout=3600,
+            patch_applied=patch_applied,
+            service_variant=service_variant,
+            image_cache_dir='/app/uploads/.image_cache'
         )
     if ocr_type == 'paddleocr':
-        return PaddleOCRPDFReader(url=ocr_url)
+        return PaddleOCRPDFReader(
+            url=ocr_url,
+            service_variant=service_variant,
+            images_dir='/app/uploads/.image_cache'
+        )
     raise ValueError(f'Unsupported LAZYRAG_OCR_SERVER_TYPE: {ocr_type!r}')
 
 

--- a/algorithm/parsing/build_document.py
+++ b/algorithm/parsing/build_document.py
@@ -8,7 +8,7 @@ from lazyllm.tools.rag.readers import PaddleOCRPDFReader
 
 from chat.pipelines.builders.get_models import get_automodel
 from chat.utils.load_config import get_retrieval_settings
-from parsing.transform import NodeParser, GeneralParser, LineSplitter
+from parsing.transform import GeneralParser, LineSplitter
 
 ALGO_ID = 'general_algo'
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -436,6 +436,8 @@ services:
       # Use neutral default; when mineru/paddleocr, set LAZYRAG_OCR_SERVER_URL (or use Makefile which sets it).
       # Avoid hardcoding mineru URL here to prevent paddleocr misconfiguration.
       LAZYRAG_OCR_SERVER_URL: ${LAZYRAG_OCR_SERVER_URL:-http://localhost:8000}
+      LAZYRAG_OCR_PATCH_APPLIED: ${LAZYRAG_OCR_PATCH_APPLIED:-false}
+      LAZYRAG_OCR_SERVICE_VARIANT: ${LAZYRAG_OCR_SERVICE_VARIANT:-online}
       LAZYRAG_MINERU_UPLOAD_MODE: ${LAZYRAG_MINERU_UPLOAD_MODE:-}
       LAZYRAG_MILVUS_URI: ${LAZYRAG_MILVUS_URI:-http://milvus:19530}
       LAZYRAG_OPENSEARCH_URI: ${LAZYRAG_OPENSEARCH_URI:-https://opensearch:9200}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -436,8 +436,8 @@ services:
       # Use neutral default; when mineru/paddleocr, set LAZYRAG_OCR_SERVER_URL (or use Makefile which sets it).
       # Avoid hardcoding mineru URL here to prevent paddleocr misconfiguration.
       LAZYRAG_OCR_SERVER_URL: ${LAZYRAG_OCR_SERVER_URL:-http://localhost:8000}
-      LAZYRAG_OCR_PATCH_APPLIED: ${LAZYRAG_OCR_PATCH_APPLIED:-false}
-      LAZYRAG_OCR_SERVICE_VARIANT: ${LAZYRAG_OCR_SERVICE_VARIANT:-online}
+      LAZYRAG_OCR_PATCH_APPLIED: ${LAZYRAG_OCR_PATCH_APPLIED:-true}
+      LAZYRAG_OCR_SERVICE_VARIANT: ${LAZYRAG_OCR_SERVICE_VARIANT:-offline}
       LAZYRAG_MINERU_UPLOAD_MODE: ${LAZYRAG_MINERU_UPLOAD_MODE:-}
       LAZYRAG_MILVUS_URI: ${LAZYRAG_MILVUS_URI:-http://milvus:19530}
       LAZYRAG_OPENSEARCH_URI: ${LAZYRAG_OPENSEARCH_URI:-https://opensearch:9200}


### PR DESCRIPTION
## 适配 OCR Reader 新接口，支持 patch 模式与 online/offline 切换

### 变更内容

**1. `algorithm/parsing/build_document.py`**
- 新增读取环境变量 `LAZYRAG_OCR_PATCH_APPLIED`（是否启用 lazyllm patch 模式）和 `LAZYRAG_OCR_SERVICE_VARIANT`（online / offline 服务类型）
- `MineruPDFReader` 适配新接口，传入：
  - `patch_applied`：控制是否使用 patch 后的本地服务协议
  - `service_variant`：控制调用 online 异步 API 或 offline 同步 API
  - `image_cache_dir='/app/uploads/.image_cache'`：统一图片缓存路径至共享 volume
  - 移除已废弃的 `post_func=NodeParser()` 参数
- `PaddleOCRPDFReader` 适配新接口，传入：
  - `service_variant`：与 Mineru 保持一致
  - `images_dir='/app/uploads/.image_cache'`：统一图片输出目录

**2. `docker-compose.yml`**
- 在 `lazyllm-algo` 服务环境变量中新增：
  - `LAZYRAG_OCR_PATCH_APPLIED`（默认 `true`）
  - `LAZYRAG_OCR_SERVICE_VARIANT`（默认 `offline`）
