### PR TITLE
feat(skill): implement built-in skills initialization

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2,3 +2,6 @@
 	path = algorithm/lazyllm
 	url = https://github.com/LazyAGI/LazyLLM.git
 	branch = main
+[submodule "algorithm/algorithm/lazyllm"]
+	path = algorithm/algorithm/lazyllm
+	url = https://github.com/LazyAGI/LazyLLM.git

--- a/algorithm/chat/tools/skill_manager.py
+++ b/algorithm/chat/tools/skill_manager.py
@@ -28,6 +28,15 @@ _FRONTMATTER_RE = re.compile(r'^---\s*\n(.*?)\n---\s*\n(.*)$', re.DOTALL)
 _MAX_DESCRIPTION_LENGTH = 1024
 _DEFAULT_CORE_API_TIMEOUT = 30
 MAX_SUGGESTIONS_PER_CALL = 5
+_RESERVED_BUILTIN_CATEGORIES = {
+    'build-in',
+    'build——in',
+    'builtin',
+    'buildin',
+    'build_in',
+    'build in',
+    'built-in',
+}
 
 
 class Suggestion(BaseModel):
@@ -128,6 +137,16 @@ def _normalize_category(category: Optional[str]) -> Optional[str]:
     if cleaned in {'.', '..'} or not _PATH_SEGMENT_RE.match(cleaned):
         return None
     return cleaned
+
+
+def _normalize_builtin_category_alias(category: Optional[str]) -> str:
+    normalized = str(category or '').strip().lower().replace('_', '-')
+    normalized = ' '.join(normalized.split())
+    return normalized
+
+
+def _is_reserved_builtin_category(category: Optional[str]) -> bool:
+    return _normalize_builtin_category_alias(category) in _RESERVED_BUILTIN_CATEGORIES
 
 
 def _parse_frontmatter(content: str) -> tuple[dict[str, Any], str]:
