### PR TITLE
Fix Feishu Wiki tree pagination, selection, and subtree sync

### DIFF
--- a/backend/scan-control-plane/internal/sourceengine/connector/feishu/connector_test.go
+++ b/backend/scan-control-plane/internal/sourceengine/connector/feishu/connector_test.go
@@ -291,6 +291,89 @@ func TestWikiFetchAndMarkdownExport(t *testing.T) {
 	if exported.ContentURI != "scan-temp://feishu-1" || exported.MimeType != "text/markdown" || temp.objects["feishu-1"] != "wiki:node-child" {
 		t.Fatalf("unexpected wiki export: %+v", exported)
 	}
+
+	exportedOriginal, err := conn.ExportObject(ctx, connector.ExportObjectRequest{
+		ObjectKey:     normalized.ObjectKey,
+		SourceVersion: normalized.SourceVersion,
+		ExportFormat:  connector.ExportFormatOriginal,
+		ProviderMeta:  normalized.ProviderMeta,
+	})
+	if err != nil {
+		t.Fatalf("export wiki original should use markdown export: %v", err)
+	}
+	if exportedOriginal.ContentURI != "scan-temp://feishu-2" || exportedOriginal.MimeType != "text/markdown" || temp.objects["feishu-2"] != "wiki:node-child" {
+		t.Fatalf("unexpected wiki original export: %+v", exportedOriginal)
+	}
+}
+
+func TestWikiPartialFetchWithObjectKeyReturnsSelectedNode(t *testing.T) {
+	t.Parallel()
+
+	conn := NewFeishuConnector(&authStub{}, newFeishuAPIStub())
+	page, err := conn.FetchPage(context.Background(), connector.FetchPageRequest{
+		SourceID:          "source-1",
+		BindingID:         "binding-1",
+		BindingGeneration: 1,
+		TargetType:        TargetTypeWikiNode,
+		TargetRef:         "space-1:node-root",
+		ScopeType:         connector.ScopeTypePartial,
+		ScopeRef:          connector.ScopeRef{"object_key": "feishu:wiki:space-1:node-root"},
+		PageSize:          10,
+		AuthConnectionID:  "auth-1",
+	})
+	if err != nil {
+		t.Fatalf("partial fetch wiki object: %v", err)
+	}
+	if got := feishuObjectKeys(page.Items); !sameStrings(got, []string{"feishu:wiki:space-1:node-root"}) {
+		t.Fatalf("partial object fetch should return selected wiki node, got %v", got)
+	}
+}
+
+func TestWikiListClampsProviderPageSizeToOpenAPILimit(t *testing.T) {
+	t.Parallel()
+
+	api := newFeishuAPIStub()
+	conn := NewFeishuConnector(&authStub{}, api)
+	_, err := conn.ListChildren(context.Background(), connector.ListChildrenRequest{
+		TargetType:       TargetTypeWikiNode,
+		TargetRef:        "space-1:node-root",
+		PageSize:         100,
+		AuthConnectionID: "auth-1",
+	})
+	if err != nil {
+		t.Fatalf("list wiki children: %v", err)
+	}
+	if len(api.wikiPageSizes) != 1 || api.wikiPageSizes[0] != 50 {
+		t.Fatalf("wiki list should clamp provider page_size to 50, got %v", api.wikiPageSizes)
+	}
+
+	_, err = conn.ListChildren(context.Background(), connector.ListChildrenRequest{
+		TargetType:       TargetTypeDriveFolder,
+		TargetRef:        "folder-root",
+		PageSize:         100,
+		AuthConnectionID: "auth-1",
+	})
+	if err != nil {
+		t.Fatalf("list drive children: %v", err)
+	}
+	if len(api.drivePageSizes) != 1 || api.drivePageSizes[0] != 100 {
+		t.Fatalf("drive list should keep provider page_size, got %v", api.drivePageSizes)
+	}
+
+	_, err = conn.FetchPage(context.Background(), connector.FetchPageRequest{
+		BindingGeneration: 1,
+		TargetType:        TargetTypeWikiNode,
+		TargetRef:         "space-1:node-root",
+		ScopeType:         connector.ScopeTypeFull,
+		PageSize:          100,
+		AuthConnectionID:  "auth-1",
+	})
+	if err != nil {
+		t.Fatalf("fetch wiki children: %v", err)
+	}
+	if len(api.wikiPageSizes) != 2 || api.wikiPageSizes[1] != 50 {
+		t.Fatalf("wiki fetch should clamp provider page_size to 50, got %v", api.wikiPageSizes)
+	}
 }
 
 func TestSearchReturnsUnsupportedForUnimplementedScopeAndDeltaUnsupported(t *testing.T) {
@@ -359,6 +442,8 @@ type feishuAPIStub struct {
 	driveChildren    map[string][]Object
 	wikiChildren     map[string][]Object
 	wikiSpaces       []Object
+	drivePageSizes   []int
+	wikiPageSizes    []int
 	driveFolderCalls int
 	downloadCalls    int
 	driveExportCalls int
@@ -404,6 +489,7 @@ func (a *feishuAPIStub) GetDriveFolder(context.Context, string, string) (Object,
 }
 
 func (a *feishuAPIStub) ListDriveChildren(_ context.Context, _ string, folderToken, cursor string, pageSize int) (ObjectPage, error) {
+	a.drivePageSizes = append(a.drivePageSizes, pageSize)
 	return objectPage(a.driveChildren[driveFolderToken(folderToken)], cursor, pageSize)
 }
 
@@ -426,6 +512,7 @@ func (a *feishuAPIStub) ExportDriveDocumentMarkdown(_ context.Context, _ string,
 }
 
 func (a *feishuAPIStub) ListWikiSpaces(_ context.Context, _ string, cursor string, pageSize int) (ObjectPage, error) {
+	a.wikiPageSizes = append(a.wikiPageSizes, pageSize)
 	return objectPage(a.wikiSpaces, cursor, pageSize)
 }
 
@@ -434,6 +521,7 @@ func (a *feishuAPIStub) GetWikiNode(_ context.Context, _ string, spaceID, nodeTo
 }
 
 func (a *feishuAPIStub) ListWikiChildren(_ context.Context, _ string, spaceID, nodeToken, cursor string, pageSize int) (ObjectPage, error) {
+	a.wikiPageSizes = append(a.wikiPageSizes, pageSize)
 	return objectPage(a.wikiChildren[spaceID+":"+nodeToken], cursor, pageSize)
 }
 

--- a/backend/scan-control-plane/internal/sourceengine/connector/feishu/export.go
+++ b/backend/scan-control-plane/internal/sourceengine/connector/feishu/export.go
@@ -40,7 +40,7 @@ func (c *FeishuConnector) locateObject(req connector.ExportObjectRequest) (expor
 			return exportTarget{}, connector.NewError(connector.ErrorCodeUnsupported, "drive file export_format is not supported")
 		}
 	case ObjectKindWikiNode:
-		if req.ExportFormat != "" && req.ExportFormat != connector.ExportFormatMarkdown {
+		if req.ExportFormat != "" && req.ExportFormat != connector.ExportFormatOriginal && req.ExportFormat != connector.ExportFormatMarkdown {
 			return exportTarget{}, connector.NewError(connector.ErrorCodeUnsupported, "wiki export_format is not supported")
 		}
 		if target.spaceID == "" {

--- a/backend/scan-control-plane/internal/sourceengine/connector/feishu/fetch.go
+++ b/backend/scan-control-plane/internal/sourceengine/connector/feishu/fetch.go
@@ -21,7 +21,12 @@ func (c *FeishuConnector) validateFetchRequest(req connector.FetchPageRequest) e
 
 func (c *FeishuConnector) fetchOnePage(ctx context.Context, token string, req connector.FetchPageRequest) (connector.RawObjectPage, error) {
 	switch req.ScopeType {
-	case connector.ScopeTypeFull, connector.ScopeTypePartial:
+	case connector.ScopeTypeFull:
+		return c.fetchListPage(ctx, token, req)
+	case connector.ScopeTypePartial:
+		if req.TargetType == TargetTypeWikiNode && scopeNodeRef(req.ScopeRef) != "" {
+			return c.fetchWatchObject(ctx, token, req)
+		}
 		return c.fetchListPage(ctx, token, req)
 	case connector.ScopeTypeWatchEvent:
 		return c.fetchWatchObject(ctx, token, req)
@@ -37,7 +42,7 @@ func (c *FeishuConnector) fetchListPage(ctx context.Context, token string, req c
 	if scoped := scopeNodeRef(req.ScopeRef); scoped != "" {
 		targetRef = scoped
 	}
-	page, err := c.listProviderPage(ctx, token, req.TargetType, req.TargetRef, targetRef, req.Cursor, req.PageSize)
+	page, err := c.listProviderPage(ctx, token, req.TargetType, req.TargetRef, targetRef, req.Cursor, providerPageSize(req.TargetType, targetRef, req.PageSize))
 	if err != nil {
 		return connector.RawObjectPage{}, err
 	}

--- a/backend/scan-control-plane/internal/sourceengine/connector/feishu/list.go
+++ b/backend/scan-control-plane/internal/sourceengine/connector/feishu/list.go
@@ -33,7 +33,7 @@ func (c *FeishuConnector) validateListRequest(req connector.ListChildrenRequest)
 }
 
 func (c *FeishuConnector) listOnePage(ctx context.Context, token string, req connector.ListChildrenRequest, cursor string) (connector.RawObjectPage, error) {
-	page, err := c.listProviderPage(ctx, token, req.TargetType, req.TargetRef, req.NodeRef, cursor, req.PageSize)
+	page, err := c.listProviderPage(ctx, token, req.TargetType, req.TargetRef, req.NodeRef, cursor, providerPageSize(req.TargetType, req.NodeRef, req.PageSize))
 	if err != nil {
 		return connector.RawObjectPage{}, err
 	}
@@ -86,6 +86,13 @@ func (c *FeishuConnector) listProviderPage(ctx context.Context, token string, ta
 	default:
 		return ObjectPage{}, connector.NewError(connector.ErrorCodeInvalidTarget, "target_type is not supported")
 	}
+}
+
+func providerPageSize(targetType connector.TargetType, nodeRef string, pageSize int) int {
+	if targetType == TargetTypeWikiNode {
+		return min(pageSize, 50)
+	}
+	return pageSize
 }
 
 func (c *FeishuConnector) listDriveRootChildren(ctx context.Context, token, cursor string, pageSize int) (ObjectPage, error) {

--- a/backend/scan-control-plane/internal/sourceengine/crawl/engine_test.go
+++ b/backend/scan-control-plane/internal/sourceengine/crawl/engine_test.go
@@ -186,6 +186,38 @@ func TestCrawlEngineFullWritesBindingRootAndNormalizesDirectChildren(t *testing.
 	}
 }
 
+func TestCrawlEngineFullIndexesDualRoleBindingRootDocument(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	now := crawlTestTime()
+	repo := newCrawlTestRepo(now)
+	repo.binding.ConnectorType = string(crawlDualRoleConnectorType)
+	conn := newCrawlTreeConnector(false, false, []connector.RawObject{docRaw("root", "", "root-v1")})
+	conn.connectorType = crawlDualRoleConnectorType
+	conn.dualRole = true
+	engine := newCrawlTestEngine(t, repo, conn, now)
+
+	result, err := engine.Run(ctx, BindingRunClaim{
+		RunID:             "run-dual-root",
+		SourceID:          "source-1",
+		BindingID:         "binding-1",
+		BindingGeneration: 1,
+		ScopeType:         connector.ScopeTypeFull,
+	})
+	if err != nil || result.Status != RunStatusSucceeded {
+		t.Fatalf("full dual-role result=%+v err=%v", result, err)
+	}
+	if conn.fetchCalls != 1 || !slices.Equal(conn.fetchScopes, []connector.ScopeType{connector.ScopeTypeWatchEvent}) {
+		t.Fatalf("expected one root fetch before BFS, calls=%d scopes=%v", conn.fetchCalls, conn.fetchScopes)
+	}
+	root := repo.objects["root"]
+	if root.ObjectKey != "root" || !root.IsDocument || root.SourceVersion != "root-v1" {
+		t.Fatalf("dual-role binding root document was not indexed: %+v", root)
+	}
+	assertCrawlState(t, repo.reducer, "root", "NEW", "CREATE")
+}
+
 func TestCrawlEnginePermissionDeniedMarksBindingErrorWithoutDeleting(t *testing.T) {
 	t.Parallel()
 
@@ -430,18 +462,21 @@ func firstTime(value, fallback time.Time) time.Time {
 }
 
 type crawlTreeConnector struct {
-	recursive   bool
-	delta       bool
-	deltaItems  []connector.RawObject
-	fetchErr    error
-	fetchCalls  int
-	fetchScopes []connector.ScopeType
-	listNodes   []string
+	connectorType connector.ConnectorType
+	recursive     bool
+	delta         bool
+	dualRole      bool
+	deltaItems    []connector.RawObject
+	fetchErr      error
+	fetchCalls    int
+	fetchScopes   []connector.ScopeType
+	listNodes     []string
 }
 
 const (
-	crawlTreeConnectorType connector.ConnectorType = "crawl_tree"
-	crawlTreeTargetType    connector.TargetType    = "crawl_tree_root"
+	crawlTreeConnectorType     connector.ConnectorType = "crawl_tree"
+	crawlDualRoleConnectorType connector.ConnectorType = "crawl_dual_role_tree"
+	crawlTreeTargetType        connector.TargetType    = "crawl_tree_root"
 )
 
 func newCrawlTreeConnector(recursive, delta bool, deltaItems []connector.RawObject) *crawlTreeConnector {
@@ -449,11 +484,16 @@ func newCrawlTreeConnector(recursive, delta bool, deltaItems []connector.RawObje
 }
 
 func (c *crawlTreeConnector) Spec() connector.ConnectorSpec {
+	connectorType := c.connectorType
+	if connectorType == "" {
+		connectorType = crawlTreeConnectorType
+	}
 	return connector.ConnectorSpec{
-		ConnectorType:          crawlTreeConnectorType,
+		ConnectorType:          connectorType,
 		TargetTypes:            []connector.TargetType{crawlTreeTargetType},
 		SupportsDelta:          c.delta,
 		SupportsRecursiveFetch: c.recursive,
+		SupportsDualRoleObject: c.dualRole,
 		MaxPageSize:            100,
 	}
 }

--- a/backend/scan-control-plane/internal/sourceengine/crawl/strategy_full.go
+++ b/backend/scan-control-plane/internal/sourceengine/crawl/strategy_full.go
@@ -9,6 +9,8 @@ import (
 type FullCrawlStrategy struct {
 	strategyBase
 	recursive bool
+	fetchRoot bool
+	rootDone  bool
 	queue     []string
 	active    bfsContainer
 }
@@ -23,6 +25,7 @@ func NewFullCrawlStrategy(input strategyInput) *FullCrawlStrategy {
 	s := &FullCrawlStrategy{
 		strategyBase: newStrategyBase(input, connector.ScopeTypeFull),
 		recursive:    input.spec.SupportsRecursiveFetch,
+		fetchRoot:    !input.spec.SupportsRecursiveFetch && input.spec.SupportsDualRoleObject,
 	}
 	if !s.recursive {
 		s.queue = []string{""}
@@ -63,6 +66,9 @@ func (s *FullCrawlStrategy) nextRecursiveRequest() (CrawlRequest, bool, error) {
 }
 
 func (s *FullCrawlStrategy) nextBFSRequest() (CrawlRequest, bool, error) {
+	if s.fetchRoot && !s.rootDone {
+		return CrawlRequest{Kind: CrawlRequestKindFetch, Fetch: s.fetchRequest(connector.ScopeTypeWatchEvent, "")}, false, nil
+	}
 	if !s.active.set {
 		if len(s.queue) == 0 {
 			s.done = true
@@ -79,6 +85,10 @@ func (s *FullCrawlStrategy) nextBFSRequest() (CrawlRequest, bool, error) {
 
 func (s *FullCrawlStrategy) observeBFSPage(page connector.RawObjectPage) {
 	s.builder.observePage(page)
+	if s.fetchRoot && !s.rootDone {
+		s.rootDone = true
+		return
+	}
 	for _, raw := range page.Items {
 		if raw.IsContainer || raw.HasChildren {
 			s.queue = append(s.queue, nodeRefForRaw(raw))

--- a/backend/scan-control-plane/internal/sourceengine/crawl/strategy_test.go
+++ b/backend/scan-control-plane/internal/sourceengine/crawl/strategy_test.go
@@ -66,6 +66,39 @@ func TestFullStrategyUsesBFSListChildrenFallback(t *testing.T) {
 	}
 }
 
+func TestFullStrategyFetchesDualRoleRootBeforeBFSChildren(t *testing.T) {
+	t.Parallel()
+
+	strategy := NewFullCrawlStrategy(strategyInput{
+		binding: strategyBinding(),
+		spec: connector.ConnectorSpec{
+			SupportsRecursiveFetch: false,
+			SupportsDualRoleObject: true,
+		},
+		claim:    strategyClaim(connector.ScopeTypeFull, nil),
+		pageSize: 10,
+	})
+
+	req, done, err := strategy.NextRequest(context.Background(), CrawlLoopState{})
+	if err != nil || done {
+		t.Fatalf("first next request done=%v err=%v", done, err)
+	}
+	if req.Kind != CrawlRequestKindFetch || req.Fetch.ScopeType != connector.ScopeTypeWatchEvent {
+		t.Fatalf("expected dual-role root fetch, got %+v", req)
+	}
+	if err := strategy.ObservePage(context.Background(), connector.RawObjectPage{Items: []connector.RawObject{{ObjectKey: "root", IsDocument: true}}}); err != nil {
+		t.Fatalf("observe root fetch: %v", err)
+	}
+
+	req, done, err = strategy.NextRequest(context.Background(), CrawlLoopState{})
+	if err != nil || done {
+		t.Fatalf("second next request done=%v err=%v", done, err)
+	}
+	if req.Kind != CrawlRequestKindListChildren || req.ListChildren.NodeRef != "" {
+		t.Fatalf("expected root children list after root fetch, got %+v", req)
+	}
+}
+
 func TestPartialStrategyCoversDeclaredSubtreeOnly(t *testing.T) {
 	t.Parallel()
 

--- a/backend/scan-control-plane/internal/sourceengine/source/engine_test.go
+++ b/backend/scan-control-plane/internal/sourceengine/source/engine_test.go
@@ -172,6 +172,98 @@ func TestCreateSourceRejectsInvalidSchedulePolicyAsInvalidRequest(t *testing.T) 
 	}
 }
 
+func TestTriggerSourceSyncSplitsObjectKeysScope(t *testing.T) {
+	t.Parallel()
+
+	now := fixedSourceTestTime()
+	repo := newSourceEngineRepoStub()
+	repo.sources["source-1"] = store.Source{SourceID: "source-1", Status: SourceStatusActive, CreatedAt: now, UpdatedAt: now}
+	repo.bindings["source-1"] = []store.Binding{{
+		SourceID:          "source-1",
+		BindingID:         "binding-1",
+		BindingGeneration: 1,
+		Status:            BindingStatusActive,
+		CreatedAt:         now,
+		UpdatedAt:         now,
+	}}
+	scheduler := &sourceScheduleSpy{}
+	engine := newTestSourceEngineWithSchedule(t, repo, &sourceCoreSpy{}, &sourceSpyConnector{}, scheduler, now)
+
+	resp, err := engine.TriggerSourceSync(context.Background(), TriggerSourceSyncRequest{
+		SourceID:  "source-1",
+		BindingID: "binding-1",
+		RequestID: "request-1",
+		ScopeType: string(connector.ScopeTypePartial),
+		ScopeRef: map[string]any{
+			"object_keys": []any{"doc-1", "doc-2"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("trigger source sync: %v", err)
+	}
+	if len(resp.RunIDs) != 2 || len(scheduler.manual) != 2 {
+		t.Fatalf("expected one manual sync per object key, resp=%+v manual=%+v", resp, scheduler.manual)
+	}
+	if scheduler.manual[0].ScopeRef["object_key"] != "doc-1" || scheduler.manual[1].ScopeRef["object_key"] != "doc-2" {
+		t.Fatalf("object_keys scope was not split: %+v", scheduler.manual)
+	}
+	if scheduler.manual[0].RequestID != "request-1" || scheduler.manual[1].RequestID != "request-1-2" {
+		t.Fatalf("split manual sync request ids are not stable: %+v", scheduler.manual)
+	}
+}
+
+func TestTriggerSourceSyncSplitsGenerateScopes(t *testing.T) {
+	t.Parallel()
+
+	now := fixedSourceTestTime()
+	repo := newSourceEngineRepoStub()
+	repo.sources["source-1"] = store.Source{SourceID: "source-1", Status: SourceStatusActive, CreatedAt: now, UpdatedAt: now}
+	repo.bindings["source-1"] = []store.Binding{{
+		SourceID:          "source-1",
+		BindingID:         "binding-1",
+		BindingGeneration: 1,
+		Status:            BindingStatusActive,
+		CreatedAt:         now,
+		UpdatedAt:         now,
+	}}
+	scheduler := &sourceScheduleSpy{}
+	engine := newTestSourceEngineWithSchedule(t, repo, &sourceCoreSpy{}, &sourceSpyConnector{}, scheduler, now)
+
+	resp, err := engine.TriggerSourceSync(context.Background(), TriggerSourceSyncRequest{
+		SourceID:  "source-1",
+		BindingID: "binding-1",
+		RequestID: "request-1",
+		ScopeType: string(connector.ScopeTypePartial),
+		ScopeRef: map[string]any{
+			"scopes": []any{
+				map[string]any{
+					"key":          "binding-1:feishu:wiki:space-1:node-1",
+					"object_key":   "feishu:wiki:space-1:node-1",
+					"node_ref":     "wiki:space-1:node-1",
+					"is_document":  true,
+					"is_container": true,
+				},
+				map[string]any{
+					"object_key":  "feishu:wiki:space-1:node-2",
+					"is_document": true,
+				},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("trigger source sync: %v", err)
+	}
+	if len(resp.RunIDs) != 2 || len(scheduler.manual) != 2 {
+		t.Fatalf("expected one manual sync per scope, resp=%+v manual=%+v", resp, scheduler.manual)
+	}
+	if scheduler.manual[0].ScopeRef["node_ref"] != "wiki:space-1:node-1" || scheduler.manual[0].ScopeRef["subtree_root"] != "feishu:wiki:space-1:node-1" {
+		t.Fatalf("container scope was not converted to subtree sync: %+v", scheduler.manual[0])
+	}
+	if scheduler.manual[1].ScopeRef["object_key"] != "feishu:wiki:space-1:node-2" {
+		t.Fatalf("document scope was not converted to object sync: %+v", scheduler.manual[1])
+	}
+}
+
 func TestCreateSourceDuplicateConnectorFingerprintCompensates(t *testing.T) {
 	t.Parallel()
 
@@ -769,6 +861,7 @@ func (sourceTestScheduleEngine) EnqueueManualSync(context.Context, scheduleengin
 
 type sourceScheduleSpy struct {
 	triggered  []store.Binding
+	manual     []scheduleengine.ManualSyncRequest
 	triggerErr error
 	nextSyncAt *time.Time
 }
@@ -797,8 +890,28 @@ func (s *sourceScheduleSpy) TriggerInitialSync(_ context.Context, binding store.
 	return []string{"job-" + strconv.Itoa(len(s.triggered))}, nil
 }
 
-func (sourceScheduleSpy) EnqueueManualSync(context.Context, scheduleengine.ManualSyncRequest) (scheduleengine.SyncRunIntent, error) {
-	return scheduleengine.SyncRunIntent{}, nil
+func (s *sourceScheduleSpy) EnqueueManualSync(_ context.Context, req scheduleengine.ManualSyncRequest) (scheduleengine.SyncRunIntent, error) {
+	s.manual = append(s.manual, req)
+	runID := "manual-job-" + strconv.Itoa(len(s.manual))
+	return scheduleengine.SyncRunIntent{
+		Run: store.SyncRun{
+			RunID:     runID,
+			SourceID:  req.SourceID,
+			BindingID: req.BindingID,
+			ScopeType: string(req.ScopeType),
+			ScopeRef:  sourceTestScopeRefJSON(req.ScopeRef),
+			Status:    store.SyncRunStatusPending,
+		},
+		Created: true,
+	}, nil
+}
+
+func sourceTestScopeRefJSON(scopeRef connector.ScopeRef) store.JSON {
+	out := store.JSON{}
+	for key, value := range scopeRef {
+		out[key] = value
+	}
+	return out
 }
 
 func sourceTestIDGenerator() func(string) string {

--- a/backend/scan-control-plane/internal/sourceengine/source/query.go
+++ b/backend/scan-control-plane/internal/sourceengine/source/query.go
@@ -2,6 +2,8 @@ package source
 
 import (
 	"context"
+	"fmt"
+	"strings"
 
 	"github.com/lazymind/scan_control_plane/internal/sourceengine/connector"
 	scheduleengine "github.com/lazymind/scan_control_plane/internal/sourceengine/schedule"
@@ -122,29 +124,49 @@ func (e *DefaultEngine) syncBindings(ctx context.Context, req TriggerSourceSyncR
 func (e *DefaultEngine) enqueueManualSyncs(ctx context.Context, req TriggerSourceSyncRequest, bindings []store.Binding) (TriggerSourceSyncResponse, error) {
 	resp := TriggerSourceSyncResponse{RunIDs: []string{}, JobIDs: []string{}, Intents: []SyncRunIntentResponse{}}
 	for _, binding := range bindings {
-		intent, err := e.schedule.EnqueueManualSync(ctx, scheduleengine.ManualSyncRequest{
-			RequestID: req.RequestID,
-			SourceID:  binding.SourceID,
-			BindingID: binding.BindingID,
-			ScopeType: connector.ScopeType(req.ScopeType),
-			ScopeRef:  syncScopeRef(req.ScopeRef),
-		})
-		if err != nil {
-			return resp, mapStoreError(err)
+		for idx, scopeRef := range syncScopeRefs(req.ScopeRef, binding.BindingID) {
+			intent, err := e.schedule.EnqueueManualSync(ctx, scheduleengine.ManualSyncRequest{
+				RequestID: scopedSyncRequestID(req.RequestID, idx),
+				SourceID:  binding.SourceID,
+				BindingID: binding.BindingID,
+				ScopeType: connector.ScopeType(req.ScopeType),
+				ScopeRef:  scopeRef,
+			})
+			if err != nil {
+				return resp, mapStoreError(err)
+			}
+			if intent.Run.RunID == "" {
+				continue
+			}
+			resp.RunIDs = append(resp.RunIDs, intent.Run.RunID)
+			resp.JobIDs = append(resp.JobIDs, intent.Run.RunID)
+			resp.Intents = append(resp.Intents, syncRunIntentToResponse(intent))
 		}
-		if intent.Run.RunID == "" {
-			continue
-		}
-		resp.RunIDs = append(resp.RunIDs, intent.Run.RunID)
-		resp.JobIDs = append(resp.JobIDs, intent.Run.RunID)
-		resp.Intents = append(resp.Intents, syncRunIntentToResponse(intent))
 	}
 	return resp, nil
 }
 
 func syncScopeRef(values map[string]any) connector.ScopeRef {
-	if len(values) == 0 {
+	refs := syncScopeRefs(values, "")
+	if len(refs) == 0 {
 		return nil
+	}
+	return refs[0]
+}
+
+func syncScopeRefs(values map[string]any, bindingID string) []connector.ScopeRef {
+	if len(values) == 0 {
+		return []connector.ScopeRef{nil}
+	}
+	if scopes := scopeRefListFromAny(values["scopes"], bindingID); len(scopes) > 0 {
+		return scopes
+	}
+	if keys := stringListFromAny(values["object_keys"]); len(keys) > 0 {
+		out := make([]connector.ScopeRef, 0, len(keys))
+		for _, key := range keys {
+			out = append(out, connector.ScopeRef{"object_key": key})
+		}
+		return out
 	}
 	out := make(connector.ScopeRef, len(values))
 	for key, value := range values {
@@ -152,7 +174,126 @@ func syncScopeRef(values map[string]any) connector.ScopeRef {
 			out[key] = s
 		}
 	}
+	return []connector.ScopeRef{out}
+}
+
+func scopeRefListFromAny(value any, bindingID string) []connector.ScopeRef {
+	values, ok := value.([]any)
+	if !ok {
+		return nil
+	}
+	out := make([]connector.ScopeRef, 0, len(values))
+	for _, item := range values {
+		scope, ok := item.(map[string]any)
+		if !ok {
+			continue
+		}
+		ref := syncScopeRefFromMap(scope, bindingID)
+		if len(ref) > 0 {
+			out = append(out, ref)
+		}
+	}
 	return out
+}
+
+func syncScopeRefFromMap(scope map[string]any, bindingID string) connector.ScopeRef {
+	ref := connector.ScopeRef{}
+	objectKey := firstSourceNonBlank(
+		stringFromAny(scope["object_key"]),
+		objectKeyFromSourceTreeKey(stringFromAny(scope["key"]), bindingID),
+	)
+	nodeRef := firstSourceNonBlank(
+		stringFromAny(scope["node_ref"]),
+		stringFromAny(scope["path"]),
+		objectKey,
+	)
+	if boolFromAny(scope["is_container"]) {
+		if nodeRef != "" {
+			ref["node_ref"] = nodeRef
+		}
+		if objectKey != "" {
+			ref["subtree_root"] = objectKey
+		}
+		return ref
+	}
+	if objectKey != "" {
+		ref["object_key"] = objectKey
+		return ref
+	}
+	if path := strings.TrimSpace(stringFromAny(scope["path"])); path != "" {
+		ref["path"] = path
+		return ref
+	}
+	if nodeRef != "" {
+		ref["node_ref"] = nodeRef
+	}
+	return ref
+}
+
+func objectKeyFromSourceTreeKey(key, bindingID string) string {
+	key = strings.TrimSpace(key)
+	bindingID = strings.TrimSpace(bindingID)
+	if key == "" || bindingID == "" || !strings.HasPrefix(key, bindingID+":") {
+		return ""
+	}
+	return strings.TrimSpace(strings.TrimPrefix(key, bindingID+":"))
+}
+
+func firstSourceNonBlank(values ...string) string {
+	for _, value := range values {
+		if trimmed := strings.TrimSpace(value); trimmed != "" {
+			return trimmed
+		}
+	}
+	return ""
+}
+
+func stringFromAny(value any) string {
+	if s, ok := value.(string); ok {
+		return s
+	}
+	return ""
+}
+
+func boolFromAny(value any) bool {
+	if b, ok := value.(bool); ok {
+		return b
+	}
+	return false
+}
+
+func stringListFromAny(value any) []string {
+	switch v := value.(type) {
+	case []string:
+		return compactSourceStrings(v)
+	case []any:
+		out := make([]string, 0, len(v))
+		for _, item := range v {
+			if s, ok := item.(string); ok {
+				out = append(out, s)
+			}
+		}
+		return compactSourceStrings(out)
+	default:
+		return nil
+	}
+}
+
+func compactSourceStrings(values []string) []string {
+	out := make([]string, 0, len(values))
+	for _, value := range values {
+		if trimmed := strings.TrimSpace(value); trimmed != "" {
+			out = append(out, trimmed)
+		}
+	}
+	return out
+}
+
+func scopedSyncRequestID(requestID string, index int) string {
+	if requestID == "" || index == 0 {
+		return requestID
+	}
+	return fmt.Sprintf("%s-%d", requestID, index+1)
 }
 
 func syncRunIntentToResponse(intent scheduleengine.SyncRunIntent) SyncRunIntentResponse {

--- a/backend/scan-control-plane/internal/sourceengine/task/planner_test.go
+++ b/backend/scan-control-plane/internal/sourceengine/task/planner_test.go
@@ -204,6 +204,44 @@ func TestGenerateTasksQueuesManualSyncForTreeNodeKey(t *testing.T) {
 	}
 }
 
+func TestGenerateTasksQueuesManualSyncForContainerScope(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	now := time.Date(2026, 5, 27, 8, 0, 0, 0, time.UTC)
+	repo := newPlannerStore(now)
+	syncer := &manualSyncSchedulerStub{}
+	planner := NewDBTaskPlanner(
+		repo,
+		WithClock(func() time.Time { return now }),
+		WithIDGenerator(repo.nextID),
+		WithManualSyncScheduler(syncer),
+	)
+
+	_, err := planner.GenerateTasks(ctx, GenerateRequest{
+		SourceID:  "source-1",
+		BindingID: "binding-1",
+		Mode:      "partial",
+		Scopes: []GenerateScope{{
+			Key:         "binding-1:feishu:wiki:space-1:node-1",
+			ObjectKey:   "feishu:wiki:space-1:node-1",
+			NodeRef:     "wiki:space-1:node-1",
+			IsDocument:  true,
+			IsContainer: true,
+		}},
+	})
+	if err != nil {
+		t.Fatalf("generate selected container scope: %v", err)
+	}
+	if len(syncer.calls) != 1 {
+		t.Fatalf("expected one sync call, got %+v", syncer.calls)
+	}
+	call := syncer.calls[0]
+	if call.ScopeType != "partial" || call.ScopeRef["node_ref"] != "wiki:space-1:node-1" || call.ScopeRef["subtree_root"] != "feishu:wiki:space-1:node-1" {
+		t.Fatalf("container scope should be converted to subtree sync: %+v", call)
+	}
+}
+
 func TestGeneratePendingTasksBypassesManualRequestLimit(t *testing.T) {
 	t.Parallel()
 

--- a/backend/scan-control-plane/internal/sourceengine/tree/source_children.go
+++ b/backend/scan-control-plane/internal/sourceengine/tree/source_children.go
@@ -76,6 +76,30 @@ func (e *DBSourceTreeQueryEngine) listLiveChildren(ctx context.Context, req Sour
 	if err != nil {
 		return TreeNodePage{}, mapConnectorError(err)
 	}
+	if shouldFetchLiveBindingRoot(req, binding) {
+		rootPage, err := conn.FetchPage(ctx, connector.FetchPageRequest{
+			SourceID:          req.SourceID,
+			BindingID:         binding.BindingID,
+			BindingGeneration: binding.BindingGeneration,
+			TargetType:        connector.TargetType(binding.TargetType),
+			TargetRef:         binding.TargetRef,
+			ScopeType:         connector.ScopeTypeWatchEvent,
+			ScopeRef:          connector.ScopeRef{"target_ref": binding.TargetRef},
+			PageSize:          1,
+			AgentID:           binding.AgentID,
+			AuthConnectionID:  binding.AuthConnectionID,
+			ProviderOptions:   liveSourceProviderOptions(binding.ProviderOptions, req.ProviderOptions),
+		})
+		if err != nil {
+			return TreeNodePage{}, mapConnectorError(err)
+		}
+		if len(rootPage.Items) > 0 {
+			rawPage.Items = rootPage.Items[:1]
+			rawPage.NextCursor = ""
+			rawPage.HasMore = false
+			rawPage.ListComplete = true
+		}
+	}
 	nodes := make([]TreeNode, 0, len(rawPage.Items))
 	for _, raw := range rawPage.Items {
 		normalized, err := conn.MapObject(ctx, raw)
@@ -174,7 +198,7 @@ func normalizeSourceNodeKey(value string, binding store.Binding) string {
 }
 
 func liveSourceNodeRef(req SourceTreeChildrenRequest, binding store.Binding) string {
-	for _, ref := range []string{req.NodeRef, req.ParentRef, req.ParentKey, req.Key} {
+	for _, ref := range []string{req.NodeRef, req.ParentRef, req.ParentKey, req.Key, req.TreeKey} {
 		if nodeRef := normalizeLiveSourceNodeRef(ref, binding); nodeRef != "" {
 			return nodeRef
 		}
@@ -184,11 +208,11 @@ func liveSourceNodeRef(req SourceTreeChildrenRequest, binding store.Binding) str
 
 func normalizeLiveSourceNodeRef(value string, binding store.Binding) string {
 	value = normalizeSourceNodeKey(value, binding)
-	if value == "" || value == binding.TreeKey || value == binding.TargetRef {
-		return ""
-	}
 	if binding.ConnectorType == "feishu" && strings.HasPrefix(value, "feishu:") {
 		return strings.TrimPrefix(value, "feishu:")
+	}
+	if value == "" || value == binding.TreeKey || value == binding.TargetRef {
+		return ""
 	}
 	return value
 }
@@ -219,6 +243,14 @@ func shouldExpandBindingRoot(req SourceTreeChildrenRequest, binding store.Bindin
 		strings.TrimSpace(req.NodeRef) == "" &&
 		strings.TrimSpace(req.ParentRef) == "" &&
 		strings.TrimSpace(req.Key) == "" &&
+		strings.TrimSpace(req.Cursor) == "" &&
 		parentKey == binding.TreeKey &&
 		binding.TreeKey != ""
+}
+
+func shouldFetchLiveBindingRoot(req SourceTreeChildrenRequest, binding store.Binding) bool {
+	if binding.ConnectorType != "feishu" || binding.TargetType != "wiki_node" {
+		return false
+	}
+	return shouldExpandBindingRoot(req, binding, effectiveSourceParentKey(req, binding))
 }

--- a/backend/scan-control-plane/internal/sourceengine/tree/tree_test.go
+++ b/backend/scan-control-plane/internal/sourceengine/tree/tree_test.go
@@ -232,6 +232,178 @@ func TestSourceTreeListChildrenUsesLiveConnectorByDefault(t *testing.T) {
 	}
 }
 
+func TestSourceTreeLiveRootRequestUsesTreeKeyNodeRef(t *testing.T) {
+	t.Parallel()
+
+	spy := &treeConnectorSpy{connectorType: connector.ConnectorType("feishu")}
+	registry, err := connector.NewDefaultConnectorRegistry(spy)
+	if err != nil {
+		t.Fatalf("create registry: %v", err)
+	}
+	repo := newTreeReadRepo()
+	repo.sources["source-1"] = store.Source{SourceID: "source-1"}
+	repo.bindings["source-1"] = []store.Binding{{
+		BindingID:        "binding-1",
+		SourceID:         "source-1",
+		TreeKey:          "feishu:wiki:space-1:node-root",
+		ConnectorType:    "feishu",
+		TargetType:       string(treeTestTargetType),
+		TargetRef:        "wiki:space-1:node-root",
+		AuthConnectionID: "auth-1",
+		Status:           "ACTIVE",
+	}}
+	engine := NewDBSourceTreeQueryEngine(
+		repo,
+		TreeQueryLimits{DefaultPageSize: 10, MaxPageSize: 100, MaxAllCurrentLevelItems: 10},
+		WithSourceTreeConnectorRegistry(registry),
+	)
+
+	_, err = engine.ListChildren(context.Background(), SourceTreeChildrenRequest{
+		SourceID:  "source-1",
+		BindingID: "binding-1",
+		TreeKey:   "feishu:wiki:space-1:node-root",
+		ParentKey: "",
+		PageSize:  40,
+	})
+	if err != nil {
+		t.Fatalf("list live root children: %v", err)
+	}
+	if len(spy.listRequests) != 1 || spy.listRequests[0].NodeRef != "wiki:space-1:node-root" {
+		t.Fatalf("live root request should pass tree_key as provider node_ref, got %+v", spy.listRequests)
+	}
+}
+
+func TestSourceTreeLiveWikiRootFallsBackToBindingTargetWhenEmpty(t *testing.T) {
+	t.Parallel()
+
+	spy := &treeConnectorSpy{
+		connectorType: connector.ConnectorType("feishu"),
+		childrenSet:   true,
+		children:      []connector.RawObject{},
+		fetchPage: connector.RawObjectPage{Items: []connector.RawObject{
+			rawTreeObject("feishu:wiki:space-1:node-root", "", "Root Wiki", true, false),
+		}},
+	}
+	registry, err := connector.NewDefaultConnectorRegistry(spy)
+	if err != nil {
+		t.Fatalf("create registry: %v", err)
+	}
+	repo := newTreeReadRepo()
+	repo.sources["source-1"] = store.Source{SourceID: "source-1"}
+	repo.bindings["source-1"] = []store.Binding{{
+		BindingID:         "binding-1",
+		SourceID:          "source-1",
+		TreeKey:           "feishu:wiki:space-1:node-root",
+		ConnectorType:     "feishu",
+		TargetType:        "wiki_node",
+		TargetRef:         "wiki:space-1:node-root",
+		BindingGeneration: 1,
+		AuthConnectionID:  "auth-1",
+		Status:            "ACTIVE",
+	}}
+	engine := NewDBSourceTreeQueryEngine(
+		repo,
+		TreeQueryLimits{DefaultPageSize: 10, MaxPageSize: 100, MaxAllCurrentLevelItems: 10},
+		WithSourceTreeConnectorRegistry(registry),
+	)
+
+	page, err := engine.ListChildren(context.Background(), SourceTreeChildrenRequest{
+		SourceID:  "source-1",
+		BindingID: "binding-1",
+		TreeKey:   "feishu:wiki:space-1:node-root",
+		PageSize:  40,
+	})
+	if err != nil {
+		t.Fatalf("list live wiki root children: %v", err)
+	}
+	if len(spy.fetchRequests) != 1 {
+		t.Fatalf("expected empty live root to fetch binding target, got %d fetches", len(spy.fetchRequests))
+	}
+	gotFetch := spy.fetchRequests[0]
+	if gotFetch.ScopeType != connector.ScopeTypeWatchEvent || gotFetch.ScopeRef["target_ref"] != "wiki:space-1:node-root" {
+		t.Fatalf("unexpected root fetch request: %+v", gotFetch)
+	}
+	if page.SearchMode != SearchModeConnector || len(page.Items) != 1 {
+		t.Fatalf("unexpected fallback page: %+v", page)
+	}
+	if page.Items[0].ObjectKey != "feishu:wiki:space-1:node-root" || !page.Items[0].Selectable {
+		t.Fatalf("binding target document was not returned as selectable root: %+v", page.Items[0])
+	}
+}
+
+func TestSourceTreeLiveWikiRootPreservesBindingRootLayer(t *testing.T) {
+	t.Parallel()
+
+	spy := &treeConnectorSpy{
+		connectorType: connector.ConnectorType("feishu"),
+		childrenSet:   true,
+		children: []connector.RawObject{
+			rawTreeObject("feishu:wiki:space-1:node-child", "feishu:wiki:space-1:node-root", "Child Wiki", true, false),
+		},
+		fetchPage: connector.RawObjectPage{Items: []connector.RawObject{
+			rawTreeObject("feishu:wiki:space-1:node-root", "", "Root Wiki", true, true),
+		}},
+	}
+	registry, err := connector.NewDefaultConnectorRegistry(spy)
+	if err != nil {
+		t.Fatalf("create registry: %v", err)
+	}
+	repo := newTreeReadRepo()
+	repo.sources["source-1"] = store.Source{SourceID: "source-1"}
+	repo.bindings["source-1"] = []store.Binding{{
+		BindingID:         "binding-1",
+		SourceID:          "source-1",
+		TreeKey:           "feishu:wiki:space-1:node-root",
+		ConnectorType:     "feishu",
+		TargetType:        "wiki_node",
+		TargetRef:         "wiki:space-1:node-root",
+		BindingGeneration: 1,
+		AuthConnectionID:  "auth-1",
+		Status:            "ACTIVE",
+	}}
+	engine := NewDBSourceTreeQueryEngine(
+		repo,
+		TreeQueryLimits{DefaultPageSize: 10, MaxPageSize: 100, MaxAllCurrentLevelItems: 10},
+		WithSourceTreeConnectorRegistry(registry),
+	)
+
+	rootPage, err := engine.ListChildren(context.Background(), SourceTreeChildrenRequest{
+		SourceID:  "source-1",
+		BindingID: "binding-1",
+		TreeKey:   "feishu:wiki:space-1:node-root",
+		PageSize:  40,
+	})
+	if err != nil {
+		t.Fatalf("list live wiki root: %v", err)
+	}
+	if len(spy.fetchRequests) != 1 {
+		t.Fatalf("expected root request to fetch binding target, got %d fetches", len(spy.fetchRequests))
+	}
+	if len(rootPage.Items) != 1 || rootPage.Items[0].ObjectKey != "feishu:wiki:space-1:node-root" {
+		t.Fatalf("root request should return binding root layer, got %+v", rootPage.Items)
+	}
+	if !rootPage.Items[0].Selectable || !rootPage.Items[0].IsDocument || !rootPage.Items[0].HasChildren {
+		t.Fatalf("dual-role wiki root should be selectable and expandable: %+v", rootPage.Items[0])
+	}
+
+	childPage, err := engine.ListChildren(context.Background(), SourceTreeChildrenRequest{
+		SourceID:  "source-1",
+		BindingID: "binding-1",
+		TreeKey:   "feishu:wiki:space-1:node-root",
+		ParentKey: "feishu:wiki:space-1:node-root",
+		PageSize:  40,
+	})
+	if err != nil {
+		t.Fatalf("list live wiki root children: %v", err)
+	}
+	if len(spy.fetchRequests) != 1 {
+		t.Fatalf("expanded root should list children without fetching root again, got %d fetches", len(spy.fetchRequests))
+	}
+	if len(childPage.Items) != 1 || childPage.Items[0].ObjectKey != "feishu:wiki:space-1:node-child" {
+		t.Fatalf("expanded root should return real children, got %+v", childPage.Items)
+	}
+}
+
 func TestSourceTreeListChildrenUsesIndexedRepoWhenUseCache(t *testing.T) {
 	t.Parallel()
 
@@ -513,16 +685,24 @@ const (
 )
 
 type treeConnectorSpy struct {
+	connectorType  connector.ConnectorType
 	supportsSearch bool
+	childrenSet    bool
 	children       []connector.RawObject
+	fetchPage      connector.RawObjectPage
 	listRequests   []connector.ListChildrenRequest
+	fetchRequests  []connector.FetchPageRequest
 	searchRequests []connector.SearchRequest
 	mapObjects     []connector.RawObject
 }
 
 func (c *treeConnectorSpy) Spec() connector.ConnectorSpec {
+	connectorType := c.connectorType
+	if connectorType == "" {
+		connectorType = treeTestConnectorType
+	}
 	return connector.ConnectorSpec{
-		ConnectorType:         treeTestConnectorType,
+		ConnectorType:         connectorType,
 		TargetTypes:           []connector.TargetType{treeTestTargetType},
 		SupportsSearch:        c.supportsSearch,
 		SupportsExportFormats: []connector.ExportFormat{connector.ExportFormatOriginal},
@@ -537,7 +717,7 @@ func (c *treeConnectorSpy) ValidateTarget(context.Context, connector.ValidateTar
 func (c *treeConnectorSpy) ListChildren(_ context.Context, req connector.ListChildrenRequest) (connector.RawObjectPage, error) {
 	c.listRequests = append(c.listRequests, req)
 	items := c.children
-	if len(items) == 0 {
+	if !c.childrenSet && len(items) == 0 {
 		items = []connector.RawObject{
 			rawTreeObject("folder-1", "", "Guides", false, true),
 			rawTreeObject("doc-1", "", "Welcome.md", true, false),
@@ -565,7 +745,11 @@ func (c *treeConnectorSpy) Search(_ context.Context, req connector.SearchRequest
 	return connector.RawObjectPage{Items: []connector.RawObject{rawTreeObject("doc-1", "", "Welcome.md", true, false)}}, nil
 }
 
-func (c *treeConnectorSpy) FetchPage(context.Context, connector.FetchPageRequest) (connector.RawObjectPage, error) {
+func (c *treeConnectorSpy) FetchPage(_ context.Context, req connector.FetchPageRequest) (connector.RawObjectPage, error) {
+	c.fetchRequests = append(c.fetchRequests, req)
+	if len(c.fetchPage.Items) > 0 || c.fetchPage.HasMore || c.fetchPage.NextCursor != "" || c.fetchPage.ListComplete {
+		return c.fetchPage, nil
+	}
 	return connector.RawObjectPage{}, connector.NewError(connector.ErrorCodeUnsupported, "not used")
 }
 

--- a/frontend/src/modules/dataSource/common/components/DataSourceSyncPickerModal.tsx
+++ b/frontend/src/modules/dataSource/common/components/DataSourceSyncPickerModal.tsx
@@ -20,7 +20,7 @@ export interface DataSourceSyncPickerModalProps {
   setSyncSelectedDocIds: (updater: string[] | ((prev: string[]) => string[])) => void;
   syncTreeLoading: boolean;
   syncTreeData: DataNode[];
-  checkedTreeKeys: string[];
+  checkedTreeKeys: TreeProps["checkedKeys"];
   selectableSyncFileKeys: Set<string>;
   onLoadSyncTreeNode?: TreeProps["loadData"];
   onCancel: () => void;
@@ -158,6 +158,7 @@ export default function DataSourceSyncPickerModal({
           <Tree
             blockNode
             checkable
+            checkStrictly
             checkedKeys={checkedTreeKeys}
             expandedKeys={expandedKeys}
             loadData={onLoadSyncTreeNode}

--- a/frontend/src/modules/dataSource/detail.tsx
+++ b/frontend/src/modules/dataSource/detail.tsx
@@ -67,12 +67,22 @@ import {
 
 const { Text } = Typography;
 
+const SCAN_TREE_PAGE_SIZE = 50;
+
 type SyncTreeDataNode = DataNode & {
   treeKey?: string;
   objectKey?: string;
-  targetRef?: string;
   nodeRef?: string;
   childrenLoaded?: boolean;
+};
+
+type SyncGenerateScope = {
+  key?: string;
+  object_key?: string;
+  node_ref?: string;
+  path?: string;
+  is_document?: boolean;
+  is_container?: boolean;
 };
 
 const fallbackSources: Record<
@@ -394,7 +404,7 @@ function collectScanTreeFileKeys(nodes: ScanV2TreeNode[]): string[] {
       if (node.children?.length) {
         walk(node.children);
       }
-      if (node.selectable === false || node.is_container === true) {
+      if (!isSelectableScanTreeDocument(node)) {
         return;
       }
       keys.push(`${node.object_key || node.key}`);
@@ -404,8 +414,30 @@ function collectScanTreeFileKeys(nodes: ScanV2TreeNode[]): string[] {
   return keys;
 }
 
+function collectScanTreeNodesByKey(nodes: ScanV2TreeNode[]) {
+  const byKey = new Map<string, ScanV2TreeNode>();
+  const walk = (items: ScanV2TreeNode[]) => {
+    items.forEach((node) => {
+      byKey.set(getScanTreeNodeKey(node), node);
+      if (node.children?.length) {
+        walk(node.children);
+      }
+    });
+  };
+  walk(nodes);
+  return byKey;
+}
+
+function isSelectableScanTreeDocument(node: ScanV2TreeNode) {
+  return node.selectable !== false && node.is_document === true;
+}
+
 function getScanTreeNodeKey(node: ScanV2TreeNode) {
   return `${node.object_key || node.key}`;
+}
+
+function getScanTreeNodeParentKey(node: ScanV2TreeNode) {
+  return `${node.parent_key || ""}`.trim();
 }
 
 function getScanTreeNodePage(payload: unknown) {
@@ -432,17 +464,10 @@ function getScanTreeNodeMergeKeys(node: ScanV2TreeNode) {
     getScanTreeNodeKey(node),
     node.key,
     node.object_key,
-    node.target_ref,
     node.node_ref,
   ]
     .map((key) => `${key || ""}`.trim())
     .filter(Boolean);
-}
-
-function uniqueScanTreeKeys(keys: Array<string | undefined>) {
-  return Array.from(
-    new Set(keys.map((key) => `${key || ""}`.trim()).filter(Boolean)),
-  );
 }
 
 function normalizeLazyScanTreeNodes(nodes: ScanV2TreeNode[]) {
@@ -451,6 +476,51 @@ function normalizeLazyScanTreeNodes(nodes: ScanV2TreeNode[]) {
     delete nextNode.children;
     return nextNode;
   });
+}
+
+function filterScanTreeChildren(parentKey: string, children: ScanV2TreeNode[]) {
+  return children.filter((child) => {
+    if (getScanTreeNodeMergeKeys(child).includes(parentKey)) {
+      return false;
+    }
+    const childParentKey = `${child.parent_key || ""}`.trim();
+    return !childParentKey || childParentKey === parentKey;
+  });
+}
+
+function buildSyncGenerateScopes(
+  selectedKeys: string[],
+  nodeByKey: Map<string, ScanV2TreeNode>,
+) {
+  const selectedSet = new Set(selectedKeys);
+  const scopes: SyncGenerateScope[] = [];
+
+  selectedKeys.forEach((key) => {
+    const node = nodeByKey.get(key);
+    if (!node) {
+      scopes.push({ object_key: key });
+      return;
+    }
+
+    let parentKey = getScanTreeNodeParentKey(node);
+    while (parentKey) {
+      if (selectedSet.has(parentKey)) {
+        return;
+      }
+      const parent = nodeByKey.get(parentKey);
+      parentKey = parent ? getScanTreeNodeParentKey(parent) : "";
+    }
+
+    scopes.push({
+      key: node.key,
+      object_key: node.object_key || key,
+      node_ref: node.node_ref || node.object_key || key,
+      is_document: node.is_document === true,
+      is_container: node.is_container === true || node.has_children === true,
+    });
+  });
+
+  return scopes;
 }
 
 function mergeScanTreeChildren(
@@ -739,7 +809,7 @@ export default function DataSourceDetail() {
                 include_documents: true,
                 include_containers: true,
                 list_mode: "page",
-                page_size: 100,
+                page_size: SCAN_TREE_PAGE_SIZE,
               },
             })
           : await client.listSourceTreeChildren({
@@ -750,7 +820,7 @@ export default function DataSourceDetail() {
                 include_documents: true,
                 include_containers: true,
                 list_mode: "page",
-                page_size: 100,
+                page_size: SCAN_TREE_PAGE_SIZE,
                 parent_key: "",
               },
             });
@@ -765,9 +835,7 @@ export default function DataSourceDetail() {
         const nextSelectableKeys = collectScanTreeFileKeys(nextTreeNodes);
 
         setSyncTreeNodes(nextTreeNodes);
-        if (!normalizedKeyword) {
-          syncTreeChildrenCacheRef.current.set("", nextTreeNodes);
-        }
+        syncTreeChildrenCacheRef.current.clear();
         setSyncKnownSelectableFileKeys((prev) => {
           const next = new Set(prev);
           nextSelectableKeys.forEach((key) => next.add(key));
@@ -804,21 +872,14 @@ export default function DataSourceDetail() {
       }
 
       const treeNode = node as SyncTreeDataNode;
-      const parentKeyCandidates = uniqueScanTreeKeys([
-        treeNode.objectKey,
-        treeNode.treeKey,
-        treeNode.targetRef,
-        treeNode.nodeRef,
-        `${treeNode.key}`,
-      ]);
-      const parentKey = parentKeyCandidates[0] || `${treeNode.key}`;
-      const mergeKey = `${treeNode.key}`;
-      const cachedChildren = parentKeyCandidates
-        .map((key) => syncTreeChildrenCacheRef.current.get(key))
-        .find((items): items is ScanV2TreeNode[] => Boolean(items));
+      const parentKey = `${treeNode.objectKey || treeNode.key || ""}`.trim();
+      if (!parentKey) {
+        return;
+      }
+      const cachedChildren = syncTreeChildrenCacheRef.current.get(parentKey);
       if (cachedChildren) {
         setSyncTreeNodes((current) =>
-          mergeScanTreeChildren(current, mergeKey, cachedChildren),
+          mergeScanTreeChildren(current, parentKey, cachedChildren),
         );
         return;
       }
@@ -835,31 +896,26 @@ export default function DataSourceDetail() {
               include_documents: true,
               include_containers: true,
               list_mode: "page",
-              page_size: 100,
+              page_size: SCAN_TREE_PAGE_SIZE,
             },
           });
           return getScanTreeNodePage(response.data);
         };
-        let treePage = await requestPage(parentKey);
-        for (const candidate of parentKeyCandidates.slice(1)) {
-          if (treePage.items.length > 0) {
-            break;
-          }
-          treePage = await requestPage(candidate);
-        }
+        const treePage = await requestPage(parentKey);
 
-        const children = normalizeLazyScanTreeNodes(treePage.items);
+        const children = filterScanTreeChildren(
+          parentKey,
+          normalizeLazyScanTreeNodes(treePage.items),
+        );
         const selectableKeys = collectScanTreeFileKeys(children);
-        parentKeyCandidates.forEach((key) => {
-          syncTreeChildrenCacheRef.current.set(key, children);
-        });
+        syncTreeChildrenCacheRef.current.set(parentKey, children);
         setSyncKnownSelectableFileKeys((prev) => {
           const next = new Set(prev);
           selectableKeys.forEach((key) => next.add(key));
           return next;
         });
         setSyncTreeNodes((current) =>
-          mergeScanTreeChildren(current, mergeKey, children),
+          mergeScanTreeChildren(current, parentKey, children),
         );
       } catch (error) {
         message.error(
@@ -903,6 +959,7 @@ export default function DataSourceDetail() {
     setSyncKnownSelectableFileKeys(new Set());
     setSyncSelectionToken("");
     setSyncTreeLoading(true);
+    syncTreeChildrenCacheRef.current.clear();
     syncTreeInitialLoadRef.current = true;
     setSyncSelectedDocIds([]);
   };
@@ -929,6 +986,12 @@ export default function DataSourceDetail() {
     }
 
     const targetSet = new Set(targetPaths);
+    const syncScopeNodesByKey = collectScanTreeNodesByKey(syncTreeNodes);
+    const targetScopes = buildSyncGenerateScopes(targetPaths, syncScopeNodesByKey);
+    if (targetScopes.length === 0) {
+      message.warning(t("admin.dataSourceDetailSelectFileFirst"));
+      return false;
+    }
     const currentTime = formatNow();
 
     stopSyncPolling();
@@ -937,29 +1000,17 @@ export default function DataSourceDetail() {
       const client = createScanV2ApiClient();
       if (detailSource.sourceType === "feishu") {
         message.info(t("admin.dataSourceDetailCloudSyncPreparing"));
-        const triggerResponse = await client.triggerSourceSync({
-          sourceId: detailSource.id,
-          triggerSourceSyncRequest: {
-            request_id: createScanRequestId("manual-sync"),
-            binding_id: detailSource.bindingId,
-            scope_type: "partial",
-            scope_ref: {
-              object_keys: targetPaths,
-            },
-          },
-        });
-        await waitForCloudSyncRun(client, detailSource.id, triggerResponse.data.run_ids?.[0]);
       }
 
       const generateTasksRequest: {
         mode: string;
         binding_id?: string;
-        object_keys: string[];
+        scopes: SyncGenerateScope[];
         priority?: number;
       } = {
         mode: "partial",
         binding_id: detailSource.bindingId,
-        object_keys: targetPaths,
+        scopes: targetScopes,
         priority: 5,
       }
 
@@ -1117,10 +1168,9 @@ export default function DataSourceDetail() {
           key: getScanTreeNodeKey(node),
           treeKey: `${node.key}`,
           objectKey: node.object_key,
-          targetRef: node.target_ref,
           nodeRef: node.node_ref,
           isLeaf: !node.has_children,
-          disableCheckbox: node.is_container === true || node.selectable === false,
+          disableCheckbox: !isSelectableScanTreeDocument(node),
           title: (
             <div className="data-source-sync-tree-file">
               <div className="data-source-sync-tree-file-main">
@@ -1144,7 +1194,10 @@ export default function DataSourceDetail() {
     return toDataNode(syncTreeNodes);
   }, [syncTreeNodes, t]);
 
-  const checkedTreeKeys = syncSelectedDocIds;
+  const checkedTreeKeys = useMemo(
+    () => ({ checked: syncSelectedDocIds, halfChecked: [] }),
+    [syncSelectedDocIds],
+  );
   const filteredSyncNodeKeys = useMemo(
     () => collectScanTreeFileKeys(syncTreeNodes),
     [syncTreeNodes],


### PR DESCRIPTION
## Summary

- Clamp Feishu Wiki tree `page_size` to the provider-supported maximum of `50` in both backend and frontend requests.
- Fix Wiki source tree loading so the selected Wiki root is preserved and child nodes resolve from the correct `object_key`.
- Prevent frontend tree cache/key collisions that caused wrong nesting such as `test1 -> test1`.
- Make manual-pull tree selection strict so checked documents can be selected and unselected independently.
- Submit selected Wiki container documents as subtree `scopes` instead of plain `object_keys`, so child documents are included during manual sync.
- Add backend support for splitting `scope_ref.scopes` into partial sync runs, including `node_ref + subtree_root` for Wiki subtree sync.
- Keep Feishu Wiki partial fetch/export behavior compatible with selected Wiki document pulls.

## Testing

- `go test ./internal/sourceengine/source ./internal/sourceengine/task ./internal/sourceengine/crawl ./internal/sourceengine/connector/feishu ./internal/server`
- Frontend production Docker build completed successfully.
- Verified on the 5024 environment that `test -> test1 -> tes2` is returned correctly and subtree sync processes child documents.