### PR TITLE
Add trace detail interface

### DIFF
--- a/algorithm/lazymind/chat/app.py
+++ b/algorithm/lazymind/chat/app.py
@@ -11,6 +11,7 @@ from lazymind.chat.api import (
     plugin_routes,
     subagent_routes,
 )
+from lazymind.chat.service.utils.trace_archive import start_local_trace_maintenance
 from lazymind.rewrite.api import rewrite_routes
 from lazymind.review.api import memory_review_routes, skill_review_routes
 
@@ -45,6 +46,7 @@ def create_app() -> FastAPI:
 
 
 app = create_app()
+start_local_trace_maintenance()
 
 if __name__ == '__main__':
     import argparse

--- a/algorithm/lazymind/chat/service/utils/trace_archive.py
+++ b/algorithm/lazymind/chat/service/utils/trace_archive.py
@@ -1,0 +1,36 @@
+import logging
+import threading
+import time
+
+_logger = logging.getLogger(__name__)
+
+_MAINTAIN_LOCAL_TRACES_INTERVAL = 86400  # 24 hours
+
+
+def _run_once():
+    try:
+        from lazyllm.tracing.backends.local import maintain_local_traces
+        result = maintain_local_traces()
+        if result['compressed_jsonl'] or result['deleted_zip']:
+            _logger.info(
+                'local trace maintenance: compressed=%d, deleted=%d',
+                len(result['compressed_jsonl']),
+                len(result['deleted_zip']),
+            )
+    except Exception:
+        _logger.warning('local trace maintenance failed', exc_info=True)
+
+
+def start_local_trace_maintenance():
+    from lazyllm.configs import config
+    if config['trace_backend'] != 'local':
+        return
+
+    def _loop():
+        _run_once()
+        while True:
+            time.sleep(_MAINTAIN_LOCAL_TRACES_INTERVAL)
+            _run_once()
+
+    t = threading.Thread(target=_loop, name='local-trace-maintenance', daemon=True)
+    t.start()

--- a/algorithm/lazymind/chat/service/utils/trace_archive.py
+++ b/algorithm/lazymind/chat/service/utils/trace_archive.py
@@ -1,10 +1,15 @@
+"""Background maintenance for local trace files (archive old JSONL, delete expired ZIP)."""
+
 import logging
 import threading
-import time
 
 _logger = logging.getLogger(__name__)
 
 _MAINTAIN_LOCAL_TRACES_INTERVAL = 86400  # 24 hours
+
+_stop_event = threading.Event()
+_thread: threading.Thread | None = None
+_lock = threading.Lock()
 
 
 def _run_once():
@@ -21,16 +26,22 @@ def _run_once():
         _logger.warning('local trace maintenance failed', exc_info=True)
 
 
-def start_local_trace_maintenance():
+def start_local_trace_maintenance(interval: int = _MAINTAIN_LOCAL_TRACES_INTERVAL):
+    global _thread
+
     from lazyllm.configs import config
     if config['trace_backend'] != 'local':
         return
 
-    def _loop():
-        _run_once()
-        while True:
-            time.sleep(_MAINTAIN_LOCAL_TRACES_INTERVAL)
-            _run_once()
+    with _lock:
+        if _thread is not None and _thread.is_alive():
+            return
+        _stop_event.clear()
 
-    t = threading.Thread(target=_loop, name='local-trace-maintenance', daemon=True)
-    t.start()
+        def _loop():
+            _run_once()
+            while not _stop_event.wait(interval):
+                _run_once()
+
+        _thread = threading.Thread(target=_loop, name='local-trace-maintenance', daemon=True)
+        _thread.start()

--- a/backend/core/agent/handlers.go
+++ b/backend/core/agent/handlers.go
@@ -484,6 +484,42 @@ func GetThreadArtifact(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	proxyThreadGet(w, r, func(threadID string) string { return threadArtifactURL(threadID, artifactID) }, "fetch thread artifact failed")
+func GetThreadResultTrace(w http.ResponseWriter, r *http.Request) {
+	threadID := strings.TrimSpace(mux.Vars(r)["thread_id"])
+	traceID := strings.TrimSpace(mux.Vars(r)["trace_id"])
+	if threadID == "" || traceID == "" {
+		common.ReplyErr(w, "thread_id and trace_id required", http.StatusBadRequest)
+		return
+	}
+	if _, err := loadUserThread(store.DB(), r, threadID); err != nil {
+		replyThreadLoadError(w, err)
+		return
+	}
+	proxy, statusCode, err := fetchUpstreamProxy(r.Context(), r, threadResultTraceURL(threadID, traceID))
+	if err != nil {
+		common.ReplyErrWithData(w, "fetch trace result failed", map[string]any{"detail": err.Error()}, statusCode)
+		return
+	}
+	writeProxyResponse(w, proxy)
+}
+func GetThreadResultTraceCompare(w http.ResponseWriter, r *http.Request) {
+	threadID := strings.TrimSpace(mux.Vars(r)["thread_id"])
+	aTraceID := strings.TrimSpace(r.URL.Query().Get("a"))
+	bTraceID := strings.TrimSpace(r.URL.Query().Get("b"))
+	if threadID == "" || aTraceID == "" || bTraceID == "" {
+		common.ReplyErr(w, "thread_id, a and b required", http.StatusBadRequest)
+		return
+	}
+	if _, err := loadUserThread(store.DB(), r, threadID); err != nil {
+		replyThreadLoadError(w, err)
+		return
+	}
+	proxy, statusCode, err := fetchUpstreamProxy(r.Context(), r, threadResultTraceCompareURL(threadID, aTraceID, bTraceID))
+	if err != nil {
+		common.ReplyErrWithData(w, "fetch trace comparison failed", map[string]any{"detail": err.Error()}, statusCode)
+		return
+	}
+	writeProxyResponse(w, proxy)
 }
 func StartThread(w http.ResponseWriter, r *http.Request)  { postThreadAction(w, r, "start") }
 func PauseThread(w http.ResponseWriter, r *http.Request)  { postThreadAction(w, r, "pause") }

--- a/backend/core/agent/helpers.go
+++ b/backend/core/agent/helpers.go
@@ -102,6 +102,18 @@ func threadResultsURL(threadID, resultKind string) string {
 	)
 }
 