@@ -320,6 +339,8 @@ def skill_manage(
             return _fail(content_error)
         if suggestions:
             return _fail("action='create' must not include 'suggestions'.")
+        if _is_reserved_builtin_category(normalized_category):
+            return _fail("build-in category is reserved.")
         if existing_skill:
             source = existing_skill.get('source', 'file')
             if not _is_writable_skill_source(source):
@@ -368,8 +389,7 @@ def skill_manage(
         )
         if not _is_writable_skill_source(source):
             return _fail(
-                f'Skill {name!r} in category {normalized_category!r} has read-only source '
-                f'{source!r}; skill_manage can only modify remote skills.'
+                'build-in skill can not be modified/deleted'
             )
 
         result = {
@@ -401,8 +421,7 @@ def skill_manage(
         source = existing_skill.get('source', 'file')
         if not _is_writable_skill_source(source):
             return _fail(
-                f'Skill {name!r} in category {normalized_category!r} has read-only source '
-                f'{source!r}; skill_manage can only remove remote skills.'
+                'build-in skill can not be modified/deleted'
             )
 
         result = {

--- a/algorithm/chat/tools/skill_manager.py
+++ b/algorithm/chat/tools/skill_manager.py
@@ -241,6 +241,18 @@ def _is_writable_skill_source(source: str) -> bool:
     return source == 'remote'
 
 
+def _suggestion_to_payload(item: Any) -> Dict[str, Any]:
+    if hasattr(item, 'model_dump'):
+        data = item.model_dump()
+        return data if isinstance(data, dict) else {}
+    if isinstance(item, dict):
+        return dict(item)
+    return {
+        'title': str(getattr(item, 'title', '') or ''),
+        'content': str(getattr(item, 'content', '') or ''),
+    }
+
+
 @fc_register('tool', execute_in_sandbox=False)
 @_handle_tool_errors
 def skill_manage(
@@ -315,10 +327,6 @@ def skill_manage(
                     f'Skill {name!r} already exists in category {normalized_category!r} '
                     f'with read-only source {source!r}; skill_manage can only write remote skills.'
                 )
-            return _fail(
-                f'Skill {name!r} already exists in category {normalized_category!r}; '
-                "use action='modify' to edit it or action='remove' to delete it first."
-            )
 
         result: Dict[str, Any] = {
             'name': name,
@@ -368,13 +376,13 @@ def skill_manage(
             'name': name,
             'action': action,
             'category': normalized_category,
-            'suggestions': [s.model_dump() for s in suggestions],
+            'suggestions': [_suggestion_to_payload(s) for s in suggestions],
         }
         payload = {
             'session_id': session_id,
             'skill_name': name,
             'category': normalized_category,
-            'suggestions': [s.model_dump() for s in suggestions],
+            'suggestions': [_suggestion_to_payload(s) for s in suggestions],
         }
         try:
             result.update(_post_core_api('/skill/suggestion', payload))
@@ -407,8 +415,9 @@ def skill_manage(
             'session_id': session_id,
             'skill_name': name,
             'category': normalized_category,
-            'reason': reason or '',
         }
+        if reason:
+            payload['reason'] = reason
         try:
             result.update(_post_core_api('/skill/remove', payload))
         except (requests.RequestException, RuntimeError) as exc:

--- a/algorithm/chat/tools/skill_manager.py
+++ b/algorithm/chat/tools/skill_manager.py
@@ -340,7 +340,7 @@ def skill_manage(
         if suggestions:
             return _fail("action='create' must not include 'suggestions'.")
         if _is_reserved_builtin_category(normalized_category):
-            return _fail("build-in category is reserved.")
+            return _fail("built-in category is reserved.")
         if existing_skill:
             source = existing_skill.get('source', 'file')
             if not _is_writable_skill_source(source):
@@ -389,7 +389,7 @@ def skill_manage(
         )
         if not _is_writable_skill_source(source) or _is_reserved_builtin_category(normalized_category):
             return _fail(
-                'build-in skill can not be modified/deleted'
+                'built-in skill can not be modified/deleted'
             )
 
         result = {
@@ -421,7 +421,7 @@ def skill_manage(
         source = existing_skill.get('source', 'file')
         if not _is_writable_skill_source(source) or _is_reserved_builtin_category(normalized_category):
             return _fail(
-                'build-in skill can not be modified/deleted'
+                'built-in skill can not be modified/deleted'
             )
 
         result = {

--- a/algorithm/chat/tools/skill_manager.py
+++ b/algorithm/chat/tools/skill_manager.py
@@ -387,7 +387,7 @@ def skill_manage(
             f'[skill_manage] MODIFY_CHECK source={source!r} '
             f'writable={_is_writable_skill_source(source)}'
         )
-        if not _is_writable_skill_source(source):
+        if not _is_writable_skill_source(source) or _is_reserved_builtin_category(normalized_category):
             return _fail(
                 'build-in skill can not be modified/deleted'
             )
@@ -419,7 +419,7 @@ def skill_manage(
                 'nothing to remove.'
             )
         source = existing_skill.get('source', 'file')
-        if not _is_writable_skill_source(source):
+        if not _is_writable_skill_source(source) or _is_reserved_builtin_category(normalized_category):
             return _fail(
                 'build-in skill can not be modified/deleted'
             )

--- a/algorithm/common/remote_fs.py
+++ b/algorithm/common/remote_fs.py
@@ -8,12 +8,26 @@ import lazyllm
 import requests
 
 from lazyllm.tools.fs import LazyLLMFSBase
+from chat.utils.load_config import load_model_config
 
 
 def _resolve_base_url() -> str:
-    agentic_config = lazyllm.globals['agentic_config']
-    base_url = str(agentic_config.get('core_api_url') or '').strip()
-    return base_url
+    config = lazyllm.globals.get('agentic_config') or {}
+    if not isinstance(config, dict):
+        config = {}
+    base_url = str(config.get('core_api_url') or '').strip()
+    if base_url:
+        return base_url
+    try:
+        model_config = load_model_config()
+    except Exception:
+        return ''
+    if not isinstance(model_config, dict):
+        return ''
+    agentic = model_config.get('agentic') or {}
+    if not isinstance(agentic, dict):
+        return ''
+    return str(agentic.get('core_api_url') or '').strip()
 
 
 def _resolve_session_id() -> str:

--- a/algorithm/common/runtime_models.inner.yaml
+++ b/algorithm/common/runtime_models.inner.yaml
@@ -2,7 +2,7 @@
 # yaml key = AutoModel(model=...) lookup name; name field = actual model name sent to the API.
 
 llm:
-  - source: openai
+  - source: minimax
     type: llm
     name: minimax-m27
     url: http://106.75.235.251:9000/v1/
@@ -12,28 +12,32 @@ evo_llm:
   - source: openai
     type: llm
     name: lazyllm
-    url: http://10.119.21.177:8000/v1/
+    # url: http://10.119.21.177:8000/v1/
+    url: http://host.docker.internal:8000/v1/
     skip_auth: true
 
 reranker:
   - source: qwen3rerank
     type: rerank
     name: Qwen3-Reranker-8B
-    url: http://10.119.24.104:8331/v1/rerank
+    # url: http://10.119.24.104:8331/v1/rerank
+    url: http://host.docker.internal:8331/v1/rerank
     skip_auth: true
 
 embed_main:
   - source: bgem3embed
     type: embed
     name: bgem3_emb_dense_custom
-    url: http://10.119.27.151:2269/embed
+    # url: http://10.119.27.151:2269/embed/
+    url: http://host.docker.internal:2269/embed
     skip_auth: true
 
 embed_sparse:
   - source: bgem3embed
     type: embed
     name: bgem3_emb_sparse_custom
-    url: http://10.119.27.151:2269/sparse_embed
+    # url: http://10.119.27.151:2269/sparse_embed
+    url: http://host.docker.internal:2269/sparse_embed
     skip_auth: true
 
 # Cross-modal (image) embed shared by image nodes and image-only retrieval branch.
@@ -41,7 +45,8 @@ embed_image:
   - source: openai
     type: cross_modal_embed
     name: siglip
-    url: http://10.119.21.178:34335/embeddings
+    # url: http://10.119.21.178:34335/embeddings
+    url: http://host.docker.internal:34335/embeddings
     skip_auth: true
 
 # Vision-language model for image-aware query rewriting and vision_extractor tool.
@@ -49,5 +54,6 @@ vlm:
   - source: openai
     type: vlm
     name: lazyllm
-    url: http://10.119.21.178:36517/v1/
+    # url: http://10.119.21.178:36517/v1/
+    url: http://host.docker.internal:36517/v1/
     skip_auth: true

--- a/backend/core/common/orm/skill_models.go
+++ b/backend/core/common/orm/skill_models.go
@@ -9,6 +9,7 @@ type SkillResource struct {
 	ID                 string          `gorm:"column:id;type:varchar(36);primaryKey"`
 	OwnerUserID        string          `gorm:"column:owner_user_id;type:varchar(255);not null;index:idx_skill_resources_owner_node_enabled,priority:1;uniqueIndex:uk_skill_resources_owner_relative_path,priority:1"`
 	OwnerUserName      string          `gorm:"column:owner_user_name;type:varchar(255);not null;default:''"`
+	SourceType         string          `gorm:"column:source_type;type:varchar(32);not null;default:'user';index:idx_skill_resources_source_type"`
 	Category           string          `gorm:"column:category;type:varchar(128);not null;index:idx_skill_resources_owner_node_enabled,priority:4"`
 	ParentSkillName    string          `gorm:"column:parent_skill_name;type:varchar(255);not null;default:''"`
 	SkillName          string          `gorm:"column:skill_name;type:varchar(255);not null;default:''"`

--- a/backend/core/evolution/service.go
+++ b/backend/core/evolution/service.go
@@ -318,11 +318,10 @@ func skillVisibleParents(ctx context.Context, db *gorm.DB, userID string) ([]orm
 	seen := make(map[string]struct{}, len(userRows))
 	for _, row := range userRows {
 		rows = append(rows, row)
-		seen[filepath.ToSlash(strings.TrimSpace(row.RelativePath))] = struct{}{}
+		seen[strings.TrimSpace(row.SkillName)] = struct{}{}
 	}
 	for _, row := range builtinRows {
-		key := filepath.ToSlash(strings.TrimSpace(row.RelativePath))
-		if _, exists := seen[key]; exists {
+		if _, exists := seen[strings.TrimSpace(row.SkillName)]; exists {
 			continue
 		}
 		rows = append(rows, row)

--- a/backend/core/evolution/service.go
+++ b/backend/core/evolution/service.go
@@ -222,11 +222,8 @@ func BuildChatResourceContext(ctx context.Context, db *gorm.DB, userID, userName
 		return nil, err
 	}
 
-	var skills []orm.SkillResource
-	if err := db.WithContext(ctx).
-		Where("owner_user_id = ? AND node_type = ? AND is_enabled = ?", userID, SkillNodeTypeParent, true).
-		Order("category ASC, skill_name ASC").
-		Find(&skills).Error; err != nil {
+	skills, err := skillVisibleParents(ctx, db, userID)
+	if err != nil {
 		return nil, err
 	}
 
@@ -300,6 +297,49 @@ func BuildChatResourceContext(ctx context.Context, db *gorm.DB, userID, userName
 		Bool("use_personalization", context.UsePersonalization).
 		Msg("built chat resource context for algorithm request")
 	return context, nil
+}
+
+func skillVisibleParents(ctx context.Context, db *gorm.DB, userID string) ([]orm.SkillResource, error) {
+	const builtinSkillOwnerUserID = "__builtin__"
+
+	var userRows []orm.SkillResource
+	if err := db.WithContext(ctx).
+		Where("owner_user_id = ? AND node_type = ?", strings.TrimSpace(userID), SkillNodeTypeParent).
+		Find(&userRows).Error; err != nil {
+		return nil, err
+	}
+	var builtinRows []orm.SkillResource
+	if err := db.WithContext(ctx).
+		Where("owner_user_id = ? AND node_type = ?", builtinSkillOwnerUserID, SkillNodeTypeParent).
+		Find(&builtinRows).Error; err != nil {
+		return nil, err
+	}
+	rows := make([]orm.SkillResource, 0, len(userRows)+len(builtinRows))
+	seen := make(map[string]struct{}, len(userRows))
+	for _, row := range userRows {
+		rows = append(rows, row)
+		seen[filepath.ToSlash(strings.TrimSpace(row.RelativePath))] = struct{}{}
+	}
+	for _, row := range builtinRows {
+		key := filepath.ToSlash(strings.TrimSpace(row.RelativePath))
+		if _, exists := seen[key]; exists {
+			continue
+		}
+		rows = append(rows, row)
+	}
+	filtered := make([]orm.SkillResource, 0, len(rows))
+	for _, row := range rows {
+		if row.IsEnabled {
+			filtered = append(filtered, row)
+		}
+	}
+	sort.Slice(filtered, func(i, j int) bool {
+		if filtered[i].Category != filtered[j].Category {
+			return filtered[i].Category < filtered[j].Category
+		}
+		return filtered[i].SkillName < filtered[j].SkillName
+	})
+	return filtered, nil
 }
 
 func ResolveSessionUser(ctx context.Context, db *gorm.DB, sessionID string) (string, string, error) {

--- a/backend/core/evolution/service_test.go
+++ b/backend/core/evolution/service_test.go
@@ -54,6 +54,31 @@ func TestBuildChatResourceContextCreatesPerUserResourcesAndSnapshots(t *testing.
 	if err := db.Create(&skill).Error; err != nil {
 		t.Fatalf("create skill: %v", err)
 	}
+	builtinSkill := orm.SkillResource{
+		ID:              "builtin-skill-1",
+		OwnerUserID:     "__builtin__",
+		OwnerUserName:   "Builtin Skills",
+		SourceType:      "builtin",
+		Category:        "review",
+		ParentSkillName: "single-document-review",
+		SkillName:       "single-document-review",
+		NodeType:        SkillNodeTypeParent,
+		FileExt:         "md",
+		RelativePath:    ParentSkillRelativePath("review", "single-document-review"),
+		Content:         "---\nname: single-document-review\ndescription: review\n---\nbody",
+		ContentSize:     int64(len([]byte("---\nname: single-document-review\ndescription: review\n---\nbody"))),
+		MimeType:        "text/markdown; charset=utf-8",
+		ContentHash:     HashContent("---\nname: single-document-review\ndescription: review\n---\nbody"),
+		IsEnabled:       true,
+		UpdateStatus:    UpdateStatusUpToDate,
+		CreateUserID:    "__builtin__",
+		CreateUserName:  "Builtin Skills",
+		CreatedAt:       now,
+		UpdatedAt:       now,
+	}
+	if err := db.Create(&builtinSkill).Error; err != nil {
+		t.Fatalf("create builtin skill: %v", err)
+	}
 
 	ctx, err := BuildChatResourceContext(context.Background(), db.DB, "u1", "User 1", "session-1")
 	if err != nil {
@@ -62,7 +87,13 @@ func TestBuildChatResourceContextCreatesPerUserResourcesAndSnapshots(t *testing.
 	if len(ctx.AvailableTools) != 1 || ctx.AvailableTools[0] != "all" {
 		t.Fatalf("unexpected available_tools: %#v", ctx.AvailableTools)
 	}
-	if len(ctx.AvailableSkills) != 1 || ctx.AvailableSkills[0] != "coding/git-workflow" {
+	if len(ctx.AvailableSkills) != 2 {
+		t.Fatalf("unexpected available_skills count: %#v", ctx.AvailableSkills)
+	}
+	if got := ctx.AvailableSkills[0]; got != "coding/git-workflow" && got != "review/single-document-review" {
+		t.Fatalf("unexpected available_skills[0]: %#v", ctx.AvailableSkills)
+	}
+	if got := ctx.AvailableSkills[1]; got != "coding/git-workflow" && got != "review/single-document-review" {
 		t.Fatalf("unexpected available_skills: %#v", ctx.AvailableSkills)
 	}
 	if ctx.Memory != "" || ctx.UserPreference != "" {
@@ -103,8 +134,8 @@ func TestBuildChatResourceContextCreatesPerUserResourcesAndSnapshots(t *testing.
 	if err := db.Model(&orm.ResourceSessionSnapshot{}).Where("session_id = ?", "session-1").Count(&snapshotCount).Error; err != nil {
 		t.Fatalf("count snapshots: %v", err)
 	}
-	if snapshotCount != 3 {
-		t.Fatalf("expected 3 snapshots, got %d", snapshotCount)
+	if snapshotCount != 4 {
+		t.Fatalf("expected 4 snapshots, got %d", snapshotCount)
 	}
 
 	var memories []orm.SystemMemory

--- a/backend/core/main.go
+++ b/backend/core/main.go
@@ -18,6 +18,7 @@ import (
 	"lazymind/core/common/readonlyorm"
 	"lazymind/core/log"
 	"lazymind/core/migrate"
+	"lazymind/core/skill"
 	"lazymind/core/store"
 	"lazymind/core/wordgroup"
 )
@@ -127,6 +128,9 @@ func main() {
 
 	// text/PrompttextInitialize（DB + Redis）。DB text ACL text；Redis textConversationtext/text/text。
 	store.Init(db.DB, readonlyDB.DB, store.MustRedisFromEnv())
+	if err := skill.SeedBuiltinSkills(context.Background(), db.DB); err != nil {
+		log.Logger.Fatal().Err(err).Msg("seed builtin skills failed")
+	}
 
 	r := mux.NewRouter()
 	r.UseEncodedPath()

--- a/backend/core/migrations/20260518120000_add_skill_source_type.down.sql
+++ b/backend/core/migrations/20260518120000_add_skill_source_type.down.sql
@@ -1,0 +1,5 @@
+-- 20260518120000_add_skill_source_type
+-- +migrate Down
+
+DROP INDEX IF EXISTS "idx_skill_resources_source_type";
+ALTER TABLE "skill_resources" DROP COLUMN "source_type";

--- a/backend/core/migrations/20260518120000_add_skill_source_type.up.sql
+++ b/backend/core/migrations/20260518120000_add_skill_source_type.up.sql
@@ -1,0 +1,5 @@
+-- 20260518120000_add_skill_source_type
+-- +migrate Up
+
+ALTER TABLE "skill_resources" ADD COLUMN "source_type" varchar(32) NOT NULL DEFAULT 'user';
+CREATE INDEX IF NOT EXISTS "idx_skill_resources_source_type" ON "skill_resources" ("source_type");

--- a/backend/core/migrations/20260519120000_normalize_builtin_skill_category.down.sql
+++ b/backend/core/migrations/20260519120000_normalize_builtin_skill_category.down.sql
@@ -1,0 +1,4 @@
+-- 20260519120000_normalize_builtin_skill_category
+-- +migrate Down
+
+-- Irreversible normalization; keep current values.

--- a/backend/core/migrations/20260519120000_normalize_builtin_skill_category.up.sql
+++ b/backend/core/migrations/20260519120000_normalize_builtin_skill_category.up.sql
@@ -1,0 +1,15 @@
+-- 20260519120000_normalize_builtin_skill_category
+-- +migrate Up
+
+UPDATE "skill_resources"
+SET
+  "category" = 'build-in',
+  "relative_path" = CASE
+    WHEN "node_type" = 'parent'
+      THEN 'build-in/' || "skill_name" || '/SKILL.md'
+    ELSE 'build-in/' || "parent_skill_name" || '/' ||
+      regexp_replace("relative_path", '^([^/]+)/([^/]+)/', '')
+  END,
+  "description" = COALESCE("description", '')
+WHERE "owner_user_id" = '__builtin__'
+  AND "category" <> 'build-in';

--- a/backend/core/migrations/20260519120000_normalize_builtin_skill_category.up.sql
+++ b/backend/core/migrations/20260519120000_normalize_builtin_skill_category.up.sql
@@ -3,13 +3,13 @@
 
 UPDATE "skill_resources"
 SET
-  "category" = 'build-in',
+  "category" = 'built-in',
   "relative_path" = CASE
     WHEN "node_type" = 'parent'
-      THEN 'build-in/' || "skill_name" || '/SKILL.md'
-    ELSE 'build-in/' || "parent_skill_name" || '/' ||
+      THEN 'built-in/' || "skill_name" || '/SKILL.md'
+    ELSE 'built-in/' || "parent_skill_name" || '/' ||
       regexp_replace("relative_path", '^([^/]+)/([^/]+)/', '')
   END,
   "description" = COALESCE("description", '')
 WHERE "owner_user_id" = '__builtin__'
-  AND "category" <> 'build-in';
+  AND "category" <> 'built-in';

--- a/backend/core/skill/builtin.go
+++ b/backend/core/skill/builtin.go
@@ -1,0 +1,417 @@
+package skill
+
+import (
+	"context"
+	"errors"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"gorm.io/gorm"
+
+	"lazymind/core/common/orm"
+	"lazymind/core/evolution"
+	appLog "lazymind/core/log"
+)
+
+const (
+	builtinSkillOwnerUserID   = "__builtin__"
+	builtinSkillOwnerUserName = "Builtin Skills"
+	builtinSkillSourceType    = "builtin"
+	userSkillSourceType       = "user"
+)
+
+type builtinSkillSeedSummary struct {
+	ParentsCreated  int
+	ChildrenCreated int
+	ParentsSkipped  int
+	ChildrenSkipped int
+}
+
+type builtinParentSeed struct {
+	Category    string
+	Name        string
+	Description string
+	Content     string
+	Tags        []string
+	Children    []builtinChildSeed
+}
+
+type builtinChildSeed struct {
+	Name         string
+	Description  string
+	RelativePath string
+	Content      string
+	FileExt      string
+}
+
+func LoadVisibleSkillRows(ctx context.Context, db *gorm.DB, userID string, nodeType string) ([]orm.SkillResource, error) {
+	userID = strings.TrimSpace(userID)
+	nodeType = strings.TrimSpace(nodeType)
+
+	var userRows []orm.SkillResource
+	if err := db.WithContext(ctx).
+		Where("owner_user_id = ? AND node_type = ?", userID, nodeType).
+		Order("updated_at DESC, created_at ASC").
+		Find(&userRows).Error; err != nil {
+		return nil, err
+	}
+	var builtinRows []orm.SkillResource
+	if err := db.WithContext(ctx).
+		Where("owner_user_id = ? AND node_type = ?", builtinSkillOwnerUserID, nodeType).
+		Order("updated_at DESC, created_at ASC").
+		Find(&builtinRows).Error; err != nil {
+		return nil, err
+	}
+
+	merged := make([]orm.SkillResource, 0, len(userRows)+len(builtinRows))
+	seen := make(map[string]struct{}, len(userRows))
+	for _, row := range userRows {
+		merged = append(merged, row)
+		seen[filepath.ToSlash(strings.TrimSpace(row.RelativePath))] = struct{}{}
+	}
+	for _, row := range builtinRows {
+		key := filepath.ToSlash(strings.TrimSpace(row.RelativePath))
+		if _, exists := seen[key]; exists {
+			continue
+		}
+		merged = append(merged, row)
+	}
+	return merged, nil
+}
+
+func VisibleChildrenByParent(rows []orm.SkillResource) map[string][]orm.SkillResource {
+	childMap := make(map[string][]orm.SkillResource)
+	for _, child := range rows {
+		key := child.Category + "/" + child.ParentSkillName
+		childMap[key] = append(childMap[key], child)
+	}
+	for key := range childMap {
+		children := childMap[key]
+		sort.Slice(children, func(i, j int) bool {
+			if children[i].RelativePath != children[j].RelativePath {
+				return children[i].RelativePath < children[j].RelativePath
+			}
+			return children[i].CreatedAt.Before(children[j].CreatedAt)
+		})
+		childMap[key] = children
+	}
+	return childMap
+}
+
+func LoadVisibleSkillByID(ctx context.Context, db *gorm.DB, userID, skillID string) (orm.SkillResource, error) {
+	var row orm.SkillResource
+	if err := db.WithContext(ctx).Where("id = ?", strings.TrimSpace(skillID)).Take(&row).Error; err != nil {
+		return orm.SkillResource{}, err
+	}
+	if strings.TrimSpace(row.OwnerUserID) == strings.TrimSpace(userID) || isBuiltinSkill(row) {
+		return row, nil
+	}
+	return orm.SkillResource{}, gorm.ErrRecordNotFound
+}
+
+func LoadVisibleParentSkill(ctx context.Context, db *gorm.DB, userID, category, skillName string) (orm.SkillResource, error) {
+	var row orm.SkillResource
+	err := db.WithContext(ctx).
+		Where("owner_user_id = ? AND category = ? AND node_type = ? AND skill_name = ?",
+			strings.TrimSpace(userID),
+			strings.TrimSpace(category),
+			evolution.SkillNodeTypeParent,
+			strings.TrimSpace(skillName),
+		).
+		Take(&row).Error
+	if err == nil {
+		return row, nil
+	}
+	if !errors.Is(err, gorm.ErrRecordNotFound) {
+		return orm.SkillResource{}, err
+	}
+	err = db.WithContext(ctx).
+		Where("owner_user_id = ? AND category = ? AND node_type = ? AND skill_name = ?",
+			builtinSkillOwnerUserID,
+			strings.TrimSpace(category),
+			evolution.SkillNodeTypeParent,
+			strings.TrimSpace(skillName),
+		).
+		Take(&row).Error
+	return row, err
+}
+
+func isBuiltinSkill(row orm.SkillResource) bool {
+	return strings.TrimSpace(row.SourceType) == builtinSkillSourceType ||
+		strings.TrimSpace(row.OwnerUserID) == builtinSkillOwnerUserID
+}
+
+func builtinSkillsRoot() string {
+	if value := strings.TrimSpace(os.Getenv("LAZYMIND_BUILTIN_SKILLS_DIR")); value != "" {
+		return value
+	}
+	if info, err := os.Stat("/skills"); err == nil && info.IsDir() {
+		return "/skills"
+	}
+	exePath, err := os.Executable()
+	if err == nil {
+		base := filepath.Dir(exePath)
+		candidates := []string{
+			filepath.Join(base, "skills"),
+			filepath.Join(base, "..", "skills"),
+			filepath.Join(base, "..", "..", "skills"),
+			filepath.Join(base, "..", "..", "..", "skills"),
+		}
+		for _, candidate := range candidates {
+			if info, statErr := os.Stat(candidate); statErr == nil && info.IsDir() {
+				return candidate
+			}
+		}
+	}
+	wd, err := os.Getwd()
+	if err == nil {
+		candidates := []string{
+			filepath.Join(wd, "skills"),
+			filepath.Join(wd, "..", "..", "skills"),
+			filepath.Join(wd, "..", "..", "..", "skills"),
+		}
+		for _, candidate := range candidates {
+			if info, statErr := os.Stat(candidate); statErr == nil && info.IsDir() {
+				return candidate
+			}
+		}
+	}
+	return ""
+}
+
+func SeedBuiltinSkills(ctx context.Context, db *gorm.DB) error {
+	root := builtinSkillsRoot()
+	if strings.TrimSpace(root) == "" {
+		appLog.Logger.Warn().Msg("builtin skills root not found; skip seeding")
+		return nil
+	}
+	parents, err := scanBuiltinSkills(root)
+	if err != nil {
+		return err
+	}
+	if len(parents) == 0 {
+		appLog.Logger.Info().Str("root", root).Msg("no builtin skills found; skip seeding")
+		return nil
+	}
+	summary, err := seedBuiltinSkillRows(ctx, db, parents)
+	if err != nil {
+		return err
+	}
+	appLog.Logger.Info().
+		Str("root", root).
+		Int("parents_created", summary.ParentsCreated).
+		Int("children_created", summary.ChildrenCreated).
+		Int("parents_skipped", summary.ParentsSkipped).
+		Int("children_skipped", summary.ChildrenSkipped).
+		Msg("builtin skills seeding completed")
+	return nil
+}
+
+func scanBuiltinSkills(root string) ([]builtinParentSeed, error) {
+	categoryEntries, err := os.ReadDir(root)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	parents := make([]builtinParentSeed, 0)
+	for _, categoryEntry := range categoryEntries {
+		categoryName := strings.TrimSpace(categoryEntry.Name())
+		if !categoryEntry.IsDir() || strings.HasPrefix(categoryName, ".") {
+			continue
+		}
+		if err := validatePathSegment(categoryName); err != nil {
+			appLog.Logger.Warn().Str("category", categoryName).Err(err).Msg("skip builtin skill category with invalid path segment")
+			continue
+		}
+		categoryDir := filepath.Join(root, categoryName)
+		skillEntries, readErr := os.ReadDir(categoryDir)
+		if readErr != nil {
+			return nil, readErr
+		}
+		for _, skillEntry := range skillEntries {
+			skillName := strings.TrimSpace(skillEntry.Name())
+			if !skillEntry.IsDir() || strings.HasPrefix(skillName, ".") {
+				continue
+			}
+			if err := validatePathSegment(skillName); err != nil {
+				appLog.Logger.Warn().Str("category", categoryName).Str("skill", skillName).Err(err).Msg("skip builtin skill with invalid path segment")
+				continue
+			}
+			skillDir := filepath.Join(categoryDir, skillName)
+			parent, parseErr := scanBuiltinSkillDir(categoryName, skillName, skillDir)
+			if parseErr != nil {
+				return nil, parseErr
+			}
+			parents = append(parents, parent)
+		}
+	}
+	sort.Slice(parents, func(i, j int) bool {
+		if parents[i].Category != parents[j].Category {
+			return parents[i].Category < parents[j].Category
+		}
+		return parents[i].Name < parents[j].Name
+	})
+	return parents, nil
+}
+
+func scanBuiltinSkillDir(category, skillName, skillDir string) (builtinParentSeed, error) {
+	skillMDPath := filepath.Join(skillDir, "SKILL.md")
+	contentBytes, err := os.ReadFile(skillMDPath)
+	if err != nil {
+		return builtinParentSeed{}, err
+	}
+	content := string(contentBytes)
+	description, err := validateParentSkillContent(skillName, "", content)
+	if err != nil {
+		return builtinParentSeed{}, err
+	}
+	children := make([]builtinChildSeed, 0)
+	walkErr := filepath.WalkDir(skillDir, func(path string, d fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if path == skillDir {
+			return nil
+		}
+		rel, err := filepath.Rel(skillDir, path)
+		if err != nil {
+			return err
+		}
+		rel = filepath.ToSlash(rel)
+		baseName := strings.TrimSpace(filepath.Base(path))
+		if d.IsDir() {
+			if strings.HasPrefix(baseName, ".") {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if baseName == "SKILL.md" {
+			return nil
+		}
+		contentBytes, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		childName := strings.TrimSuffix(filepath.Base(rel), filepath.Ext(rel))
+		if strings.TrimSpace(childName) == "" {
+			childName = strings.ReplaceAll(rel, "/", "_")
+		}
+		children = append(children, builtinChildSeed{
+			Name:         childName,
+			Description:  rel,
+			RelativePath: rel,
+			Content:      string(contentBytes),
+			FileExt:      normalizeExt(filepath.Ext(rel)),
+		})
+		return nil
+	})
+	if walkErr != nil {
+		return builtinParentSeed{}, walkErr
+	}
+	sort.Slice(children, func(i, j int) bool {
+		return children[i].RelativePath < children[j].RelativePath
+	})
+	return builtinParentSeed{
+		Category:    category,
+		Name:        skillName,
+		Description: description,
+		Content:     content,
+		Children:    children,
+	}, nil
+}
+
+func seedBuiltinSkillRows(ctx context.Context, db *gorm.DB, parents []builtinParentSeed) (builtinSkillSeedSummary, error) {
+	summary := builtinSkillSeedSummary{}
+	now := time.Now()
+	for _, parent := range parents {
+		parentRelPath := parentRelativePath(parent.Category, parent.Name)
+		var existingParent orm.SkillResource
+		parentErr := db.WithContext(ctx).
+			Where("owner_user_id = ? AND relative_path = ?", builtinSkillOwnerUserID, parentRelPath).
+			Take(&existingParent).Error
+		if parentErr == nil {
+			summary.ParentsSkipped++
+		} else if errors.Is(parentErr, gorm.ErrRecordNotFound) {
+			row := orm.SkillResource{
+				ID:              evolution.NewID(),
+				OwnerUserID:     builtinSkillOwnerUserID,
+				OwnerUserName:   builtinSkillOwnerUserName,
+				SourceType:      builtinSkillSourceType,
+				Category:        parent.Category,
+				SkillName:       parent.Name,
+				NodeType:        evolution.SkillNodeTypeParent,
+				Description:     parent.Description,
+				FileExt:         "md",
+				RelativePath:    parentRelPath,
+				Content:         parent.Content,
+				ContentSize:     skillContentSize(parent.Content),
+				MimeType:        mimeTypeForExt("md"),
+				ContentHash:     evolution.HashContent(parent.Content),
+				Version:         1,
+				IsEnabled:       true,
+				UpdateStatus:    evolution.UpdateStatusUpToDate,
+				CreateUserID:    builtinSkillOwnerUserID,
+				CreateUserName:  builtinSkillOwnerUserName,
+				CreatedAt:       now,
+				UpdatedAt:       now,
+			}
+			if err := db.WithContext(ctx).Create(&row).Error; err != nil {
+				return summary, err
+			}
+			existingParent = row
+			summary.ParentsCreated++
+		} else {
+			return summary, parentErr
+		}
+
+		for _, child := range parent.Children {
+			childRelPath := filepath.ToSlash(filepath.Join(parent.Category, parent.Name, child.RelativePath))
+			var existingChild orm.SkillResource
+			childErr := db.WithContext(ctx).
+				Where("owner_user_id = ? AND relative_path = ?", builtinSkillOwnerUserID, childRelPath).
+				Take(&existingChild).Error
+			if childErr == nil {
+				summary.ChildrenSkipped++
+				continue
+			}
+			if !errors.Is(childErr, gorm.ErrRecordNotFound) {
+				return summary, childErr
+			}
+			row := orm.SkillResource{
+				ID:              evolution.NewID(),
+				OwnerUserID:     builtinSkillOwnerUserID,
+				OwnerUserName:   builtinSkillOwnerUserName,
+				SourceType:      builtinSkillSourceType,
+				Category:        parent.Category,
+				ParentSkillName: existingParent.SkillName,
+				SkillName:       child.Name,
+				NodeType:        evolution.SkillNodeTypeChild,
+				Description:     child.Description,
+				FileExt:         child.FileExt,
+				RelativePath:    childRelPath,
+				Content:         child.Content,
+				ContentSize:     skillContentSize(child.Content),
+				MimeType:        mimeTypeForExt(child.FileExt),
+				ContentHash:     evolution.HashContent(child.Content),
+				Version:         1,
+				IsEnabled:       true,
+				UpdateStatus:    evolution.UpdateStatusUpToDate,
+				CreateUserID:    builtinSkillOwnerUserID,
+				CreateUserName:  builtinSkillOwnerUserName,
+				CreatedAt:       now,
+				UpdatedAt:       now,
+			}
+			if err := db.WithContext(ctx).Create(&row).Error; err != nil {
+				return summary, err
+			}
+			summary.ChildrenCreated++
+		}
+	}
+	return summary, nil
+}

--- a/backend/core/skill/builtin.go
+++ b/backend/core/skill/builtin.go
@@ -21,6 +21,7 @@ const (
 	builtinSkillOwnerUserID   = "__builtin__"
 	builtinSkillOwnerUserName = "Builtin Skills"
 	builtinSkillSourceType    = "builtin"
+	builtinSkillCategory      = "build-in"
 	userSkillSourceType       = "user"
 )
 
@@ -32,7 +33,6 @@ type builtinSkillSeedSummary struct {
 }
 
 type builtinParentSeed struct {
-	Category    string
 	Name        string
 	Description string
 	Content     string
@@ -75,6 +75,36 @@ func LoadVisibleSkillRows(ctx context.Context, db *gorm.DB, userID string, nodeT
 	}
 	for _, row := range builtinRows {
 		key := filepath.ToSlash(strings.TrimSpace(row.RelativePath))
+		if _, exists := seen[key]; exists {
+			continue
+		}
+		merged = append(merged, row)
+	}
+	return merged, nil
+}
+
+func loadRuntimeVisibleSkillRows(ctx context.Context, db *gorm.DB, userID string, nodeType string) ([]orm.SkillResource, error) {
+	rows, err := LoadVisibleSkillRows(ctx, db, userID, nodeType)
+	if err != nil {
+		return nil, err
+	}
+
+	userRows := make([]orm.SkillResource, 0, len(rows))
+	builtinRows := make([]orm.SkillResource, 0, len(rows))
+	seen := make(map[string]struct{}, len(rows))
+	for _, row := range rows {
+		if isBuiltinSkill(row) {
+			builtinRows = append(builtinRows, row)
+			continue
+		}
+		userRows = append(userRows, row)
+		seen[strings.TrimSpace(row.SkillName)+"\x00"+strings.TrimSpace(row.NodeType)] = struct{}{}
+	}
+
+	merged := make([]orm.SkillResource, 0, len(rows))
+	merged = append(merged, userRows...)
+	for _, row := range builtinRows {
+		key := strings.TrimSpace(row.SkillName) + "\x00" + strings.TrimSpace(row.NodeType)
 		if _, exists := seen[key]; exists {
 			continue
 		}
@@ -252,15 +282,12 @@ func scanBuiltinSkills(root string) ([]builtinParentSeed, error) {
 		}
 	}
 	sort.Slice(parents, func(i, j int) bool {
-		if parents[i].Category != parents[j].Category {
-			return parents[i].Category < parents[j].Category
-		}
 		return parents[i].Name < parents[j].Name
 	})
 	return parents, nil
 }
 
-func scanBuiltinSkillDir(category, skillName, skillDir string) (builtinParentSeed, error) {
+func scanBuiltinSkillDir(_ string, skillName, skillDir string) (builtinParentSeed, error) {
 	skillMDPath := filepath.Join(skillDir, "SKILL.md")
 	contentBytes, err := os.ReadFile(skillMDPath)
 	if err != nil {
@@ -318,7 +345,6 @@ func scanBuiltinSkillDir(category, skillName, skillDir string) (builtinParentSee
 		return children[i].RelativePath < children[j].RelativePath
 	})
 	return builtinParentSeed{
-		Category:    category,
 		Name:        skillName,
 		Description: description,
 		Content:     content,
@@ -330,7 +356,7 @@ func seedBuiltinSkillRows(ctx context.Context, db *gorm.DB, parents []builtinPar
 	summary := builtinSkillSeedSummary{}
 	now := time.Now()
 	for _, parent := range parents {
-		parentRelPath := parentRelativePath(parent.Category, parent.Name)
+		parentRelPath := parentRelativePath(builtinSkillCategory, parent.Name)
 		var existingParent orm.SkillResource
 		parentErr := db.WithContext(ctx).
 			Where("owner_user_id = ? AND relative_path = ?", builtinSkillOwnerUserID, parentRelPath).
@@ -343,7 +369,7 @@ func seedBuiltinSkillRows(ctx context.Context, db *gorm.DB, parents []builtinPar
 				OwnerUserID:     builtinSkillOwnerUserID,
 				OwnerUserName:   builtinSkillOwnerUserName,
 				SourceType:      builtinSkillSourceType,
-				Category:        parent.Category,
+				Category:        builtinSkillCategory,
 				SkillName:       parent.Name,
 				NodeType:        evolution.SkillNodeTypeParent,
 				Description:     parent.Description,
@@ -371,7 +397,7 @@ func seedBuiltinSkillRows(ctx context.Context, db *gorm.DB, parents []builtinPar
 		}
 
 		for _, child := range parent.Children {
-			childRelPath := filepath.ToSlash(filepath.Join(parent.Category, parent.Name, child.RelativePath))
+			childRelPath := filepath.ToSlash(filepath.Join(builtinSkillCategory, parent.Name, child.RelativePath))
 			var existingChild orm.SkillResource
 			childErr := db.WithContext(ctx).
 				Where("owner_user_id = ? AND relative_path = ?", builtinSkillOwnerUserID, childRelPath).
@@ -388,7 +414,7 @@ func seedBuiltinSkillRows(ctx context.Context, db *gorm.DB, parents []builtinPar
 				OwnerUserID:     builtinSkillOwnerUserID,
 				OwnerUserName:   builtinSkillOwnerUserName,
 				SourceType:      builtinSkillSourceType,
-				Category:        parent.Category,
+				Category:        builtinSkillCategory,
 				ParentSkillName: existingParent.SkillName,
 				SkillName:       child.Name,
 				NodeType:        evolution.SkillNodeTypeChild,

--- a/backend/core/skill/builtin.go
+++ b/backend/core/skill/builtin.go
@@ -21,7 +21,7 @@ const (
 	builtinSkillOwnerUserID   = "__builtin__"
 	builtinSkillOwnerUserName = "Builtin Skills"
 	builtinSkillSourceType    = "builtin"
-	builtinSkillCategory      = "build-in"
+	builtinSkillCategory      = "built-in"
 	userSkillSourceType       = "user"
 )
 

--- a/backend/core/skill/fs.go
+++ b/backend/core/skill/fs.go
@@ -15,6 +15,29 @@ import (
 	"lazymind/core/evolution"
 )
 
+var reservedBuiltinCategories = map[string]struct{}{
+	"build-in": {},
+	"build——in": {},
+	"builtin":  {},
+	"buildin":  {},
+	"build_in": {},
+	"build in": {},
+	"built-in": {},
+}
+
+func normalizedBuiltinCategoryAlias(value string) string {
+	value = strings.TrimSpace(strings.ToLower(value))
+	value = strings.ReplaceAll(value, "_", "-")
+	value = strings.Join(strings.Fields(value), " ")
+	return value
+}
+
+func isReservedBuiltinCategory(value string) bool {
+	normalized := normalizedBuiltinCategoryAlias(value)
+	_, ok := reservedBuiltinCategories[normalized]
+	return ok
+}
+
 type parentFrontmatter struct {
 	Name        string `yaml:"name"`
 	Description string `yaml:"description"`

--- a/backend/core/skill/handler.go
+++ b/backend/core/skill/handler.go
@@ -508,16 +508,22 @@ func loadRemoveSkill(ctx context.Context, db *gorm.DB, userID string, req remove
 	if req.ID != "" {
 		var skillRow orm.SkillResource
 		err := db.WithContext(ctx).Where("owner_user_id = ? AND id = ?", userID, req.ID).Take(&skillRow).Error
+		if err == nil && isBuiltinSkill(skillRow) {
+			return orm.SkillResource{}, errBuiltinSkillReadonly
+		}
 		return skillRow, err
 	}
 	if req.Category == "" || req.SkillName == "" {
 		return orm.SkillResource{}, errRemoveTargetRequired
 	}
-	state, err := evolution.LoadParentSkillState(ctx, db, userID, req.Category, req.SkillName)
+	row, err := LoadVisibleParentSkill(ctx, db, userID, req.Category, req.SkillName)
 	if err != nil {
 		return orm.SkillResource{}, err
 	}
-	return *state.Resource, nil
+	if isBuiltinSkill(row) {
+		return orm.SkillResource{}, errBuiltinSkillReadonly
+	}
+	return row, nil
 }
 
 func init() {

--- a/backend/core/skill/management.go
+++ b/backend/core/skill/management.go
@@ -188,6 +188,10 @@ func CreateManaged(w http.ResponseWriter, r *http.Request) {
 			common.ReplyErr(w, err.Error(), http.StatusBadRequest)
 			return
 		}
+		if isReservedBuiltinCategory(req.Category) {
+			common.ReplyErr(w, "build-in category is reserved", http.StatusBadRequest)
+			return
+		}
 	}
 
 	createdSkillID := ""
@@ -904,11 +908,14 @@ func createParentSkill(ctx context.Context, db *gorm.DB, userID, userName string
 }
 
 func createParentSkillWithContent(ctx context.Context, db *gorm.DB, userID, userName string, req createSkillRequest, fullContent, description string) error {
+	if isReservedBuiltinCategory(req.Category) {
+		return errors.New("build-in category is reserved")
+	}
 	relPath := parentRelativePath(req.Category, req.Name)
 	var count int64
 	if err := db.WithContext(ctx).
 		Model(&orm.SkillResource{}).
-		Where("owner_user_id = ? AND node_type = ? AND skill_name = ?", userID, evolution.SkillNodeTypeParent, req.Name).
+		Where("owner_user_id = ? AND node_type = ? AND category = ? AND skill_name = ?", userID, evolution.SkillNodeTypeParent, req.Category, req.Name).
 		Count(&count).Error; err != nil {
 		return err
 	}
@@ -1018,7 +1025,7 @@ func resolveParentSkill(ctx context.Context, db *gorm.DB, userID, parentSkillID,
 		return orm.SkillResource{}, errors.New("parent_skill_id required")
 	}
 	query := db.WithContext(ctx).
-		Where("owner_user_id = ? AND node_type = ? AND skill_name = ?", userID, evolution.SkillNodeTypeParent, parentSkillName)
+		Where("owner_user_id = ? AND node_type = ? AND category = ? AND skill_name = ?", userID, evolution.SkillNodeTypeParent, category, parentSkillName)
 	if category != "" {
 		query = query.Where("category = ?", category)
 	}
@@ -1172,6 +1179,9 @@ func updateParentSkill(ctx context.Context, db *gorm.DB, userID, userName string
 		if err := validatePathSegment(newCategory); err != nil {
 			return err
 		}
+		if isReservedBuiltinCategory(newCategory) {
+			return errors.New("build-in category is reserved")
+		}
 	}
 	newBody := currentBody
 	if req.Content != nil {
@@ -1188,10 +1198,10 @@ func updateParentSkill(ctx context.Context, db *gorm.DB, userID, userName string
 	newDescription = resolvedDescription
 	if oldCategory != newCategory || oldName != newName {
 		var count int64
-		if oldName != newName {
+		if oldName != newName || oldCategory != newCategory {
 			if err := db.WithContext(ctx).
 				Model(&orm.SkillResource{}).
-				Where("owner_user_id = ? AND node_type = ? AND skill_name = ? AND id <> ?", userID, evolution.SkillNodeTypeParent, newName, row.ID).
+				Where("owner_user_id = ? AND node_type = ? AND category = ? AND skill_name = ? AND id <> ?", userID, evolution.SkillNodeTypeParent, newCategory, newName, row.ID).
 				Count(&count).Error; err != nil {
 				return err
 			}

--- a/backend/core/skill/management.go
+++ b/backend/core/skill/management.go
@@ -26,6 +26,7 @@ var (
 	errDraftPreviewNotFound    = errors.New("skill draft not found")
 	errAutoEvoApplyConflict    = errors.New("auto_evo apply conflict")
 	errPendingRemoveSuggestion = errors.New("skill has pending remove suggestion")
+	errBuiltinSkillReadonly    = errors.New("builtin skill is read-only")
 )
 
 func normalizedSkillUpdateStatus(status string) string {
@@ -48,19 +49,13 @@ func List(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	var parents []orm.SkillResource
-	if err := db.WithContext(r.Context()).
-		Where("owner_user_id = ? AND node_type = ?", userID, evolution.SkillNodeTypeParent).
-		Order("updated_at DESC").
-		Find(&parents).Error; err != nil {
+	parents, err := LoadVisibleSkillRows(r.Context(), db, userID, evolution.SkillNodeTypeParent)
+	if err != nil {
 		common.ReplyErr(w, "query skills failed", http.StatusInternalServerError)
 		return
 	}
-	var children []orm.SkillResource
-	if err := db.WithContext(r.Context()).
-		Where("owner_user_id = ? AND node_type = ?", userID, evolution.SkillNodeTypeChild).
-		Order("created_at ASC").
-		Find(&children).Error; err != nil {
+	children, err := LoadVisibleSkillRows(r.Context(), db, userID, evolution.SkillNodeTypeChild)
+	if err != nil {
 		common.ReplyErr(w, "query skills failed", http.StatusInternalServerError)
 		return
 	}
@@ -73,11 +68,7 @@ func List(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	childMap := make(map[string][]orm.SkillResource)
-	for _, child := range children {
-		key := child.Category + "/" + child.ParentSkillName
-		childMap[key] = append(childMap[key], child)
-	}
+	childMap := VisibleChildrenByParent(children)
 
 	keyword := strings.TrimSpace(r.URL.Query().Get("keyword"))
 	category := strings.TrimSpace(r.URL.Query().Get("category"))
@@ -368,6 +359,10 @@ func Generate(w http.ResponseWriter, r *http.Request) {
 		common.ReplyErr(w, "skill not found", http.StatusNotFound)
 		return
 	}
+	if isBuiltinSkill(row) {
+		common.ReplyErr(w, errBuiltinSkillReadonly.Error(), http.StatusForbidden)
+		return
+	}
 	if row.NodeType != evolution.SkillNodeTypeParent {
 		common.ReplyErr(w, "only parent skill supports generate", http.StatusBadRequest)
 		return
@@ -517,6 +512,10 @@ func Confirm(w http.ResponseWriter, r *http.Request) {
 		common.ReplyErr(w, "skill not found", http.StatusNotFound)
 		return
 	}
+	if isBuiltinSkill(row) {
+		common.ReplyErr(w, errBuiltinSkillReadonly.Error(), http.StatusForbidden)
+		return
+	}
 	if row.NodeType != evolution.SkillNodeTypeParent {
 		common.ReplyErr(w, "only parent skill supports confirm", http.StatusBadRequest)
 		return
@@ -597,6 +596,10 @@ func Discard(w http.ResponseWriter, r *http.Request) {
 		common.ReplyErr(w, "skill not found", http.StatusNotFound)
 		return
 	}
+	if isBuiltinSkill(row) {
+		common.ReplyErr(w, errBuiltinSkillReadonly.Error(), http.StatusForbidden)
+		return
+	}
 	if row.NodeType != evolution.SkillNodeTypeParent {
 		common.ReplyErr(w, "only parent skill supports discard", http.StatusBadRequest)
 		return
@@ -630,8 +633,8 @@ func getReadableSkillDetail(ctx context.Context, db *gorm.DB, userID, skillID st
 	if err := db.WithContext(ctx).Where("id = ?", skillID).Take(&row).Error; err != nil {
 		return nil, err
 	}
-	if strings.TrimSpace(row.OwnerUserID) == strings.TrimSpace(userID) {
-		return getSkillDetail(ctx, db, row.OwnerUserID, skillID)
+	if strings.TrimSpace(row.OwnerUserID) == strings.TrimSpace(userID) || isBuiltinSkill(row) {
+		return getSkillDetailByRow(ctx, db, userID, row)
 	}
 
 	allowed, err := hasSharedSkillReadAccess(ctx, db, userID, row)
@@ -641,7 +644,7 @@ func getReadableSkillDetail(ctx context.Context, db *gorm.DB, userID, skillID st
 	if !allowed {
 		return nil, gorm.ErrRecordNotFound
 	}
-	return getSkillDetail(ctx, db, row.OwnerUserID, skillID)
+	return getSkillDetailByRow(ctx, db, row.OwnerUserID, row)
 }
 
 func hasSharedSkillReadAccess(ctx context.Context, db *gorm.DB, userID string, row orm.SkillResource) (bool, error) {
@@ -721,16 +724,21 @@ func getSkillDetail(ctx context.Context, db *gorm.DB, userID, skillID string) (m
 	if err := db.WithContext(ctx).Where("id = ? AND owner_user_id = ?", skillID, userID).Take(&row).Error; err != nil {
 		return nil, err
 	}
+	return getSkillDetailByRow(ctx, db, userID, row)
+}
+
+func getSkillDetailByRow(ctx context.Context, db *gorm.DB, userID string, row orm.SkillResource) (map[string]any, error) {
 	suggestionRows := []orm.SkillResource{row}
 	if row.NodeType == evolution.SkillNodeTypeParent {
-		var children []orm.SkillResource
-		if err := db.WithContext(ctx).
-			Where("owner_user_id = ? AND node_type = ? AND category = ? AND parent_skill_name = ?", userID, evolution.SkillNodeTypeChild, row.Category, row.SkillName).
-			Order("created_at ASC").
-			Find(&children).Error; err != nil {
+		children, err := LoadVisibleSkillRows(ctx, db, userID, evolution.SkillNodeTypeChild)
+		if err != nil {
 			return nil, err
 		}
-		suggestionRows = append(suggestionRows, children...)
+		for _, child := range children {
+			if child.Category == row.Category && child.ParentSkillName == row.SkillName {
+				suggestionRows = append(suggestionRows, child)
+			}
+		}
 	}
 	suggestionStatesByKey, err := loadSuggestionStatesByKey(ctx, db, userID, suggestionRows)
 	if err != nil {
@@ -757,6 +765,8 @@ func getSkillDetail(ctx context.Context, db *gorm.DB, userID, skillID string) (m
 		"has_pending_remove_suggestion":  suggestionState.HasPendingRemove,
 		"suggestion_status":              suggestionState.Status,
 		"node_type":                      row.NodeType,
+		"source_type":                    firstNonEmpty(strings.TrimSpace(row.SourceType), userSkillSourceType),
+		"is_builtin":                     isBuiltinSkill(row),
 		"parent_id":                      "",
 		"parent_skill_id":                "",
 		"parent_skill_name":              row.ParentSkillName,
@@ -770,15 +780,18 @@ func getSkillDetail(ctx context.Context, db *gorm.DB, userID, skillID string) (m
 		}
 	}
 	if row.NodeType == evolution.SkillNodeTypeParent {
-		var children []orm.SkillResource
-		if err := db.WithContext(ctx).
-			Where("owner_user_id = ? AND node_type = ? AND category = ? AND parent_skill_name = ?", userID, evolution.SkillNodeTypeChild, row.Category, row.SkillName).
-			Order("created_at ASC").
-			Find(&children).Error; err != nil {
+		children, err := LoadVisibleSkillRows(ctx, db, userID, evolution.SkillNodeTypeChild)
+		if err != nil {
 			return nil, err
 		}
-		childItems := make([]map[string]any, 0, len(children))
+		filteredChildren := make([]orm.SkillResource, 0, len(children))
 		for _, child := range children {
+			if child.Category == row.Category && child.ParentSkillName == row.SkillName {
+				filteredChildren = append(filteredChildren, child)
+			}
+		}
+		childItems := make([]map[string]any, 0, len(filteredChildren))
+		for _, child := range filteredChildren {
 			childSuggestionState := canonicalSkillSuggestionState(suggestionStatesByKey[skillSuggestionResourceKey(child)])
 			childContent, _ := storedSkillContent(child)
 			childItems = append(childItems, map[string]any{
@@ -797,6 +810,8 @@ func getSkillDetail(ctx context.Context, db *gorm.DB, userID, skillID string) (m
 				"has_pending_remove_suggestion":  childSuggestionState.HasPendingRemove,
 				"suggestion_status":              childSuggestionState.Status,
 				"node_type":                      child.NodeType,
+				"source_type":                    firstNonEmpty(strings.TrimSpace(child.SourceType), userSkillSourceType),
+				"is_builtin":                     isBuiltinSkill(child),
 				"parent_id":                      row.ID,
 				"parent_skill_id":                row.ID,
 				"parent_skill_name":              child.ParentSkillName,
@@ -814,6 +829,9 @@ func buildDraftPreviewResponse(ctx context.Context, db *gorm.DB, userID, skillID
 	var row orm.SkillResource
 	if err := db.WithContext(ctx).Where("id = ? AND owner_user_id = ?", skillID, userID).Take(&row).Error; err != nil {
 		return draftPreviewResponse{}, err
+	}
+	if isBuiltinSkill(row) {
+		return draftPreviewResponse{}, errBuiltinSkillReadonly
 	}
 	if row.NodeType != evolution.SkillNodeTypeParent {
 		return draftPreviewResponse{}, errDraftPreviewParentOnly
@@ -1059,6 +1077,9 @@ func updateSkill(ctx context.Context, db *gorm.DB, userID, userName, skillID str
 	if err := db.WithContext(ctx).Where("id = ? AND owner_user_id = ?", skillID, userID).Take(&row).Error; err != nil {
 		return err
 	}
+	if isBuiltinSkill(row) {
+		return errBuiltinSkillReadonly
+	}
 	if row.NodeType == evolution.SkillNodeTypeParent {
 		return updateParentSkill(ctx, db, userID, userName, &row, req)
 	}
@@ -1069,6 +1090,9 @@ func DeleteSkill(ctx context.Context, db *gorm.DB, userID, skillID string) error
 	var row orm.SkillResource
 	if err := db.WithContext(ctx).Where("id = ? AND owner_user_id = ?", skillID, userID).Take(&row).Error; err != nil {
 		return err
+	}
+	if isBuiltinSkill(row) {
+		return errBuiltinSkillReadonly
 	}
 	if row.NodeType == evolution.SkillNodeTypeParent {
 		return deleteParentSkill(ctx, db, userID, &row)
@@ -1933,6 +1957,8 @@ func replySkillError(w http.ResponseWriter, err error) {
 	switch {
 	case err == nil:
 		return
+	case errors.Is(err, errBuiltinSkillReadonly):
+		common.ReplyErr(w, err.Error(), http.StatusForbidden)
 	case errors.Is(err, gorm.ErrRecordNotFound):
 		common.ReplyErr(w, "skill not found", http.StatusNotFound)
 	case errors.Is(err, gorm.ErrDuplicatedKey):

--- a/backend/core/skill/management.go
+++ b/backend/core/skill/management.go
@@ -189,7 +189,7 @@ func CreateManaged(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		if isReservedBuiltinCategory(req.Category) {
-			common.ReplyErr(w, "build-in category is reserved", http.StatusBadRequest)
+			common.ReplyErr(w, "built-in category is reserved", http.StatusBadRequest)
 			return
 		}
 	}
@@ -909,7 +909,7 @@ func createParentSkill(ctx context.Context, db *gorm.DB, userID, userName string
 
 func createParentSkillWithContent(ctx context.Context, db *gorm.DB, userID, userName string, req createSkillRequest, fullContent, description string) error {
 	if isReservedBuiltinCategory(req.Category) {
-		return errors.New("build-in category is reserved")
+		return errors.New("built-in category is reserved")
 	}
 	relPath := parentRelativePath(req.Category, req.Name)
 	var count int64
@@ -1180,7 +1180,7 @@ func updateParentSkill(ctx context.Context, db *gorm.DB, userID, userName string
 			return err
 		}
 		if isReservedBuiltinCategory(newCategory) {
-			return errors.New("build-in category is reserved")
+			return errors.New("built-in category is reserved")
 		}
 	}
 	newBody := currentBody

--- a/backend/core/skill/management_test.go
+++ b/backend/core/skill/management_test.go
@@ -8,6 +8,7 @@ import (
 	"net"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -101,6 +102,171 @@ func newSkillTestDB(t *testing.T) *orm.DB {
 		t.Fatalf("auto migrate: %v", err)
 	}
 	return db
+}
+
+func TestLoadVisibleSkillRowsMergesBuiltinWithUserOverride(t *testing.T) {
+	db := newSkillTestDB(t)
+
+	now := time.Now()
+	userParent := orm.SkillResource{
+		ID:            "user-parent",
+		OwnerUserID:   "u1",
+		OwnerUserName: "User 1",
+		SourceType:    userSkillSourceType,
+		Category:      "search",
+		SkillName:     "paper-search",
+		NodeType:      evolution.SkillNodeTypeParent,
+		Description:   "user override",
+		FileExt:       "md",
+		RelativePath:  evolution.ParentSkillRelativePath("search", "paper-search"),
+		Content:       "---\nname: paper-search\ndescription: user override\n---\nbody",
+		ContentHash:   evolution.HashContent("---\nname: paper-search\ndescription: user override\n---\nbody"),
+		IsEnabled:     true,
+		CreateUserID:  "u1",
+		CreateUserName:"User 1",
+		CreatedAt:     now,
+		UpdatedAt:     now,
+	}
+	builtinParent := orm.SkillResource{
+		ID:            "builtin-parent",
+		OwnerUserID:   builtinSkillOwnerUserID,
+		OwnerUserName: builtinSkillOwnerUserName,
+		SourceType:    builtinSkillSourceType,
+		Category:      "review",
+		SkillName:     "single-document-review",
+		NodeType:      evolution.SkillNodeTypeParent,
+		Description:   "builtin review",
+		FileExt:       "md",
+		RelativePath:  evolution.ParentSkillRelativePath("review", "single-document-review"),
+		Content:       "---\nname: single-document-review\ndescription: builtin review\n---\nbody",
+		ContentHash:   evolution.HashContent("---\nname: single-document-review\ndescription: builtin review\n---\nbody"),
+		IsEnabled:     true,
+		CreateUserID:  builtinSkillOwnerUserID,
+		CreateUserName:builtinSkillOwnerUserName,
+		CreatedAt:     now,
+		UpdatedAt:     now,
+	}
+	builtinDuplicate := orm.SkillResource{
+		ID:            "builtin-duplicate",
+		OwnerUserID:   builtinSkillOwnerUserID,
+		OwnerUserName: builtinSkillOwnerUserName,
+		SourceType:    builtinSkillSourceType,
+		Category:      "search",
+		SkillName:     "paper-search",
+		NodeType:      evolution.SkillNodeTypeParent,
+		Description:   "builtin duplicate",
+		FileExt:       "md",
+		RelativePath:  evolution.ParentSkillRelativePath("search", "paper-search"),
+		Content:       "---\nname: paper-search\ndescription: builtin duplicate\n---\nbody",
+		ContentHash:   evolution.HashContent("---\nname: paper-search\ndescription: builtin duplicate\n---\nbody"),
+		IsEnabled:     true,
+		CreateUserID:  builtinSkillOwnerUserID,
+		CreateUserName:builtinSkillOwnerUserName,
+		CreatedAt:     now,
+		UpdatedAt:     now,
+	}
+	if err := db.Create(&[]orm.SkillResource{userParent, builtinParent, builtinDuplicate}).Error; err != nil {
+		t.Fatalf("create skill rows: %v", err)
+	}
+
+	rows, err := LoadVisibleSkillRows(context.Background(), db.DB, "u1", evolution.SkillNodeTypeParent)
+	if err != nil {
+		t.Fatalf("load visible rows: %v", err)
+	}
+	if len(rows) != 2 {
+		t.Fatalf("expected 2 visible rows, got %d", len(rows))
+	}
+	seen := map[string]orm.SkillResource{}
+	for _, row := range rows {
+		seen[row.RelativePath] = row
+	}
+	if got := seen[evolution.ParentSkillRelativePath("search", "paper-search")].OwnerUserID; got != "u1" {
+		t.Fatalf("expected user override for paper-search, got owner %q", got)
+	}
+	if got := seen[evolution.ParentSkillRelativePath("review", "single-document-review")].OwnerUserID; got != builtinSkillOwnerUserID {
+		t.Fatalf("expected builtin fallback for review skill, got owner %q", got)
+	}
+}
+
+func TestSeedBuiltinSkillsImportsAuxiliaryFiles(t *testing.T) {
+	db := newSkillTestDB(t)
+
+	root := t.TempDir()
+	skillDir := filepath.Join(root, "search", "paper-search")
+	if err := os.MkdirAll(filepath.Join(skillDir, "scripts"), 0o755); err != nil {
+		t.Fatalf("mkdir skill dir: %v", err)
+	}
+	parentContent := "---\nname: paper-search\ndescription: Search papers\n---\n# Paper Search\n"
+	if err := os.WriteFile(filepath.Join(skillDir, "SKILL.md"), []byte(parentContent), 0o644); err != nil {
+		t.Fatalf("write SKILL.md: %v", err)
+	}
+	scriptContent := "print('hello')\n"
+	if err := os.WriteFile(filepath.Join(skillDir, "scripts", "search_arxiv.py"), []byte(scriptContent), 0o644); err != nil {
+		t.Fatalf("write script: %v", err)
+	}
+
+	t.Setenv("LAZYMIND_BUILTIN_SKILLS_DIR", root)
+	if err := SeedBuiltinSkills(context.Background(), db.DB); err != nil {
+		t.Fatalf("seed builtin skills: %v", err)
+	}
+
+	var parent orm.SkillResource
+	if err := db.Where("owner_user_id = ? AND relative_path = ?", builtinSkillOwnerUserID, evolution.ParentSkillRelativePath("search", "paper-search")).Take(&parent).Error; err != nil {
+		t.Fatalf("query builtin parent: %v", err)
+	}
+	if parent.SourceType != builtinSkillSourceType {
+		t.Fatalf("expected builtin source type, got %q", parent.SourceType)
+	}
+
+	var child orm.SkillResource
+	if err := db.Where("owner_user_id = ? AND relative_path = ?", builtinSkillOwnerUserID, "search/paper-search/scripts/search_arxiv.py").Take(&child).Error; err != nil {
+		t.Fatalf("query builtin child: %v", err)
+	}
+	if child.Content != scriptContent {
+		t.Fatalf("expected child content %q, got %q", scriptContent, child.Content)
+	}
+	if child.ParentSkillName != "paper-search" {
+		t.Fatalf("expected child parent skill name paper-search, got %q", child.ParentSkillName)
+	}
+}
+
+func TestGetReadableSkillDetailAllowsBuiltinForAnyUser(t *testing.T) {
+	db := newSkillTestDB(t)
+
+	now := time.Now()
+	row := orm.SkillResource{
+		ID:            "builtin-detail",
+		OwnerUserID:   builtinSkillOwnerUserID,
+		OwnerUserName: builtinSkillOwnerUserName,
+		SourceType:    builtinSkillSourceType,
+		Category:      "review",
+		SkillName:     "single-document-review",
+		NodeType:      evolution.SkillNodeTypeParent,
+		Description:   "builtin review",
+		FileExt:       "md",
+		RelativePath:  evolution.ParentSkillRelativePath("review", "single-document-review"),
+		Content:       "---\nname: single-document-review\ndescription: builtin review\n---\nbody",
+		ContentHash:   evolution.HashContent("---\nname: single-document-review\ndescription: builtin review\n---\nbody"),
+		IsEnabled:     true,
+		CreateUserID:  builtinSkillOwnerUserID,
+		CreateUserName:builtinSkillOwnerUserName,
+		CreatedAt:     now,
+		UpdatedAt:     now,
+	}
+	if err := db.Create(&row).Error; err != nil {
+		t.Fatalf("create builtin skill: %v", err)
+	}
+
+	item, err := getReadableSkillDetail(context.Background(), db.DB, "u1", row.ID)
+	if err != nil {
+		t.Fatalf("get readable builtin detail: %v", err)
+	}
+	if got := item["is_builtin"]; got != true {
+		t.Fatalf("expected is_builtin=true, got %#v", got)
+	}
+	if got := item["source_type"]; got != builtinSkillSourceType {
+		t.Fatalf("expected source_type=%q, got %#v", builtinSkillSourceType, got)
+	}
 }
 
 func TestInternalCreateCreatesSkillDirectly(t *testing.T) {

--- a/backend/core/skill/management_test.go
+++ b/backend/core/skill/management_test.go
@@ -132,12 +132,12 @@ func TestLoadVisibleSkillRowsMergesBuiltinWithUserOverride(t *testing.T) {
 		OwnerUserID:   builtinSkillOwnerUserID,
 		OwnerUserName: builtinSkillOwnerUserName,
 		SourceType:    builtinSkillSourceType,
-		Category:      "review",
+		Category:      builtinSkillCategory,
 		SkillName:     "single-document-review",
 		NodeType:      evolution.SkillNodeTypeParent,
 		Description:   "builtin review",
 		FileExt:       "md",
-		RelativePath:  evolution.ParentSkillRelativePath("review", "single-document-review"),
+		RelativePath:  evolution.ParentSkillRelativePath(builtinSkillCategory, "single-document-review"),
 		Content:       "---\nname: single-document-review\ndescription: builtin review\n---\nbody",
 		ContentHash:   evolution.HashContent("---\nname: single-document-review\ndescription: builtin review\n---\nbody"),
 		IsEnabled:     true,
@@ -183,8 +183,62 @@ func TestLoadVisibleSkillRowsMergesBuiltinWithUserOverride(t *testing.T) {
 	if got := seen[evolution.ParentSkillRelativePath("search", "paper-search")].OwnerUserID; got != "u1" {
 		t.Fatalf("expected user override for paper-search, got owner %q", got)
 	}
-	if got := seen[evolution.ParentSkillRelativePath("review", "single-document-review")].OwnerUserID; got != builtinSkillOwnerUserID {
+	if got := seen[evolution.ParentSkillRelativePath(builtinSkillCategory, "single-document-review")].OwnerUserID; got != builtinSkillOwnerUserID {
 		t.Fatalf("expected builtin fallback for review skill, got owner %q", got)
+	}
+}
+
+func TestLoadRuntimeVisibleSkillRowsPrefersUserByName(t *testing.T) {
+	db := newSkillTestDB(t)
+
+	now := time.Now()
+	userRow := orm.SkillResource{
+		ID:             "user-deep-research",
+		OwnerUserID:    "u1",
+		OwnerUserName:  "User 1",
+		SourceType:     userSkillSourceType,
+		Category:       "research",
+		SkillName:      "deep-research",
+		NodeType:       evolution.SkillNodeTypeParent,
+		RelativePath:   evolution.ParentSkillRelativePath("research", "deep-research"),
+		Content:        "---\nname: deep-research\ndescription: user\n---\nbody",
+		ContentHash:    evolution.HashContent("---\nname: deep-research\ndescription: user\n---\nbody"),
+		IsEnabled:      true,
+		CreateUserID:   "u1",
+		CreateUserName: "User 1",
+		CreatedAt:      now,
+		UpdatedAt:      now,
+	}
+	builtinRow := orm.SkillResource{
+		ID:             "builtin-deep-research",
+		OwnerUserID:    builtinSkillOwnerUserID,
+		OwnerUserName:  builtinSkillOwnerUserName,
+		SourceType:     builtinSkillSourceType,
+		Category:       builtinSkillCategory,
+		SkillName:      "deep-research",
+		NodeType:       evolution.SkillNodeTypeParent,
+		RelativePath:   evolution.ParentSkillRelativePath(builtinSkillCategory, "deep-research"),
+		Content:        "---\nname: deep-research\ndescription: builtin\n---\nbody",
+		ContentHash:    evolution.HashContent("---\nname: deep-research\ndescription: builtin\n---\nbody"),
+		IsEnabled:      true,
+		CreateUserID:   builtinSkillOwnerUserID,
+		CreateUserName: builtinSkillOwnerUserName,
+		CreatedAt:      now,
+		UpdatedAt:      now,
+	}
+	if err := db.Create(&[]orm.SkillResource{userRow, builtinRow}).Error; err != nil {
+		t.Fatalf("create skill rows: %v", err)
+	}
+
+	rows, err := loadRuntimeVisibleSkillRows(context.Background(), db.DB, "u1", evolution.SkillNodeTypeParent)
+	if err != nil {
+		t.Fatalf("load runtime visible rows: %v", err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("expected 1 runtime visible row, got %d", len(rows))
+	}
+	if rows[0].OwnerUserID != "u1" {
+		t.Fatalf("expected runtime visible row to prefer user skill, got owner %q", rows[0].OwnerUserID)
 	}
 }
 
@@ -211,7 +265,7 @@ func TestSeedBuiltinSkillsImportsAuxiliaryFiles(t *testing.T) {
 	}
 
 	var parent orm.SkillResource
-	if err := db.Where("owner_user_id = ? AND relative_path = ?", builtinSkillOwnerUserID, evolution.ParentSkillRelativePath("search", "paper-search")).Take(&parent).Error; err != nil {
+	if err := db.Where("owner_user_id = ? AND relative_path = ?", builtinSkillOwnerUserID, evolution.ParentSkillRelativePath(builtinSkillCategory, "paper-search")).Take(&parent).Error; err != nil {
 		t.Fatalf("query builtin parent: %v", err)
 	}
 	if parent.SourceType != builtinSkillSourceType {
@@ -219,7 +273,7 @@ func TestSeedBuiltinSkillsImportsAuxiliaryFiles(t *testing.T) {
 	}
 
 	var child orm.SkillResource
-	if err := db.Where("owner_user_id = ? AND relative_path = ?", builtinSkillOwnerUserID, "search/paper-search/scripts/search_arxiv.py").Take(&child).Error; err != nil {
+	if err := db.Where("owner_user_id = ? AND relative_path = ?", builtinSkillOwnerUserID, "build-in/paper-search/scripts/search_arxiv.py").Take(&child).Error; err != nil {
 		t.Fatalf("query builtin child: %v", err)
 	}
 	if child.Content != scriptContent {
@@ -2216,7 +2270,7 @@ func TestCreateChildSkillPersistsDescription(t *testing.T) {
 	}
 }
 
-func TestCreateParentSkillRejectsDuplicateParentNameAcrossCategories(t *testing.T) {
+func TestCreateParentSkillAllowsSameNameAcrossCategories(t *testing.T) {
 	db := newSkillTestDB(t)
 
 	req := createSkillRequest{
@@ -2235,16 +2289,16 @@ func TestCreateParentSkillRejectsDuplicateParentNameAcrossCategories(t *testing.
 		Category:    "ops",
 		Content:     "# Git Workflow\n\nDuplicate name should be rejected.",
 	}
-	if err := createParentSkill(context.Background(), db.DB, "u1", "User 1", duplicateReq); !errors.Is(err, gorm.ErrDuplicatedKey) {
-		t.Fatalf("expected duplicate parent skill name error, got %v", err)
+	if err := createParentSkill(context.Background(), db.DB, "u1", "User 1", duplicateReq); err != nil {
+		t.Fatalf("expected same name across categories to be allowed, got %v", err)
 	}
 
 	var count int64
 	if err := db.Model(&orm.SkillResource{}).Where("owner_user_id = ? AND node_type = ? AND skill_name = ?", "u1", evolution.SkillNodeTypeParent, "git-workflow").Count(&count).Error; err != nil {
 		t.Fatalf("count parent skills: %v", err)
 	}
-	if count != 1 {
-		t.Fatalf("expected exactly one parent skill named git-workflow, got %d", count)
+	if count != 2 {
+		t.Fatalf("expected exactly two parent skills named git-workflow across categories, got %d", count)
 	}
 }
 
@@ -2291,7 +2345,7 @@ func TestUpdateParentSkillRebuildsContentFromBodyOnlyPayload(t *testing.T) {
 	}
 }
 
-func TestUpdateParentSkillRejectsDuplicateParentNameAcrossCategories(t *testing.T) {
+func TestUpdateParentSkillAllowsDuplicateNameAcrossCategories(t *testing.T) {
 	db := newSkillTestDB(t)
 
 	firstReq := createSkillRequest{
@@ -2319,16 +2373,16 @@ func TestUpdateParentSkillRejectsDuplicateParentNameAcrossCategories(t *testing.
 	}
 
 	updateReq := updateSkillRequest{Name: stringPtr("git-workflow")}
-	if err := updateSkill(context.Background(), db.DB, "u1", "User 1", second.ID, updateReq); !errors.Is(err, gorm.ErrDuplicatedKey) {
-		t.Fatalf("expected duplicate parent skill name error, got %v", err)
+	if err := updateSkill(context.Background(), db.DB, "u1", "User 1", second.ID, updateReq); err != nil {
+		t.Fatalf("expected duplicate name across categories to be allowed, got %v", err)
 	}
 
 	var unchanged orm.SkillResource
 	if err := db.Where("id = ?", second.ID).Take(&unchanged).Error; err != nil {
 		t.Fatalf("query unchanged parent skill: %v", err)
 	}
-	if unchanged.SkillName != "release-check" {
-		t.Fatalf("expected skill name to remain release-check, got %q", unchanged.SkillName)
+	if unchanged.SkillName != "git-workflow" {
+		t.Fatalf("expected skill name to update to git-workflow, got %q", unchanged.SkillName)
 	}
 }
 

--- a/backend/core/skill/management_test.go
+++ b/backend/core/skill/management_test.go
@@ -273,7 +273,7 @@ func TestSeedBuiltinSkillsImportsAuxiliaryFiles(t *testing.T) {
 	}
 
 	var child orm.SkillResource
-	if err := db.Where("owner_user_id = ? AND relative_path = ?", builtinSkillOwnerUserID, "build-in/paper-search/scripts/search_arxiv.py").Take(&child).Error; err != nil {
+	if err := db.Where("owner_user_id = ? AND relative_path = ?", builtinSkillOwnerUserID, "built-in/paper-search/scripts/search_arxiv.py").Take(&child).Error; err != nil {
 		t.Fatalf("query builtin child: %v", err)
 	}
 	if child.Content != scriptContent {

--- a/backend/core/skill/remote_fs.go
+++ b/backend/core/skill/remote_fs.go
@@ -266,15 +266,15 @@ func remoteFSInfoEntry(r *http.Request, db *gorm.DB, userID string, parsed remot
 }
 
 func listRemoteFSCategories(r *http.Request, db *gorm.DB, userID string) ([]remoteFSEntry, error) {
-	var rows []orm.SkillResource
-	if err := db.WithContext(r.Context()).
-		Where("owner_user_id = ? AND node_type = ? AND is_enabled = ?", userID, evolution.SkillNodeTypeParent, true).
-		Order("category ASC, updated_at DESC").
-		Find(&rows).Error; err != nil {
+	rows, err := LoadVisibleSkillRows(r.Context(), db, userID, evolution.SkillNodeTypeParent)
+	if err != nil {
 		return nil, err
 	}
 	seen := map[string]remoteFSEntry{}
 	for _, row := range rows {
+		if !row.IsEnabled {
+			continue
+		}
 		category := strings.TrimSpace(row.Category)
 		if category == "" {
 			continue
@@ -288,38 +288,44 @@ func listRemoteFSCategories(r *http.Request, db *gorm.DB, userID string) ([]remo
 }
 
 func listRemoteFSSkills(r *http.Request, db *gorm.DB, userID, category string) ([]remoteFSEntry, error) {
-	var rows []orm.SkillResource
-	if err := db.WithContext(r.Context()).
-		Where("owner_user_id = ? AND category = ? AND node_type = ? AND is_enabled = ?", userID, strings.TrimSpace(category), evolution.SkillNodeTypeParent, true).
-		Order("skill_name ASC").
-		Find(&rows).Error; err != nil {
+	rows, err := LoadVisibleSkillRows(r.Context(), db, userID, evolution.SkillNodeTypeParent)
+	if err != nil {
 		return nil, err
 	}
 	entries := make([]remoteFSEntry, 0, len(rows))
 	for _, row := range rows {
+		if !row.IsEnabled || strings.TrimSpace(row.Category) != strings.TrimSpace(category) {
+			continue
+		}
 		entries = append(entries, remoteFSEntry{Name: remoteFSJoin(row.Category, row.SkillName, ""), Type: remoteFSTypeDir, Size: 0, Mtime: formatRemoteFSMtime(row.UpdatedAt)})
 	}
 	return entries, nil
 }
 
 func loadRemoteFSSkillFiles(r *http.Request, db *gorm.DB, userID, category, skillName string) (map[string]remoteFSFile, error) {
-	var rows []orm.SkillResource
-	if err := db.WithContext(r.Context()).
-		Where("owner_user_id = ? AND category = ? AND is_enabled = ? AND (skill_name = ? OR parent_skill_name = ?)",
-			strings.TrimSpace(userID), strings.TrimSpace(category), true, strings.TrimSpace(skillName), strings.TrimSpace(skillName)).
-		Order("node_type ASC, relative_path ASC").
-		Find(&rows).Error; err != nil {
+	parent, err := LoadVisibleParentSkill(r.Context(), db, userID, category, skillName)
+	if err != nil {
+		return nil, err
+	}
+	rows, err := LoadVisibleSkillRows(r.Context(), db, userID, evolution.SkillNodeTypeChild)
+	if err != nil {
 		return nil, err
 	}
 	files := map[string]remoteFSFile{}
-	foundParent := false
+	allRows := make([]orm.SkillResource, 0, len(rows)+1)
+	allRows = append(allRows, parent)
 	for _, row := range rows {
-		internal := remoteFSInternalPath(category, skillName, row)
-		if internal == "" {
+		if !row.IsEnabled {
 			continue
 		}
-		if row.NodeType == evolution.SkillNodeTypeParent {
-			foundParent = true
+		if row.Category == parent.Category && row.ParentSkillName == parent.SkillName {
+			allRows = append(allRows, row)
+		}
+	}
+	for _, row := range allRows {
+		internal := remoteFSInternalPath(parent.Category, parent.SkillName, row)
+		if internal == "" {
+			continue
 		}
 		content, err := storedSkillContent(row)
 		if err != nil {
@@ -345,9 +351,6 @@ func loadRemoteFSSkillFiles(r *http.Request, db *gorm.DB, userID, category, skil
 			Content:      content,
 			UpdatedAt:    row.UpdatedAt,
 		}
-	}
-	if !foundParent {
-		return nil, gorm.ErrRecordNotFound
 	}
 	return files, nil
 }

--- a/backend/core/skill/remote_fs.go
+++ b/backend/core/skill/remote_fs.go
@@ -1,6 +1,7 @@
 package skill
 
 import (
+	"context"
 	"errors"
 	"net/http"
 	"path/filepath"
@@ -266,7 +267,7 @@ func remoteFSInfoEntry(r *http.Request, db *gorm.DB, userID string, parsed remot
 }
 
 func listRemoteFSCategories(r *http.Request, db *gorm.DB, userID string) ([]remoteFSEntry, error) {
-	rows, err := LoadVisibleSkillRows(r.Context(), db, userID, evolution.SkillNodeTypeParent)
+	rows, err := loadRemoteFSVisibleParents(r.Context(), db, userID)
 	if err != nil {
 		return nil, err
 	}
@@ -288,7 +289,7 @@ func listRemoteFSCategories(r *http.Request, db *gorm.DB, userID string) ([]remo
 }
 
 func listRemoteFSSkills(r *http.Request, db *gorm.DB, userID, category string) ([]remoteFSEntry, error) {
-	rows, err := LoadVisibleSkillRows(r.Context(), db, userID, evolution.SkillNodeTypeParent)
+	rows, err := loadRemoteFSVisibleParents(r.Context(), db, userID)
 	if err != nil {
 		return nil, err
 	}
@@ -303,11 +304,11 @@ func listRemoteFSSkills(r *http.Request, db *gorm.DB, userID, category string) (
 }
 
 func loadRemoteFSSkillFiles(r *http.Request, db *gorm.DB, userID, category, skillName string) (map[string]remoteFSFile, error) {
-	parent, err := LoadVisibleParentSkill(r.Context(), db, userID, category, skillName)
+	parent, err := loadRemoteFSVisibleParent(r.Context(), db, userID, skillName)
 	if err != nil {
 		return nil, err
 	}
-	rows, err := LoadVisibleSkillRows(r.Context(), db, userID, evolution.SkillNodeTypeChild)
+	rows, err := loadRemoteFSVisibleChildren(r.Context(), db, userID)
 	if err != nil {
 		return nil, err
 	}
@@ -353,6 +354,83 @@ func loadRemoteFSSkillFiles(r *http.Request, db *gorm.DB, userID, category, skil
 		}
 	}
 	return files, nil
+}
+
+func loadRemoteFSVisibleParents(ctx context.Context, db *gorm.DB, userID string) ([]orm.SkillResource, error) {
+	const builtinSkillOwnerUserID = "__builtin__"
+
+	var userRows []orm.SkillResource
+	if err := db.WithContext(ctx).
+		Where("owner_user_id = ? AND node_type = ?", strings.TrimSpace(userID), evolution.SkillNodeTypeParent).
+		Find(&userRows).Error; err != nil {
+		return nil, err
+	}
+	var builtinRows []orm.SkillResource
+	if err := db.WithContext(ctx).
+		Where("owner_user_id = ? AND node_type = ?", builtinSkillOwnerUserID, evolution.SkillNodeTypeParent).
+		Find(&builtinRows).Error; err != nil {
+		return nil, err
+	}
+	rows := make([]orm.SkillResource, 0, len(userRows)+len(builtinRows))
+	seen := make(map[string]struct{}, len(userRows))
+	for _, row := range userRows {
+		rows = append(rows, row)
+		seen[strings.TrimSpace(row.SkillName)] = struct{}{}
+	}
+	for _, row := range builtinRows {
+		if _, exists := seen[strings.TrimSpace(row.SkillName)]; exists {
+			continue
+		}
+		rows = append(rows, row)
+	}
+	return rows, nil
+}
+
+func loadRemoteFSVisibleChildren(ctx context.Context, db *gorm.DB, userID string) ([]orm.SkillResource, error) {
+	const builtinSkillOwnerUserID = "__builtin__"
+
+	var userRows []orm.SkillResource
+	if err := db.WithContext(ctx).
+		Where("owner_user_id = ? AND node_type = ?", strings.TrimSpace(userID), evolution.SkillNodeTypeChild).
+		Find(&userRows).Error; err != nil {
+		return nil, err
+	}
+	var builtinRows []orm.SkillResource
+	if err := db.WithContext(ctx).
+		Where("owner_user_id = ? AND node_type = ?", builtinSkillOwnerUserID, evolution.SkillNodeTypeChild).
+		Find(&builtinRows).Error; err != nil {
+		return nil, err
+	}
+	rows := make([]orm.SkillResource, 0, len(userRows)+len(builtinRows))
+	seen := make(map[string]struct{}, len(userRows))
+	for _, row := range userRows {
+		rows = append(rows, row)
+		seen[strings.TrimSpace(row.ParentSkillName)+"\x00"+strings.TrimSpace(row.SkillName)] = struct{}{}
+	}
+	for _, row := range builtinRows {
+		key := strings.TrimSpace(row.ParentSkillName) + "\x00" + strings.TrimSpace(row.SkillName)
+		if _, exists := seen[key]; exists {
+			continue
+		}
+		rows = append(rows, row)
+	}
+	return rows, nil
+}
+
+func loadRemoteFSVisibleParent(ctx context.Context, db *gorm.DB, userID, skillName string) (orm.SkillResource, error) {
+	var row orm.SkillResource
+	err := db.WithContext(ctx).
+		Where("owner_user_id = ? AND node_type = ? AND skill_name = ?", strings.TrimSpace(userID), evolution.SkillNodeTypeParent, strings.TrimSpace(skillName)).
+		Take(&row).Error
+	if err == nil {
+		return row, nil
+	}
+	if !errors.Is(err, gorm.ErrRecordNotFound) {
+		return orm.SkillResource{}, err
+	}
+	return row, db.WithContext(ctx).
+		Where("owner_user_id = ? AND node_type = ? AND skill_name = ?", builtinSkillOwnerUserID, evolution.SkillNodeTypeParent, strings.TrimSpace(skillName)).
+		Take(&row).Error
 }
 
 func remoteFSInternalPath(category, skillName string, row orm.SkillResource) string {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -275,6 +275,7 @@ services:
       - ./api/backend:/openapi-export
       - /tmp/evo:/var/lib/lazymind/evo
       - ./data/core/uploads:/var/lib/lazymind/uploads
+      - ./skills:/skills:ro
     expose:
       - "8000"
     environment:
@@ -314,6 +315,7 @@ services:
     volumes:
       - ./backend/core:/app
       - ./data/core/uploads:/var/lib/lazymind/uploads
+      - ./skills:/skills:ro
     environment:
       <<: *core-env
     depends_on:

--- a/frontend/src/i18n/locales/en-US.ts
+++ b/frontend/src/i18n/locales/en-US.ts
@@ -1232,7 +1232,7 @@ const enUS = {
     memoryViewItem: "View",
     memoryEditItem: "Edit",
     memoryShareItem: "Share",
-    memoryBuiltinCategoryReserved: "build-in category is reserved.",
+    memoryBuiltinCategoryReserved: "built-in category is reserved.",
     memorySkillDetailTitle: "Skill Detail",
     memorySkillDetailLoadFailed: "Failed to load skill detail",
     memorySkillDetailMarkdownPreview: "Markdown Preview",

--- a/frontend/src/i18n/locales/en-US.ts
+++ b/frontend/src/i18n/locales/en-US.ts
@@ -1232,6 +1232,7 @@ const enUS = {
     memoryViewItem: "View",
     memoryEditItem: "Edit",
     memoryShareItem: "Share",
+    memoryBuiltinCategoryReserved: "build-in category is reserved.",
     memorySkillDetailTitle: "Skill Detail",
     memorySkillDetailLoadFailed: "Failed to load skill detail",
     memorySkillDetailMarkdownPreview: "Markdown Preview",

--- a/frontend/src/i18n/locales/zh-CN.ts
+++ b/frontend/src/i18n/locales/zh-CN.ts
@@ -1162,7 +1162,7 @@ const zhCN = {
     memoryViewItem: "查看",
     memoryEditItem: "编辑",
     memoryShareItem: "分享",
-    memoryBuiltinCategoryReserved: "build-in category is reserved.",
+    memoryBuiltinCategoryReserved: "built-in category is reserved.",
     memorySkillDetailTitle: "技能详情",
     memorySkillDetailLoadFailed: "加载技能详情失败",
     memorySkillDetailMarkdownPreview: "Markdown 预览",

--- a/frontend/src/i18n/locales/zh-CN.ts
+++ b/frontend/src/i18n/locales/zh-CN.ts
@@ -1162,6 +1162,7 @@ const zhCN = {
     memoryViewItem: "查看",
     memoryEditItem: "编辑",
     memoryShareItem: "分享",
+    memoryBuiltinCategoryReserved: "build-in category is reserved.",
     memorySkillDetailTitle: "技能详情",
     memorySkillDetailLoadFailed: "加载技能详情失败",
     memorySkillDetailMarkdownPreview: "Markdown 预览",

--- a/frontend/src/modules/admin/pages/memory/skillApi.ts
+++ b/frontend/src/modules/admin/pages/memory/skillApi.ts
@@ -32,6 +32,8 @@ interface SkillNode {
   auto_evo_apply_status?: string;
   auto_evo_generation?: number;
   auto_evo_error?: string;
+  source_type?: string;
+  is_builtin?: boolean;
   children?: SkillNode[];
   [key: string]: unknown;
 }
@@ -54,6 +56,8 @@ export interface SkillAssetRecord {
   autoEvoApplyStatus?: string;
   autoEvoGeneration?: number;
   autoEvoError?: string;
+  sourceType?: string;
+  isBuiltin?: boolean;
 }
 
 export interface SkillDraftGeneratePayload {
@@ -289,6 +293,8 @@ const normalizeSkillNode = (raw: SkillNode, parentId?: string): SkillAssetRecord
     autoEvoApplyStatus: toStringValue(raw.auto_evo_apply_status || ""),
     autoEvoGeneration: typeof raw.auto_evo_generation === "number" ? raw.auto_evo_generation : 0,
     autoEvoError: toStringValue(raw.auto_evo_error || ""),
+    sourceType: toStringValue(raw.source_type || ""),
+    isBuiltin: toBoolean(raw.is_builtin, false),
   };
 };
 

--- a/frontend/src/modules/memory/index.tsx
+++ b/frontend/src/modules/memory/index.tsx
@@ -4441,7 +4441,7 @@ export default function MemoryManagement() {
       render: (tags: string[], record) =>
         !record.parentId && (tags.length || record.isBuiltin) ? (
           <div className="memory-tag-group">
-            {record.isBuiltin ? <Tag key="build-in-skill">build-in skill</Tag> : null}
+            {record.isBuiltin ? <Tag key="build-in-skill">built-in skill</Tag> : null}
             {tags.map((item) => (
               <Tag key={item}>{item}</Tag>
             ))}

--- a/frontend/src/modules/memory/index.tsx
+++ b/frontend/src/modules/memory/index.tsx
@@ -420,6 +420,37 @@ export default function MemoryManagement() {
     () => skillAssets.filter((item) => !item.parentId),
     [skillAssets],
   );
+  const skillById = useMemo(() => new Map(skillAssets.map((item) => [item.id, item])), [skillAssets]);
+  const isBuiltinSkillOrChild = useCallback(
+    (record: StructuredAsset) => {
+      if (activeTab !== "skills") {
+        return false;
+      }
+
+      if (isReservedBuiltinSkillCategory(record.category || "")) {
+        return true;
+      }
+
+      if (!record.parentId) {
+        return false;
+      }
+
+      let currentParentId = record.parentId;
+      while (currentParentId) {
+        const parentSkill = skillById.get(currentParentId);
+        if (!parentSkill) {
+          return false;
+        }
+        if (isReservedBuiltinSkillCategory(parentSkill.category || "")) {
+          return true;
+        }
+        currentParentId = parentSkill.parentId || "";
+      }
+
+      return false;
+    },
+    [activeTab, skillById],
+  );
   const parentSkillOptions = useMemo(
     () =>
       topLevelSkills
@@ -3407,8 +3438,8 @@ export default function MemoryManagement() {
     if (activeTab === "experience") {
       return;
     }
-    if (activeTab === "skills" && "isBuiltin" in item && item.isBuiltin) {
-      message.warning("build-in skill can not be modified/deleted");
+      if (activeTab === "skills" && "id" in item && isBuiltinSkillOrChild(item)) {
+      message.warning(t("admin.memoryBuiltinCategoryReserved"));
       return;
     }
 
@@ -3785,7 +3816,7 @@ export default function MemoryManagement() {
         !isChildSkill &&
         isReservedBuiltinSkillCategory(payload.category)
       ) {
-        message.warning("build-in category is reserved");
+        message.warning(t("admin.memoryBuiltinCategoryReserved"));
         return;
       }
 
@@ -4430,7 +4461,7 @@ export default function MemoryManagement() {
       render: (_value, record) => {
         const disabledByRemoveSuggestion =
           activeTab === "skills" && Boolean(record.hasPendingRemoveSuggestion);
-        const disabledByBuiltin = activeTab === "skills" && Boolean(record.isBuiltin);
+        const disabledByBuiltin = isBuiltinSkillOrChild(record);
         const autoEvoDisabled = disabledByRemoveSuggestion || disabledByBuiltin;
         const switchNode = (
           <Switch
@@ -4438,8 +4469,8 @@ export default function MemoryManagement() {
             disabled={autoEvoDisabled}
             loading={skillAutoEvoLoading.has(record.id)}
             onChange={(checked) => {
-              if (record.isBuiltin) {
-                message.warning("build-in skill can not be modified/deleted");
+              if (disabledByBuiltin) {
+                message.warning(t("admin.memoryBuiltinCategoryReserved"));
                 return;
               }
               if (checked && record.hasPendingRemoveSuggestion) {
@@ -4471,7 +4502,7 @@ export default function MemoryManagement() {
           />
         );
         return disabledByBuiltin ? (
-          <Tooltip title="build-in skill can not be modified/deleted">{switchNode}</Tooltip>
+          <Tooltip title={t("admin.memoryBuiltinCategoryReserved")}>{switchNode}</Tooltip>
         ) : disabledByRemoveSuggestion ? (
           <Tooltip title={t("admin.memorySkillAutoEvoDisabledByRemove")}>{switchNode}</Tooltip>
         ) : (
@@ -4485,6 +4516,7 @@ export default function MemoryManagement() {
       width: 250,
       fixed: "right",
       render: (_value, record) => {
+        const disabledByBuiltinCategory = isBuiltinSkillOrChild(record);
         const pendingProposal =
           activeTab === "skills" ? getPendingProposal("skills", record.id) : undefined;
         const hasBackendPendingReview =
@@ -4493,11 +4525,14 @@ export default function MemoryManagement() {
           (Boolean(record.hasPendingReviewSuggestions) ||
             isPendingReviewSuggestionStatus(record.suggestionStatus));
         const canReviewChange =
+          !disabledByBuiltinCategory &&
           !record.autoEvo &&
           (Boolean(pendingProposal) ||
             isSkillUpdatePending(record.updateStatus) ||
             hasBackendPendingReview);
-        const reviewTooltip = record.autoEvo
+        const reviewTooltip = disabledByBuiltinCategory
+          ? t("admin.memoryBuiltinCategoryReserved")
+          : record.autoEvo
           ? t("admin.memoryDiffNoPending")
           : pendingProposal
           ? t("admin.memoryDiffReviewAction")
@@ -4529,14 +4564,20 @@ export default function MemoryManagement() {
                     }
                   />
                 </Tooltip>
-                <Tooltip title={t("admin.memoryEditItem")}>
+                <Tooltip
+                  title={
+                    disabledByBuiltinCategory
+                      ? t("admin.memoryBuiltinCategoryReserved")
+                      : t("admin.memoryEditItem")
+                  }
+                >
                   <Button
                     type="text"
                     icon={<EditOutlined />}
-                    disabled={Boolean(record.isBuiltin)}
+                    disabled={disabledByBuiltinCategory}
                     onClick={() => {
-                      if (record.isBuiltin) {
-                        message.warning("build-in skill can not be modified/deleted");
+                      if (disabledByBuiltinCategory) {
+                        message.warning(t("admin.memoryBuiltinCategoryReserved"));
                         return;
                       }
                       openModal("edit", record);
@@ -4544,20 +4585,33 @@ export default function MemoryManagement() {
                   />
                 </Tooltip>
                 {!record.parentId ? (
-                  <Tooltip title={t("admin.memoryShareItem")}>
+                  <Tooltip
+                    title={
+                      disabledByBuiltinCategory
+                        ? t("admin.memoryBuiltinCategoryReserved")
+                        : t("admin.memoryShareItem")
+                    }
+                  >
                     <Button
                       type="text"
                       icon={<LinkOutlined />}
+                      disabled={disabledByBuiltinCategory}
                       onClick={() => openShareModal("skills", record)}
                     />
                   </Tooltip>
                 ) : null}
-                <Tooltip title={t("admin.memoryDeleteItem")}>
+                <Tooltip
+                  title={
+                    disabledByBuiltinCategory
+                      ? t("admin.memoryBuiltinCategoryReserved")
+                      : t("admin.memoryDeleteItem")
+                  }
+                >
                   <Button
                     type="text"
                     danger
                     icon={<DeleteOutlined />}
-                    disabled={Boolean(record.isBuiltin)}
+                    disabled={disabledByBuiltinCategory}
                     onClick={() => handleDelete(record)}
                   />
                 </Tooltip>

--- a/frontend/src/modules/memory/index.tsx
+++ b/frontend/src/modules/memory/index.tsx
@@ -155,6 +155,21 @@ import {
   skillUploadAccept,
 } from "./shared";
 
+const RESERVED_BUILTIN_SKILL_CATEGORIES = new Set([
+  "build-in",
+  "builtin",
+  "buildin",
+  "build_in",
+  "build in",
+  "built-in",
+]);
+
+const normalizeBuiltinCategoryAlias = (value: string): string =>
+  value.trim().toLowerCase().replaceAll("_", "-").replace(/\s+/g, " ");
+
+const isReservedBuiltinSkillCategory = (value: string): boolean =>
+  RESERVED_BUILTIN_SKILL_CATEGORIES.has(normalizeBuiltinCategoryAlias(value));
+
 import "./index.scss";
 
 const backendSuggestionPageSize = 20;
@@ -3392,6 +3407,10 @@ export default function MemoryManagement() {
     if (activeTab === "experience") {
       return;
     }
+    if (activeTab === "skills" && "isBuiltin" in item && item.isBuiltin) {
+      message.warning("build-in skill can not be modified/deleted");
+      return;
+    }
 
     const itemName = "title" in item ? item.title : "term" in item ? item.term : item.name;
 
@@ -3760,6 +3779,15 @@ export default function MemoryManagement() {
         content: draft.content.trim(),
         protect: draft.protect,
       };
+
+      if (
+        activeTab === "skills" &&
+        !isChildSkill &&
+        isReservedBuiltinSkillCategory(payload.category)
+      ) {
+        message.warning("build-in category is reserved");
+        return;
+      }
 
       if (activeTab === "skills") {
         const parentSkill = payload.parentId
@@ -4380,8 +4408,9 @@ export default function MemoryManagement() {
       key: "tags",
       width: 260,
       render: (tags: string[], record) =>
-        !record.parentId && tags.length ? (
+        !record.parentId && (tags.length || record.isBuiltin) ? (
           <div className="memory-tag-group">
+            {record.isBuiltin ? <Tag key="build-in-skill">build-in skill</Tag> : null}
             {tags.map((item) => (
               <Tag key={item}>{item}</Tag>
             ))}
@@ -4401,12 +4430,18 @@ export default function MemoryManagement() {
       render: (_value, record) => {
         const disabledByRemoveSuggestion =
           activeTab === "skills" && Boolean(record.hasPendingRemoveSuggestion);
+        const disabledByBuiltin = activeTab === "skills" && Boolean(record.isBuiltin);
+        const autoEvoDisabled = disabledByRemoveSuggestion || disabledByBuiltin;
         const switchNode = (
           <Switch
             checked={Boolean(record.autoEvo) && !disabledByRemoveSuggestion}
-            disabled={disabledByRemoveSuggestion}
+            disabled={autoEvoDisabled}
             loading={skillAutoEvoLoading.has(record.id)}
             onChange={(checked) => {
+              if (record.isBuiltin) {
+                message.warning("build-in skill can not be modified/deleted");
+                return;
+              }
               if (checked && record.hasPendingRemoveSuggestion) {
                 message.warning(t("admin.memorySkillAutoEvoDisabledByRemove"));
                 void refreshSkillAssets({ preserveChangeProposals: true });
@@ -4435,7 +4470,9 @@ export default function MemoryManagement() {
             }}
           />
         );
-        return disabledByRemoveSuggestion ? (
+        return disabledByBuiltin ? (
+          <Tooltip title="build-in skill can not be modified/deleted">{switchNode}</Tooltip>
+        ) : disabledByRemoveSuggestion ? (
           <Tooltip title={t("admin.memorySkillAutoEvoDisabledByRemove")}>{switchNode}</Tooltip>
         ) : (
           switchNode
@@ -4496,7 +4533,14 @@ export default function MemoryManagement() {
                   <Button
                     type="text"
                     icon={<EditOutlined />}
-                    onClick={() => openModal("edit", record)}
+                    disabled={Boolean(record.isBuiltin)}
+                    onClick={() => {
+                      if (record.isBuiltin) {
+                        message.warning("build-in skill can not be modified/deleted");
+                        return;
+                      }
+                      openModal("edit", record);
+                    }}
                   />
                 </Tooltip>
                 {!record.parentId ? (
@@ -4513,6 +4557,7 @@ export default function MemoryManagement() {
                     type="text"
                     danger
                     icon={<DeleteOutlined />}
+                    disabled={Boolean(record.isBuiltin)}
                     onClick={() => handleDelete(record)}
                   />
                 </Tooltip>

--- a/frontend/src/modules/memory/pages/skillDetail/index.tsx
+++ b/frontend/src/modules/memory/pages/skillDetail/index.tsx
@@ -77,7 +77,6 @@ export default function MemorySkillDetailPage() {
     [itemId, skillAssets],
   );
   const skill = detail || cachedSkill;
-  const isReadOnlySkill = Boolean(skill?.isBuiltin);
   const renderAsMarkdown = skill ? isMarkdownSkill(skill) : false;
   const previewContent = useMemo(
     () => stripLeadingMetaLines(skill?.content || ""),
@@ -159,9 +158,6 @@ export default function MemorySkillDetailPage() {
   }
 
   const handleStartInlineEdit = () => {
-    if (isReadOnlySkill) {
-      return;
-    }
     setInlineContentDraft(stripLeadingMetaLines(skill?.content || ""));
     setIsInlineEditing(true);
   };
@@ -236,7 +232,7 @@ export default function MemorySkillDetailPage() {
   };
 
   const handleStartTitleEdit = () => {
-    if (!skill || titleSaving || isReadOnlySkill) {
+    if (!skill || titleSaving) {
       return;
     }
     setTitleDraft(skill.name || "");
@@ -312,7 +308,7 @@ export default function MemorySkillDetailPage() {
   };
 
   const handleStartDescriptionEdit = () => {
-    if (!skill || descriptionSaving || isReadOnlySkill) {
+    if (!skill || descriptionSaving) {
       return;
     }
     setDescriptionDraft(skill.description || "");
@@ -443,17 +439,13 @@ export default function MemorySkillDetailPage() {
                 </div>
               ) : (
                 <>
-                  {isReadOnlySkill ? (
+                  <button
+                    type="button"
+                    className="memory-skill-detail-title-trigger"
+                    onClick={handleStartTitleEdit}
+                  >
                     <h3>{skill.name}</h3>
-                  ) : (
-                    <button
-                      type="button"
-                      className="memory-skill-detail-title-trigger"
-                      onClick={handleStartTitleEdit}
-                    >
-                      <h3>{skill.name}</h3>
-                    </button>
-                  )}
+                  </button>
                   {isDescriptionEditing ? (
                     <div
                       className="memory-skill-detail-description-editor"
@@ -481,19 +473,13 @@ export default function MemorySkillDetailPage() {
                       />
                     </div>
                   ) : (
-                    <>
-                      {isReadOnlySkill ? (
-                        <p>{skill.description || "-"}</p>
-                      ) : (
-                        <button
-                          type="button"
-                          className="memory-skill-detail-description-trigger"
-                          onClick={handleStartDescriptionEdit}
-                        >
-                          <p>{skill.description || "-"}</p>
-                        </button>
-                      )}
-                    </>
+                    <button
+                      type="button"
+                      className="memory-skill-detail-description-trigger"
+                      onClick={handleStartDescriptionEdit}
+                    >
+                      <p>{skill.description || "-"}</p>
+                    </button>
                   )}
                 </>
               )}
@@ -531,13 +517,11 @@ export default function MemorySkillDetailPage() {
                     : t("admin.memorySkillDetailPlainPreview")}
                 </label>
                 <span>
-                  {isReadOnlySkill
-                    ? t("admin.memoryReadonlyDescription")
-                    : t("admin.memorySkillDetailInlineEditHint")}
+                  {t("admin.memorySkillDetailInlineEditHint")}
                 </span>
               </div>
               <Space size={8}>
-                {isReadOnlySkill ? null : isInlineEditing ? (
+                {isInlineEditing ? (
                   <>
                     <Button onClick={handleCancelInlineEdit} disabled={inlineSaving}>
                       {t("common.cancel")}
@@ -558,11 +542,9 @@ export default function MemorySkillDetailPage() {
               </Space>
             </div>
             <div
-              className={`memory-skill-detail-content${
-                !isInlineEditing && !isReadOnlySkill ? " is-clickable" : ""
-              }`}
+              className={`memory-skill-detail-content${!isInlineEditing ? " is-clickable" : ""}`}
               onClick={() => {
-                if (!isInlineEditing && !isReadOnlySkill) {
+                if (!isInlineEditing) {
                   handleStartInlineEdit();
                 }
               }}

--- a/frontend/src/modules/memory/pages/skillDetail/index.tsx
+++ b/frontend/src/modules/memory/pages/skillDetail/index.tsx
@@ -77,6 +77,7 @@ export default function MemorySkillDetailPage() {
     [itemId, skillAssets],
   );
   const skill = detail || cachedSkill;
+  const isReadOnlySkill = Boolean(skill?.isBuiltin);
   const renderAsMarkdown = skill ? isMarkdownSkill(skill) : false;
   const previewContent = useMemo(
     () => stripLeadingMetaLines(skill?.content || ""),
@@ -158,6 +159,9 @@ export default function MemorySkillDetailPage() {
   }
 
   const handleStartInlineEdit = () => {
+    if (isReadOnlySkill) {
+      return;
+    }
     setInlineContentDraft(stripLeadingMetaLines(skill?.content || ""));
     setIsInlineEditing(true);
   };
@@ -232,7 +236,7 @@ export default function MemorySkillDetailPage() {
   };
 
   const handleStartTitleEdit = () => {
-    if (!skill || titleSaving) {
+    if (!skill || titleSaving || isReadOnlySkill) {
       return;
     }
     setTitleDraft(skill.name || "");
@@ -308,7 +312,7 @@ export default function MemorySkillDetailPage() {
   };
 
   const handleStartDescriptionEdit = () => {
-    if (!skill || descriptionSaving) {
+    if (!skill || descriptionSaving || isReadOnlySkill) {
       return;
     }
     setDescriptionDraft(skill.description || "");
@@ -439,13 +443,17 @@ export default function MemorySkillDetailPage() {
                 </div>
               ) : (
                 <>
-                  <button
-                    type="button"
-                    className="memory-skill-detail-title-trigger"
-                    onClick={handleStartTitleEdit}
-                  >
+                  {isReadOnlySkill ? (
                     <h3>{skill.name}</h3>
-                  </button>
+                  ) : (
+                    <button
+                      type="button"
+                      className="memory-skill-detail-title-trigger"
+                      onClick={handleStartTitleEdit}
+                    >
+                      <h3>{skill.name}</h3>
+                    </button>
+                  )}
                   {isDescriptionEditing ? (
                     <div
                       className="memory-skill-detail-description-editor"
@@ -473,13 +481,19 @@ export default function MemorySkillDetailPage() {
                       />
                     </div>
                   ) : (
-                    <button
-                      type="button"
-                      className="memory-skill-detail-description-trigger"
-                      onClick={handleStartDescriptionEdit}
-                    >
-                      <p>{skill.description || "-"}</p>
-                    </button>
+                    <>
+                      {isReadOnlySkill ? (
+                        <p>{skill.description || "-"}</p>
+                      ) : (
+                        <button
+                          type="button"
+                          className="memory-skill-detail-description-trigger"
+                          onClick={handleStartDescriptionEdit}
+                        >
+                          <p>{skill.description || "-"}</p>
+                        </button>
+                      )}
+                    </>
                   )}
                 </>
               )}
@@ -516,10 +530,14 @@ export default function MemorySkillDetailPage() {
                     ? t("admin.memorySkillDetailMarkdownPreview")
                     : t("admin.memorySkillDetailPlainPreview")}
                 </label>
-                <span>{t("admin.memorySkillDetailInlineEditHint")}</span>
+                <span>
+                  {isReadOnlySkill
+                    ? t("admin.memoryReadonlyDescription")
+                    : t("admin.memorySkillDetailInlineEditHint")}
+                </span>
               </div>
               <Space size={8}>
-                {isInlineEditing ? (
+                {isReadOnlySkill ? null : isInlineEditing ? (
                   <>
                     <Button onClick={handleCancelInlineEdit} disabled={inlineSaving}>
                       {t("common.cancel")}
@@ -540,9 +558,11 @@ export default function MemorySkillDetailPage() {
               </Space>
             </div>
             <div
-              className={`memory-skill-detail-content${!isInlineEditing ? " is-clickable" : ""}`}
+              className={`memory-skill-detail-content${
+                !isInlineEditing && !isReadOnlySkill ? " is-clickable" : ""
+              }`}
               onClick={() => {
-                if (!isInlineEditing) {
+                if (!isInlineEditing && !isReadOnlySkill) {
                   handleStartInlineEdit();
                 }
               }}

--- a/frontend/src/modules/memory/pages/skillDetail/index.tsx
+++ b/frontend/src/modules/memory/pages/skillDetail/index.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState } from "react";
-import { Alert, Button, Empty, Input, Space, Tag, message } from "antd";
+import { Alert, Button, Empty, Input, Space, Tag, Tooltip, message } from "antd";
 import { useParams } from "react-router-dom";
 import MarkdownViewer from "@/modules/knowledge/components/MarkdownViewer";
 import { DetailPageHeader } from "@/components/ui";
@@ -23,6 +23,9 @@ const isMarkdownSkill = (asset: StructuredAsset) => {
   const ext = (asset.fileExt || "").trim().toLowerCase().replace(/^\./, "");
   return markdownExtensions.has(ext) || hasMarkdownShape(asset.content || "");
 };
+
+const isReservedBuiltinSkillCategory = (value: string): boolean =>
+  value.trim().toLowerCase().replaceAll("_", "-").replace(/\s+/g, " ") === "built-in";
 
 const META_LINE_REGEX = /^\s*(?:\*\*)?\s*(name|description)\s*(?:\*\*)?\s*[:：][^\n]*$/gim;
 
@@ -76,7 +79,38 @@ export default function MemorySkillDetailPage() {
     () => skillAssets.find((item: StructuredAsset) => item.id === itemId) || null,
     [itemId, skillAssets],
   );
+  const skillById = useMemo(
+    () => new Map(skillAssets.map((item) => [item.id, item])),
+    [skillAssets],
+  );
   const skill = detail || cachedSkill;
+  const isBuiltinSkillOrChild = useMemo(() => {
+    if (!skill) {
+      return false;
+    }
+
+    let current: StructuredAsset | undefined = skill;
+    while (current) {
+      if (isReservedBuiltinSkillCategory(current.category || "")) {
+        return true;
+      }
+      if (!current.parentId) {
+        return false;
+      }
+      current = skillById.get(current.parentId);
+    }
+
+    return false;
+  }, [skill, skillById]);
+  const canEditSkillDetail = Boolean(skill) && !isBuiltinSkillOrChild;
+  useEffect(() => {
+    if (canEditSkillDetail) {
+      return;
+    }
+    setIsInlineEditing(false);
+    setIsTitleEditing(false);
+    setIsDescriptionEditing(false);
+  }, [canEditSkillDetail]);
   const renderAsMarkdown = skill ? isMarkdownSkill(skill) : false;
   const previewContent = useMemo(
     () => stripLeadingMetaLines(skill?.content || ""),
@@ -158,6 +192,9 @@ export default function MemorySkillDetailPage() {
   }
 
   const handleStartInlineEdit = () => {
+    if (!canEditSkillDetail) {
+      return;
+    }
     setInlineContentDraft(stripLeadingMetaLines(skill?.content || ""));
     setIsInlineEditing(true);
   };
@@ -232,7 +269,7 @@ export default function MemorySkillDetailPage() {
   };
 
   const handleStartTitleEdit = () => {
-    if (!skill || titleSaving) {
+    if (!skill || titleSaving || !canEditSkillDetail) {
       return;
     }
     setTitleDraft(skill.name || "");
@@ -308,7 +345,7 @@ export default function MemorySkillDetailPage() {
   };
 
   const handleStartDescriptionEdit = () => {
-    if (!skill || descriptionSaving) {
+    if (!skill || descriptionSaving || !canEditSkillDetail) {
       return;
     }
     setDescriptionDraft(skill.description || "");
@@ -439,13 +476,17 @@ export default function MemorySkillDetailPage() {
                 </div>
               ) : (
                 <>
-                  <button
-                    type="button"
-                    className="memory-skill-detail-title-trigger"
-                    onClick={handleStartTitleEdit}
-                  >
+                  {canEditSkillDetail ? (
+                    <button
+                      type="button"
+                      className="memory-skill-detail-title-trigger"
+                      onClick={handleStartTitleEdit}
+                    >
+                      <h3>{skill.name}</h3>
+                    </button>
+                  ) : (
                     <h3>{skill.name}</h3>
-                  </button>
+                  )}
                   {isDescriptionEditing ? (
                     <div
                       className="memory-skill-detail-description-editor"
@@ -472,7 +513,7 @@ export default function MemorySkillDetailPage() {
                         className="memory-skill-detail-description-input"
                       />
                     </div>
-                  ) : (
+                  ) : canEditSkillDetail ? (
                     <button
                       type="button"
                       className="memory-skill-detail-description-trigger"
@@ -480,6 +521,8 @@ export default function MemorySkillDetailPage() {
                     >
                       <p>{skill.description || "-"}</p>
                     </button>
+                  ) : (
+                    <p>{skill.description || "-"}</p>
                   )}
                 </>
               )}
@@ -535,16 +578,28 @@ export default function MemorySkillDetailPage() {
                     </Button>
                   </>
                 ) : (
-                  <Button onClick={handleStartInlineEdit}>
-                    {t("common.edit")}
-                  </Button>
+                  <Tooltip
+                    title={
+                      canEditSkillDetail
+                        ? undefined
+                        : t("admin.memoryBuiltinCategoryReserved")
+                    }
+                  >
+                    <span>
+                      <Button onClick={handleStartInlineEdit} disabled={!canEditSkillDetail}>
+                        {t("common.edit")}
+                      </Button>
+                    </span>
+                  </Tooltip>
                 )}
               </Space>
             </div>
             <div
-              className={`memory-skill-detail-content${!isInlineEditing ? " is-clickable" : ""}`}
+              className={`memory-skill-detail-content${
+                !isInlineEditing && canEditSkillDetail ? " is-clickable" : ""
+              }`}
               onClick={() => {
-                if (!isInlineEditing) {
+                if (!isInlineEditing && canEditSkillDetail) {
                   handleStartInlineEdit();
                 }
               }}

--- a/frontend/src/modules/memory/shared.ts
+++ b/frontend/src/modules/memory/shared.ts
@@ -34,6 +34,8 @@ export interface StructuredAsset extends BaseAsset {
   parentId?: string;
   fileExt?: string;
   isEnabled?: boolean;
+  isBuiltin?: boolean;
+  sourceType?: string;
   hasPendingReviewSuggestions?: boolean;
   hasPendingRemoveSuggestion?: boolean;
   suggestionStatus?: string;

--- a/frontend/src/modules/memory/skillApi.ts
+++ b/frontend/src/modules/memory/skillApi.ts
@@ -34,6 +34,8 @@ interface SkillNode {
   auto_evo_apply_status?: string;
   auto_evo_generation?: number;
   auto_evo_error?: string;
+  source_type?: string;
+  is_builtin?: boolean;
   children?: SkillNode[];
   [key: string]: unknown;
 }
@@ -58,6 +60,8 @@ export interface SkillAssetRecord {
   autoEvoApplyStatus?: string;
   autoEvoGeneration?: number;
   autoEvoError?: string;
+  sourceType?: string;
+  isBuiltin?: boolean;
 }
 
 export interface SkillDraftGeneratePayload {
@@ -295,6 +299,8 @@ const normalizeSkillNode = (raw: SkillNode, parentId?: string): SkillAssetRecord
     autoEvoApplyStatus: toStringValue(raw.auto_evo_apply_status || ""),
     autoEvoGeneration: typeof raw.auto_evo_generation === "number" ? raw.auto_evo_generation : 0,
     autoEvoError: toStringValue(raw.auto_evo_error || ""),
+    sourceType: toStringValue(raw.source_type || ""),
+    isBuiltin: toBoolean(raw.is_builtin, false),
   };
 };
 

--- a/skills/research/deep-research/SKILL.md
+++ b/skills/research/deep-research/SKILL.md
@@ -1,0 +1,210 @@
+---
+name: deep-research
+description: Use this skill instead of WebSearch for ANY question requiring comprehensive, multi-source research. Trigger on queries explicitly asking for deep analysis, such as "research X", "deep dive into X", "comprehensive review of X", "systematic comparison between X and Y", "investigate the landscape of X", or Chinese equivalents like "调研一下X", "深入研究X", "全面对比X与Y", "X的详细综述", "深度调查X". Do NOT trigger on simple factual questions. Provides systematic multi-angle research methodology, prioritizing internal knowledge base (KB) searches before performing broad web searches. Use this proactively when the user's question needs extensive information gathering and synthesis.
+---
+
+# Deep Research Skill
+
+## Overview
+
+This skill provides a systematic methodology for conducting thorough research. **Load this skill BEFORE starting any content generation task** to ensure you gather sufficient information from multiple angles, depths, and sources. Always prioritize searching the internal Knowledge Base (KB) before reaching out to the open web.
+
+## When to Use This Skill
+
+**Always load this skill when:**
+
+### Research Questions
+- User asks for comprehensive analysis: "research X", "deep dive into X", "detailed comparison of X and Y", "investigate the landscape of X", "thorough analysis of X"
+- User uses Chinese research triggers: "调研一下X", "深入分析X", "全面调查X", "X与Y的深度对比", "详细梳理X的发展历程", "X的现状与未来趋势"
+- User wants to understand a *complex* concept, technology, or topic in depth, rather than just seeking a simple definition.
+- The question requires synthesizing current, comprehensive information from multiple distinct sources (Internal KB + Web).
+- A single web search or factual retrieval would be explicitly insufficient to answer properly.
+
+### Content Generation (Pre-research)
+- Creating presentations (PPT/slides)
+- Writing articles, reports, or documentation
+- Producing videos or multimedia content
+- Any content that requires real-world information, examples, or current data
+
+## Core Principle
+
+**Never generate content based solely on general knowledge.** The quality of your output directly depends on the quality and quantity of research conducted beforehand. A single search query is NEVER enough.
+
+## Research Methodology
+
+### Phase 1: Internal Knowledge Base (KB) Retrieval
+
+Always start by checking if the required information already exists internally.
+
+1. **Semantic Search**: Use `kb_search` with natural language queries to find conceptual matches.
+2. **Keyword Search**: Use `kb_keyword_search` for exact terminology, product names, or specific jargon.
+3. **Context Expansion**: If you find relevant nodes, optionally use `kb_get_window_nodes` or `kb_get_parent_node` to understand the full context of the internal documents.
+
+*Decision Gate: Evaluate the KB results. If the KB contains comprehensive, up-to-date answers covering all dimensions of the user's query, you may skip to Phase 4. If information is missing, outdated, or incomplete, proceed to Phase 2.*
+
+### Phase 2: Broad Web Exploration
+
+If KB results are insufficient, turn to the web using `web_search` to map the external landscape:
+
+1. **Initial Survey**: Search for the main topic to understand the overall context
+2. **Identify Dimensions**: From initial results, identify key subtopics, themes, angles, or aspects that need deeper exploration
+3. **Map the Territory**: Note different perspectives, stakeholders, or viewpoints that exist
+
+Example:
+```
+Topic: "AI in healthcare"
+Initial searches:
+- "AI healthcare applications 2024"
+- "artificial intelligence medical diagnosis"
+- "healthcare AI market trends"
+
+Identified dimensions:
+- Diagnostic AI (radiology, pathology)
+- Treatment recommendation systems
+- Administrative automation
+- Patient monitoring
+- Regulatory landscape
+- Ethical considerations
+```
+
+### Phase 3: Deep Dive
+
+For each important dimension identified in Phase2, conduct targeted research:
+
+1. **Specific Queries**: Use `web_search` with precise keywords for each subtopic.
+2. **Multiple Phrasings**: Try different keyword combinations and phrasings
+3. **Fetch Full Content**: Use the `url_fetch` tool to read important sources in full, not just snippets.
+4. **Follow References**: When sources mention other important resources, search for those too
+
+
+Example:
+```
+Dimension: "Diagnostic AI in radiology"
+Targeted searches:
+- "AI radiology FDA approved systems"
+- "chest X-ray AI detection accuracy"
+- "radiology AI clinical trials results"
+
+Then fetch and read:
+- Key research papers or summaries
+- Industry reports
+- Real-world case studies
+```
+
+### Phase 4: Diversity & Validation
+
+Ensure comprehensive coverage by seeking diverse information types:
+
+| Information Type | Purpose | Example Searches |
+|-----------------|---------|------------------|
+| **Facts & Data** | Concrete evidence | "statistics", "data", "numbers", "market size" |
+| **Examples & Cases** | Real-world applications | "case study", "example", "implementation" |
+| **Expert Opinions** | Authority perspectives | "expert analysis", "interview", "commentary" |
+| **Trends & Predictions** | Future direction | "trends 2024", "forecast", "future of" |
+| **Comparisons** | Context and alternatives | "vs", "comparison", "alternatives" |
+| **Challenges & Criticisms** | Balanced view | "challenges", "limitations", "criticism" |
+
+### Phase 5: Synthesis Check
+
+Before proceeding to content generation, verify:
+
+- [ ] Did I check the internal KB first?
+- [ ] Have I searched from at least 3-5 different angles?
+- [ ] Have I used `url_fetch` to read the most important web sources in full?
+- [ ] Do I have concrete data, examples, and expert perspectives?
+- [ ] Have I explored both positive aspects and challenges/limitations?
+- [ ] Is my information current and from authoritative sources?
+
+**If any answer is NO, continue researching before generating content.**
+
+## Search Strategy Tips
+
+### Effective Query Patterns
+
+```
+# Be specific with context
+❌ "AI trends"
+✅ "enterprise AI adoption trends 2024"
+
+# Include authoritative source hints
+"[topic] research paper"
+"[topic] McKinsey report"
+"[topic] industry analysis"
+
+# Search for specific content types
+"[topic] case study"
+"[topic] statistics"
+"[topic] expert interview"
+
+# Use temporal qualifiers — always use the ACTUAL current year from <current_date>
+"[topic] 2026"   # ← replace with real current year, never hardcode a past year
+"[topic] latest"
+"[topic] recent developments"
+```
+
+### Temporal Awareness for Web Search
+
+**Always check `<current_date>` in your context before forming ANY search query.**
+
+`<current_date>` gives you the full date: year, month, day, and weekday (e.g. `2026-02-28, Saturday`). Use the right level of precision depending on what the user is asking:
+
+| User intent | Temporal precision needed | Example query |
+|---|---|---|
+| "today / this morning / just released" | **Month + Day** | `"tech news February 28 2026"` |
+| "this week" | **Week range** | `"technology releases week of Feb 24 2026"` |
+| "recently / latest / new" | **Month** | `"AI breakthroughs February 2026"` |
+| "this year / trends" | **Year** | `"software trends 2026"` |
+
+**Rules:**
+- When the user asks about "today" or "just released", use **month + day + year** in your search queries to get same-day results
+- Never drop to year-only when day-level precision is needed — `"tech news 2026"` will NOT surface today's news
+- Try multiple phrasings: numeric form (`2026-02-28`), written form (`February 28 2026`), and relative terms (`today`, `this week`) across different queries
+
+❌ User asks "what's new in tech today" → searching `"new technology 2026"` → misses today's news
+✅ User asks "what's new in tech today" → searching `"new technology February 28 2026"` + `"tech news today Feb 28"` → gets today's results
+
+### When to Use url_fetch
+
+Use `url_fetch` to read full content when:
+- A search result looks highly relevant and authoritative
+- You need detailed information beyond the snippet
+- The source contains data, case studies, or expert analysis
+- You want to understand the full context of a finding
+
+### Iterative Refinement
+
+Research is iterative. After initial searches:
+1. Review what you've learned
+2. Identify gaps in your understanding
+3. Formulate new, more targeted queries
+4. Repeat until you have comprehensive coverage
+
+## Quality Bar
+
+Your research is sufficient when you can confidently answer:
+- What are the key facts and data points?
+- What are 2-3 concrete real-world examples?
+- What do experts say about this topic?
+- What are the current trends and future directions?
+- What are the challenges or limitations?
+- What makes this topic relevant or important now?
+
+## Common Mistakes to Avoid
+
+- ❌ Stopping after 1-2 searches
+- ❌ Relying on search snippets without reading full sources
+- ❌ Searching only one aspect of a multi-faceted topic
+- ❌ Ignoring contradicting viewpoints or challenges
+- ❌ Using outdated information when current data exists
+- ❌ Starting content generation before research is complete
+
+## Output
+
+After completing research, you should have:
+1. A comprehensive understanding of the topic from multiple angles
+2. Specific facts, data points, and statistics
+3. Real-world examples and case studies
+4. Expert perspectives and authoritative sources
+5. Current trends and relevant context
+
+**Only then proceed to content generation**, using the gathered information to create high-quality, well-informed content.

--- a/skills/review/single-document-review/SKILL.md
+++ b/skills/review/single-document-review/SKILL.md
@@ -1,0 +1,117 @@
+---
+name: single-document-review
+description: Use this skill when the user requests to review, analyze, critique, or summarize a SINGLE academic paper, general document, internal report, proposal, or web article. Supports comprehensive structured reviews covering methodology/logic assessment, strengths, weaknesses, and constructive feedback. Retrieves content using native tools (`url_fetch`, `kb_search`, `arxiv_search`) and outputs the analysis directly in the chat.
+---
+
+# Single Document & Paper Review Skill
+
+## Overview
+
+This skill produces structured, professional-grade analyses of single academic papers or general business/technical documents. It adapts established academic peer-review standards to evaluate both scientific publications and corporate reports (e.g., whitepapers, strategic memos, design docs). 
+
+The review covers **executive summary, strengths, weaknesses, methodology/logic assessment, contextual positioning, and actionable recommendations** — all grounded in evidence from the text itself.
+
+## When to Use This Skill
+
+**Always load this skill when:**
+- User provides a single URL (arXiv, blog, documentation) or file path and asks to "review", "analyze", or "summarize" it.
+- User queries a specific document from the Knowledge Base (`kb_search`) for detailed critique.
+- User wants to understand the strengths, weaknesses, and validity of a specific study, proposal, or report.
+- User requests a peer-review-style evaluation of their own drafted document.
+
+*Note: If the user asks to synthesize or compare MULTIPLE documents, use the multi-document systematic review skill instead.*
+
+## Available Tools & Acquisition
+
+Depending on how the user provides the document, use the appropriate native tool to ingest the text into your context:
+- **Academic Papers:** Use `url_fetch` on the HTML version (e.g., `https://ar5iv.labs.arxiv.org/html/<id>`) or use `arxiv_search` for metadata.
+- **Web Articles:** Use `url_fetch`.
+- **Internal Knowledge:** Use `kb_search` or `kb_keyword_search` to pull the specific document from the Knowledge Base.
+
+## Review Methodology (Internal Processing)
+
+Once the document is loaded into your context, perform a deep reading pass using your internal attention. 
+
+### Phase 1: Comprehension & Metadata Extraction
+Identify:
+1. **Title & Creators**: Authors, Departments, or Organizations.
+2. **Document Type**: Is this an Empirical Paper, Theoretical Proof, Business Proposal, Technical Design Doc, or Quarterly Report?
+3. **Core Claims**: What are the 2-3 main arguments or contributions?
+
+### Phase 2: Critical Analysis & Context
+1. **Contextualization**: If necessary, perform a quick `kb_search` (for internal docs) or `arxiv_search` (for academic docs) to see if this document aligns with or contradicts existing knowledge.
+2. **Methodology / Logic Assessment**: Evaluate based on the document type:
+   - *For Academic/Technical*: Assess Soundness, Novelty, Reproducibility, and Statistical/Data Rigor.
+   - *For Business/General*: Assess Clarity, Strategic Alignment, Feasibility, and Evidence Rigor (are claims backed by data?).
+
+### Phase 3: Strengths and Weaknesses Extraction
+For each strength or weakness, explicitly note:
+- **What**: The specific observation.
+- **Where**: Section/figure/table reference.
+- **Why it matters**: Impact on the document's overall reliability or utility.
+
+## Output Format
+
+Do not attempt to save the review to a file. **Directly output the complete review in Markdown format in the chat.** Use the following unified template, adapting the fields based on whether the document is academic or general:
+
+```markdown
+# Document Review: [Title]
+
+## Metadata
+- **Creator(s) / Author(s)**: [Name or Department]
+- **Type**: [Academic Paper / Business Proposal / Technical Spec / etc.]
+- **Date / Context**: [Year or specific context]
+
+## Executive Summary
+[2-3 paragraph summary of the document's core objective, approach, and main findings/proposals. State your overall assessment upfront: what it does well, where it falls short, and its overall significance.]
+
+## Key Claims & Contributions
+1. [First major claim/contribution — one sentence]
+2. [Second major claim/contribution — one sentence]
+3. [Additional claims if any]
+
+## Strengths
+### S1: [Concise strength title]
+[Detailed explanation with specific references to sections. Explain WHY this is a strength.]
+
+### S2: [Concise strength title]
+[...]
+
+## Weaknesses & Limitations
+### W1: [Concise weakness title]
+[Detailed explanation with specific references. Explain the impact of this weakness on the document's claims. Suggest how it could be addressed.]
+
+### W2: [Concise weakness title]
+[...]
+
+## Rigor & Logic Assessment
+| Criterion | Rating (1-5) | Assessment Justification |
+|-----------|:---:|------------|
+| Clarity & Structure | X | [Brief justification] |
+| Evidence / Data Quality | X | [Brief justification] |
+| Methodology / Feasibility | X | [Brief justification] |
+| Contextual Alignment | X | [Brief justification, e.g., how it fits into the broader field or company strategy] |
+
+*(Note: Adjust the criteria names slightly if reviewing a highly theoretical physics paper vs. a corporate marketing plan).*
+
+## Questions for the Creators
+1. [Specific question that would clarify a concern or ambiguity]
+2. [Question about methodology choices, alternative approaches, or implementation details]
+
+## Actionable Recommendations
+**Overall Assessment**: [Strongly Endorse / Endorse with Revisions / Neutral / Needs Major Rework]
+
+**Specific Suggestions for Improvement:**
+1. [Actionable, constructive suggestion to fix W1]
+2. [Actionable, constructive suggestion to fix W2]
+3. [Minor formatting/typo fixes if applicable]
+```
+
+## Review Principles
+
+- **Constructive Criticism:** Always suggest how to fix a problem. Don't just point out flaws; propose solutions.
+- **Be Specific:** Reference exact sections, claims, or data points.
+  - ❌ "The report lacks detail."
+  - ✅ "Section 3 claims a 20% growth rate but provides no historical data or citation to back this projection."
+- **Evaluate on its Own Merits:** Do not penalize a business memo for not being an academic paper, or vice versa. Judge it by the standards of its intended format.
+- **Maintain Objectivity:** Ensure your tone is professional, respectful, and strictly analytical.

--- a/skills/review/systematic-document-and-literature-review/SKILL.md
+++ b/skills/review/systematic-document-and-literature-review/SKILL.md
@@ -1,0 +1,99 @@
+---
+name: systematic-document-and-literature-review
+description: Use this skill when the user wants a systematic review, thematic synthesis, or cross-document analysis across multiple academic papers OR provided general documents (reports, internal memos, web articles). Retrieves sources via arXiv, internal Knowledge Base (KB), or direct URLs. Analyzes the content within the current context and outputs a fully structured synthesis report directly in the chat.
+---
+
+# Systematic Document & Literature Review Skill
+
+## Overview
+
+This skill produces a structured **systematic review and synthesis** across multiple academic papers or general documents. Given a topic query or a list of specific files/URLs, it gathers the source material, analyzes the content (objectives, methodology, key findings, limitations) sequentially, synthesizes themes, and outputs a final structured report directly to the user.
+
+**Distinct from single-document review:** This skill does breadth-first synthesis across many sources. If the user hands you exactly one document or one paper URL and asks "review this", route to a standard reading or single-document review skill instead.
+
+## When to Use This Skill
+
+Use this skill when the user wants any of the following:
+
+- A literature survey on an academic topic ("survey transformer attention variants")
+- A thematic synthesis across internal documents ("synthesize the last 5 quarterly reports from the KB and find common trends")
+- A cross-document comparison ("compare the methodologies across these provided architecture design URLs")
+- An overview of trends across a set of files, URLs, or an arXiv time window
+
+Do **not** use this skill when:
+
+- The user provides exactly one document/paper and asks to review it.
+- The user asks a factual question that does not require synthesizing multiple sources.
+
+## Workflow
+
+The workflow has four phases. Follow them in order.
+
+### Phase 1: Plan
+
+Before doing any retrieval, confirm the following with the user. If any of these are unclear, ask **one** clarifying question that covers the missing pieces. 
+
+- **Source Material**: Are we searching an academic database (`arxiv_search`), an internal Knowledge Base (`kb_search`), or reviewing specific URLs (`url_fetch`)?
+- **Scope**: How many sources total? **(Limit to max 15-20 sources to prevent context overflow)**.
+- **Output Format**: APA, IEEE, BibTeX, or Standard Professional Report (default for non-academic documents).
+
+### Phase 2: Acquire Sources
+
+Depending on the Source Material established in Phase 1, follow the appropriate acquisition path:
+
+#### Path A: Academic Literature (arXiv)
+Use the native `arxiv_search` tool. 
+- Extract 2-3 core keywords from the user's prompt. Do not use overly long phrases.
+- Use relevance sorting unless chronological order is strictly requested.
+
+#### Path B: Internal Documents (Knowledge Base)
+Use `kb_search` or `kb_keyword_search` to find relevant internal documents. 
+- Gather the returned nodes. If context is missing, use `kb_get_window_nodes` or `kb_get_parent_node` to ensure sufficient text for the subagents.
+
+#### Path C: Provided URLs
+If the user provides a list of links or file paths:
+- Verify the list (cap at 50). 
+- Use `url_fetch` (for web links) to ingest the content.
+
+### Phase 3: Analyze & Synthesize (Internal Processing)
+
+Once you have ingested the source texts into your context, carefully analyze them. You must mentally or explicitly (in your thinking process) extract the following for *each* source:
+- Primary objective
+- Approach or methodology
+- Key findings
+- Limitations or next steps
+
+**Cross-source synthesis**: Then, look across all analyzed sources to identify:
+- **Themes**: 3-5 recurring directions, topics, or problem framings.
+- **Convergences**: Findings or arguments that multiple documents agree on.
+- **Disagreements**: Where sources reach different conclusions.
+- **Gaps**: What the collective set of documents does not address.
+
+### Phase 4: Output Final Report
+
+Do not attempt to save to a file. **Directly output the final synthesized report in the chat.** Use markdown formatting. If the user requested a Standard Professional Report, strictly use the following structure:
+
+```markdown
+# Systematic Review: [Topic Name]
+
+## 1. Executive Summary
+[A high-level 3-5 sentence summary of the entire review, highlighting the most critical insights.]
+
+## 2. Thematic Synthesis
+### Themes
+- **[Theme 1]**: [Explanation based on sources]
+- **[Theme 2]**: [Explanation based on sources]
+### Convergences & Disagreements
+[Where do the documents align? Where do they conflict?]
+### Knowledge Gaps
+[What is missing from the current literature/documents?]
+
+## 3. Source Annotations
+[Briefly list each analyzed source with its core objective and key finding. E.g.:]
+* **[Source Title/ID]**: [1-sentence objective]. Key finding: [1-2 sentences].
+
+## 4. References / Analyzed Sources
+[List of all URLs, arXiv IDs, or document names analyzed.]
+```
+
+If the user requested APA/IEEE format, adjust the formatting and citation style accordingly.

--- a/skills/search/paper-search/SKILL.md
+++ b/skills/search/paper-search/SKILL.md
@@ -1,0 +1,67 @@
+---
+name: paper-search
+description: "Primary skill for searching, retrieving, and reading academic papers from arXiv."
+---
+
+# Paper Search Skill
+
+## Overview
+
+This skill provides a streamlined workflow for searching and reading academic papers from arXiv. You must default to using the system's native tools for searching and reading. Use local scripts only for specific formatting tasks (like BibTeX) or as a fallback mechanism.
+
+## Available Tools & Priority
+
+1. **`arxiv_search` (Primary)**: Use this first for querying papers by keyword, author, or ID.
+2. **`url_fetch` (Primary)**: Use this to read abstracts and full-text HTML papers.
+3. **`run_script` (Optional/Fallback)**: Use this *only* to generate BibTeX citations OR if `arxiv_search` fails to return valid results. This tool returns a dictionary.
+
+---
+
+## Workflow & Tool Usage Guide
+
+### Phase 1: Search & Discovery
+
+**Primary Method:**
+When the user asks for papers on a topic, immediately call the native `arxiv_search` tool with appropriate keywords.
+- Example: `arxiv_search(query="large language models")`
+
+**Fallback Method (If `arxiv_search` fails or returns empty/errors):**
+If the native tool malfunctions, use `run_script` to execute the fallback Python search script.
+- Tool Call Configuration:
+  ```json
+  {
+    "name": "paper-search",
+    "rel_path": "scripts/search_arxiv.py",
+    "args": ["<your_search_query>"]
+  }
+  ```
+
+### Phase 2: Content Retrieval
+
+Once you have identified target arXiv IDs, retrieve their content using `url_fetch`.
+
+1. **Read the Abstract**
+- URL Format: `https://arxiv.org/abs/<arxiv_id>`
+- Example: `url_fetch(url="https://arxiv.org/abs/2402.03300")`
+2. **Read the Full Paper (HTML Version)**
+To read the actual paper content (Methodology, Experiments, etc.), fetch the HTML version (preserves text and tables better than PDFs):
+- URL Format: `https://ar5iv.labs.arxiv.org/html/<arxiv_id>`
+- Example: `url_fetch(url="https://ar5iv.labs.arxiv.org/html/2402.03300")`
+
+### Phase 3: BibTeX Generation (Optional)
+
+If the user specifically asks for BibTeX citations, the native tools might not format it correctly. Use `run_script` to execute the BibTeX generator.
+- Tool Call Configuration:
+  ```json
+  {
+    "name": "paper-search",
+    "rel_path": "scripts/get_bibtex.py",
+    "args": ["<arxiv_id>"]
+  }
+  ```
+Example `<arxiv_id>: 2402.03300`
+
+## Constraints & Rules
+- **Tool Priority:** Always attempt `arxiv_search` before resorting to `scripts/search_arxiv.py`.
+- **Arguments Format:** When using `run_script`, the `args` parameter MUST be a List of strings (`List[str]`).
+- **ID Versioning:** `2402.03300` resolves to the latest version. Use unversioned IDs for lookups unless the user specifically requests an older version.

--- a/skills/search/paper-search/scripts/get_bibtex.py
+++ b/skills/search/paper-search/scripts/get_bibtex.py
@@ -1,0 +1,49 @@
+import sys
+import urllib.request
+import xml.etree.ElementTree as ET
+
+def get_bibtex(arxiv_id):
+    url = f"https://export.arxiv.org/api/query?id_list={arxiv_id}"
+    try:
+        req = urllib.request.Request(url, headers={'User-Agent': 'Mozilla/5.0'})
+        with urllib.request.urlopen(req) as response:
+            xml_data = response.read()
+            
+        ns = {'a': 'http://www.w3.org/2005/Atom', 'arxiv': 'http://arxiv.org/schemas/atom'}
+        root = ET.fromstring(xml_data)
+        entry = root.find('a:entry', ns)
+        
+        if entry:
+            title = entry.find('a:title', ns).text.strip().replace('\n', ' ')
+            authors = ' and '.join(a.find('a:name', ns).text for a in entry.findall('a:author', ns))
+            year = entry.find('a:published', ns).text[:4]
+            raw_id = entry.find('a:id', ns).text.strip().split('/abs/')[-1]
+            
+            cat_elem = entry.find('arxiv:primary_category', ns)
+            primary = cat_elem.get('term') if cat_elem is not None else 'cs.LG'
+            last_name = entry.find('a:author', ns).find('a:name', ns).text.split()[-1]
+            
+            print("STATUS: SUCCESS")
+            print("--- BIBTEX START ---")
+            print(f"@article{{{last_name}{year}_{raw_id.replace('.', '')},")
+            print(f"  title     = {{{title}}},")
+            print(f"  author    = {{{authors}}},")
+            print(f"  year      = {{{year}}},")
+            print(f"  eprint    = {{{raw_id}}},")
+            print(f"  archivePrefix = {{arXiv}},")
+            print(f"  primaryClass  = {{{primary}}},")
+            print(f"  url       = {{https://arxiv.org/abs/{raw_id}}}")
+            print("}")
+            print("--- BIBTEX END ---")
+        else:
+            print(f"ERROR: Paper with ID {arxiv_id} not found.")
+            
+    except Exception as e:
+        print(f"ERROR: Failed generating BibTeX. Details: {e}")
+
+if __name__ == "__main__":
+    if len(sys.argv) > 1:
+        target_id = sys.argv[1]
+        get_bibtex(target_id)
+    else:
+        print("ERROR: Missing arXiv ID argument.")

--- a/skills/search/paper-search/scripts/search_arxiv.py
+++ b/skills/search/paper-search/scripts/search_arxiv.py
@@ -1,0 +1,48 @@
+import sys
+import urllib.request
+import urllib.parse
+import xml.etree.ElementTree as ET
+
+def search_arxiv(query, max_results=5):
+    encoded_query = urllib.parse.quote(query).replace('%20', '+')
+    url = f"https://export.arxiv.org/api/query?search_query={encoded_query}&max_results={max_results}&sortBy=submittedDate&sortOrder=descending"
+    
+    try:
+        req = urllib.request.Request(url, headers={'User-Agent': 'Mozilla/5.0'})
+        with urllib.request.urlopen(req) as response:
+            xml_data = response.read()
+            
+        ns = {'a': 'http://www.w3.org/2005/Atom'}
+        root = ET.fromstring(xml_data)
+        entries = root.findall('a:entry', ns)
+        
+        if not entries:
+            print("STATUS: NO_RESULTS")
+            print(f"No papers found for query: '{query}'")
+            return
+
+        print(f"Search Results for '{query}':\n" + "="*40)
+        for i, entry in enumerate(entries):
+            title = entry.find('a:title', ns).text.strip().replace('\n', ' ')
+            arxiv_id = entry.find('a:id', ns).text.strip().split('/abs/')[-1]
+            published = entry.find('a:published', ns).text[:10]
+            authors = ', '.join(a.find('a:name', ns).text for a in entry.findall('a:author', ns))
+            summary = entry.find('a:summary', ns).text.strip().replace('\n', ' ')
+            
+            print(f"Result [{i+1}] ID: {arxiv_id}")
+            print(f"Title: {title}")
+            print(f"Authors: {authors}")
+            print(f"Published: {published}")
+            print(f"Abstract: {summary[:200]}...")
+            print(f"URL: https://arxiv.org/abs/{arxiv_id}")
+            print("-" * 40)
+            
+    except Exception as e:
+        print(f"ERROR: Failed fetching data from arXiv. Details: {e}")
+
+if __name__ == "__main__":
+    if len(sys.argv) > 1:
+        search_query = sys.argv[1]
+        search_arxiv(search_query)
+    else:
+        print("ERROR: Missing search query argument.")

--- a/tests/algorithm/test_remote_fs.py
+++ b/tests/algorithm/test_remote_fs.py
@@ -180,7 +180,7 @@ def test_skill_manager_reads_reference_from_remote_mock_server(monkeypatch, mock
 
     assert skill_doc['status'] == 'ok'
     assert 'Example Skill' in skill_doc['content']
-    assert '(source: remote,' in manager.build_prompt('use example')
+    assert 'path: remote://skills/writing/example' in manager.build_prompt('use example')
     assert reference_doc == {
         'status': 'ok',
         'path': 'remote://skills/writing/example/references/examples/daily-update.md',

--- a/tests/algorithm/test_skill_memory_tools.py
+++ b/tests/algorithm/test_skill_memory_tools.py
@@ -206,9 +206,38 @@ def test_skill_manage_rejects_writes_to_non_remote_skills(monkeypatch):
 
     assert modify_result == {
         'success': False,
-        'reason': "Skill 'builtin' in category 'writing' has read-only source 'file'; skill_manage can only modify remote skills.",
+        'reason': "build-in skill can not be modified/deleted",
     }
     assert remove_result == {
         'success': False,
-        'reason': "Skill 'builtin' in category 'writing' has read-only source 'file'; skill_manage can only remove remote skills.",
+        'reason': "build-in skill can not be modified/deleted",
     }
+
+
+def test_skill_manage_rejects_reserved_builtin_categories(monkeypatch):
+    monkeypatch.setattr(
+        skill_manager_mod,
+        '_agentic_config',
+        lambda: {'session_id': 'sid-1', 'skill_fs_url': 'remote://skills,.agentic/skills'},
+    )
+    monkeypatch.setattr(skill_manager_mod, 'list_all_skill_entries', lambda _base_dir: {})
+
+    content = (
+        '---\n'
+        'name: new_skill\n'
+        'description: A test skill.\n'
+        '---\n'
+        'Use this skill for tests.\n'
+    )
+
+    for category in ['build-in', 'build——in', 'builtin', 'buildin', 'build_in']:
+        result = skill_manager_mod.skill_manage(
+            'new_skill',
+            'create',
+            category=category,
+            content=content,
+        )
+        assert result == {
+            'success': False,
+            'reason': 'build-in category is reserved.',
+        }

--- a/tests/algorithm/test_skill_memory_tools.py
+++ b/tests/algorithm/test_skill_memory_tools.py
@@ -206,11 +206,11 @@ def test_skill_manage_rejects_writes_to_non_remote_skills(monkeypatch):
 
     assert modify_result == {
         'success': False,
-        'reason': "build-in skill can not be modified/deleted",
+        'reason': "built-in skill can not be modified/deleted",
     }
     assert remove_result == {
         'success': False,
-        'reason': "build-in skill can not be modified/deleted",
+        'reason': "built-in skill can not be modified/deleted",
     }
 
 
@@ -239,5 +239,5 @@ def test_skill_manage_rejects_reserved_builtin_categories(monkeypatch):
         )
         assert result == {
             'success': False,
-            'reason': 'build-in category is reserved.',
+            'reason': 'built-in category is reserved.',
         }


### PR DESCRIPTION
# Built-in Skill Integration Plan
## Scanning & Seeding Strategy
### Scanning Rules:
- Trigger Timing: When the core service starts.
- Scan Path: LazyRAG/skills/ directory.
- Filtering Rule: Ignore all hidden directories starting with ..
- Parsing Structure: Parse skill information according to the skills/<category>/<skill_name>/SKILL.md specification.

### Seeding Rules (Seed-if-missing):
- Unified Category: For all scanned skills, force override the category field to built-in when writing to the backend skill_resources table.
- Global Singleton: Built-in skills are "system-level resources", requiring only one copy in the database. No need to duplicate them for each individual user.
- Incremental Seeding: Adopt a "skip if exists" strategy. If a built-in skill with the same name already exists in the database, skip it directly. Strictly do not overwrite existing data (to protect potential state changes or version differences).

## Data Integration & Context Building
- Runtime Merge Principle: Final available skills = System built-in skills (built-in) ∪ Current user-defined skills (user-defined).
- Specific Modifications:
    - Chat Context (BuildChatResourceContext, line 211): Modified the logic so that when injecting the available Skill list into the LLM, it must merge built-in and user skills.
    - File System Display (remote_fs.go, line 268): The remote-fs directory list mounted to the LLM or Agent now simultaneously includes the paths of built-in skills.
    - Management APIs (Skill List/Get API): When the frontend requests the skill list, the backend must return the merged data, ensuring users can see both built-in and their own custom skills on the management page.

## Naming Conflicts & Priority Handling
- Uniqueness Validation Downgrade: Skill deduplication logic is changed from "global name uniqueness" to "Category + Name combination uniqueness".

- Same-Name Allowance: Allow users to create custom skills with the exact same name as built-in skills. For example, if built-in/deep-research exists, users can still create user-custom/deep-research.

- Priority Strategy (User Override): When the LLM or system invokes a skill with a conflicting name, follow the "user skill takes precedence" principle (User > Built-in).

## Permissions & Security Isolation
- Reserved Category: built-in serves as a protected system-level Category.
    - Interception Point 1 (Frontend): When users create a new skill, they are prohibited from selecting/inputting built-in in the dropdown or input box.
- Read-Only Protection: Built-in skills are read-only for all standard users.
    - Interception Point 2 (Frontend UI): For skill list items where category == 'built-in', gray out or hide the "Modify/Delete" buttons. If a user attempts to trigger an operation via other means, display a unified toast: built-in category is reserved.
    - Interception Point 3 (Algorithm Agent): When the SkillManage Agent attempts to modify or delete a built-in skill via tools, it must be intercepted and return the failure reason.
    - Interception Point 4 (Backend Fallback): Add a hard interception at the backend Modify/Remove API: If the target skill's category == 'built-in', directly reject the request and return a 403 / 400 error.

# Code Changes Details
## Backend Changes (✅)
- Establish standard identity for builtin skills (backend/core/skill/builtin.go, line 20)
    - Fixed fields: owner_user_id = "builtin", source_type = "builtin" (new), category = "built-in".

- Unify builtin validation function (builtin.go, line 173)
    - Judgment criteria for isBuiltinSkill(row): source_type == "builtin" OR owner_user_id == "builtin".

- Prohibit writing to builtin category in Create API (backend/core/skill/management.go, line 186)
    - When creating a skill, if the category hits the reserved builtin category, directly return built-in category is reserved.

- Update/Delete APIs are builtin read-only (management.go, line 1082 & 1096)
    - In updateSkill() and DeleteSkill(), if the target is builtin, directly return errBuiltinSkillReadonly.

- Category validation during parent skill update (management.go, line 1176)
    - Attempting to change a skill to the reserved builtin category directly throws built-in category is reserved.

- List/Detail APIs return builtin flags (management.go, line 760)
    - Return source_type and is_builtin fields for frontend display and disable logic.

- Prioritize user skills at runtime (builtin.go, line 51 & 86)
    - LoadVisibleSkillRows() fetches user skills first, then appends builtin skills.
    - loadRuntimeVisibleSkillRows() deduplicates by skillName + nodeType, ensuring user skills take priority on name collisions.

- User priority in remote_fs read pipeline (backend/core/skill/remote_fs.go, line 359)
    - Parent skills are deduplicated by skillName, child skills by parentSkillName + skillName, all prioritizing user skills.

- User priority in evolution read pipeline (backend/core/evolution/service.go, line 302)
    - skillVisibleParents() uses user-first, builtin-second, name-deduplication logic (actual self-evolution of builtin skills is disabled).

- Add reserved category definitions in backend (backend/core/skill/fs.go, line 18)
    - Uniformly define reserved builtin category aliases in the backend.

## Algorithm Changes (✅)
- Add builtin category alias judgment (algorithm/chat/tools/skill_manager.py, line 31)
    - Added _RESERVED_BUILTIN_CATEGORIES etc., unifying build-in / builtin / buildin / build_in / build in / built-in as reserved categories.

- Update skill_manage.create (skill_manager.py, line 336)
    - If the category hits the reserved builtin category, directly return built-in category is reserved.

- Update skill_manage.modify / remove (skill_manager.py, line 370 & 413)
    - If the target skill source is unwritable or belongs to builtin, intercept and return built-in skill can not be modified/deleted.

- Update skill index structure (skill_manager.py, line 214)
    - list_all_skill_entries() now returns name/category/path/source. Subsequent operations will judge if a remote skill is writable based on source.

- Current algorithm builtin judgment criteria (skill_manager.py, line 259)
    - Judgment standard: Writable source source == "remote" AND the category hits a builtin reserved alias.

## Frontend Changes (✅)
- Skill API integrates state fields (frontend/src/modules/memory/skillApi.ts, line 37 & admin path line 35)
    - When parsing list/details, map the backend's source_type -> sourceType and is_builtin -> isBuiltin to the frontend model.

- Add builtin category alias judgment in frontend (frontend/src/modules/memory/index.tsx, line 158)
    - Align with algorithm/backend to uniformly recognize various built-in spellings.

- Add isBuiltinSkillOrChild() (index.tsx, line 423)
    - Judgment logic: If the current node or its parent node category hits builtin, it is considered a read-only skill under the builtin system.

- Intercept builtin category during create/edit save (index.tsx, line 3593)
    - When saving a draft, if it is a parent skill and the category hits a reserved category, directly intercept and prompt without submitting.

- Add tags on the list page (index.tsx, line 4442)
    - Builtin parent skills display a built-in skill tag.

- Disable auto-evolution switch (index.tsx, line 4462)
    - The auto_evo Switch is disabled with a prompt for builtin skills and their child nodes.

- Disable operation columns (index.tsx, line 4518)
    - Disabled for builtin and its child nodes: Review, Edit, Share, Delete. Tooltips uniformly display memoryBuiltinCategoryReserved.

- Supplement i18n prompt text (zh-CN.ts line 1165, en-US.ts line 1235)
    - Added unified text: built-in category is reserved.    