### PR TITLE
[feature] Add enable_trace in chat api

### DIFF
--- a/algorithm/lazymind/chat/service/chat_service.py
+++ b/algorithm/lazymind/chat/service/chat_service.py
@@ -4,7 +4,7 @@ import json
 import time
 from typing import Any, Dict, List, Optional, Union
 import lazyllm
-from lazyllm import LOG
+from lazyllm import LOG, set_trace_context
 from fastapi.responses import StreamingResponse
 from lazymind.chat.config import (
     LAZYMIND_LLM_PRIORITY,
@@ -116,6 +116,14 @@ async def handle_chat(query: str, history: Optional[List[Dict[str, Any]]],
     inject_tool_config(tool_config)
     lazyllm.globals['agentic_config'] = agentic_config
     active_configs = filter_tools(DEFAULT_TOOLS, available_tools)
+    set_trace_context({
+        'enabled': bool(trace),
+        'trace_id': session_id if trace else None,
+        'session_id': session_id,
+        'sampled': True,
+        'module_trace': {'default': True},
+        'request_tags': ['handle_chat'],
+    })
     runtime_prompt = build_system_prompt(
         {cfg.name for cfg in active_configs},
         environment_context=environment_context,


### PR DESCRIPTION
# PR 内容
基于重构后的 chat 接口加入观测开关
只需要在 chat_service.py 文件里设置观测上下文参数即可。

# 本地验证
- 本地验证了 enable_trace=True/False 两种场景，可以正常得到观测数据
<img width="459" height="440" alt="image" src="https://github.com/user-attachments/assets/07caaafc-385c-4b88-8b9c-3c779fe5d81c" />

- module_trace 部分 disable 验证生效
```python
set_trace_context({
    'enabled': bool(trace),
    'trace_id': session_id if trace else None,
    'session_id': session_id,
    'sampled': True,
    'module_trace': {
        'default': True,
        'by_name': {'llm': False},
        'by_class': {'OnlineChatModule': False},
    },
    'request_tags': ['handle_chat'],
})
```

# 备注
依赖 evo 部分传入 32hex 格式的 session_id 作为观测数据，且接口中的 `trace` 参数为 true.