+func threadResultTraceURL(threadID, traceID string) string {
+	return common.JoinURL(
+		agentServiceEndpoint(),
+		"/v1/evo/threads/"+url.PathEscape(threadID)+"/results/traces/"+url.PathEscape(traceID),
+	)
+}
+
+func threadResultTraceCompareURL(threadID, aTraceID, bTraceID string) string {
+	base := common.JoinURL(agentServiceEndpoint(), "/v1/evo/threads/"+url.PathEscape(threadID)+"/results/traces-compare")
+	return base + "?a=" + url.QueryEscape(aTraceID) + "&b=" + url.QueryEscape(bTraceID)
+}
+
 func reportContentURL(reportID, format string) string {
 	base := common.JoinURL(agentServiceEndpoint(), "/v1/evo/reports/"+url.PathEscape(reportID)+"/content")
 	if strings.TrimSpace(format) == "" {

--- a/backend/core/openapi_registry.go
+++ b/backend/core/openapi_registry.go
@@ -459,6 +459,20 @@ type agentFileContentOpenAPIResponse struct {
 	FileSize int64  `json:"file_size"`
 }
 
+type agentThreadPathParams struct {
+	ThreadID string `path:"thread_id"`
+}
+
+type agentTracePathParams struct {
+	ThreadID string `path:"thread_id"`
+	TraceID  string `path:"trace_id"`
+}
+
+type agentTraceCompareQueryParams struct {
+	A string `query:"a" required:"true"`
+	B string `query:"b" required:"true"`
+}
+
 type agentThreadListQueryParams struct {
 	PageSize  int32  `query:"page_size"`
 	PageToken string `query:"page_token"`
@@ -524,6 +538,29 @@ type agentEvalReportBadCaseListOpenAPIResponse struct {
 	Items         []agentEvalReportBadCaseListItemOpenAPIResponse `json:"items"`
 	TotalSize     int                                             `json:"total_size"`
 	NextPageToken string                                          `json:"next_page_token"`
+}
+	
+type agentTraceSummaryOpenAPIResponse struct {
+	Status         string   `json:"status"`
+	LatencyMS      *float64 `json:"latency_ms,omitempty"`
+	RoundCount     int      `json:"round_count"`
+	ToolCallCount  int      `json:"tool_call_count"`
+	RetrievalCount int      `json:"retrieval_count"`
+	RerankCount    int      `json:"rerank_count"`
+}
+
+type agentTraceDetailOpenAPIResponse struct {
+	TraceID     string                           `json:"trace_id"`
+	TraceStatus string                           `json:"trace_status"`
+	Query       string                           `json:"query"`
+	Summary     agentTraceSummaryOpenAPIResponse `json:"summary"`
+	Trace       map[string]any                   `json:"trace,omitempty"`
+}
+
+type agentTraceCompareOpenAPIResponse struct {
+	Query string                          `json:"query"`
+	A     agentTraceDetailOpenAPIResponse `json:"a"`
+	B     agentTraceDetailOpenAPIResponse `json:"b"`
 }
 
 type skillPathParams struct {
@@ -2308,6 +2345,7 @@ func registeredCoreOperations() []openAPIOperation {
 		},
 		{
 			Method:      "GET",
+<<<<<<< HEAD
 			Path:        "/agent/threads/{thread_id}/results/eval-reports",
 			Summary:     "GET /agent/threads/{thread_id}/results/eval-reports",
 			Description: "Returns eval report artifact rows from Evo, with core-added report_id, bad_case_count, and trace_coverage when available. Existing report fields remain under data except bad_cases, which is served by the dedicated bad-case list endpoint.",
@@ -2324,6 +2362,24 @@ func registeredCoreOperations() []openAPIOperation {
 			PathParams:  agentEvalReportBadCaseListPathParams{},
 			QueryParams: agentEvalReportBadCaseListQueryParams{},
 			Responses:   map[int]openAPIResponse{200: resp("Eval report bad case list", agentEvalReportBadCaseListOpenAPIResponse{})},
+=======
+			Path:        "/agent/threads/{thread_id}/results/traces/{trace_id}",
+			Summary:     "Get agent trace detail",
+			Description: "Get one trace detail for a thread owned by the current user.",
+			Tags:        []string{"agent"},
+			PathParams:  agentTracePathParams{},
+			Responses:   map[int]openAPIResponse{200: resp("Agent trace detail", agentTraceDetailOpenAPIResponse{})},
+		},
+		{
+			Method:      "GET",
+			Path:        "/agent/threads/{thread_id}/results/traces-compare",
+			Summary:     "Compare agent traces",
+			Description: "Compare two trace details in a thread. Query parameters a and b are trace IDs.",
+			Tags:        []string{"agent"},
+			PathParams:  agentThreadPathParams{},
+			QueryParams: agentTraceCompareQueryParams{},
+			Responses:   map[int]openAPIResponse{200: resp("Agent trace comparison", agentTraceCompareOpenAPIResponse{})},
+>>>>>>> d794fdf (feat: add trace detail and abtest interface)
 		},
 		{
 			Method:      "POST",

--- a/backend/core/routes.go
+++ b/backend/core/routes.go
@@ -152,6 +152,8 @@ func registerAllRoutes(r *mux.Router) {
 	handleAPI(r, "GET", "/agent/threads/{thread_id}/results/abtests", []string{"qa.read"}, agent.GetThreadResultAbtests)
 	handleAPI(r, "GET", "/agent/threads/{thread_id}/flow-status", []string{"qa.read"}, agent.GetThreadFlowStatus)
 	handleAPI(r, "GET", "/agent/threads/{thread_id}/artifacts/{artifact_id}", []string{"qa.read"}, agent.GetThreadArtifact)
+	handleAPI(r, "GET", "/agent/threads/{thread_id}/results/traces/{trace_id}", []string{"qa.read"}, agent.GetThreadResultTrace)
+	handleAPI(r, "GET", "/agent/threads/{thread_id}/results/traces-compare", []string{"qa.read"}, agent.GetThreadResultTraceCompare)
 	handleAPI(r, "POST", "/agent/threads/{thread_id}:messages", []string{"qa.write"}, agent.StreamThreadMessages)
 	handleAPI(r, "POST", "/agent/threads/{thread_id}:start", []string{"qa.write"}, agent.StartThread)
 	handleAPI(r, "POST", "/agent/threads/{thread_id}:pause", []string{"qa.write"}, agent.PauseThread)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,6 +16,7 @@ x-mirror-args: &mirror-args
   BASE_LAZYMIND_IMAGE: ${BASE_LAZYMIND_IMAGE:-base_code}
 
 x-trace-config: &trace-config
+  TZ: ${TZ:-Asia/Shanghai}
   LANGFUSE_HOST: ${LANGFUSE_HOST:-}
   LANGFUSE_BASE_URL: ${LANGFUSE_BASE_URL:-}
   LANGFUSE_PUBLIC_KEY: ${LANGFUSE_PUBLIC_KEY:-}

--- a/evo/operations/abtest/cutover.py
+++ b/evo/operations/abtest/cutover.py
@@ -96,9 +96,10 @@ class CompareABTestOperation:
             ref = ArtifactRef.parse(str(raw_ref))
             judge = typed_payload(ctx, ref, 'JudgeResult')
             case_id = validate_case_id(str(judge.get('case_id') or ''))
+
             if case_id in rows:
                 raise ValueError(f'duplicate JudgeResult case_id: {case_id}')
-            rows[case_id] = judge | {'judge_ref': str(ref)}
+            rows[case_id] = judge | {'judge_ref': str(ref), 'query': self._case_query(ctx, judge)}
         return rows
 
     def _delta(self, case_id, before, after, policy) -> dict[str, Any]:
@@ -107,9 +108,28 @@ class CompareABTestOperation:
         d, epsilon = delta[policy['primary_metric']], policy['regression_epsilon']
         return {'case_id': case_id, 'baseline_judge_ref': before['judge_ref'],
                 'candidate_judge_ref': after['judge_ref'],
-                'before': b | {'quality_label': before.get('quality_label', 'bad')},
-                'after': a | {'quality_label': after.get('quality_label', 'bad')}, 'delta': delta,
+                'query': before.get('query') or after.get('query') or '',
+                'before': b | self._case_delta_side(before),
+                'after': a | self._case_delta_side(after), 'delta': delta,
                 'outcome': 'improved' if d > epsilon else 'regressed' if d < -epsilon else 'unchanged'}
+
+    def _case_query(self, ctx, row) -> str:
+        try:
+            case_ref = ArtifactRef.parse(str(row.get('case_ref') or ''))
+            case = typed_payload(ctx, case_ref, 'DatasetCase')
+            return str(case.get('question') or '').strip()
+        except (TypeError, ValueError, KeyError):
+            return ''
+
+    def _case_delta_side(self, row) -> dict[str, Any]:
+        return {'quality_label': row.get('quality_label', 'bad'),
+                'trace_id': str(row.get('trace_id') or '').strip(),
+                'reason': self._case_reason(row)}
+
+    def _case_reason(self, row) -> str:
+        reason = row.get('reason') or row.get('judge_reason') or ''
+        if isinstance(reason, list): return '; '.join(str(item) for item in reason if str(item).strip())
+        return str(reason or '')
 
     def _case_scores(self, row) -> dict[str, float]:
         out = {metric: self._number(row.get(metric), metric) for metric in METRICS}

--- a/evo/service/api.py
+++ b/evo/service/api.py
@@ -21,6 +21,7 @@ from evo.artifact_runtime import ArtifactKey, ArtifactRef
 from evo.message_intent import MessageSessionStore
 from evo.message_intent.planner import LazyLLMPlannerClient, StructuredJSONNextIntentPlanner
 from evo.message_intent.service import MessageIntentService
+from evo.traces import build_trace_compare_view, build_trace_detail_view
 
 BODY_REQUIRED = Body(...)
 BODY_DEFAULT = Body(default_factory=dict)
@@ -171,6 +172,14 @@ def create_app(*, planner_factory: Any | None = None) -> FastAPI:
         hub.get_thread(thread_id)
         last = request.headers.get('last-event-id') or ''
         return EventSourceResponse(hub.events(thread_id, int(last) if last.isdigit() else since))
+
+    @app.get('/v1/evo/threads/{thread_id}/results/traces/{trace_id}')
+    def trace_detail(thread_id: str, trace_id: str) -> dict:
+        return hub.trace_detail(thread_id, trace_id)
+
+    @app.get('/v1/evo/threads/{thread_id}/results/traces-compare')
+    def trace_compare(thread_id: str, a: str, b: str) -> dict:
+        return hub.trace_compare(thread_id, a, b)
 
     @app.get('/v1/evo/threads/{thread_id}/results/{kind}')
     def results(thread_id: str, kind: str) -> list[dict]:
@@ -440,6 +449,21 @@ class EvoMessageHub:
         rows = [row for artifact_id in RESULT_ARTIFACTS[kind] if (
             row := self._artifact_runtime_row(thread_id, artifact_id))]
         return _frontend_result_rows(kind, rows)
+
+    def trace_detail(self, thread_id: str, trace_id: str) -> dict:
+        self._meta(thread_id)
+        return build_trace_detail_view(
+            trace_id,
+            lambda artifact_id: self._thread_artifact_payload(thread_id, artifact_id),
+        )
+
+    def trace_compare(self, thread_id: str, a: str, b: str) -> dict:
+        self._meta(thread_id)
+        return build_trace_compare_view(
+            a,
+            b,
+            lambda artifact_id: self._thread_artifact_payload(thread_id, artifact_id),
+        )
 
     def artifact(self, thread_id: str, artifact_id: str) -> dict:
         row = self._artifact_runtime_row(thread_id, ARTIFACT_ID_ALIASES.get(artifact_id, artifact_id))

--- a/evo/traces/__init__.py
+++ b/evo/traces/__init__.py
@@ -1,0 +1,24 @@
+from .detail import build_trace_compare_view, build_trace_detail_view
+from .models import (
+    TraceCompareView,
+    TraceDetailView,
+    TraceIOKind,
+    TraceIOView,
+    TraceNodeView,
+    TraceSummaryView,
+    TraceView,
+)
+from .tree import build_trace_view
+
+__all__ = [
+    'TraceCompareView',
+    'TraceDetailView',
+    'TraceIOKind',
+    'TraceIOView',
+    'TraceNodeView',
+    'TraceSummaryView',
+    'TraceView',
+    'build_trace_compare_view',
+    'build_trace_detail_view',
+    'build_trace_view',
+]

--- a/evo/traces/detail.py
+++ b/evo/traces/detail.py
@@ -1,0 +1,199 @@
+from __future__ import annotations
+
+import dataclasses
+import os
+import time
+from dataclasses import asdict
+from typing import Any, Callable, Iterator
+
+from lazyllm.tracing.consume import get_single_trace
+from lazyllm.tracing.consume.reconstruction.extractors.utils import parse_jsonish, query_from_input
+from lazyllm.tracing.datamodel.structured import ExecutionStep, RawData, StructuredTrace, TraceMetadata
+from lazyllm.tracing.semantics import SemanticType
+
+from evo.projections.traces.models import TraceCompareView, TraceDetailView, TraceSummaryView
+from evo.projections.traces.tree import build_trace_view
+
+
+TraceArtifactLoader = Callable[[str], Any]
+
+
+def build_trace_detail_view(trace_id: str, load_artifact: TraceArtifactLoader | None = None) -> dict:
+    return asdict(_build_trace_detail(trace_id, load_artifact))
+
+
+def build_trace_compare_view(a: str, b: str, load_artifact: TraceArtifactLoader | None = None) -> dict:
+    return asdict(_build_trace_compare(a, b, load_artifact))
+
+
+def _build_trace_detail(trace_id: str, load_artifact: TraceArtifactLoader | None) -> TraceDetailView:
+    trace = _load_trace(trace_id, load_artifact)
+    trace_status = 'success' if trace else 'trace_missing'
+    return TraceDetailView(
+        trace_id=trace_id,
+        trace_status=trace_status,
+        query=_trace_query(trace.execution_tree.raw_data if trace and trace.execution_tree else None),
+        summary=_trace_summary(trace, trace_status),
+        trace=build_trace_view(trace),
+    )
+
+
+def _build_trace_compare(a: str, b: str, load_artifact: TraceArtifactLoader | None) -> TraceCompareView:
+    side_a = _build_trace_detail(a, load_artifact)
+    side_b = _build_trace_detail(b, load_artifact)
+    return TraceCompareView(query=side_a.query or side_b.query, a=side_a, b=side_b)
+
+
+def _load_trace(trace_id: str, load_artifact: TraceArtifactLoader | None) -> StructuredTrace | None:
+    trace_id = str(trace_id or '').strip()
+    if not trace_id:
+        return None
+    if load_artifact is not None:
+        for artifact_id in (f'trace_{trace_id}', trace_id):
+            try:
+                trace = _structured_trace_from_payload(load_artifact(artifact_id))
+            except Exception:
+                trace = None
+            if trace:
+                return trace
+    backend = os.getenv('LAZYLLM_TRACE_CONSUME_BACKEND') or os.getenv('LAZYLLM_TRACE_BACKEND') or None
+    for _ in range(3):
+        try:
+            trace = get_single_trace(trace_id, backend=backend) if backend else get_single_trace(trace_id)
+        except Exception:
+            trace = None
+        if isinstance(trace, StructuredTrace):
+            return trace
+        converted = _structured_trace_from_payload(trace)
+        if converted:
+            return converted
+        time.sleep(0.2)
+    return None
+
+
+def _structured_trace_from_payload(payload: Any) -> StructuredTrace | None:
+    if isinstance(payload, StructuredTrace):
+        return payload
+    if dataclasses.is_dataclass(payload):
+        payload = asdict(payload)
+    if not isinstance(payload, dict):
+        return None
+    root = payload.get('execution_tree') or payload.get('root')
+    if not isinstance(root, dict):
+        return None
+    metadata = payload.get('metadata') if isinstance(payload.get('metadata'), dict) else {}
+    trace_id = str(payload.get('trace_id') or metadata.get('trace_id') or '')
+    try:
+        return StructuredTrace(
+            trace_id=trace_id,
+            metadata=_trace_metadata(metadata),
+            execution_tree=_execution_step(root),
+        )
+    except Exception:
+        return None
+
+
+def _trace_metadata(value: dict[str, Any]) -> TraceMetadata:
+    nested = value.get('metadata') if isinstance(value.get('metadata'), dict) else {}
+    return TraceMetadata(
+        name=_optional_str(value.get('name')),
+        start_time=_float(value.get('start_time')),
+        end_time=_optional_float(value.get('end_time')),
+        latency_ms=_optional_float(value.get('latency_ms')),
+        status=str(value.get('status') or 'unknown'),
+        error_message=_optional_str(value.get('error_message')),
+        tags=value.get('tags') if isinstance(value.get('tags'), list) else [],
+        session_id=_optional_str(value.get('session_id')),
+        user_id=_optional_str(value.get('user_id')),
+        metadata=dict(nested),
+    )
+
+
+def _execution_step(value: dict[str, Any]) -> ExecutionStep:
+    raw = value.get('raw_data') if isinstance(value.get('raw_data'), dict) else {}
+    semantic_data = value.get('semantic_data') if isinstance(value.get('semantic_data'), dict) else None
+    children = value.get('children') if isinstance(value.get('children'), list) else []
+    return ExecutionStep(
+        step_id=str(value.get('step_id') or value.get('node_id') or ''),
+        name=str(value.get('name') or ''),
+        node_type=str(value.get('node_type') or value.get('type') or ''),
+        semantic_type=_optional_str(value.get('semantic_type')),
+        status=str(value.get('status') or ''),
+        start_time=_float(value.get('start_time')),
+        end_time=_optional_float(value.get('end_time')),
+        latency_ms=_optional_float(value.get('latency_ms')),
+        raw_data=RawData(input=raw.get('input'), output=raw.get('output')),
+        semantic_data=semantic_data,
+        error_message=_optional_str(value.get('error_message')),
+        children=[_execution_step(child) for child in children if isinstance(child, dict)],
+    )
+
+
+def _trace_query(raw_data: RawData | None) -> str:
+    inputs = parse_jsonish(raw_data.input) if raw_data else None
+    query = query_from_input(inputs)
+    return query if isinstance(query, str) else ''
+
+
+def _trace_summary(trace: StructuredTrace | None, trace_status: str) -> TraceSummaryView:
+    tree = trace.execution_tree if trace else None
+    metadata = trace.metadata if trace else None
+    nodes = list(_walk_tree(tree)) if tree else []
+    status = str((metadata.status if metadata else '') or (tree.status if tree else '') or trace_status)
+    return TraceSummaryView(
+        status=status,
+        latency_ms=metadata.latency_ms if metadata else None,
+        round_count=_agent_round_count(tree),
+        tool_call_count=_tool_call_count(nodes),
+        retrieval_count=sum(1 for node in nodes if node.semantic_type == SemanticType.RETRIEVER),
+        rerank_count=sum(1 for node in nodes if node.semantic_type == SemanticType.RERANK),
+    )
+
+
+def _walk_tree(node: ExecutionStep | None) -> Iterator[ExecutionStep]:
+    if node is None:
+        return
+    yield node
+    for child in node.children:
+        yield from _walk_tree(child)
+
+
+def _agent_round_count(root: ExecutionStep | None) -> int:
+    def visit(node: ExecutionStep, in_agent: bool) -> int:
+        semantic_type = node.semantic_type
+        in_agent = in_agent or semantic_type == SemanticType.AGENT
+        if in_agent and semantic_type in (SemanticType.TOOL, SemanticType.RETRIEVER, SemanticType.RERANK):
+            return 0
+        return int(in_agent and semantic_type == SemanticType.LLM) + sum(visit(child, in_agent) for child in node.children)
+
+    return visit(root, False) if root else 0
+
+
+def _tool_call_count(nodes: list[ExecutionStep]) -> int:
+    count = 0
+    for node in nodes:
+        if node.semantic_type != SemanticType.TOOL:
+            continue
+        raw_input = parse_jsonish(node.raw_data.input)
+        args = raw_input.get('args') if isinstance(raw_input, dict) else None
+        tool_calls = args[0] if isinstance(args, list) and args else None
+        count += len(tool_calls) if isinstance(tool_calls, list) else 1
+    return count
+
+
+def _optional_str(value: Any) -> str | None:
+    return str(value) if value not in (None, '') else None
+
+
+def _float(value: Any) -> float:
+    out = _optional_float(value)
+    return out if out is not None else 0.0
+
+
+def _optional_float(value: Any) -> float | None:
+    if value in (None, ''):
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None

--- a/evo/traces/detail.py
+++ b/evo/traces/detail.py
@@ -164,7 +164,8 @@ def _agent_round_count(root: ExecutionStep | None) -> int:
         in_agent = in_agent or semantic_type == SemanticType.AGENT
         if in_agent and semantic_type in (SemanticType.TOOL, SemanticType.RETRIEVER, SemanticType.RERANK):
             return 0
-        return int(in_agent and semantic_type == SemanticType.LLM) + sum(visit(child, in_agent) for child in node.children)
+        is_agent_llm = int(in_agent and semantic_type == SemanticType.LLM)
+        return is_agent_llm + sum(visit(child, in_agent) for child in node.children)
 
     return visit(root, False) if root else 0
 

--- a/evo/traces/io.py
+++ b/evo/traces/io.py
@@ -1,0 +1,420 @@
+from __future__ import annotations
+
+from typing import Any
+
+from lazyllm.tracing.datamodel.structured import ExecutionStep
+from lazyllm.tracing.semantics import SemanticType
+
+from evo.projections.traces.models import TraceIOKind, TraceIOView
+from evo.projections.traces.tools import is_tool_node
+from evo.projections.traces.values import (
+    arguments_summary,
+    compact_display_value,
+    display_summary,
+    drop_empty,
+    io,
+    looks_internal_call_repr,
+    parse_jsonish,
+    project_dict,
+    raw_projection,
+    safe_json,
+    string_field,
+    text_summary,
+    tool_result_summary,
+)
+
+
+def normalize_io(value: Any, *, node: ExecutionStep, direction: str) -> TraceIOView:
+    parsed = parse_jsonish(value)
+    first = _first_arg(parsed)
+    tool_node = is_tool_node(node)
+
+    if direction == 'input' and node.name in {'run_chat_pipeline', 'traced_call'}:
+        return _request_context_io(first)
+    if direction == 'input' and node.semantic_type == SemanticType.LLM:
+        return _llm_input_io(parsed, first)
+    if direction == 'input' and node.semantic_type == SemanticType.RETRIEVER:
+        return _query_input_io(TraceIOKind.RETRIEVER_QUERY, node.semantic_data, first)
+    if direction == 'input' and node.semantic_type == SemanticType.RERANK:
+        return _query_input_io(TraceIOKind.RERANK_QUERY, node.semantic_data, first)
+    if _is_assistant_message(first):
+        return _assistant_message_io(first)
+    if _is_assistant_message(parsed):
+        return _assistant_message_io(parsed)
+    if node.semantic_type == SemanticType.TOOL or node.name == 'ToolManager':
+        if direction == 'input' and isinstance(first, list):
+            return _tool_call_batch_io(first)
+        if direction == 'output' and isinstance(parsed, list):
+            return _tool_result_batch_io(parsed)
+    if direction == 'input' and tool_node and isinstance(first, dict):
+        return _tool_arguments_io(node.name, first)
+    if direction == 'output' and tool_node:
+        return _tool_output_io(node.name, parsed)
+    if direction == 'output' and node.semantic_type == SemanticType.RETRIEVER:
+        data = node.semantic_data if isinstance(node.semantic_data, dict) else {}
+        return _retriever_result_io(data)
+    if direction == 'output' and node.semantic_type == SemanticType.RERANK:
+        data = node.semantic_data if isinstance(node.semantic_data, dict) else {}
+        return _rerank_result_io(data)
+    return _fallback_io(parsed)
+
+
+def retriever_data(data: dict[str, Any]) -> dict[str, Any]:
+    filters = data.get('filters') if isinstance(data.get('filters'), dict) else {}
+    return drop_empty({
+        'query': data.get('query'),
+        'kb_id': filters.get('kb_id'),
+        'filters': filters or None,
+        'group_name': data.get('group_name'),
+        'mode': data.get('mode'),
+        'topk': data.get('topk'),
+        'node_count': data.get('node_count'),
+        'similarity': data.get('similarity'),
+        'similarity_cut_off': data.get('similarity_cut_off'),
+        'index': data.get('index'),
+        'target': data.get('target'),
+    })
+
+
+def rerank_data(data: dict[str, Any]) -> dict[str, Any]:
+    return drop_empty({
+        'query': data.get('query'),
+        'rerank_model': data.get('rerank_model'),
+        'candidate_node_count': data.get('candidate_node_count'),
+        'node_count': data.get('node_count'),
+        'topk': data.get('topk'),
+        'output_format': data.get('output_format'),
+    })
+
+
+def _first_arg(value: Any) -> Any:
+    if isinstance(value, dict) and isinstance(value.get('args'), list) and value['args']:
+        return parse_jsonish(value['args'][0])
+    return value
+
+
+def _request_context_io(value: Any) -> TraceIOView:
+    data = value if isinstance(value, dict) else {}
+    query = str(data.get('query') or '') if data else ''
+    return io(
+        TraceIOKind.REQUEST_CONTEXT,
+        text_summary(query) or 'request context',
+        drop_empty({
+            'query': query,
+            'dataset': string_field(data, 'dataset'),
+            'stream': data.get('stream'),
+            'use_memory': data.get('use_memory'),
+            'filters': project_dict(data.get('filters')),
+            'available_tools': data.get('available_tools')
+            if isinstance(data.get('available_tools'), list)
+            else None,
+            'available_skill_count': len(data.get('available_skills') or []),
+            'file_count': len(data.get('files') or []),
+            'image_file_count': len(data.get('image_files') or []),
+        }),
+    )
+
+
+def _llm_input_io(raw_input: Any, first: Any) -> TraceIOView:
+    kwargs = raw_input.get('kwargs') if isinstance(raw_input, dict) else {}
+    kwargs = kwargs if isinstance(kwargs, dict) else {}
+    if isinstance(first, dict) and isinstance(first.get('input'), list):
+        messages = [
+            raw_projection(message)
+            for message in first['input']
+            if isinstance(message, dict)
+        ]
+        tool_count = sum(1 for item in messages if item.get('role') == 'tool')
+        summary = (
+            f'{len(messages)} messages'
+            if tool_count != len(messages)
+            else f'{tool_count} tool messages'
+        )
+        return io(
+            TraceIOKind.LLM_MESSAGES,
+            summary,
+            drop_empty({
+                'message_count': len(messages),
+                'tool_message_count': tool_count,
+                'messages': messages,
+            }),
+        )
+    prompt = first
+    if isinstance(first, dict):
+        prompt = first.get('query') or first.get('prompt') or safe_json(first)
+    prompt_text = str(prompt or '')
+    return io(
+        TraceIOKind.LLM_PROMPT,
+        text_summary(prompt_text) or 'llm prompt',
+        drop_empty({
+            'prompt': text_summary(prompt_text, limit=2000),
+            'history_count': len(kwargs.get('llm_chat_history') or []),
+        }),
+    )
+
+
+def _query_input_io(kind: TraceIOKind, semantic_data: Any, first: Any) -> TraceIOView:
+    data = semantic_data if isinstance(semantic_data, dict) else {}
+    query = data.get('query') or (first if isinstance(first, str) else None)
+    if isinstance(query, str) and looks_internal_call_repr(query):
+        query = None
+    return io(
+        kind,
+        text_summary(query) if query else kind.value,
+        drop_empty({
+            'query': text_summary(query, limit=1000) if query is not None else None,
+            'filters': project_dict(data.get('filters')),
+            'topk': data.get('topk'),
+            'group_name': string_field(data, 'group_name'),
+            'mode': string_field(data, 'mode'),
+            'rerank_model': string_field(data, 'rerank_model'),
+        }),
+    )
+
+
+def _assistant_message_io(message: dict[str, Any]) -> TraceIOView:
+    calls = _tool_call_data(message.get('tool_calls') or [])
+    content = str(message.get('content') or '')
+    reasoning = str(message.get('reasoning_content') or '')
+    suffix = f', {len(calls)} tool calls' if calls else ''
+    return io(
+        TraceIOKind.ASSISTANT_MESSAGE,
+        f'assistant message{suffix}',
+        drop_empty({
+            'role': string_field(message, 'role'),
+            'content': text_summary(content, limit=2000),
+            'reasoning_content': text_summary(reasoning, limit=2000),
+            'tool_call_count': len(calls),
+            'tool_calls': calls,
+        }),
+    )
+
+
+def _tool_call_batch_io(calls: list[Any]) -> TraceIOView:
+    items = _tool_call_data(calls)
+    names = [
+        str(function.get('name'))
+        for item in items
+        for function in [item.get('function') if isinstance(item.get('function'), dict) else {}]
+        if function.get('name')
+    ]
+    return io(
+        TraceIOKind.TOOL_CALL_BATCH,
+        f'{len(items)} tool calls' + (f': {", ".join(names)}' if names else ''),
+        drop_empty({'tool_call_count': len(items), 'tool_calls': items}),
+    )
+
+
+def _tool_result_batch_io(results: list[Any]) -> TraceIOView:
+    items: list[dict[str, Any]] = []
+    success_count = 0
+    error_count = 0
+    for result in results:
+        parsed = parse_jsonish(result)
+        if isinstance(parsed, dict):
+            if parsed.get('success') is True or parsed.get('status') == 'ok':
+                success_count += 1
+            if parsed.get('success') is False or parsed.get('status') == 'error' or parsed.get('error'):
+                error_count += 1
+            items.append(raw_projection(parsed))
+        else:
+            items.append({'value': raw_projection(parsed)})
+    summary = f'{len(items)} results, {success_count} success'
+    if error_count:
+        summary += f', {error_count} error'
+    return io(
+        TraceIOKind.TOOL_RESULT_BATCH,
+        summary,
+        drop_empty({
+            'result_count': len(items),
+            'success_count': success_count,
+            'error_count': error_count,
+            'results': items,
+        }),
+    )
+
+
+def _tool_arguments_io(tool_name: str, arguments: dict[str, Any]) -> TraceIOView:
+    payload = raw_projection(arguments)
+    summary = arguments_summary(payload)
+    return io(TraceIOKind.TOOL_ARGUMENTS, summary or f'{tool_name} arguments', payload)
+
+
+def _tool_output_io(tool_name: str, value: Any) -> TraceIOView:
+    if not isinstance(value, dict):
+        return _fallback_io(value)
+    if value.get('success') is False or value.get('status') == 'error' or value.get('error'):
+        return io(
+            TraceIOKind.TOOL_ERROR,
+            str(value.get('error') or value.get('reason') or 'tool error'),
+            raw_projection(value),
+        )
+    if tool_name == 'calculator':
+        expression = value.get('expression')
+        result = value.get('result')
+        summary = (
+            f'{expression} = {result}'
+            if expression is not None and result is not None
+            else tool_result_summary(value)
+        )
+        return io(TraceIOKind.CALCULATOR_RESULT, summary, raw_projection(value))
+    if tool_name.startswith('kb_') or tool_name == 'kb_search':
+        return _result_collection_io(TraceIOKind.KB_SEARCH_RESULT, value)
+    if tool_name in {'web_search', 'arxiv_search'}:
+        return _result_collection_io(TraceIOKind.WEB_SEARCH_RESULT, value)
+    return io(TraceIOKind.TOOL_RESULT, tool_result_summary(value), raw_projection(value))
+
+
+def _result_collection_io(kind: TraceIOKind, value: dict[str, Any]) -> TraceIOView:
+    payload = raw_projection(value)
+    result = payload.get('result') if isinstance(payload.get('result'), dict) else payload
+    items = result.get('items') if isinstance(result.get('items'), list) else []
+    total = result.get('total', len(items))
+    return io(kind, f'{total} results', payload)
+
+
+def _retriever_result_io(data: dict[str, Any]) -> TraceIOView:
+    payload = retriever_data(data)
+    scores = data.get('scores') if isinstance(data.get('scores'), list) else []
+    node_ids = data.get('returned_node_ids')
+    node_ids = node_ids if isinstance(node_ids, list) else []
+    if scores:
+        payload['scores'] = raw_projection(scores)
+    if node_ids:
+        payload['returned_node_ids'] = raw_projection(node_ids)
+    count = payload.get('node_count')
+    group = payload.get('group_name')
+    summary = (
+        f'{group + " " if group else ""}retriever returned {count} nodes'
+        if count is not None
+        else 'retriever result'
+    )
+    return io(TraceIOKind.RETRIEVER_RESULT, summary, payload)
+
+
+def _rerank_result_io(data: dict[str, Any]) -> TraceIOView:
+    payload = rerank_data(data)
+    scores = data.get('scores') if isinstance(data.get('scores'), list) else []
+    if scores:
+        payload['scores'] = raw_projection(scores)
+        payload['score_count'] = len(scores)
+    return io(
+        TraceIOKind.RERANK_RESULT,
+        f'{len(scores)} scores by {payload.get("rerank_model")}' if scores else 'rerank result',
+        payload,
+    )
+
+
+def _fallback_io(value: Any) -> TraceIOView:
+    parsed = parse_jsonish(value)
+    if parsed is None:
+        return io(TraceIOKind.NULL, '')
+    if (
+        isinstance(parsed, dict)
+        and isinstance(parsed.get('args'), list)
+        and isinstance(parsed.get('kwargs'), dict)
+    ):
+        return _call_input_io(parsed)
+    if isinstance(parsed, str) and looks_internal_call_repr(parsed):
+        return io(TraceIOKind.CALL_INPUT, 'internal call input')
+    if isinstance(parsed, dict):
+        return _object_io(parsed)
+    if isinstance(parsed, list):
+        return _list_io(parsed)
+    if isinstance(parsed, bool):
+        kind = TraceIOKind.BOOLEAN
+    elif isinstance(parsed, (int, float)):
+        kind = TraceIOKind.NUMBER
+    else:
+        kind = TraceIOKind.STRING
+    return io(kind, text_summary(str(parsed)), {'value': compact_display_value(parsed)})
+
+
+def _call_input_io(value: dict[str, Any]) -> TraceIOView:
+    display_value = _call_display_value(value)
+    summary = display_summary(display_value)
+    payload = _call_input_data(display_value)
+    return io(TraceIOKind.CALL_INPUT, summary or 'call input', payload)
+
+
+def _tool_call_data(calls: Any) -> list[dict[str, Any]]:
+    if not isinstance(calls, list):
+        return []
+    return [
+        projected
+        for call in calls
+        if isinstance(call, dict)
+        for projected in [raw_projection(call)]
+        if isinstance(projected, dict)
+    ]
+
+
+def _call_display_value(value: dict[str, Any]) -> Any:
+    args = value.get('args') if isinstance(value.get('args'), list) else []
+    kwargs = value.get('kwargs') if isinstance(value.get('kwargs'), dict) else {}
+    if args:
+        return parse_jsonish(args[0])
+    if 'x' in kwargs:
+        return parse_jsonish(kwargs['x'])
+    if len(kwargs) == 1:
+        return parse_jsonish(next(iter(kwargs.values())))
+    return kwargs
+
+
+def _call_input_data(value: Any) -> dict[str, Any]:
+    if isinstance(value, dict):
+        payload = drop_empty({
+            'argument': compact_display_value(value.get('value')) if 'value' in value else None,
+            'query': string_field(value, 'query'),
+            'expression': string_field(value, 'expression'),
+            'keyword': string_field(value, 'keyword'),
+            'url': string_field(value, 'url'),
+            'filters': project_dict(value.get('filters')),
+        })
+        return payload or raw_projection(value)
+    return drop_empty({'argument': compact_display_value(value)})
+
+
+def _object_io(value: dict[str, Any], *, limit: int = 12) -> TraceIOView:
+    items: list[dict[str, Any]] = []
+    for key, item in list(value.items())[:limit]:
+        items.append(drop_empty({
+            'name': str(key),
+            'summary': display_summary(item),
+            'value': compact_display_value(item),
+        }))
+    return io(
+        TraceIOKind.OBJECT,
+        display_summary(value) or f'{len(value)} fields',
+        drop_empty({
+            'field_count': len(value),
+            'truncated_count': max(len(value) - limit, 0) or None,
+            'fields': items,
+        }),
+    )
+
+
+def _list_io(values: list[Any], *, limit: int = 12) -> TraceIOView:
+    items = [
+        drop_empty({
+            'index': idx,
+            'summary': display_summary(item),
+            'value': compact_display_value(item),
+        })
+        for idx, item in enumerate(values[:limit])
+    ]
+    return io(
+        TraceIOKind.LIST,
+        f'{len(values)} items',
+        drop_empty({
+            'item_count': len(values),
+            'truncated_count': max(len(values) - limit, 0) or None,
+            'values': items,
+        }),
+    )
+
+
+def _is_assistant_message(value: Any) -> bool:
+    return isinstance(value, dict) and (
+        value.get('role') == 'assistant' or 'tool_calls' in value or 'reasoning_content' in value
+    )

--- a/evo/traces/models.py
+++ b/evo/traces/models.py
@@ -56,7 +56,6 @@ class TraceNodeView:
     status: str
     start_time: float
     end_time: float | None
-    latency: float | None
     input: TraceIOView
     output: TraceIOView
     metadata: dict[str, Any] = field(default_factory=dict)

--- a/evo/traces/models.py
+++ b/evo/traces/models.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any
+
+
+@dataclass
+class TraceSummaryView:
+    status: str
+    latency_ms: float | None
+    round_count: int
+    tool_call_count: int
+    retrieval_count: int
+    rerank_count: int
+
+
+class TraceIOKind(str, Enum):
+    REQUEST_CONTEXT = 'request_context'
+    CALL_INPUT = 'call_input'
+    LLM_PROMPT = 'llm_prompt'
+    LLM_MESSAGES = 'llm_messages'
+    ASSISTANT_MESSAGE = 'assistant_message'
+    TOOL_CALL_BATCH = 'tool_call_batch'
+    TOOL_RESULT_BATCH = 'tool_result_batch'
+    TOOL_ARGUMENTS = 'tool_arguments'
+    TOOL_RESULT = 'tool_result'
+    TOOL_ERROR = 'tool_error'
+    CALCULATOR_RESULT = 'calculator_result'
+    KB_SEARCH_RESULT = 'kb_search_result'
+    WEB_SEARCH_RESULT = 'web_search_result'
+    RETRIEVER_QUERY = 'retriever_query'
+    RETRIEVER_RESULT = 'retriever_result'
+    RERANK_QUERY = 'rerank_query'
+    RERANK_RESULT = 'rerank_result'
+    OBJECT = 'object'
+    LIST = 'list'
+    STRING = 'string'
+    NUMBER = 'number'
+    BOOLEAN = 'boolean'
+    NULL = 'null'
+
+
+@dataclass
+class TraceIOView:
+    kind: TraceIOKind
+    summary: str
+    data: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class TraceNodeView:
+    id: str
+    name: str
+    type: str
+    status: str
+    start_time: float
+    end_time: float | None
+    latency: float | None
+    input: TraceIOView
+    output: TraceIOView
+    metadata: dict[str, Any] = field(default_factory=dict)
+    children: list['TraceNodeView'] = field(default_factory=list)
+
+
+@dataclass
+class TraceView:
+    trace_id: str
+    metadata: dict[str, Any]
+    root: TraceNodeView
+
+
+@dataclass
+class TraceDetailView:
+    trace_id: str
+    trace_status: str
+    query: str
+    summary: TraceSummaryView
+    trace: TraceView | None
+
+
+@dataclass
+class TraceCompareView:
+    query: str
+    a: TraceDetailView
+    b: TraceDetailView

--- a/evo/traces/tools.py
+++ b/evo/traces/tools.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+from functools import lru_cache
+from typing import Any
+
+from lazyllm.tracing.datamodel.structured import ExecutionStep
+
+from evo.projections.traces.values import drop_empty
+
+_FALLBACK_CHAT_TOOL_NAMES = frozenset({
+    'ArxivSearch',
+    'BingSearch',
+    'BochaSearch',
+    'GoogleSearch',
+    'SciverseSearch',
+    'TavilySearch',
+    'WikipediaSearch',
+    'calculator',
+    'get_skill',
+    'kb_get_parent_node',
+    'kb_get_window_nodes',
+    'kb_keyword_search',
+    'kb_search',
+    'memory_editor',
+    'read_reference',
+    'run_script',
+    'skill_editor',
+    'url_fetch',
+    'vision_extractor',
+    'vocab_learn',
+    'vocab_manage',
+})
+
+
+def is_tool_node(node: ExecutionStep) -> bool:
+    return node.name in registered_chat_tool_names()
+
+
+@lru_cache(maxsize=1)
+def registered_chat_tool_names() -> frozenset[str]:
+    try:
+        from lazymind.chat.service.component import get_all_tool_groups
+    except Exception:
+        return _FALLBACK_CHAT_TOOL_NAMES
+
+    names: set[str] = set()
+    for group in get_all_tool_groups():
+        if not isinstance(group, dict):
+            continue
+        for method in group.get('methods') or []:
+            if isinstance(method, dict) and (name := str(method.get('name') or '').strip()):
+                names.add(name)
+    return frozenset(names) | _FALLBACK_CHAT_TOOL_NAMES
+
+
+def tool_metadata(value: Any, *, fallback_tool: str) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        return {'tool_name': fallback_tool}
+    result = value.get('result') if isinstance(value.get('result'), dict) else value
+    items = result.get('items') if isinstance(result.get('items'), list) else None
+    return drop_empty({
+        'tool_name': value.get('tool') or value.get('name') or fallback_tool,
+        'success': value.get('success'),
+        'status': value.get('status') or result.get('status'),
+        'error': value.get('error') or result.get('error'),
+        'total': result.get('total'),
+        'item_count': len(items) if items is not None else None,
+    })

--- a/evo/traces/tree.py
+++ b/evo/traces/tree.py
@@ -60,7 +60,6 @@ def _view_node(node: ExecutionStep) -> TraceNodeView:
         status=node.status,
         start_time=node.start_time,
         end_time=node.end_time,
-        latency=_latency(node.start_time, node.end_time),
         input=normalize_io(raw_data.input if raw_data else None, node=node, direction='input'),
         output=normalize_io(raw_data.output if raw_data else None, node=node, direction='output'),
         metadata=_node_metadata(node),
@@ -131,8 +130,3 @@ def _node_metadata(node: ExecutionStep) -> dict[str, Any]:
         metadata['error_message'] = node.error_message
     return drop_empty(metadata)
 
-
-def _latency(start_time: float | None, end_time: float | None) -> float | None:
-    if start_time is None or end_time is None:
-        return None
-    return end_time - start_time

--- a/evo/traces/tree.py
+++ b/evo/traces/tree.py
@@ -1,0 +1,138 @@
+from __future__ import annotations
+
+from dataclasses import asdict
+from typing import Any
+
+from lazyllm.tracing.datamodel.structured import ExecutionStep, StructuredTrace
+from lazyllm.tracing.semantics import SemanticType
+
+from evo.projections.traces.models import TraceNodeView, TraceView
+from evo.projections.traces.io import normalize_io, rerank_data, retriever_data
+from evo.projections.traces.tools import is_tool_node, tool_metadata
+from evo.projections.traces.values import drop_empty, parse_jsonish, pick
+
+
+def build_trace_view(trace: StructuredTrace | None) -> TraceView | None:
+    if trace is None or trace.execution_tree is None:
+        return None
+    return TraceView(
+        trace_id=trace.trace_id,
+        metadata=_trace_metadata(trace),
+        root=_view_root(trace.execution_tree),
+    )
+
+
+def _trace_metadata(trace: StructuredTrace) -> dict[str, Any]:
+    metadata = asdict(trace.metadata)
+    nested = metadata.pop('metadata', None)
+    if isinstance(nested, dict):
+        metadata.update(nested)
+    return drop_empty(metadata)
+
+
+def _view_root(root: ExecutionStep) -> TraceNodeView:
+    view = _view_node(root)
+    rounds = [_view_node(node) for node in _find_round_nodes(root)]
+    if rounds:
+        view.children = rounds
+    return view
+
+
+def _find_round_nodes(root: ExecutionStep) -> list[ExecutionStep]:
+    rounds: list[ExecutionStep] = []
+    stack = [root]
+    while stack:
+        node = stack.pop()
+        if node.name == '_StreamingFunctionCall':
+            rounds.append(node)
+            continue
+        stack.extend(reversed(node.children))
+    return rounds
+
+
+def _view_node(node: ExecutionStep) -> TraceNodeView:
+    children_source = _merged_direct_children(node)
+    raw_data = node.raw_data
+    return TraceNodeView(
+        id=node.step_id,
+        name=node.name,
+        type=str(node.semantic_type or node.node_type or 'unknown'),
+        status=node.status,
+        start_time=node.start_time,
+        end_time=node.end_time,
+        latency=_latency(node.start_time, node.end_time),
+        input=normalize_io(raw_data.input if raw_data else None, node=node, direction='input'),
+        output=normalize_io(raw_data.output if raw_data else None, node=node, direction='output'),
+        metadata=_node_metadata(node),
+        children=_view_child_list(children_source),
+    )
+
+
+def _merged_direct_children(node: ExecutionStep) -> list[ExecutionStep]:
+    children = list(node.children)
+    if (
+        len(children) == 1
+        and children[0].name == 'Pipeline'
+        and (node.name == '_StreamingFunctionCall' or is_tool_node(node))
+    ):
+        return list(children[0].children)
+    return children
+
+
+def _view_child_list(children: list[ExecutionStep]) -> list[TraceNodeView]:
+    view: list[TraceNodeView] = []
+    for child in children:
+        if child.name == 'IFS':
+            view.extend(_view_child_list(list(child.children)))
+        elif child.name == '_post_action' and not child.children:
+            continue
+        elif child.name == '_post_action':
+            view.extend(_view_post_action(child))
+        elif child.name == '_safe_call':
+            target = child.children[0] if len(child.children) == 1 else child
+            view.append(_view_node(target))
+        else:
+            view.append(_view_node(child))
+    return view
+
+
+def _view_post_action(node: ExecutionStep) -> list[TraceNodeView]:
+    if len(node.children) != 1 or node.children[0].name != 'ToolManager':
+        return [_view_node(node)]
+    manager = node.children[0]
+    manager_children = list(manager.children)
+    if len(manager_children) == 1 and manager_children[0].name == 'Diverter':
+        manager_children = list(manager_children[0].children)
+    view = _view_node(manager)
+    view.children = _view_child_list(manager_children)
+    return [view]
+
+
+def _node_metadata(node: ExecutionStep) -> dict[str, Any]:
+    semantic = node.semantic_type
+    data = node.semantic_data if isinstance(node.semantic_data, dict) else {}
+    metadata: dict[str, Any] = {}
+    if semantic == SemanticType.LLM:
+        usage = data.get('usage') if isinstance(data.get('usage'), dict) else {}
+        metadata.update(pick(data, 'model_name', 'stream', 'temperature', 'top_p', 'max_tokens', 'answer_length'))
+        metadata.update(pick(usage, 'input_tokens', 'output_tokens', 'total_tokens'))
+    elif semantic == SemanticType.RETRIEVER:
+        metadata.update({key: value for key, value in retriever_data(data).items() if key != 'filters'})
+    elif semantic == SemanticType.RERANK:
+        metadata.update(rerank_data(data))
+    elif semantic == SemanticType.TOOL or is_tool_node(node):
+        output = parse_jsonish(node.raw_data.output if node.raw_data else None)
+        metadata.update(tool_metadata(output, fallback_tool=node.name))
+    elif semantic == SemanticType.WORKFLOW_CONTROL:
+        metadata.update({'control_type': node.name, 'child_count': len(node.children)})
+    elif semantic == SemanticType.AGENT:
+        metadata.update({'agent_name': node.name, 'child_count': len(node.children)})
+    if node.error_message:
+        metadata['error_message'] = node.error_message
+    return drop_empty(metadata)
+
+
+def _latency(start_time: float | None, end_time: float | None) -> float | None:
+    if start_time is None or end_time is None:
+        return None
+    return end_time - start_time

--- a/evo/traces/tree.py
+++ b/evo/traces/tree.py
@@ -129,4 +129,3 @@ def _node_metadata(node: ExecutionStep) -> dict[str, Any]:
     if node.error_message:
         metadata['error_message'] = node.error_message
     return drop_empty(metadata)
-

--- a/evo/traces/values.py
+++ b/evo/traces/values.py
@@ -1,0 +1,205 @@
+from __future__ import annotations
+
+import ast
+import json
+from typing import Any
+
+from evo.projections.traces.models import TraceIOKind, TraceIOView
+
+
+_RAW_PROJECTION_EXCLUDED_KEYS = frozenset({
+    'uid',
+    'user_id',
+    'session_id',
+    'files',
+    'image_files',
+})
+_RAW_PROJECTION_PARSE_STRING_KEYS = frozenset({'arguments', 'content'})
+_SUMMARY_KEYS = (
+    'value',
+    'query',
+    'expression',
+    'keyword',
+    'url',
+    'final_url',
+    'title',
+    'name',
+    'docid',
+    'document_id',
+    'node_id',
+    'target',
+    'content',
+    'description',
+    'text',
+)
+_ARGUMENT_SUMMARY_KEYS = ('query', 'expression', 'keyword', 'name', 'url', 'node_id', 'docid', 'target')
+_TOOL_RESULT_SUMMARY_KEYS = ('success', 'status', 'tool', 'expression', 'total')
+
+
+def raw_projection(
+    value: Any,
+    *,
+    key: str | None = None,
+    list_limit: int = 20,
+    dict_limit: int = 40,
+) -> Any:
+    if isinstance(value, str):
+        parsed = parse_jsonish(value) if key in _RAW_PROJECTION_PARSE_STRING_KEYS else value
+        if parsed is not value:
+            return raw_projection(parsed, list_limit=list_limit, dict_limit=dict_limit)
+        return text_summary(value, limit=1000)
+    parsed = parse_jsonish(value)
+    if isinstance(parsed, (int, float, bool)) or parsed is None:
+        return parsed
+    if isinstance(parsed, list):
+        return [
+            raw_projection(item, list_limit=list_limit, dict_limit=dict_limit)
+            for item in parsed[:list_limit]
+            if item not in (None, '', [], {})
+        ]
+    if isinstance(parsed, dict):
+        projected: dict[str, Any] = {}
+        for raw_key, item in list(parsed.items())[:dict_limit]:
+            if raw_key in _RAW_PROJECTION_EXCLUDED_KEYS or item in (None, '', [], {}):
+                continue
+            projected[str(raw_key)] = raw_projection(
+                item,
+                key=str(raw_key),
+                list_limit=list_limit,
+                dict_limit=dict_limit,
+            )
+        return projected
+    return text_summary(str(parsed), limit=1000)
+
+
+def display_summary(value: Any) -> str:
+    parsed = parse_jsonish(value)
+    if isinstance(parsed, dict):
+        for key in _SUMMARY_KEYS:
+            if parsed.get(key) not in (None, '', [], {}):
+                return text_summary(parsed[key])
+        if isinstance(parsed.get('input'), list):
+            return f'{len(parsed["input"])} messages'
+        if isinstance(parsed.get('items'), list):
+            return f'{len(parsed["items"])} items'
+        return object_summary(parsed)
+    if isinstance(parsed, list):
+        return f'{len(parsed)} items'
+    return text_summary(parsed)
+
+
+def compact_display_value(value: Any) -> Any:
+    parsed = parse_jsonish(value)
+    if isinstance(parsed, str):
+        return text_summary(parsed, limit=1000)
+    if isinstance(parsed, (int, float, bool)) or parsed is None:
+        return parsed
+    if isinstance(parsed, list):
+        return raw_projection(parsed, list_limit=8, dict_limit=8)
+    if isinstance(parsed, dict):
+        return raw_projection(parsed, list_limit=8, dict_limit=8)
+    return text_summary(str(parsed), limit=1000)
+
+
+def parse_jsonish(value: Any) -> Any:
+    if not isinstance(value, str):
+        return value
+    text = value.strip()
+    if not text:
+        return value
+    try:
+        return json.loads(text)
+    except (TypeError, ValueError):
+        pass
+    try:
+        return ast.literal_eval(text)
+    except (SyntaxError, ValueError, TypeError):
+        return value
+
+
+def drop_empty(value: dict[str, Any]) -> dict[str, Any]:
+    return {key: item for key, item in value.items() if item not in (None, '', [], {})}
+
+
+def project_dict(value: Any) -> dict[str, Any] | None:
+    return raw_projection(value) if isinstance(value, dict) else None
+
+
+def io(kind: TraceIOKind, summary: str, data: dict[str, Any] | None = None) -> TraceIOView:
+    return TraceIOView(kind=kind, summary=summary, data=data or {})
+
+
+def pick(value: dict[str, Any], *keys: str) -> dict[str, Any]:
+    return {key: value.get(key) for key in keys if value.get(key) is not None}
+
+
+def string_field(value: dict[str, Any], key: str, *, limit: int = 1000) -> str | None:
+    item = value.get(key)
+    if item in (None, '', [], {}):
+        return None
+    return text_summary(item, limit=limit)
+
+
+def arguments_summary(arguments: dict[str, Any]) -> str:
+    suggestions = arguments.get('suggestions')
+    if isinstance(suggestions, list):
+        return f'{len(suggestions)} suggestions'
+    for key in _ARGUMENT_SUMMARY_KEYS:
+        if arguments.get(key) not in (None, ''):
+            return text_summary(arguments[key], limit=160)
+    return object_summary(arguments)
+
+
+def tool_result_summary(value: Any) -> str:
+    if not isinstance(value, dict):
+        return text_summary(str(value))
+    result = value.get('result') if isinstance(value.get('result'), dict) else value
+    parts: list[str] = []
+    for key in _TOOL_RESULT_SUMMARY_KEYS:
+        source = result if isinstance(result, dict) and key in result else value
+        if key in source and source.get(key) not in (None, ''):
+            parts.append(f'{key}={text_summary(source.get(key), limit=80)}')
+    if value.get('result') is not None and not isinstance(value.get('result'), dict):
+        parts.append(f'result={text_summary(value.get("result"), limit=160)}')
+    if value.get('value') not in (None, ''):
+        parts.append(f'value={text_summary(value.get("value"), limit=80)}')
+    items = result.get('items') if isinstance(result.get('items'), list) else None
+    if items is not None:
+        parts.append(f'items={len(items)}')
+    if not parts and value.get('error'):
+        parts.append(f'error={text_summary(value.get("error"), limit=160)}')
+    return ' '.join(parts) or object_summary(value)
+
+
+def object_summary(value: dict[str, Any]) -> str:
+    suggestions = value.get('suggestions')
+    if isinstance(suggestions, list):
+        return f'{len(suggestions)} suggestions'
+    parts: list[str] = []
+    for key, item in value.items():
+        if isinstance(item, (dict, list)):
+            continue
+        if item not in (None, ''):
+            parts.append(f'{key}={text_summary(item, limit=80)}')
+        if len(parts) >= 3:
+            break
+    return ' '.join(parts) or f'{len(value)} fields'
+
+
+def looks_internal_call_repr(value: str) -> bool:
+    text = value.strip()
+    return text.startswith("{'args':") and "'kwargs':" in text
+
+
+def text_summary(value: Any, *, limit: int = 240) -> str:
+    text = ' '.join(str(value or '').split())
+    if len(text) > limit:
+        return text[:limit - 3] + '...'
+    return text
+
+
+def safe_json(value: Any) -> str:
+    try:
+        return json.dumps(value, ensure_ascii=False, default=str)
+    except TypeError:
+        return str(value)


### PR DESCRIPTION
# 添加观测后端接口

1. `results/traces/{trace_id}`

返回具体某个观测链路的数据，已对详细的观测字段进行整合和简化，便于展示

2. `results/traces-compare`

返回AB-Test阶段的两条观测链路的数据整合

# 其他

## 添加本地观测后端时区环境

设置 `TZ: ${TZ:-Asia/Shanghai}` 时区变量，保证本地trace文件的时间正确

## 添加观测数据归档逻辑

归档逻辑：7天内的`trace.jsonl`不动，7-30天的打包为zip，30天以上的压缩包删除。

启动服务时执行1次归档操作，之后每天执行1次归档操作；也可以手动执行：

```
LAZYLLM_TRACE_LOCAL_ARCHIVE_SECONDS=3600 \
LAZYLLM_TRACE_LOCAL_ARCHIVE_RETENTION_SECONDS=86400 \
python -c "from lazyllm.tracing.backends.local import maintain_local_traces; print(maintain_local_traces('This is your trace storage path.'))"
```