### PR TITLE
feat(tracing): 观测业务参数透传

### DIFF
--- a/algorithm/chat/app/api/chat_routes.py
+++ b/algorithm/chat/app/api/chat_routes.py
@@ -36,6 +36,11 @@ async def chat(
     ] = None,
     user_id: Annotated[Optional[str], Body(description='User ID for loading user-specific vocabulary')] = None,
     trace: Annotated[Optional[bool], Body(description='Enable trace recording (for admin debugging only)')] = False,
+    trace_id: Annotated[Optional[str], Body(description='Caller-provided LazyLLM trace ID')] = None,
+    trace_context: Annotated[
+        Optional[Dict[str, Any]],
+        Body(description='Business context to attach to the LazyLLM trace root metadata'),
+    ] = None,
     llm_config: Annotated[
         Optional[Dict[str, Any]],
         Body(
@@ -71,6 +76,8 @@ async def chat(
         dataset=dataset,
         priority=priority,
         trace=bool(trace),
+        trace_id=(trace_id or '').strip() or None,
+        trace_context=trace_context,
         available_tools=available_tools,
         available_skills=available_skills,
         memory=memory,

--- a/algorithm/chat/app/core/chat_service.py
+++ b/algorithm/chat/app/core/chat_service.py
@@ -6,7 +6,7 @@ from typing import Any, Dict, List, Optional, Union
 import lazyllm
 from lazyllm import LOG
 import lazyllm.tracing.collect.configs  # noqa: F401
-from lazyllm.tracing import enable_trace, get_trace_context, set_trace_context
+from lazyllm.tracing import current_trace, enable_trace, get_trace_context, set_trace_context
 from lazyllm.tracing.collect import runtime as tracing_runtime
 from fastapi.responses import StreamingResponse
 from chat.components.process.sensitive_filter import SensitiveFilter
@@ -23,7 +23,8 @@ rag_sem = asyncio.Semaphore(MAX_CONCURRENCY)
 sensitive_filter = SensitiveFilter(SENSITIVE_WORDS_PATH)
 
 
-def _run_ppl_with_trace(ppl, ppl_args, *, session_id, dataset, mode_tag, trace_enabled, model_config):
+def _run_ppl_with_trace(ppl, ppl_args, *, session_id, dataset, mode_tag,
+                        trace_enabled, model_config, trace_id=None, trace_context=None):
     lazyllm.globals._init_sid(sid=session_id)
     lazyllm.locals._init_sid(sid=session_id)
     inject_model_config(model_config)
@@ -32,14 +33,19 @@ def _run_ppl_with_trace(ppl, ppl_args, *, session_id, dataset, mode_tag, trace_e
         return ppl(*ppl_args), None
 
     captured: Dict[str, Any] = {}
+    metadata = trace_context if isinstance(trace_context, dict) else None
 
     def run_chat_pipeline(*args, **kwargs):
+        trace = current_trace()
+        if trace and metadata:
+            trace.update_metadata(metadata)
         out = ppl(*args, **kwargs)
         captured['trace_id'] = get_trace_context().trace_id
         return out
 
     result = enable_trace(
         run_chat_pipeline, *ppl_args,
+        trace_id=trace_id,
         session_id=session_id,
         request_tags=[f'dataset:{dataset}', f'mode:{mode_tag}'],
         module_trace={'default': True},
@@ -51,10 +57,12 @@ def _run_ppl_with_trace(ppl, ppl_args, *, session_id, dataset, mode_tag, trace_e
     return result, trace_id
 
 
-def _set_request_trace(enabled: bool, *, session_id: str, dataset: str, mode_tag: str) -> None:
+def _set_request_trace(enabled: bool, *, session_id: str, dataset: str,
+                       mode_tag: str, trace_id: Optional[str] = None) -> None:
     set_trace_context({
         'enabled': bool(enabled),
         'sampled': True,
+        'trace_id': trace_id,
         'session_id': session_id,
         'request_tags': [f'dataset:{dataset}', f'mode:{mode_tag}'],
         'module_trace': {'default': True},
@@ -190,7 +198,9 @@ async def handle_chat(query: str, history: Optional[List[Dict[str, Any]]],
                       environment_context: Optional[Dict[str, Any]] = None,
                       user_id: Optional[str] = None,
                       model_config: Optional[Dict[str, Any]] = None,
-                      tool_config: Optional[Dict[str, str]] = None) -> Union[Dict[str, Any], StreamingResponse]:
+                      tool_config: Optional[Dict[str, str]] = None,
+                      trace_id: Optional[str] = None,
+                      trace_context: Optional[Dict[str, Any]] = None) -> Union[Dict[str, Any], StreamingResponse]:
     priority = LAZYMIND_LLM_PRIORITY if priority is None else priority
 
     start_time = time.time()
@@ -239,20 +249,34 @@ async def handle_chat(query: str, history: Optional[List[Dict[str, Any]]],
 
     async def event_stream(params: Dict[str, Any]) -> Any:
         nonlocal first_frame_logged
+        actual_trace_id = trace_id if trace else None
+        trace_metadata = trace_context if isinstance(trace_context, dict) else None
+        metadata_applied = False
         try:
             async with rag_sem:
                 _init_session()
-                async_result, trace_id = await asyncio.to_thread(
-                    _run_ppl_with_trace, agentic_rag, (params,),
+                _set_request_trace(
+                    bool(trace),
                     session_id=session_id, dataset=dataset,
                     mode_tag='stream_reasoning' if reasoning else 'stream',
-                    trace_enabled=trace, model_config=model_config,
+                    trace_id=trace_id,
                 )
-                if trace_id is not None:
+                async_result = agentic_rag(params)
+                if actual_trace_id is not None:
                     yield _sse_line(
-                        _resp(200, 'success', _attach_trace_info({}, trace_id), 0.0)
+                        _resp(200, 'success', _attach_trace_info({}, actual_trace_id), 0.0)
                     )
                 async for chunk in async_result:
+                    if trace:
+                        active_trace = current_trace()
+                        if active_trace:
+                            if trace_metadata and not metadata_applied:
+                                active_trace.update_metadata(trace_metadata)
+                                metadata_applied = True
+                            if actual_trace_id is None:
+                                actual_trace_id = active_trace.trace_id
+                        if actual_trace_id is None:
+                            actual_trace_id = get_trace_context().trace_id
                     now = time.time()
                     if not first_frame_logged:
                         first_cost = round(now - start_time, 3)
@@ -296,6 +320,17 @@ async def handle_chat(query: str, history: Optional[List[Dict[str, Any]]],
 
         cost = round(time.time() - start_time, 3)
         final_resp['cost'] = cost
+        if trace and actual_trace_id is None:
+            active_trace = current_trace()
+            if active_trace:
+                if trace_metadata and not metadata_applied:
+                    active_trace.update_metadata(trace_metadata)
+                actual_trace_id = active_trace.trace_id
+            if actual_trace_id is None:
+                actual_trace_id = get_trace_context().trace_id
+        if actual_trace_id:
+            final_resp['data'] = _attach_trace_info(final_resp['data'], actual_trace_id)
+            _flush_trace_exporter()
         yield _sse_line(final_resp)
 
         log_chat_request(query, session_id, filters, other_files, databases, image_files,

--- a/algorithm/chat/app/core/chat_service.py
+++ b/algorithm/chat/app/core/chat_service.py
@@ -232,6 +232,10 @@ async def handle_chat(query: str, history: Optional[List[Dict[str, Any]]],
         environment_context=environment_context,
         user_id=user_id,
     )
+    if isinstance(trace_context, dict):
+        query_params['trace_context'] = dict(trace_context)
+    if trace_id:
+        query_params['trace_id'] = trace_id
 
     def _init_session():
         lazyllm.globals._init_sid(sid=session_id)

--- a/algorithm/chat/pipelines/agentic.py
+++ b/algorithm/chat/pipelines/agentic.py
@@ -14,7 +14,7 @@ from typing import Any, Dict
 
 import lazyllm
 from lazyllm import loop, once_wrapper
-from lazyllm.tracing import set_trace_context
+from lazyllm.tracing import current_trace, set_trace_context
 from lazyllm.tools.agent.functionCall import FunctionCall
 from lazyllm.tools.fs.client import FS
 
@@ -337,6 +337,7 @@ async def _agentic_forward_stream(
     worker_done = threading.Event()
     output_lock = threading.Lock()
     streamed_text = False
+    trace_metadata_applied = False
     text_scanner, citation_plugin = _build_stream_citation_scanner(runtime_params)
 
     lazyllm.globals._init_sid(global_sid)
@@ -345,6 +346,18 @@ async def _agentic_forward_stream(
     _clear_orphaned_lazyllm_queue_lock()
     lazyllm.FileSystemQueue().clear()
     lazyllm.FileSystemQueue.get_instance('think').clear()
+
+    def _apply_trace_metadata() -> None:
+        nonlocal trace_metadata_applied
+        if trace_metadata_applied:
+            return
+        metadata = runtime_params.get('trace_context')
+        if not isinstance(metadata, dict):
+            return
+        trace = current_trace()
+        if trace:
+            trace.update_metadata(metadata)
+            trace_metadata_applied = True
 
     def _drain_stream_frames() -> list[dict[str, Any]]:
         nonlocal streamed_text
@@ -381,6 +394,7 @@ async def _agentic_forward_stream(
     def _emit_event(event: dict[str, Any]) -> None:
         if closed.is_set():
             return
+        _apply_trace_metadata()
         with output_lock:
             _flush_stream_frames_to_queue()
             tool_event = dict(event)
@@ -409,6 +423,7 @@ async def _agentic_forward_stream(
                 history=history,
                 stream_event_callback=_emit_event,
             )
+            _apply_trace_metadata()
             if not closed.is_set():
                 with output_lock:
                     _flush_stream_frames_to_queue()

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,6 +16,7 @@ x-mirror-args: &mirror-args
   BASE_LAZYMIND_IMAGE: ${BASE_LAZYMIND_IMAGE:-base_lazymind}
 
 x-trace-config: &trace-config
+  TZ: ${TX:-Asia/Shanghai}
   LANGFUSE_HOST: ${LANGFUSE_HOST:-}
   LANGFUSE_BASE_URL: ${LANGFUSE_BASE_URL:-}
   LANGFUSE_PUBLIC_KEY: ${LANGFUSE_PUBLIC_KEY:-}

--- a/evo/abtest/runner.py
+++ b/evo/abtest/runner.py
@@ -263,6 +263,7 @@ def _wait_health(candidate: ChatInstance, timeout_s: float = 60) -> None:
 def _phase_run_eval(c: _Ctx) -> None:
     if c.candidate is None:
         raise RuntimeError('candidate chat is not available')
+    eval_id = f'cand-{c.inputs.abtest_id}'
     report = run_eval(
         dataset_id=c.inputs.dataset_id,
         target_chat_url=f'{c.candidate.base_url}/api/chat/stream',
@@ -277,6 +278,9 @@ def _phase_run_eval(c: _Ctx) -> None:
         model_config=c.inputs.model_config,
         persist_report=False,
         attempt_id=c.inputs.abtest_id,
+        scene='abtest',
+        report_id=eval_id,
+        algorithm_version=c.inputs.apply_id,
         resume=_has_eval_partial(c),
         cancel=c.cancel,
         on_progress=lambda current, total: c.log.append_event(
@@ -290,7 +294,6 @@ def _phase_run_eval(c: _Ctx) -> None:
             payload={'current': current, 'total': total, 'dataset_id': c.inputs.dataset_id},
         ),
     )
-    eval_id = report.get('report_id') or f'cand-{c.inputs.abtest_id}'
     report['report_id'] = eval_id
     c.state['new_eval_id'] = eval_id
     _atomic_write(c.ws.eval_path(eval_id), json.dumps(report, ensure_ascii=False, indent=2))

--- a/evo/datagen/__init__.py
+++ b/evo/datagen/__init__.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 import logging
+import uuid
 from typing import Any
 from evo.datagen.attempts import save_attempt, start_attempt
 from evo.datagen.evaluate import create_evaluate_task
@@ -253,8 +254,10 @@ def run_eval(dataset_id: str, target_chat_url: str, *, cfg: EvoConfig, llm_facto
              filters: dict[str, Any] | None = None, require_trace: bool = True,
              model_config: dict[str, Any] | None = None, persist_report: bool = True, attempt_id: str | None = None,
              resume: bool = True, cancel=None, on_progress=None, on_judge_progress=None,
+             scene: str = 'eval', report_id: str | None = None, algorithm_version: str = 'baseline',
              ) -> dict[str, Any]:
     _log.info('start eval dataset_id=%s target=%s', dataset_id, target_chat_url)
+    report_id = report_id or attempt_id or uuid.uuid4().hex
     rag_workers = max(1, int(rag_max_workers or max_workers))
     judge_workers = max(1, int(judge_max_workers or max_workers))
     attempt_dir, prev = start_attempt(cfg.storage.base_dir / 'datasets' / dataset_id, 'eval_attempts', attempt_id)
@@ -263,7 +266,18 @@ def run_eval(dataset_id: str, target_chat_url: str, *, cfg: EvoConfig, llm_facto
         if resume else []
     )
     queued = [row for row in prev.get('eval_queue') or [] if row.get('case_id')] if resume else []
-    meta: dict[str, Any] = {'eval_name': dataset_id, 'eval_set_id': '', 'kb_id': ''}
+    meta: dict[str, Any] = {
+        'report_id': report_id,
+        'eval_name': dataset_id,
+        'eval_set_id': '',
+        'kb_id': '',
+    }
+    base_trace_context = {
+        'report_id': report_id,
+        'dataset_id': dataset_id,
+        'knowledge_base_id': meta.get('kb_id', ''),
+        'algorithm_version': algorithm_version,
+    }
 
     def save_eval_attempt() -> None:
         report = build_eval_report(done, meta)
@@ -279,6 +293,8 @@ def run_eval(dataset_id: str, target_chat_url: str, *, cfg: EvoConfig, llm_facto
         filters=filters or {},
         require_trace=require_trace,
         model_config=model_config,
+        scene=scene,
+        trace_context=base_trace_context,
         skip_case_ids={row.get('case_id') for row in done + queued},
         on_item=lambda item: (queued.append(item), save_eval_attempt()),
         cancel=cancel,
@@ -286,6 +302,8 @@ def run_eval(dataset_id: str, target_chat_url: str, *, cfg: EvoConfig, llm_facto
     )
     _check_cancel(cancel)
     meta.update(eval_data)
+    meta['report_id'] = report_id
+    base_trace_context['knowledge_base_id'] = meta.get('kb_id', '')
     save_eval_attempt()
     eval_queue = [row for row in _unique_by_case(queued) if row.get('case_id') not in {x.get('case_id') for x in done}]
     if not eval_queue and not done:
@@ -297,9 +315,11 @@ def run_eval(dataset_id: str, target_chat_url: str, *, cfg: EvoConfig, llm_facto
         on_item=lambda item: (done.append(item), save_eval_attempt()),
         cancel=cancel,
         on_progress=_offset_progress(on_judge_progress, _case_count(done), int(eval_data.get('total_cases') or 0)),
+        trace_context=base_trace_context,
     )
     _check_cancel(cancel)
     done = _unique_by_case(done)
+    eval_data['report_id'] = report_id
     report = build_eval_report(done, eval_data)
     save_attempt(attempt_dir, report)
     total = int(eval_data.get('total_cases') or len(done))

--- a/evo/datagen/evaluate.py
+++ b/evo/datagen/evaluate.py
@@ -38,7 +38,7 @@ def evaluate_answer(question: str, ground_truth: str, rag_answer: str, key_point
         )
         return {
             **result,
-            'judge_trace_id': expected_trace_id,
+            'judge_trace_id': captured.get('trace_id') or expected_trace_id or '',
             'judge_trace_status': trace_status(
                 require_trace=True,
                 actual_trace_id=captured.get('trace_id', ''),

--- a/evo/datagen/evaluate.py
+++ b/evo/datagen/evaluate.py
@@ -18,7 +18,7 @@ def evaluate_answer(question: str, ground_truth: str, rag_answer: str, key_point
                     trace_context: dict[str, Any] | None = None,
                     ) -> dict[str, Any]:
     if trace_context:
-        expected_trace_id = str(trace_context.get('trace_id') or '')
+        expected_trace_id = str(trace_context['trace_id']) if trace_context.get('trace_id') else None
         captured: dict[str, str] = {}
 
         def _run() -> dict[str, Any]:

--- a/evo/datagen/evaluate.py
+++ b/evo/datagen/evaluate.py
@@ -34,7 +34,6 @@ def evaluate_answer(question: str, ground_truth: str, rag_answer: str, key_point
             _run,
             trace_id=expected_trace_id,
             session_id=f"evo:judge:{trace_context.get('report_id', '')}",
-            request_tags=_judge_request_tags(trace_context),
             module_trace={'default': True},
         )
         return {
@@ -161,14 +160,3 @@ def create_evaluate_task(
     finally:
         executor.shutdown(wait=False, cancel_futures=True)
     return result_list
-
-
-def _judge_request_tags(trace_context: dict[str, Any]) -> list[str]:
-    tags = ['scene:judge']
-    report_id = str(trace_context.get('report_id') or '')
-    case_id = str(trace_context.get('case_id') or '')
-    if report_id:
-        tags.append(f'report:{report_id}')
-    if case_id:
-        tags.append(f'case:{case_id}')
-    return tags

--- a/evo/datagen/evaluate.py
+++ b/evo/datagen/evaluate.py
@@ -4,8 +4,10 @@ import logging
 import re
 from concurrent.futures import FIRST_COMPLETED, ThreadPoolExecutor, wait
 from typing import Any
+from lazyllm.tracing import current_trace, enable_trace
 from evo.datagen.llm import chat
 from evo.datagen.prompts import prompt_evaluate
+from evo.datagen.trace_context import derive_trace_context, trace_status
 from evo.harness.plan import StopRequested
 
 _log = logging.getLogger('evo.datagen.evaluate')
@@ -13,7 +15,38 @@ _log = logging.getLogger('evo.datagen.evaluate')
 
 def evaluate_answer(question: str, ground_truth: str, rag_answer: str, key_points: list[str],
                     retrieve_contexts: list[str], *, llm_factory=None,
+                    trace_context: dict[str, Any] | None = None,
                     ) -> dict[str, Any]:
+    if trace_context:
+        expected_trace_id = str(trace_context.get('trace_id') or '')
+        captured: dict[str, str] = {}
+
+        def _run() -> dict[str, Any]:
+            trace = current_trace()
+            if trace:
+                trace.update_metadata(trace_context)
+                captured['trace_id'] = trace.trace_id
+            return evaluate_answer(
+                question, ground_truth, rag_answer, key_points, retrieve_contexts, llm_factory=llm_factory
+            )
+
+        result = enable_trace(
+            _run,
+            trace_id=expected_trace_id,
+            session_id=f"evo:judge:{trace_context.get('report_id', '')}",
+            request_tags=_judge_request_tags(trace_context),
+            module_trace={'default': True},
+        )
+        return {
+            **result,
+            'judge_trace_id': expected_trace_id,
+            'judge_trace_status': trace_status(
+                require_trace=True,
+                actual_trace_id=captured.get('trace_id', ''),
+                expected_trace_id=expected_trace_id,
+            ),
+        }
+
     kp_str = ', '.join(key_points) if isinstance(key_points, list) else str(key_points)
     rc_str = '\n'.join(retrieve_contexts) if isinstance(retrieve_contexts, list) else str(retrieve_contexts)
     prompt = prompt_evaluate(question, ground_truth, rag_answer, kp_str, rc_str)
@@ -60,7 +93,16 @@ def _score01(value: Any) -> float:
     return round(score, 4)
 
 
-def create_evaluate_task(eval_queue: list[dict], *, llm_factory=None, max_workers: int = 10, on_item=None, cancel=None, on_progress=None) -> list[dict]:  # noqa: E501
+def create_evaluate_task(
+    eval_queue: list[dict],
+    *,
+    llm_factory=None,
+    max_workers: int = 10,
+    on_item=None,
+    cancel=None,
+    on_progress=None,
+    trace_context: dict[str, Any] | None = None,
+) -> list[dict]:
     result_list: list[dict] = []
     done = 0
     total = len(eval_queue)
@@ -76,6 +118,11 @@ def create_evaluate_task(eval_queue: list[dict], *, llm_factory=None, max_worker
                 item = next(iterator)
             except StopIteration:
                 return False
+            judge_trace_context = (
+                derive_trace_context(trace_context, scene='judge', case_id=str(item.get('case_id') or ''))
+                if trace_context is not None
+                else None
+            )
             pending[executor.submit(
                 evaluate_answer,
                 item['question'],
@@ -84,6 +131,7 @@ def create_evaluate_task(eval_queue: list[dict], *, llm_factory=None, max_worker
                 item.get('key_points', []),
                 item.get('retrieve_contexts', []),
                 llm_factory=llm_factory,
+                trace_context=judge_trace_context,
             )] = item
             return True
 
@@ -113,3 +161,14 @@ def create_evaluate_task(eval_queue: list[dict], *, llm_factory=None, max_worker
     finally:
         executor.shutdown(wait=False, cancel_futures=True)
     return result_list
+
+
+def _judge_request_tags(trace_context: dict[str, Any]) -> list[str]:
+    tags = ['scene:judge']
+    report_id = str(trace_context.get('report_id') or '')
+    case_id = str(trace_context.get('case_id') or '')
+    if report_id:
+        tags.append(f'report:{report_id}')
+    if case_id:
+        tags.append(f'case:{case_id}')
+    return tags

--- a/evo/datagen/queue.py
+++ b/evo/datagen/queue.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from concurrent.futures import FIRST_COMPLETED, ThreadPoolExecutor, wait
 from typing import Any
 from evo.datagen.rag_client import call_rag_chat, RAGTargetRequiredError
+from evo.datagen.trace_context import derive_trace_context
 from evo.datagen.validate import require_valid_eval_case
 from evo.harness.plan import StopRequested
 
@@ -22,6 +23,8 @@ def get_eval_queue(
     filters: dict[str, Any] | None = None,
     require_trace: bool = True,
     model_config: dict[str, Any] | None = None,
+    scene: str = 'eval',
+    trace_context: dict[str, Any] | None = None,
     skip_case_ids: set[str] | None = None,
     on_item=None,
     cancel=None,
@@ -33,6 +36,7 @@ def get_eval_queue(
         eval_data = json.load(f)
     cases = eval_data.get('cases', [])
     eval_filters = _eval_filters(filters or {}, eval_data)
+    case_trace_context = _eval_trace_context(trace_context or {}, eval_name, eval_data)
     if case_id:
         cases = [c for c in cases if c.get('case_id') == case_id]
     if skip_case_ids:
@@ -62,6 +66,8 @@ def get_eval_queue(
                 eval_filters,
                 require_trace,
                 model_config,
+                scene,
+                case_trace_context,
             )] = (case, attempt)
 
         def submit_next() -> bool:
@@ -127,6 +133,14 @@ def _eval_filters(filters: dict[str, Any], eval_data: dict[str, Any]) -> dict[st
     return out
 
 
+def _eval_trace_context(trace_context: dict[str, Any], eval_name: str, eval_data: dict[str, Any]) -> dict[str, Any]:
+    return {
+        **trace_context,
+        'dataset_id': trace_context.get('dataset_id') or eval_name,
+        'knowledge_base_id': trace_context.get('knowledge_base_id') or eval_data.get('kb_id', ''),
+    }
+
+
 def _build_eval_item(
     case: dict,
     target_chat_url: str,
@@ -134,9 +148,12 @@ def _build_eval_item(
     filters: dict[str, Any],
     require_trace: bool,
     model_config: dict[str, Any] | None,
+    scene: str,
+    trace_context: dict[str, Any] | None,
 ) -> dict:
     question = case['question']
     ground_truth = case['ground_truth']
+    case_trace_context = derive_trace_context(trace_context or {}, scene=scene, case_id=case['case_id'])
     rag_result = call_rag_chat(
         question,
         target_chat_url,
@@ -144,6 +161,8 @@ def _build_eval_item(
         filters,
         require_trace=require_trace,
         model_config=model_config,
+        trace_id=case_trace_context['trace_id'],
+        trace_context=case_trace_context,
     )
     metrics = _calculate_metrics(
         case.get('reference_chunk_ids', []),
@@ -167,6 +186,7 @@ def _build_eval_item(
         'retrieve_chunk_ids': rag_result['chunk_ids'],
         'retrieve_doc_ids': rag_result['doc_ids'],
         'trace_id': rag_result['trace_id'],
+        'trace_status': rag_result.get('trace_status', ''),
         'rag_trace': rag_result.get('trace'),
         'context_recall': metrics['context_recall'],
         'doc_recall': metrics['doc_recall'],

--- a/evo/datagen/rag_client.py
+++ b/evo/datagen/rag_client.py
@@ -141,12 +141,13 @@ def _normalize_rag_result(
     data_obj = result.get('data') if isinstance(result.get('data'), dict) else {}
     sources = result.get('sources') or data_obj.get('sources') or data_obj.get('recall') or []
     trace = data_obj.get('trace') if isinstance(data_obj.get('trace'), dict) else None
-    trace_id = result.get('trace_id') or data_obj.get('trace_id') or (trace or {}).get('trace_id') or (trace or {}).get('id') or ''  # noqa: E501
+    actual_trace_id = result.get('trace_id') or data_obj.get('trace_id') or (trace or {}).get('trace_id') or (trace or {}).get('id') or ''  # noqa: E501
     status = trace_status(
         require_trace=require_trace,
-        actual_trace_id=str(trace_id or ''),
+        actual_trace_id=str(actual_trace_id or ''),
         expected_trace_id=expected_trace_id,
     )
+    trace_id = expected_trace_id or actual_trace_id
     answer = result.get('answer') or data_obj.get('answer') or data_obj.get('text') or data_obj.get('data') or ''
     return {
         'answer': answer,

--- a/evo/datagen/rag_client.py
+++ b/evo/datagen/rag_client.py
@@ -147,7 +147,7 @@ def _normalize_rag_result(
         actual_trace_id=str(actual_trace_id or ''),
         expected_trace_id=expected_trace_id,
     )
-    trace_id = expected_trace_id or actual_trace_id
+    trace_id = actual_trace_id or expected_trace_id
     answer = result.get('answer') or data_obj.get('answer') or data_obj.get('text') or data_obj.get('data') or ''
     return {
         'answer': answer,

--- a/evo/datagen/rag_client.py
+++ b/evo/datagen/rag_client.py
@@ -6,6 +6,7 @@ import uuid
 import urllib.error
 import urllib.request
 from typing import Any
+from evo.datagen.trace_context import trace_status
 from evo.runtime.config import EVO_RAG_MAX_RETRIES, EVO_RAG_RETRY_BACKOFF_S, EVO_RAG_TIMEOUT_S
 
 _log = logging.getLogger('evo.datagen.rag_client')
@@ -25,14 +26,26 @@ class RAGTraceMissing(RuntimeError):
     kind = 'permanent'
 
 
-def call_rag_chat(question: str, target_chat_url: str, dataset_name: str = '', filters: dict[str, Any] | None = None,
-                  *, require_trace: bool = True, model_config: dict[str, Any] | None = None,
-                  ) -> dict[str, Any]:
+def call_rag_chat(
+    question: str,
+    target_chat_url: str,
+    dataset_name: str = '',
+    filters: dict[str, Any] | None = None,
+    *,
+    require_trace: bool = True,
+    model_config: dict[str, Any] | None = None,
+    trace_id: str | None = None,
+    trace_context: dict[str, Any] | None = None,
+) -> dict[str, Any]:
     if not target_chat_url:
         raise RAGTargetRequiredError('target_chat_url is required for RAG evaluation')
     target_chat_url = _stream_chat_url(target_chat_url)
     session_id = f'evo-eval-{uuid.uuid4().hex}'
     payload = {'query': question, 'trace': require_trace, 'session_id': session_id}
+    if trace_id:
+        payload['trace_id'] = trace_id
+    if isinstance(trace_context, dict):
+        payload['trace_context'] = trace_context
     if dataset_name:
         payload['dataset'] = dataset_name
     if filters:
@@ -53,7 +66,11 @@ def call_rag_chat(question: str, target_chat_url: str, dataset_name: str = '', f
                 raise RAGCallFailed(f'RAG_CALL_FAILED: invalid response {type(result).__name__}')
             code = result.get('code')
             if code in (None, 200):
-                return _normalize_rag_result(result, require_trace=require_trace)
+                return _normalize_rag_result(
+                    result,
+                    require_trace=require_trace,
+                    expected_trace_id=trace_id,
+                )
             message = result.get('msg') or result
             if not _is_retryable_chat_error(code, message) or attempt == attempts:
                 raise RAGCallFailed(f'RAG_CALL_FAILED: {message}')
@@ -116,15 +133,20 @@ def _open_rag_stream(req: urllib.request.Request) -> dict[str, Any]:
     }
 
 
-def _normalize_rag_result(result: dict[str, Any], *, require_trace: bool) -> dict[str, Any]:
+def _normalize_rag_result(
+    result: dict[str, Any], *, require_trace: bool, expected_trace_id: str | None = None
+) -> dict[str, Any]:
     if not isinstance(result, dict):
         raise RAGCallFailed(f'RAG_CALL_FAILED: invalid response {type(result).__name__}')
     data_obj = result.get('data') if isinstance(result.get('data'), dict) else {}
     sources = result.get('sources') or data_obj.get('sources') or data_obj.get('recall') or []
     trace = data_obj.get('trace') if isinstance(data_obj.get('trace'), dict) else None
     trace_id = result.get('trace_id') or data_obj.get('trace_id') or (trace or {}).get('trace_id') or (trace or {}).get('id') or ''  # noqa: E501
-    if require_trace and not trace_id and not trace:
-        raise RAGTraceMissing('target chat did not return trace_id or inline trace')
+    status = trace_status(
+        require_trace=require_trace,
+        actual_trace_id=str(trace_id or ''),
+        expected_trace_id=expected_trace_id,
+    )
     answer = result.get('answer') or data_obj.get('answer') or data_obj.get('text') or data_obj.get('data') or ''
     return {
         'answer': answer,
@@ -134,6 +156,7 @@ def _normalize_rag_result(result: dict[str, Any], *, require_trace: bool) -> dic
         'chunk_ids': result.get('chunk_ids') or _pluck_any(sources, ('chunk_id', 'segment_id', 'segement_id')),
         'doc_ids': result.get('doc_ids') or _pluck_any(sources, ('doc_id', 'document_id')),
         'trace_id': trace_id,
+        'trace_status': status,
         'trace': trace,
     }
 

--- a/evo/datagen/trace_context.py
+++ b/evo/datagen/trace_context.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+import uuid
+from typing import Any
+
+
+TRACE_CONTEXT_BASE_KEYS = (
+    'report_id',
+    'dataset_id',
+    'knowledge_base_id',
+    'algorithm_version',
+)
+
+TRACE_CONTEXT_KEYS = (
+    'trace_id',
+    'scene',
+    *TRACE_CONTEXT_BASE_KEYS,
+    'case_id',
+)
+
+
+def new_trace_id() -> str:
+    return uuid.uuid4().hex
+
+
+def derive_trace_context(base: dict[str, Any] | None, *, scene: str, case_id: str) -> dict[str, Any]:
+    context = {
+        key: _clean_value((base or {}).get(key, ''))
+        for key in TRACE_CONTEXT_BASE_KEYS
+    }
+    context.update(
+        {
+            'trace_id': new_trace_id(),
+            'scene': _clean_value(scene),
+            'case_id': _clean_value(case_id),
+        }
+    )
+    return {key: context[key] for key in TRACE_CONTEXT_KEYS}
+
+
+def _clean_value(value: Any) -> str:
+    return '' if value is None else str(value)
+
+
+__all__ = [
+    'TRACE_CONTEXT_BASE_KEYS',
+    'TRACE_CONTEXT_KEYS',
+    'derive_trace_context',
+    'new_trace_id',
+]

--- a/evo/datagen/trace_context.py
+++ b/evo/datagen/trace_context.py
@@ -38,6 +38,16 @@ def derive_trace_context(base: dict[str, Any] | None, *, scene: str, case_id: st
     return {key: context[key] for key in TRACE_CONTEXT_KEYS}
 
 
+def trace_status(*, require_trace: bool, actual_trace_id: str, expected_trace_id: str | None = None) -> str:
+    if not require_trace:
+        return 'trace_disabled'
+    if not actual_trace_id:
+        return 'trace_missing'
+    if expected_trace_id and actual_trace_id != expected_trace_id:
+        return 'trace_collection_failed'
+    return 'success'
+
+
 def _clean_value(value: Any) -> str:
     return '' if value is None else str(value)
 
@@ -47,4 +57,5 @@ __all__ = [
     'TRACE_CONTEXT_KEYS',
     'derive_trace_context',
     'new_trace_id',
+    'trace_status',
 ]

--- a/evo/datagen/writer.py
+++ b/evo/datagen/writer.py
@@ -32,7 +32,7 @@ def build_eval_report(eval_results: list[dict], eval_data: dict) -> dict[str, An
         round(sum(answer_correctness_list) / len(answer_correctness_list), 4) if answer_correctness_list else 0.0
     )
     return {
-        'report_id': str(uuid.uuid4()),
+        'report_id': eval_data.get('report_id') or str(uuid.uuid4()),
         'dataset_id': eval_data.get('eval_name', ''),
         'eval_name': eval_data.get('eval_name', ''),
         'eval_set_id': eval_data.get('eval_set_id', ''),

--- a/evo/service/executors/eval_.py
+++ b/evo/service/executors/eval_.py
@@ -67,6 +67,9 @@ def execute(ctx: ExecCtx, tid: str) -> None:
                 model_config=model_config,
                 persist_report=False,
                 attempt_id=tid,
+                scene='eval',
+                report_id=tid,
+                algorithm_version='baseline',
                 resume=bool(payload.get('resume', True)),
                 cancel=token.requested,
                 on_progress=lambda current, total: elog.append_event(


### PR DESCRIPTION
## 概述

为 evo 评测与 A/B 测试打通端到端 trace 关联：调用方可以向 chat 传入 `trace_id` / `trace_context`，RAG chat、judge 与队列任务会使用一致的 case 级 trace 上下文，并将业务字段写入 LazyLLM trace metadata，便于按 `report_id`、`dataset_id`、`knowledge_base_id`、`algorithm_version`、`scene`、`case_id` 等维度检索与分析观测数据。

## 变更说明

### Chat / Agentic

- `/api/chat/stream` 新增 `trace_id`、`trace_context` 请求字段，并透传到 `handle_chat`。
- `handle_chat` 将 `trace_id` / `trace_context` 写入 agentic runtime params，确保 agentic worker 线程能拿到业务上下文。
- 流式 chat 通过 `set_trace_context` 传入 `trace_id`，并在 SSE 响应中返回实际 `trace_id`。
- `agentic.py` 在 worker 线程内读取 `runtime_params['trace_context']`，通过 `current_trace().update_metadata(...)` 幂等写入 LazyLLM trace metadata，避免只在外层 SSE 线程写 metadata 导致 root trace 不可见。
- 更新 `algorithm/lazyllm` 子模块到 `252b0dd`，包含 LazyLLM 侧流式 tracing 相关支持。

### Evo datagen / A/B

- 新增 `evo/datagen/trace_context.py`，统一 trace 上下文字段与派生逻辑：
  - `trace_id`
  - `scene`
  - `report_id`
  - `dataset_id`
  - `knowledge_base_id`
  - `algorithm_version`
  - `case_id`
- `queue.py` 为每个 eval case 派生 case 级 trace context，并传入 RAG chat。
- `rag_client.py` 在调用 chat 时发送 `trace_id` / `trace_context`，并规范化返回中的 `trace_id` 与 `trace_status`。
- `evaluate.py` 为 judge 阶段派生独立 trace context，使用 `enable_trace(trace_id=...)` 建立关联，并写入 judge trace metadata。
- eval / A-B 入口与报告写入链路透传 trace context，确保 RAG、judge、队列任务使用同一套业务维度。

## 验证

- 已完成 main rebase 并解决冲突。
- 已执行：
  - `python -m py_compile algorithm/chat/app/core/chat_service.py`
  - `python -m py_compile algorithm/chat/pipelines/agentic.py`

## 注意

- 本 PR 不修改 LazyTraceContext 的 schema；`trace_context` 作为业务 metadata 通过 chat agentic runtime params 进入 worker 线程，并在当前 LazyLLM trace 可见时写入 metadata。
