### PR TITLE
 fix(Tracing): trace agentic RAG retrieval components

### DIFF
--- a/algorithm/chat/components/process/adaptive_topk.py
+++ b/algorithm/chat/components/process/adaptive_topk.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple
 
-from lazyllm import LOG
+from lazyllm import LOG, ModuleBase
 
 
 # ------------- utility functions -----------------
@@ -129,18 +129,19 @@ def adaptive_k_select_from_nodes(
     return selected, k, diag
 
 
-class AdaptiveKComponent:
+class AdaptiveKComponent(ModuleBase):
     def __init__(
         self,
         get_score: Callable[[Any], float] = lambda n: n.relevance_score,
         get_token_len: Optional[Callable[[Any], int]] = None,
         **kwargs,
     ):
+        super().__init__()
         self.get_score = get_score
         self.get_token_len = get_token_len
         self.kwargs = kwargs or {}
 
-    def __call__(self, nodes: List[Any], **kwargs) -> List[Any]:
+    def forward(self, nodes: List[Any], **kwargs) -> List[Any]:
         self.kwargs.update(kwargs or {})
         selected, k, diag = adaptive_k_select_from_nodes(
             nodes,

--- a/algorithm/chat/components/process/context_expansion.py
+++ b/algorithm/chat/components/process/context_expansion.py
@@ -1,6 +1,6 @@
 import time
 from typing import List, Optional, Set, Tuple
-from lazyllm import LOG, Document
+from lazyllm import LOG, Document, ModuleBase
 from lazyllm.tools.rag import DocNode
 
 _RPC_RETRIES = 2
@@ -39,10 +39,12 @@ def _relevance_key(n: DocNode) -> Tuple:
     return (-(getattr(n, 'relevance_score', 0.0) or 0.0), n.uid)
 
 
-class ContextExpansionComponent:
+class ContextExpansionComponent(ModuleBase):
     def __init__(self, document: Document, token_budget: int = 3000,
                  score_decay: float = 0.98, max_seeds: Optional[int] = None,
-                 max_new_nodes_per_seed: int = 2):
+                 max_new_nodes_per_seed: int = 2,
+                 return_trace: bool = False, **kwargs):
+        super().__init__(return_trace=return_trace, **kwargs)
         self.document = document
         self.token_budget = token_budget
         self.score_decay = score_decay
@@ -73,7 +75,7 @@ class ContextExpansionComponent:
         neighbors.sort(key=_node_sort_key)
         return neighbors
 
-    def __call__(self, nodes: List[DocNode], **kwargs) -> List[DocNode]:
+    def forward(self, nodes: List[DocNode], **kwargs) -> List[DocNode]:
         if not nodes:
             return nodes
         seeds = sorted(nodes, key=_relevance_key)

--- a/algorithm/chat/pipelines/agentic.py
+++ b/algorithm/chat/pipelines/agentic.py
@@ -77,7 +77,7 @@ def _augment_query_with_attached_images(query: str, config: dict[str, Any]) -> s
         rewriter = QueryImageRewriter(
             vlm=AutoModel(model='vlm', config=get_config_path()),
         )
-        out = rewriter.forward(payload)
+        out = rewriter(payload)
         if isinstance(out, dict):
             nq = out.get('query')
             if isinstance(nq, str) and nq.strip():

--- a/algorithm/vocab/vocab_manager.py
+++ b/algorithm/vocab/vocab_manager.py
@@ -20,14 +20,14 @@ from __future__ import annotations
 import threading
 from typing import Callable, List, Optional, Union
 
-from lazyllm import LOG, AutoModel
+from lazyllm import LOG, AutoModel, ModuleBase
 from lazyllm.tools.rag.query_enh_ac import QueryEnhACProcessor
 from chat.utils.load_config import get_config_path
 
 from .db import fetch_vocab_for_user_id
 
 
-class VocabManager:
+class VocabManager(ModuleBase):
     """Single-user vocabulary manager: bound to one user_id, loads vocabulary from DB, supports hot-reload.
 
     Args:
@@ -37,6 +37,7 @@ class VocabManager:
     """
 
     def __init__(self, user_id: str = '', *, data_source: Optional[Callable] = None) -> None:
+        super().__init__()
         self._user_id = user_id
         self._lock = threading.RLock()
         actual_source = data_source if data_source is not None else self._load_from_db
@@ -88,7 +89,7 @@ class VocabManager:
             LOG.info(f'[VocabManager] reloaded for user_id={self._user_id!r}, vocab_size={count}')
             return count
 
-    def __call__(self, query: Union[str, List]) -> Union[str, List]:
+    def forward(self, query: Union[str, List]) -> Union[str, List]:
         """Enhance the query using the vocabulary and return;
         returns as-is when vocabulary is empty, no match survives filtering, or enhancement fails."""
         with self._lock:


### PR DESCRIPTION
 ## 概述

  为 agentic RAG 检索链路补齐关键处理组件的 trace 观测：让检索后处理、图像 query 改写和词表增强管理统一经过 `ModuleBase.__call__`，从而被 LazyLLM tracing hook 捕获，便于在 Langfuse 中定位检索流程中的 query 改写、adaptive top-k、上下文扩展等步骤。

## 效果截图
<img width="433" height="554" alt="image" src="https://github.com/user-attachments/assets/e3cea3c3-3a10-4281-8ba4-5c6d7033548c" />


  ## 变更说明

  ### Chat / Agentic RAG

  - `AdaptiveKComponent` 继承 `ModuleBase`，将原 `__call__` 执行逻辑迁移到 `forward()`，确保 adaptive top-k 阶段进入 trace。
  - `ContextExpansionComponent` 继承 `ModuleBase`，将原 `__call__` 执行逻辑迁移到 `forward()`，确保上下文扩展阶段进入 trace。
  - `QueryImageRewriter` 调用方式从 `rewriter.forward(payload)` 改为 `rewriter(payload)`，避免绕过 `ModuleBase.__call__` hook。
  - `VocabManager` 继承 `ModuleBase`，将词表增强入口从 `__call__` 迁移到 `forward()`，使 trace 能展示 `parse_query -> VocabManager` 的调用关系。
  -
