### PR TITLE
feat(skill-review): Algorithm pipeline optimization

### DIFF
--- a/algorithm/lazymind/review/skill_review/cluster.py
+++ b/algorithm/lazymind/review/skill_review/cluster.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
 
+import os
 import time
 from collections import defaultdict
 from concurrent.futures import as_completed
 from pathlib import Path
+from tempfile import gettempdir
+from typing import Any
 
 import numpy as np
 from lazyllm import LOG, ThreadPoolExecutor
@@ -15,16 +18,44 @@ from lazymind.review.skill_review.config import (
     STAGE_CLUSTER,
     STAGE_FILES,
 )
+from lazymind.review.skill_review.json_call import call_json
+from lazymind.review.skill_review.prompt import cluster_prompt
 from lazymind.review.skill_review.schemas import SkillDraft, TaskCluster
 from lazymind.review.skill_review.reports import finish_stage_report, stage_error, start_stage, write_json_file
 
 MIN_VALID_EMBEDDING_RATIO = 0.8
+DEFAULT_LLM_CLUSTER_THRESHOLD = 5
+UMAP_RANDOM_STATE = 42
+
+_CLUSTER_SCHEMA = {
+    'title': 'skill_draft_cluster_response',
+    'type': 'object',
+    'properties': {
+        'clusters': {
+            'type': 'array',
+            'items': {
+                'type': 'object',
+                'properties': {
+                    'task_scope': {'type': 'string'},
+                    'draft_indexes': {
+                        'type': 'array',
+                        'items': {'type': 'integer'},
+                    },
+                },
+                'required': ['task_scope', 'draft_indexes'],
+            },
+        },
+    },
+    'required': ['clusters'],
+}
 
 
 def cluster_drafts(
     drafts: list[SkillDraft],
     emb,
     *,
+    llm=None,
+    llm_cluster_threshold: int = DEFAULT_LLM_CLUSTER_THRESHOLD,
     max_workers: int = DEFAULT_STAGE_WORKERS,
     embedding_max_chars: int = DEFAULT_EMBEDDING_MAX_CHARS,
     embedding_retries: int = DEFAULT_EMBEDDING_RETRIES,
@@ -62,6 +93,34 @@ def cluster_drafts(
                 draft_count=len(drafts),
                 valid_embedding_count=len(drafts),
                 failed_embedding_count=0,
+            ),
+        )
+
+    if len(drafts) <= llm_cluster_threshold:
+        if llm is None:
+            raise ValueError('llm is required for small-sample skill draft clustering')
+        try:
+            clusters = _llm_clusters(drafts, llm)
+            errors: list[dict] = []
+        except Exception as exc:
+            errors = [stage_error(STAGE_CLUSTER, 'llm_cluster', exc)]
+            LOG.error(f'cluster stage failed during LLM clustering: {exc}')
+            clusters = []
+        if artifact_dir is not None:
+            write_json_file(artifact_dir / STAGE_FILES[STAGE_CLUSTER], clusters)
+        return clusters, finish_stage_report(
+            STAGE_CLUSTER,
+            started_at,
+            input_count=len(drafts),
+            output_count=len(clusters),
+            errors=errors,
+            status='failed' if not clusters else 'completed',
+            metadata=_cluster_report_metadata(
+                draft_count=len(drafts),
+                valid_embedding_count=0,
+                failed_embedding_count=0,
+                method='llm',
+                llm_cluster_threshold=llm_cluster_threshold,
             ),
         )
 
@@ -129,11 +188,12 @@ def cluster_drafts(
         )
 
     try:
-        labels = _hdbscan_labels(np.array(embeddings))
+        labels, cluster_metadata = _embedding_cluster_labels(np.array(embeddings))
+        metadata.update(cluster_metadata)
         clusters = _clusters_from_labels(valid_drafts, labels)
     except Exception as exc:
-        errors.append(stage_error(STAGE_CLUSTER, 'hdbscan', exc))
-        LOG.error(f'cluster stage failed during HDBSCAN: {exc}')
+        errors.append(stage_error(STAGE_CLUSTER, 'embedding_clustering', exc))
+        LOG.error(f'cluster stage failed during embedding clustering: {exc}')
         clusters = []
     if artifact_dir is not None:
         write_json_file(artifact_dir / STAGE_FILES[STAGE_CLUSTER], clusters)
