### PR TITLE
feat: add VITE_HIDE_EVO env var to hide Self-Evolution page in frontend

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -66,3 +66,10 @@
 #   container — file-watcher runs as a Docker service (recommended)
 #   host      — file-watcher runs as a host process (for local debugging)
 #LAZYMIND_FILE_WATCHER_MODE=container
+
+# Frontend feature flags
+# ---------------------------------------------------------------------------
+# VITE_HIDE_EVO: hide the Self-Evolution (Evo) page from the web UI.
+#   Not set (default) — Evo page is visible
+#   Set to any value   — Evo page is hidden
+#VITE_HIDE_EVO=true

--- a/frontend/src/layouts/MainLayout.tsx
+++ b/frontend/src/layouts/MainLayout.tsx
@@ -148,13 +148,14 @@ export default function MainLayout() {
       icon: <ApiOutlined />,
     },
   ];
+  const hideEvo = !!import.meta.env.VITE_HIDE_EVO;
   const aiEvolutionNavItems = [
     {
       key: "/memory-management",
       label: t("layout.memoryManagement"),
       icon: <AppstoreOutlined />,
     },
-    ...(isAdminUser && developerActive
+    ...(isAdminUser && developerActive && !hideEvo
       ? [
           {
             key: "/self-evolution",
@@ -239,10 +240,10 @@ export default function MainLayout() {
   }, [developerActive, isAdminUser]);
 
   useEffect(() => {
-    if (pathname.startsWith("/self-evolution") && (!isAdminUser || !developerActive)) {
+    if (pathname.startsWith("/self-evolution") && (hideEvo || !isAdminUser || !developerActive)) {
       navigate("/agent/chat", { replace: true });
     }
-  }, [pathname, isAdminUser, developerActive, navigate]);
+  }, [pathname, isAdminUser, developerActive, navigate, hideEvo]);
 
   useEffect(() => {
     if (!pathname.startsWith("/agent/chat")) {

--- a/frontend/src/layouts/MainLayout.tsx
+++ b/frontend/src/layouts/MainLayout.tsx
@@ -148,7 +148,7 @@ export default function MainLayout() {
       icon: <ApiOutlined />,
     },
   ];
-  const hideEvo = !!import.meta.env.VITE_HIDE_EVO;
+  const hideEvo = import.meta.env.VITE_HIDE_EVO === "true";
   const aiEvolutionNavItems = [
     {
       key: "/memory-management",

--- a/frontend/src/vite-env.d.ts
+++ b/frontend/src/vite-env.d.ts
@@ -2,6 +2,7 @@
 
 interface ImportMetaEnv {
   readonly VITE_API_BASE_URL: string;
+  readonly VITE_HIDE_EVO?: string;
 }
 
 interface ImportMeta {


### PR DESCRIPTION
## Summary

  Add a `VITE_HIDE_EVO` environment variable to optionally hide the Self-Evolution (Evo) page from the web UI.

  - When the variable is not set (default), Evo page remains visible — no behavior change
  - When set to any value (e.g. `VITE_HIDE_EVO=true`), the sidebar nav entry is hidden and direct URL access redirects to the chat page
  - Frontend-only change, no backend modifications

  ## Changes

  - `frontend/src/vite-env.d.ts` — add `VITE_HIDE_EVO` type declaration
  - `frontend/src/layouts/MainLayout.tsx` — conditionally hide nav item & add route guard
  - `.env.example` — add configuration documentation

  ## Usage

  ```env
  # Set at build time or in frontend/.env
  VITE_HIDE_EVO=true