### PR TITLE
fix: remove unused wordgroup import causing build failure

### DIFF
--- a/backend/core/main.go
+++ b/backend/core/main.go
@@ -22,7 +22,6 @@ import (
 	"lazymind/core/migrate"
 	"lazymind/core/modelprovider"
 	"lazymind/core/store"
-	"lazymind/core/wordgroup"
 )
 
 //go:embed docs.html


### PR DESCRIPTION
Commit 2e180b8 删除了 wordgroup.StartPeriodicVocabExtract 调用但遗漏了 import，导致 go build 失败。修复：移除未使用的 wordgroup 导入。