@@ -234,6 +294,8 @@ def _cluster_report_metadata(
     draft_count: int,
     valid_embedding_count: int,
     failed_embedding_count: int,
+    method: str = 'embedding',
+    llm_cluster_threshold: int = DEFAULT_LLM_CLUSTER_THRESHOLD,
 ) -> dict:
     valid_embedding_ratio = valid_embedding_count / draft_count if draft_count else 1.0
     return {
@@ -242,27 +304,132 @@ def _cluster_report_metadata(
         'failed_embedding_count': failed_embedding_count,
         'valid_embedding_ratio': valid_embedding_ratio,
         'min_valid_embedding_ratio': MIN_VALID_EMBEDDING_RATIO,
+        'method': method,
+        'llm_cluster_threshold': llm_cluster_threshold,
     }
 
 
+def _llm_clusters(drafts: list[SkillDraft], llm) -> list[TaskCluster]:
+    payload = call_json(llm, cluster_prompt(_cluster_prompt_items(drafts)), _CLUSTER_SCHEMA)
+    raw_clusters = payload.get('clusters')
+    if not isinstance(raw_clusters, list):
+        raise ValueError('LLM cluster response must contain clusters list')
+
+    clusters: list[TaskCluster] = []
+    seen: set[int] = set()
+    expected = set(range(len(drafts)))
+    for cluster in raw_clusters:
+        if not isinstance(cluster, dict):
+            raise ValueError(f'cluster item must be an object: {cluster!r}')
+        task_scope = str(cluster.get('task_scope') or '').strip()
+        indexes = cluster.get('draft_indexes')
+        if not task_scope:
+            raise ValueError(f'cluster task_scope must be non-empty: {cluster!r}')
+        if not isinstance(indexes, list) or not indexes:
+            raise ValueError(f'cluster draft_indexes must be a non-empty list: {cluster!r}')
+
+        normalized_indexes = []
+        for raw_index in indexes:
+            if not isinstance(raw_index, int):
+                raise ValueError(f'cluster draft index must be integer: {raw_index!r}')
+            if raw_index not in expected:
+                raise ValueError(f'cluster draft index out of range: {raw_index}')
+            if raw_index in seen:
+                raise ValueError(f'cluster draft index appears more than once: {raw_index}')
+            seen.add(raw_index)
+            normalized_indexes.append(raw_index)
+        selected = [drafts[index] for index in normalized_indexes]
+        clusters.append(TaskCluster(task_scope=task_scope, drafts=selected))
+
+    missing = sorted(expected - seen)
+    if missing:
+        raise ValueError(f'LLM cluster response omitted draft indexes: {missing}')
+    return clusters
+
+
+def _cluster_prompt_items(drafts: list[SkillDraft]) -> list[dict[str, Any]]:
+    items = []
+    for index, draft in enumerate(drafts):
+        signature = draft.cluster_signature
+        items.append({
+            'draft_index': index,
+            'intent': signature.intent,
+            'procedure': signature.procedure,
+            'boundaries': signature.boundaries,
+        })
+    return items
+
+
 def _cluster_text(draft: SkillDraft) -> str:
-    description = draft.contextual_description
+    signature = draft.cluster_signature
     parts = [
-        description.applicable_scenario.strip(),
-        description.execution_summary.strip(),
+        signature.intent.strip(),
+        '\n'.join(step.strip() for step in signature.procedure if step.strip()),
+        signature.boundaries.strip(),
     ]
     text = '\n'.join(part for part in parts if part)
-    return text or description.task_goal or description.key_result or 'General task'
+    if not text:
+        raise ValueError(f'skill draft {draft.session_id} has empty cluster_signature')
+    return text
 
 
-def _hdbscan_labels(embeddings: np.ndarray) -> list[int]:
-    min_cluster_size = max(2, min(5, len(embeddings) // 3))
+def _embedding_cluster_labels(embeddings: np.ndarray) -> tuple[list[int], dict]:
+    reduced_embeddings, reduction_metadata = _umap_reduce_embeddings(embeddings)
+    hdbscan_labels, hdbscan_metadata = _hdbscan_labels(reduced_embeddings)
+    hdbscan_stats = _label_stats(hdbscan_labels)
+    hdbscan_stats.update(hdbscan_metadata)
+    _raise_if_degenerate_labels(hdbscan_stats)
+    return hdbscan_labels, {
+        'embedding_clusterer': 'umap_hdbscan',
+        'embedding_cluster_stats': hdbscan_stats,
+        'embedding_reduction': reduction_metadata,
+    }
+
+
+def _umap_reduce_embeddings(embeddings: np.ndarray) -> tuple[np.ndarray, dict]:
+    _ensure_numba_cache_dir()
+    try:
+        from umap import UMAP
+    except ImportError as exc:
+        raise ImportError('umap-learn is required for embedding clustering') from exc
+
+    sample_count = len(embeddings)
+    n_neighbors = max(2, min(sample_count - 1, int(round(sample_count ** 0.5 * 2))))
+    n_components = max(2, min(5, sample_count - 2))
+    reducer = UMAP(
+        n_neighbors=n_neighbors,
+        n_components=n_components,
+        min_dist=0.0,
+        metric='cosine',
+        random_state=UMAP_RANDOM_STATE,
+    )
+    reduced = reducer.fit_transform(embeddings)
+    return np.asarray(reduced, dtype=float), {
+        'method': 'umap',
+        'input_dimension': int(np.asarray(embeddings).shape[1]),
+        'output_dimension': int(n_components),
+        'n_neighbors': int(n_neighbors),
+        'min_dist': 0.0,
+        'metric': 'cosine',
+        'random_state': UMAP_RANDOM_STATE,
+    }
+
+
+def _ensure_numba_cache_dir() -> None:
+    cache_dir = Path(gettempdir()) / 'lazymind_numba_cache'
+    cache_dir.mkdir(parents=True, exist_ok=True)
+    os.environ.setdefault('NUMBA_CACHE_DIR', str(cache_dir))
+
+
+def _hdbscan_labels(embeddings: np.ndarray) -> tuple[list[int], dict]:
+    min_cluster_size = max(2, min(10, int(round(len(embeddings) ** 0.5)) - 1))
+    min_samples = 1
     try:
         import hdbscan
 
         clusterer = hdbscan.HDBSCAN(
             min_cluster_size=min_cluster_size,
-            min_samples=1,
+            min_samples=min_samples,
             metric='euclidean',
         )
     except ImportError:
@@ -270,11 +437,46 @@ def _hdbscan_labels(embeddings: np.ndarray) -> list[int]:
 
         clusterer = HDBSCAN(
             min_cluster_size=min_cluster_size,
-            min_samples=1,
+            min_samples=min_samples,
             metric='euclidean',
         )
     labels = clusterer.fit_predict(embeddings)
-    return [int(label) for label in labels]
+    return [int(label) for label in labels], {
+        'min_cluster_size': int(min_cluster_size),
+        'min_samples': int(min_samples),
+        'metric': 'euclidean',
+    }
+
+
+def _label_stats(labels: list[int]) -> dict:
+    grouped: dict[int, int] = defaultdict(int)
+    noise_count = 0
+    for label in labels:
+        if label == -1:
+            noise_count += 1
+        else:
+            grouped[label] += 1
+    singleton_count = noise_count + sum(1 for size in grouped.values() if size == 1)
+    cluster_count = noise_count + len(grouped)
+    total_count = len(labels)
+    return {
+        'total_count': total_count,
+        'cluster_count': cluster_count,
+        'singleton_count': singleton_count,
+        'noise_count': noise_count,
+        'singleton_ratio': singleton_count / total_count if total_count else 0.0,
+        'cluster_ratio': cluster_count / total_count if total_count else 0.0,
+    }
+
+
+def _raise_if_degenerate_labels(stats: dict) -> None:
+    total_count = stats['total_count']
+    if total_count < 2:
+        return
+    if stats['noise_count'] == total_count:
+        raise RuntimeError(f'UMAP+HDBSCAN produced only noise labels: {stats}')
+    if stats['cluster_count'] == total_count:
+        raise RuntimeError(f'UMAP+HDBSCAN produced only singleton clusters: {stats}')
 
 
 def _clusters_from_labels(drafts: list[SkillDraft], labels: list[int]) -> list[TaskCluster]:
@@ -303,8 +505,8 @@ def _cluster_from_indexes(drafts: list[SkillDraft], indexes: list[int]) -> TaskC
 
 def _cluster_scope(drafts: list[SkillDraft]) -> str:
     for draft in drafts:
-        description = draft.contextual_description
-        scope = description.applicable_scenario or description.task_goal
+        signature = draft.cluster_signature
+        scope = signature.intent or signature.boundaries
         if scope:
             return scope
-    return 'General task'
+    raise ValueError('cannot derive task scope from empty cluster signatures')

--- a/algorithm/lazymind/review/skill_review/draft.py
+++ b/algorithm/lazymind/review/skill_review/draft.py
@@ -9,7 +9,7 @@ from tqdm import tqdm
 from lazyllm import AutoModel, LOG, ThreadPoolExecutor
 
 from lazymind.review.skill_review.schemas import (
-    ContextualDescription,
+    ClusterSignature,
     GuidelineSet,
     RefinedTrajectory,
     SkillDraft,
@@ -19,7 +19,7 @@ from lazymind.review.skill_review.config import DEFAULT_STAGE_WORKERS, STAGE_DRA
 from lazymind.review.skill_review.json_call import call_json
 from lazymind.review.skill_review.reports import finish_stage_report, stage_error, start_stage, write_json_file
 from lazymind.review.skill_review.prompt import (
-    contextual_description_prompt,
+    cluster_signature_prompt,
     guidelines_prompt,
     pending_skill_draft_prompt,
     refined_trajectory_prompt,
@@ -46,11 +46,11 @@ _PENDING_SKILL_DRAFT_SCHEMA = {
     'title': 'pending_skill_draft_response',
     'type': 'object',
     'properties': {
-        'contextual_description': ContextualDescription.model_json_schema(),
+        'cluster_signature': ClusterSignature.model_json_schema(),
         'refined_trajectory': RefinedTrajectory.model_json_schema(),
         'guidelines': GuidelineSet.model_json_schema(),
     },
-    'required': ['contextual_description', 'refined_trajectory', 'guidelines'],
+    'required': ['cluster_signature', 'refined_trajectory', 'guidelines'],
 }
 
 
@@ -106,12 +106,16 @@ def build_skill_drafts(
     return drafts, report
 
 
-def _draft_jobs(trajectories: list[Trajectory], pending_records: list[dict], llm: AutoModel) -> list[dict]:
+def _draft_jobs(
+    trajectories: list[Trajectory],
+    pending_records: list[dict],
+    llm: AutoModel,
+) -> list[dict]:
     jobs = [
         {
             'kind': 'trajectory',
             'item_id': trajectory.session_id,
-            'build': lambda trajectory=trajectory: _build_trajectory_draft(trajectory, llm),
+            'build': lambda trajectory=trajectory: _build_trajectory_draft(trajectory, llm.share()),
         }
         for trajectory in trajectories
     ]
@@ -119,7 +123,7 @@ def _draft_jobs(trajectories: list[Trajectory], pending_records: list[dict], llm
         {
             'kind': 'pending_skill',
             'item_id': str(record.get('id') or index),
-            'build': lambda record=record: _build_pending_skill_draft(record, llm),
+            'build': lambda record=record: _build_pending_skill_draft(record, llm.share()),
         }
         for index, record in enumerate(pending_records)
     )
@@ -156,13 +160,13 @@ def _build_trajectory_draft(trajectory: Trajectory, llm: AutoModel) -> SkillDraf
             LOG.info(f'[SkillReview] skip skill draft for trajectory {trajectory.session_id}')
             return None
 
-        contextual_description = _build_contextual_description(trajectory, llm)
+        cluster_signature = _build_cluster_signature(trajectory, llm)
         refined_trajectory = _build_refined_trajectory(trajectory, llm)
-        guidelines = _build_guidelines(trajectory_text, refined_trajectory, llm)
+        guidelines = _build_guidelines(trajectory, refined_trajectory, llm)
 
         return SkillDraft(
             session_id=trajectory.session_id,
-            contextual_description=contextual_description,
+            cluster_signature=cluster_signature,
             refined_trajectory=refined_trajectory,
             guidelines=guidelines,
             source_trajectory=trajectory.session_id,
@@ -188,12 +192,12 @@ def _build_pending_skill_draft(record: dict, llm: AutoModel) -> SkillDraft:
         pending_skill_draft_prompt(skill_name, skill_content),
         _PENDING_SKILL_DRAFT_SCHEMA,
     )
-    contextual_description = ContextualDescription.model_validate(payload.get('contextual_description') or {})
+    cluster_signature = ClusterSignature.model_validate(payload.get('cluster_signature'))
     refined_trajectory = _normalize_refined_trajectory(payload.get('refined_trajectory'))
     guidelines = GuidelineSet.model_validate(payload.get('guidelines') or {})
     return SkillDraft(
         session_id=record_id,
-        contextual_description=contextual_description,
+        cluster_signature=cluster_signature,
         refined_trajectory=refined_trajectory,
         guidelines=guidelines,
         source_trajectory=record_id,
@@ -205,30 +209,38 @@ def _build_skill_extraction_gate(
     trajectory: Trajectory,
     llm: AutoModel,
 ) -> dict:
-    parsed = call_json(llm, skill_extraction_gate_prompt(trajectory.steps_text), _SKILL_EXTRACTION_GATE_SCHEMA)
+    parsed = call_json(
+        llm,
+        skill_extraction_gate_prompt(trajectory.steps_text),
+        _SKILL_EXTRACTION_GATE_SCHEMA,
+    )
     should_extract = parsed.get('should_extract')
     if not isinstance(should_extract, bool):
         raise ValueError(f'skill extraction gate response must contain boolean {should_extract} {parsed}')
     return parsed
 
 
-def _build_contextual_description(
+def _build_cluster_signature(
     trajectory: Trajectory,
     llm: AutoModel,
-) -> ContextualDescription:
-    parsed = call_json(llm, contextual_description_prompt(trajectory.steps_text), ContextualDescription)
-    parsed['environment'] = {
-        'called_tools': trajectory.called_tools,
-        'called_skills': trajectory.called_skills,
-    }
-    return ContextualDescription.model_validate(parsed)
+) -> ClusterSignature:
+    parsed = call_json(
+        llm,
+        cluster_signature_prompt(trajectory.steps_text),
+        ClusterSignature,
+    )
+    return ClusterSignature.model_validate(parsed)
 
 
 def _build_refined_trajectory(
     trajectory: Trajectory,
     llm: AutoModel,
 ) -> RefinedTrajectory:
-    parsed = call_json(llm, refined_trajectory_prompt(trajectory.steps_text), RefinedTrajectory)
+    parsed = call_json(
+        llm,
+        refined_trajectory_prompt(trajectory.steps_text),
+        RefinedTrajectory,
+    )
     return _normalize_refined_trajectory(parsed)
 
 
@@ -255,13 +267,13 @@ def _normalize_refined_trajectory(parsed) -> RefinedTrajectory:
 
 
 def _build_guidelines(
-    trajectory_text: str,
+    trajectory: Trajectory,
     refined_trajectory: RefinedTrajectory,
     llm: AutoModel,
 ) -> GuidelineSet:
     parsed = call_json(
         llm,
-        guidelines_prompt(trajectory=trajectory_text,
+        guidelines_prompt(trajectory=trajectory.steps_text,
                           refined_trajectory=refined_trajectory.model_dump()),
         GuidelineSet,
     )

--- a/algorithm/lazymind/review/skill_review/draft.py
+++ b/algorithm/lazymind/review/skill_review/draft.py
@@ -115,7 +115,7 @@ def _draft_jobs(
         {
             'kind': 'trajectory',
             'item_id': trajectory.session_id,
-            'build': lambda trajectory=trajectory: _build_trajectory_draft(trajectory, llm.share()),
+            'build': lambda trajectory=trajectory: _build_trajectory_draft(trajectory, llm),
         }
         for trajectory in trajectories
     ]
@@ -123,7 +123,7 @@ def _draft_jobs(
         {
             'kind': 'pending_skill',
             'item_id': str(record.get('id') or index),
-            'build': lambda record=record: _build_pending_skill_draft(record, llm.share()),
+            'build': lambda record=record: _build_pending_skill_draft(record, llm),
         }
         for index, record in enumerate(pending_records)
     )
@@ -153,8 +153,6 @@ def _draft_report_metadata(
 
 def _build_trajectory_draft(trajectory: Trajectory, llm: AutoModel) -> SkillDraft | None:
     try:
-        trajectory_text = trajectory.steps_text
-
         gate = _build_skill_extraction_gate(trajectory, llm)
         if not gate.get('should_extract'):
             LOG.info(f'[SkillReview] skip skill draft for trajectory {trajectory.session_id}')

--- a/algorithm/lazymind/review/skill_review/miner.py
+++ b/algorithm/lazymind/review/skill_review/miner.py
@@ -275,9 +275,6 @@ def _collect_source_skills(cluster: TaskCluster) -> dict[str, str]:
     result: dict[str, str] = {}
     for draft in cluster.drafts:
         raw_skills = draft.source_skills
-        if not raw_skills:
-            environment = draft.contextual_description.environment or {}
-            raw_skills = environment.get('called_skills') if isinstance(environment, dict) else {}
         if isinstance(raw_skills, dict):
             items = raw_skills.items()
         elif isinstance(raw_skills, list):
@@ -313,9 +310,11 @@ def _cluster_item_id(index: int, cluster: TaskCluster) -> str:
 def _write_candidate_skill_files(artifact_dir: Path, candidates: list[CandidateSkill]) -> None:
     skill_dir = artifact_dir / 'skills'
     skill_dir.mkdir(parents=True, exist_ok=True)
-    for index, candidate in enumerate(candidates, start=1):
-        filename = f'{index:02d}_{_safe_filename(candidate.skill_name)}.md'
-        path = skill_dir / filename
+    used_names: set[str] = set()
+    for candidate in candidates:
+        skill_name = _unique_skill_dir_name(_safe_filename(candidate.skill_name), used_names)
+        path = skill_dir / skill_name / 'SKILL.md'
+        path.parent.mkdir(parents=True, exist_ok=True)
         tmp = path.with_suffix(path.suffix + '.tmp')
         tmp.write_text(candidate.content, encoding='utf-8')
         tmp.replace(path)
@@ -324,3 +323,13 @@ def _write_candidate_skill_files(artifact_dir: Path, candidates: list[CandidateS
 def _safe_filename(value: str) -> str:
     safe = ''.join(ch if ch.isalnum() or ch in ('-', '_', '.') else '_' for ch in value.strip())
     return safe or 'skill'
+
+
+def _unique_skill_dir_name(name: str, used_names: set[str]) -> str:
+    candidate = name
+    suffix = 2
+    while candidate in used_names:
+        candidate = f'{name}_{suffix}'
+        suffix += 1
+    used_names.add(candidate)
+    return candidate

--- a/algorithm/lazymind/review/skill_review/prompt.py
+++ b/algorithm/lazymind/review/skill_review/prompt.py
@@ -103,31 +103,37 @@ Return ONLY valid JSON:
 """
 
 
-def contextual_description_prompt(trajectory: str) -> str:
+def cluster_signature_prompt(trajectory: str) -> str:
     return f"""
 You are an expert Agent Memory Abstraction Engine.
 
-Your task is to summarize the trajectory into a structured "contextual_description" for future task clustering and skill mining.
+Your task is to extract a compact "cluster_signature" for future task clustering and skill mining.
 
 # Objective
 
-Extract the high-level task context and execution outcome from the trajectory.
+Extract only the reusable task structure needed to decide whether multiple drafts should become one skill.
 
 The output should describe:
-1. What the agent tried to achieve
-2. In what scenario/environment
-3. What strategy/process it used
-4. What key result/outcome was obtained
-5. What tools/skills/environment were involved
+1. The reusable task intent
+2. The high-level reusable procedure
+3. The applicability boundary for the skill
 
 # Requirements
 
-- Focus on task-level abstraction instead of low-level actions
-- Preserve only reusable and clusterable information
-- Remove noisy operational details
-- Avoid case-specific wording
-- The description should be generic enough to group similar tasks together
-- If the task failed, explicitly explain the failure reason briefly
+- Preserve reusable workflow structure, not case-specific details
+- Describe the broad reusable skill family, not the narrow observed case
+- Keep wording general enough for reusable skill mining, but not vague
+- Remove names, ids, dates, locations, prices, exact quantities, and incidental tool errors
+- Do not mention exact tool names unless they define the reusable task
+- Do not include every observed root cause in the intent; prefer a task-family description
+- Do not include fallback options, alternative resolutions, or customer choice variants in the intent unless they define a materially different workflow
+- Merge adjacent diagnostics into broader steps when they belong to the same troubleshooting workflow
+- Use 3-6 procedure steps
+- Boundaries must be one concise paragraph describing the positive applicability scope and only materially different workflows it should not cover
+- Do not exclude nearby variants that the same reusable procedure can handle
+- Do not exclude alternative remediation options, fallback paths, optional checks, or customer preference variants that belong to the same task family
+- Do not exclude cases based on incidental episode outcomes, such as whether a tool succeeded or failed
+- Avoid vague phrases like "help the user" or "solve the issue"
 - output should be in the same language as the trajectory
 
 # Output Format
@@ -135,10 +141,9 @@ The output should describe:
 Return ONLY valid JSON:
 
 {{
-  "task_goal": "...",
-  "applicable_scenario": "...",
-  "execution_summary": "...",
-  "key_result": "..."
+  "intent": "...",
+  "procedure": ["...", "...", "..."],
+  "boundaries": "..."
 }}
 
 # Trajectory
@@ -262,13 +267,13 @@ Your task is to convert an existing pending skill into a reusable skill draft.
 The pending skill is already structured, so extract only the three core parts needed by
 the skill mining pipeline:
 
-1. contextual_description
+1. cluster_signature
 2. refined_trajectory
 3. guidelines
 
 # Requirements
 
-- Use the title to identify the intended scenario, task goal, and capability.
+- Use the title and content to identify the reusable intent, procedure, and applicability boundary.
 - Split the skill content into meaningful operational steps for refined_trajectory.
 - Summarize the guidance embedded in each step into concise guidelines.
 - Keep the output abstract and reusable; do not copy Markdown headings mechanically.
@@ -280,11 +285,10 @@ the skill mining pipeline:
 Return ONLY valid JSON:
 
 {{
-  "contextual_description": {{
-    "task_goal": "...",
-    "applicable_scenario": "...",
-    "execution_summary": "...",
-    "key_result": "..."
+  "cluster_signature": {{
+    "intent": "...",
+    "procedure": ["...", "...", "..."],
+    "boundaries": "..."
   }},
   "refined_trajectory": {{
     "steps": [
@@ -410,8 +414,8 @@ Return ONLY valid JSON:
 def draft_prompt(trajectory: dict[str, Any]) -> str:
     return (
         'You extract a reusable skill draft from one agent trajectory.\n'
-        'Return JSON only with keys: contextual_description, refined_trajectory, guidelines.\n'
-        'contextual_description has task_goal, applicable_scenario, execution_summary, key_result, environment.\n'
+        'Return JSON only with keys: cluster_signature, refined_trajectory, guidelines.\n'
+        'cluster_signature has intent, procedure, boundaries.\n'
         'refined_trajectory has steps: step_index, role, action, state, tool_name, skill_name.\n'
         'guidelines has success_patterns and failure_patterns, each item has related_step and guideline.\n\n'
         f'TRAJECTORY:\n{json.dumps(trajectory, ensure_ascii=False, indent=2)}'
@@ -420,8 +424,20 @@ def draft_prompt(trajectory: dict[str, Any]) -> str:
 
 def cluster_prompt(drafts: list[dict[str, Any]]) -> str:
     return (
-        'Cluster skill drafts by task type. Return JSON only: {"clusters":[{"task_scope":"...","draft_indexes":[0]}]}.\n'
-        f'DRAFTS:\n{json.dumps(drafts, ensure_ascii=False, indent=2)}'
+        'Cluster skill draft signatures into reusable skill families.\n'
+        'Return JSON only: {"clusters":[{"task_scope":"...","draft_indexes":[0]}]}.\n\n'
+        'Merge drafts when they share the same reusable task intent, high-level procedure, and applicability scope.\n'
+        'Do not split drafts merely because one case has an extra root cause, a different outcome, a tool failure, '
+        'a different language/style, or a narrower boundary statement.\n'
+        'Do not split drafts merely because one includes an extra fallback option, alternative remediation path, '
+        'plan/customer choice variant, or broader/narrower wording.\n'
+        'Keep drafts separate only when an agent would need a materially different procedure or the combined skill '
+        'would become ambiguous.\n'
+        'A singleton cluster is allowed only when no existing cluster can handle that draft without changing the core procedure.\n'
+        'If a draft differs only by an extra fallback option, broader wording, or an alternative customer choice, '
+        'merge it into the closest broader cluster.\n'
+        'Every draft index must appear exactly once. Use the provided draft_index values.\n\n'
+        f'DRAFT_SIGNATURES:\n{json.dumps(drafts, ensure_ascii=False, indent=2)}'
     )
 
 
@@ -688,15 +704,13 @@ Use Markdown in the "content" field. The content is the entire `SKILL.md` file, 
 
 Required structure:
 - YAML frontmatter delimited by `---`
-- `name`, `category`, and `description` fields in frontmatter
+- `name` and `description` fields in frontmatter
 - Markdown instructions after the closing `---`
 
 Frontmatter requirements:
 - `name` must be lowercase letters, numbers, and hyphens only
 - `name` must be no more than 64 characters
 - `name` must not start or end with a hyphen
-- `category` must be a concise lowercase classification for the skill, such as `research`, `coding`, `writing`, `data-analysis`, `tool-use`, `planning`, `debugging`, `review`, or `general`
-- `category` must describe the reusable task family, not the source trajectory, user, project, or implementation detail
 - `description` must state when to use the skill and what reusable capability it provides
 - keep frontmatter concise; do not put trajectory history in metadata
 
@@ -738,26 +752,19 @@ Return ONLY valid JSON.
 
 {{
   "skill_name": "...",
-  "category": "...",
   "applicable_scenario": "...",
   "content": "..."
 }}
 
 # Field Requirements
 
-## category
-The same category value used in the SKILL.md YAML frontmatter.
-Choose the most specific reusable task family that fits the skill, using lowercase words and hyphens.
-Use `general` only when no more informative category applies.
-
 ## content
 A complete SKILL.md-style Markdown document.
 
 The content must:
 - be the full content of a valid `SKILL.md` file
-- start with YAML frontmatter containing at least `name`, `category`, and `description`
+- start with YAML frontmatter containing at least `name` and `description`
 - use a portable skill name that follows lowercase hyphenated naming rules
-- keep the top-level JSON `category` and frontmatter `category` identical
 - preserve the outline's procedure order
 - synthesize guidelines into natural step guidance
 - include recovery advice where failure patterns imply a branch

--- a/algorithm/lazymind/review/skill_review/schemas.py
+++ b/algorithm/lazymind/review/skill_review/schemas.py
@@ -48,12 +48,10 @@ class Trajectory(BaseModel):
     qualified: bool = False
 
 
-class ContextualDescription(BaseModel):
-    task_goal: str = ''
-    applicable_scenario: str = ''
-    execution_summary: str = ''
-    key_result: str = ''
-    environment: Dict[str, Any] = Field(default_factory=dict)
+class ClusterSignature(BaseModel):
+    intent: str
+    procedure: List[str] = Field(default_factory=list)
+    boundaries: str
 
 
 class RefinedTrajectory(BaseModel):
@@ -77,7 +75,7 @@ class GuidelineSet(BaseModel):
 
 class SkillDraft(BaseModel):
     session_id: str
-    contextual_description: ContextualDescription
+    cluster_signature: ClusterSignature
     refined_trajectory: RefinedTrajectory
     guidelines: GuidelineSet
     source_trajectory: str = ''

--- a/algorithm/lazymind/review/skill_review/trajectory.py
+++ b/algorithm/lazymind/review/skill_review/trajectory.py
@@ -55,6 +55,8 @@ def build_trajectory(
             called_tools.add(tool_name)
         if skill_name and skill_content:
             called_skills[skill_name] = skill_content
+        if not message.get('content').strip():
+            continue
         steps.append(
             TrajectoryStep(
                 step_index=len(steps) + 1,


### PR DESCRIPTION
优化skill review链路，提升生成质量和稳定性，具体包括：
1.  prompt调优
2. 将 `context_description` 替换为更通用的字段表达，并同步调整 Prompt，增强 Skill 内容的泛化能力。
4. 优化聚类策略，由之前的hdbscan直接聚类改为：
   - Draft 数量 < 20：使用 LLM 直接聚类；
   - Draft 数量 ≥ 20：使用 UMAP 降维 + HDBSCAN 聚类。
