### PR TITLE
feat: add local_fs tool, /api/chat/tools proxy route, and code cleanups

### DIFF
--- a/algorithm/Dockerfile
+++ b/algorithm/Dockerfile
@@ -31,7 +31,7 @@ RUN set -eu; \
     apt-get update && apt-get install -y --no-install-recommends \
         ca-certificates curl ffmpeg build-essential gcc \
         libgl1 libglib2.0-0 libsm6 libxext6 libxrender1 libxcb1 \
-        python3-dev \
+        python3-dev ripgrep \
     && update-ca-certificates \
     && rm -rf /var/lib/apt/lists/*
 

--- a/algorithm/lazymind/chat/engine/prompts/guidance.py
+++ b/algorithm/lazymind/chat/engine/prompts/guidance.py
@@ -145,7 +145,14 @@ TOOL_AVAILABILITY_GUIDANCE = (
     "# Tool availability rules\n"
     "Only call tools that are currently registered and active in this session.\n"
     "If a requested tool is not registered, not active, or not available, explicitly tell the user it is unavailable.\n"
-    "Do not silently remove the request, do not pretend the tool call succeeded, and do not substitute a different tool without telling the user."
+    "Do not silently remove the request, do not pretend the tool call succeeded, and do not substitute a different tool without telling the user.\n"
+    "\n"
+    "## Tool group discovery\n"
+    "Some tools are organized into groups. When you see a `get_<Group>_methods` tool "
+    "(e.g. `get_KBToolGroup_methods`), you MUST call it FIRST before using any "
+    "individual tool from that group. The discovery tool returns the list of available "
+    "sub-tools and activates the group. Without this call, individual tools in that "
+    "group may not be registered or active."
 )
 TOOL_USE_ENFORCEMENT_GUIDANCE = (
     "# Tool-use enforcement\n"

--- a/algorithm/lazymind/chat/engine/tools/__init__.py
+++ b/algorithm/lazymind/chat/engine/tools/__init__.py
@@ -6,6 +6,7 @@ registration side effects happen in one consistent place.
 
 from .calculator import calculator
 from .kb import KBToolGroup, TempKBToolGroup
+from .local_fs import LocalFSToolGroup
 from .memory_editor import memory_editor
 from .memory_reader import read_memory
 from .multimodal import image_editor, image_generator, vision_extractor
@@ -18,6 +19,7 @@ __all__ = [
     'image_editor',
     'image_generator',
     'KBToolGroup',
+    'LocalFSToolGroup',
     'TempKBToolGroup',
     'memory_editor',
     'read_memory',

--- a/algorithm/lazymind/chat/engine/tools/algo/search_kb.py
+++ b/algorithm/lazymind/chat/engine/tools/algo/search_kb.py
@@ -1,6 +1,7 @@
-from typing import Any, Callable, List, Optional
+import re
+from typing import Any, Callable, Dict, List, Optional
 
-from lazyllm import Document, parallel
+from lazyllm import Document, LOG, parallel
 from lazyllm.tools.rag import Reranker, Retriever, TempDocRetriever
 from lazyllm.tools.rag.rank_fusion.reciprocal_rank_fusion import RRFFusion
 
@@ -8,6 +9,35 @@ from lazymind.chat.engine.tools.algo.kb_adaptive_topk import AdaptiveKComponent
 from lazymind.chat.engine.tools.algo.kb_context_expansion import ContextExpansionComponent
 from lazymind.chat.engine.tools.infra import get_vocab_manager
 from lazymind.config import config as _cfg
+
+# ── Embedding / retrieval API error diagnosis ──────────────────────────────
+# Patterns that indicate a remote API failure (balance, auth, network, config).
+# Grouped by category so callers can log or surface a human-readable hint.
+_API_ERROR_PATTERNS: List[tuple] = [
+    (re.compile(r'account balance is insufficient', re.I),
+     'EMBEDDING_API_BALANCE', 'Embedding API account balance is insufficient. Please top up your account.'),
+    (re.compile(r'Invalid token|Invalid api_key|Api key is invalid|not authorized', re.I),
+     'EMBEDDING_API_AUTH', 'Embedding API key is invalid or unauthorized. Please check your API key.'),
+    (re.compile(r'No source is configured for dynamic embedding', re.I),
+     'EMBEDDING_API_NOSOURCE', 'Embedding model source is not configured. Check LAZYMIND_MODEL_CONFIG_PATH or model config.'),
+    (re.compile(r'connection.*refused|ConnectionRefusedError|Name or service not known|Failed to resolve', re.I),
+     'EMBEDDING_API_NETWORK', 'Cannot reach embedding API — network or DNS error.'),
+    (re.compile(r'timed out|ReadTimeout|Read timed out', re.I),
+     'EMBEDDING_API_TIMEOUT', 'Embedding API request timed out. Check network or API endpoint.'),
+]
+
+
+def _diagnose_api_error(error_message: str) -> Optional[Dict[str, str]]:
+    """Check an error message for known embedding API failure patterns.
+
+    Returns a dict with ``code`` and ``hint`` if a pattern matches, or ``None``.
+    """
+    if not error_message:
+        return None
+    for pattern, code, hint in _API_ERROR_PATTERNS:
+        if pattern.search(error_message):
+            return {'code': code, 'hint': hint}
+    return None
 
 
 def _adaptive_get_token_len(n: Any) -> int:
@@ -39,7 +69,19 @@ def _search_text(
     rerank_topk: int,
     k_max: int,
 ) -> List[Any]:
-    nodes = retrieve_fn(expanded)
+    try:
+        nodes = retrieve_fn(expanded)
+    except Exception as e:
+        diagnosis = _diagnose_api_error(str(e))
+        if diagnosis:
+            LOG.error(f'[kb_search] Embedding API error detected: '
+                      f'code={diagnosis["code"]} hint={diagnosis["hint"]}')
+            LOG.error(f'[kb_search] Original error: {e}')
+            raise RuntimeError(
+                f'{diagnosis["hint"]} (original: {e})'
+            ) from e
+        raise
+
     ranked = reranker(nodes, query=expanded, topk=rerank_topk) if reranker else _pass_through_rerank(nodes)
     merged = _adaptive_k(ranked or [], k_max=k_max)
     return _ctx_expand(merged)

--- a/algorithm/lazymind/chat/engine/tools/algo/search_kb.py
+++ b/algorithm/lazymind/chat/engine/tools/algo/search_kb.py
@@ -1,7 +1,6 @@
-import re
-from typing import Any, Callable, Dict, List, Optional
+from typing import Any, Callable, List, Optional
 
-from lazyllm import Document, LOG, parallel
+from lazyllm import Document, parallel
 from lazyllm.tools.rag import Reranker, Retriever, TempDocRetriever
 from lazyllm.tools.rag.rank_fusion.reciprocal_rank_fusion import RRFFusion
 
@@ -9,35 +8,6 @@ from lazymind.chat.engine.tools.algo.kb_adaptive_topk import AdaptiveKComponent
 from lazymind.chat.engine.tools.algo.kb_context_expansion import ContextExpansionComponent
 from lazymind.chat.engine.tools.infra import get_vocab_manager
 from lazymind.config import config as _cfg
-
-# ── Embedding / retrieval API error diagnosis ──────────────────────────────
-# Patterns that indicate a remote API failure (balance, auth, network, config).
-# Grouped by category so callers can log or surface a human-readable hint.
-_API_ERROR_PATTERNS: List[tuple] = [
-    (re.compile(r'account balance is insufficient', re.I),
-     'EMBEDDING_API_BALANCE', 'Embedding API account balance is insufficient. Please top up your account.'),
-    (re.compile(r'Invalid token|Invalid api_key|Api key is invalid|not authorized', re.I),
-     'EMBEDDING_API_AUTH', 'Embedding API key is invalid or unauthorized. Please check your API key.'),
-    (re.compile(r'No source is configured for dynamic embedding', re.I),
-     'EMBEDDING_API_NOSOURCE', 'Embedding model source is not configured. Check LAZYMIND_MODEL_CONFIG_PATH or model config.'),
-    (re.compile(r'connection.*refused|ConnectionRefusedError|Name or service not known|Failed to resolve', re.I),
-     'EMBEDDING_API_NETWORK', 'Cannot reach embedding API — network or DNS error.'),
-    (re.compile(r'timed out|ReadTimeout|Read timed out', re.I),
-     'EMBEDDING_API_TIMEOUT', 'Embedding API request timed out. Check network or API endpoint.'),
-]
-
-
-def _diagnose_api_error(error_message: str) -> Optional[Dict[str, str]]:
-    """Check an error message for known embedding API failure patterns.
-
-    Returns a dict with ``code`` and ``hint`` if a pattern matches, or ``None``.
-    """
-    if not error_message:
-        return None
-    for pattern, code, hint in _API_ERROR_PATTERNS:
-        if pattern.search(error_message):
-            return {'code': code, 'hint': hint}
-    return None
 
 
 def _adaptive_get_token_len(n: Any) -> int:
@@ -69,19 +39,7 @@ def _search_text(
     rerank_topk: int,
     k_max: int,
 ) -> List[Any]:
-    try:
-        nodes = retrieve_fn(expanded)
-    except Exception as e:
-        diagnosis = _diagnose_api_error(str(e))
-        if diagnosis:
-            LOG.error(f'[kb_search] Embedding API error detected: '
-                      f'code={diagnosis["code"]} hint={diagnosis["hint"]}')
-            LOG.error(f'[kb_search] Original error: {e}')
-            raise RuntimeError(
-                f'{diagnosis["hint"]} (original: {e})'
-            ) from e
-        raise
-
+    nodes = retrieve_fn(expanded)
     ranked = reranker(nodes, query=expanded, topk=rerank_topk) if reranker else _pass_through_rerank(nodes)
     merged = _adaptive_k(ranked or [], k_max=k_max)
     return _ctx_expand(merged)

--- a/algorithm/lazymind/chat/engine/tools/local_fs.py
+++ b/algorithm/lazymind/chat/engine/tools/local_fs.py
@@ -41,8 +41,6 @@ class LocalFSToolGroup:
 
     __public_apis__ = ['glob', 'grep', 'read', 'info']
 
-    # ── activation / path helpers ───────────────────────────────────────
-
     def _get_allowed_paths(self) -> List[str]:
         return lazyllm.globals['agentic_config'].get('localfs_paths', [])
 
@@ -81,8 +79,6 @@ class LocalFSToolGroup:
             raise ValueError(f'Path is not a directory: {path}')
         return resolved
 
-    # ── ripgrep helpers ─────────────────────────────────────────────────
-
     @staticmethod
     def _has_rg() -> bool:
         return bool(_RG_BINARY)
@@ -93,8 +89,6 @@ class LocalFSToolGroup:
             [_RG_BINARY] + args,
             capture_output=True, text=True, timeout=_RG_TIMEOUT, cwd=cwd,
         )
-
-    # ── glob ────────────────────────────────────────────────────────────
 
     @handle_tool_errors
     def glob(self, pattern: str, path: Optional[str] = None) -> Dict[str, Any]:
@@ -121,8 +115,6 @@ class LocalFSToolGroup:
             'match_count': len(raw),
             'matches': raw[:200],
         })
-
-    # ── grep ────────────────────────────────────────────────────────────
 
     @handle_tool_errors
     def grep(
@@ -226,8 +218,6 @@ class LocalFSToolGroup:
             'matches': matches,
         })
 
-    # ── read ────────────────────────────────────────────────────────────
-
     @handle_tool_errors
     def read(
         self,
@@ -266,8 +256,6 @@ class LocalFSToolGroup:
             'end_line': start_line + len(chunk),
             'content': ''.join(chunk),
         })
-
-    # ── info ────────────────────────────────────────────────────────────
 
     @handle_tool_errors
     def info(self, path: Optional[str] = None) -> Dict[str, Any]:

--- a/algorithm/lazymind/chat/engine/tools/local_fs.py
+++ b/algorithm/lazymind/chat/engine/tools/local_fs.py
@@ -212,7 +212,7 @@ class LocalFSToolGroup:
                                 })
                                 if len(matches) >= max_results:
                                     break
-                except (OSError, PermissionError):
+                except OSError:
                     continue
                 if len(matches) >= max_results:
                     break
@@ -253,7 +253,7 @@ class LocalFSToolGroup:
         try:
             with open(safe_path, 'r', encoding='utf-8', errors='replace') as fh:
                 lines = fh.readlines()
-        except (OSError, PermissionError) as exc:
+        except OSError as exc:
             return tool_error('read', f'Cannot read file: {exc}')
 
         total = len(lines)

--- a/algorithm/lazymind/chat/engine/tools/local_fs.py
+++ b/algorithm/lazymind/chat/engine/tools/local_fs.py
@@ -1,0 +1,310 @@
+# Copyright (c) 2026 LazyAGI. All rights reserved.
+"""Read-only local filesystem tool group.
+
+Activated only when ``tool_config`` includes a ``localfs`` path whitelist.
+All operations are constrained to the whitelisted paths.
+
+Backend: prefers ripgrep_ (``rg``) for ``grep`` and ``glob`` when available;
+falls back to Python stdlib otherwise.  The two backends differ in edge-case
+behaviour (hidden files, .gitignore, binary-file detection, regex dialect) —
+rg is the primary path and Python is a best-effort fallback.
+
+.. _ripgrep: https://github.com/BurntSushi/ripgrep
+"""
+from __future__ import annotations
+
+import datetime
+import fnmatch
+import glob as _glob
+import json
+import os
+import re
+import shutil
+import subprocess
+from typing import Any, Dict, List, Optional
+
+import lazyllm
+
+from lazymind.chat.engine.tools.infra import handle_tool_errors, tool_error, tool_success
+
+_RG_BINARY = shutil.which('rg') or ''
+_RG_TIMEOUT = 30
+
+
+class LocalFSToolGroup:
+    """Read-only local filesystem tools.
+
+    Activated when ``tool_config`` contains ``{"localfs": ["/path1", ...]}``.
+    The whitelist is stored in ``agentic_config['localfs_paths']`` and every
+    operation validates the target path against it.
+    """
+
+    __public_apis__ = ['glob', 'grep', 'read', 'info']
+
+    # ── activation ──────────────────────────────────────────────────────
+
+    def __key_source__(self) -> Any:
+        agentic_config = lazyllm.globals.get('agentic_config') or {}
+        return agentic_config.get('localfs_paths')
+
+    # ── path helpers ────────────────────────────────────────────────────
+
+    def _get_allowed_paths(self) -> List[str]:
+        agentic_config = lazyllm.globals.get('agentic_config') or {}
+        paths = agentic_config.get('localfs_paths', [])
+        if isinstance(paths, str):
+            return [paths]
+        return list(paths)
+
+    def _resolve(self, target: str) -> str:
+        """Resolve *target* to an absolute path within the whitelist.
+
+        Raises:
+            PermissionError: if *target* is outside the allowed set.
+        """
+        allowed = self._get_allowed_paths()
+        if not allowed:
+            raise PermissionError('localfs 未配置可用路径')
+        target = os.path.abspath(target)
+        for base in allowed:
+            base = os.path.abspath(base)
+            if target == base or target.startswith(base + os.sep):
+                return target
+        raise PermissionError(f'路径 {target} 不在允许范围内: {allowed}')
+
+    def _resolve_dir(self, path: Optional[str]) -> str:
+        """Resolve *path* to a directory within the whitelist.
+
+        When *path* is ``None`` or ``"."``, falls back to the first allowed path
+        that is a directory (or the first allowed path).
+        """
+        if path is None or str(path).strip() in ('', '.'):
+            allowed = self._get_allowed_paths()
+            if not allowed:
+                raise PermissionError('localfs 未配置可用路径')
+            for base in allowed:
+                abs_base = os.path.abspath(base)
+                if os.path.isdir(abs_base):
+                    return abs_base
+            return os.path.abspath(allowed[0])
+        resolved = self._resolve(str(path))
+        if not os.path.isdir(resolved):
+            raise ValueError(f'路径不是目录: {path}')
+        return resolved
+
+    # ── ripgrep helpers ─────────────────────────────────────────────────
+
+    @staticmethod
+    def _has_rg() -> bool:
+        return bool(_RG_BINARY)
+
+    @staticmethod
+    def _run_rg(args: List[str], cwd: str) -> subprocess.CompletedProcess:
+        return subprocess.run(
+            [_RG_BINARY] + args,
+            capture_output=True, text=True, timeout=_RG_TIMEOUT, cwd=cwd,
+        )
+
+    # ── glob ────────────────────────────────────────────────────────────
+
+    @handle_tool_errors
+    def glob(self, pattern: str, path: Optional[str] = None) -> Dict[str, Any]:
+        """在允许的路径内按 glob 模式匹配文件。
+
+        Args:
+            pattern: glob 模式，如 ``**/*.py``、``*.md``。
+            path: 搜索起始目录，默认使用白名单中的第一个目录。
+
+        Returns:
+            dict with ``pattern``, ``path``, ``match_count``, ``matches``.
+        """
+        safe_dir = self._resolve_dir(path)
+        if self._has_rg():
+            proc = self._run_rg(['--files', '--glob', pattern], cwd=safe_dir)
+            raw = [os.path.join(safe_dir, p) for p in proc.stdout.splitlines() if p.strip()]
+        else:
+            py_pattern = pattern if '**' in pattern else f'**/{pattern}'
+            raw = _glob.glob(py_pattern, root_dir=safe_dir, recursive=True)
+        raw.sort()
+        return tool_success('glob', {
+            'pattern': pattern,
+            'path': safe_dir,
+            'match_count': len(raw),
+            'matches': raw[:200],
+        })
+
+    # ── grep ────────────────────────────────────────────────────────────
+
+    @handle_tool_errors
+    def grep(
+        self,
+        pattern: str,
+        path: Optional[str] = None,
+        glob: str = '*',
+        max_results: int = 50,
+    ) -> Dict[str, Any]:
+        """在允许的路径内递归搜索文件内容。
+
+        Args:
+            pattern: 正则表达式搜索模式（ripgrep 默认正则，Python 回退也支持）。
+            path: 搜索起始目录，默认使用白名单中的第一个目录。
+            glob: 文件名过滤（仅搜索匹配的文件），默认 ``*``。
+            max_results: 最大返回结果数，默认 50。
+
+        Returns:
+            dict with ``pattern``, ``path``, ``match_count``, ``matches``.
+        """
+        safe_dir = self._resolve_dir(path)
+        if self._has_rg():
+            return self._grep_rg(pattern, safe_dir, glob, max_results)
+        return self._grep_py(pattern, safe_dir, glob, max_results)
+
+    def _grep_rg(
+        self, pattern: str, safe_dir: str, glob_filter: str, max_results: int,
+    ) -> Dict[str, Any]:
+        args = ['--json', '--no-heading', '-g', glob_filter, '--', pattern]
+        try:
+            proc = self._run_rg(args, cwd=safe_dir)
+        except subprocess.TimeoutExpired:
+            return tool_error('grep', f'搜索超时（>{_RG_TIMEOUT}s）', error_type='Timeout')
+
+        matches: List[Dict[str, Any]] = []
+        for line in proc.stdout.splitlines():
+            if not line.strip():
+                continue
+            try:
+                entry = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if entry.get('type') != 'match':
+                continue
+            data = entry.get('data', {})
+            fpath = os.path.join(safe_dir, data.get('path', {}).get('text', ''))
+            content = data.get('lines', {}).get('text', '').rstrip()
+            lineno = data.get('line_number', 0)
+            matches.append({
+                'file': fpath,
+                'line': lineno,
+                'content': content[:500],
+            })
+            if len(matches) >= max_results:
+                break
+
+        return tool_success('grep', {
+            'pattern': pattern,
+            'path': safe_dir,
+            'match_count': len(matches),
+            'matches': matches,
+        })
+
+    def _grep_py(
+        self, pattern: str, safe_dir: str, glob_filter: str, max_results: int,
+    ) -> Dict[str, Any]:
+        try:
+            regex = re.compile(pattern)
+        except re.error as exc:
+            return tool_error('grep', f'无效的正则表达式: {exc}')
+
+        matches: List[Dict[str, Any]] = []
+        for root, _dirs, files in os.walk(safe_dir):
+            for fn in files:
+                if not fnmatch.fnmatch(fn, glob_filter):
+                    continue
+                fpath = os.path.join(root, fn)
+                try:
+                    with open(fpath, 'r', encoding='utf-8', errors='replace') as fh:
+                        for lineno, line in enumerate(fh, 1):
+                            if regex.search(line):
+                                matches.append({
+                                    'file': fpath,
+                                    'line': lineno,
+                                    'content': line.rstrip()[:500],
+                                })
+                                if len(matches) >= max_results:
+                                    break
+                except (OSError, PermissionError):
+                    continue
+                if len(matches) >= max_results:
+                    break
+            if len(matches) >= max_results:
+                break
+
+        return tool_success('grep', {
+            'pattern': pattern,
+            'path': safe_dir,
+            'match_count': len(matches),
+            'matches': matches,
+        })
+
+    # ── read ────────────────────────────────────────────────────────────
+
+    @handle_tool_errors
+    def read(
+        self,
+        filepath: str,
+        start_line: int = 0,
+        max_lines: int = 500,
+    ) -> Dict[str, Any]:
+        """读取允许范围内的文本文件内容。
+
+        Args:
+            filepath: 文件路径（必须在白名单内）。
+            start_line: 起始行号（0-based），默认 0。
+            max_lines: 最大读取行数，默认 500。
+
+        Returns:
+            dict with ``filepath``, ``total_lines``, ``start_line``,
+            ``end_line``, ``content``.
+        """
+        safe_path = self._resolve(filepath)
+        if not os.path.isfile(safe_path):
+            return tool_error('read', f'文件不存在: {filepath}')
+
+        try:
+            with open(safe_path, 'r', encoding='utf-8', errors='replace') as fh:
+                lines = fh.readlines()
+        except (OSError, PermissionError) as exc:
+            return tool_error('read', f'无法读取文件: {exc}')
+
+        total = len(lines)
+        chunk = lines[start_line:start_line + max_lines]
+
+        return tool_success('read', {
+            'filepath': safe_path,
+            'total_lines': total,
+            'start_line': start_line,
+            'end_line': start_line + len(chunk),
+            'content': ''.join(chunk),
+        })
+
+    # ── info ────────────────────────────────────────────────────────────
+
+    @handle_tool_errors
+    def info(self, path: Optional[str] = None) -> Dict[str, Any]:
+        """获取文件或目录的元信息。
+
+        Args:
+            path: 路径（必须在白名单内），默认使用白名单中的第一个路径。
+
+        Returns:
+            dict with ``path``, ``type``, ``size``, ``mtime``.
+        """
+        if path is None or str(path).strip() in ('', '.'):
+            allowed = self._get_allowed_paths()
+            if not allowed:
+                return tool_error('info', 'localfs 未配置可用路径')
+            safe_path = os.path.abspath(allowed[0])
+        else:
+            safe_path = self._resolve(str(path))
+
+        try:
+            st = os.stat(safe_path)
+        except OSError as exc:
+            return tool_error('info', f'无法获取文件信息: {exc}')
+
+        return tool_success('info', {
+            'path': safe_path,
+            'type': 'directory' if os.path.isdir(safe_path) else 'file',
+            'size': st.st_size,
+            'mtime': datetime.datetime.fromtimestamp(st.st_mtime).isoformat(),
+        })

--- a/algorithm/lazymind/chat/engine/tools/local_fs.py
+++ b/algorithm/lazymind/chat/engine/tools/local_fs.py
@@ -41,20 +41,14 @@ class LocalFSToolGroup:
 
     __public_apis__ = ['glob', 'grep', 'read', 'info']
 
-    # ── activation ──────────────────────────────────────────────────────
-
-    def __key_source__(self) -> Any:
-        agentic_config = lazyllm.globals.get('agentic_config') or {}
-        return agentic_config.get('localfs_paths')
-
-    # ── path helpers ────────────────────────────────────────────────────
+    # ── activation / path helpers ───────────────────────────────────────
 
     def _get_allowed_paths(self) -> List[str]:
-        agentic_config = lazyllm.globals.get('agentic_config') or {}
-        paths = agentic_config.get('localfs_paths', [])
-        if isinstance(paths, str):
-            return [paths]
-        return list(paths)
+        paths = lazyllm.globals['agentic_config']['localfs_paths']
+        return [paths] if isinstance(paths, str) else paths
+
+    def __key_source__(self) -> Any:
+        return self._get_allowed_paths()
 
     def _resolve(self, target: str) -> str:
         """Resolve *target* to an absolute path within the whitelist.
@@ -63,8 +57,6 @@ class LocalFSToolGroup:
             PermissionError: if *target* is outside the allowed set.
         """
         allowed = self._get_allowed_paths()
-        if not allowed:
-            raise PermissionError('localfs 未配置可用路径')
         target = os.path.abspath(target)
         for base in allowed:
             base = os.path.abspath(base)
@@ -80,8 +72,6 @@ class LocalFSToolGroup:
         """
         if path is None or str(path).strip() in ('', '.'):
             allowed = self._get_allowed_paths()
-            if not allowed:
-                raise PermissionError('localfs 未配置可用路径')
             for base in allowed:
                 abs_base = os.path.abspath(base)
                 if os.path.isdir(abs_base):
@@ -291,8 +281,6 @@ class LocalFSToolGroup:
         """
         if path is None or str(path).strip() in ('', '.'):
             allowed = self._get_allowed_paths()
-            if not allowed:
-                return tool_error('info', 'localfs 未配置可用路径')
             safe_path = os.path.abspath(allowed[0])
         else:
             safe_path = self._resolve(str(path))

--- a/algorithm/lazymind/chat/engine/tools/local_fs.py
+++ b/algorithm/lazymind/chat/engine/tools/local_fs.py
@@ -44,8 +44,7 @@ class LocalFSToolGroup:
     # ── activation / path helpers ───────────────────────────────────────
 
     def _get_allowed_paths(self) -> List[str]:
-        paths = lazyllm.globals['agentic_config'].get('localfs_paths')
-        return [paths] if isinstance(paths, str) else paths
+        return lazyllm.globals['agentic_config'].get('localfs_paths', [])
 
     def __key_source__(self) -> Any:
         return self._get_allowed_paths()
@@ -62,7 +61,7 @@ class LocalFSToolGroup:
             base = os.path.abspath(base)
             if target == base or target.startswith(base + os.sep):
                 return target
-        raise PermissionError(f'路径 {target} 不在允许范围内: {allowed}')
+        raise PermissionError(f'Path {target} is not within allowed paths: {allowed}')
 
     def _resolve_dir(self, path: Optional[str]) -> str:
         """Resolve *path* to a directory within the whitelist.
@@ -79,7 +78,7 @@ class LocalFSToolGroup:
             return os.path.abspath(allowed[0])
         resolved = self._resolve(str(path))
         if not os.path.isdir(resolved):
-            raise ValueError(f'路径不是目录: {path}')
+            raise ValueError(f'Path is not a directory: {path}')
         return resolved
 
     # ── ripgrep helpers ─────────────────────────────────────────────────
@@ -99,11 +98,11 @@ class LocalFSToolGroup:
 
     @handle_tool_errors
     def glob(self, pattern: str, path: Optional[str] = None) -> Dict[str, Any]:
-        """在允许的路径内按 glob 模式匹配文件。
+        """Match files by glob pattern within allowed paths.
 
         Args:
-            pattern: glob 模式，如 ``**/*.py``、``*.md``。
-            path: 搜索起始目录，默认使用白名单中的第一个目录。
+            pattern: Glob pattern, e.g. ``**/*.py``, ``*.md``.
+            path: Search root directory; defaults to the first allowed path.
 
         Returns:
             dict with ``pattern``, ``path``, ``match_count``, ``matches``.
@@ -133,13 +132,14 @@ class LocalFSToolGroup:
         glob: str = '*',
         max_results: int = 50,
     ) -> Dict[str, Any]:
-        """在允许的路径内递归搜索文件内容。
+        """Recursively search file contents within allowed paths.
 
         Args:
-            pattern: 正则表达式搜索模式（ripgrep 默认正则，Python 回退也支持）。
-            path: 搜索起始目录，默认使用白名单中的第一个目录。
-            glob: 文件名过滤（仅搜索匹配的文件），默认 ``*``。
-            max_results: 最大返回结果数，默认 50。
+            pattern: Regex search pattern (ripgrep dialect by default; Python
+                fallback also supported).
+            path: Search root directory; defaults to the first allowed path.
+            glob: Filename filter (only search matching files), default ``*``.
+            max_results: Maximum results to return, default 50.
 
         Returns:
             dict with ``pattern``, ``path``, ``match_count``, ``matches``.
@@ -156,7 +156,7 @@ class LocalFSToolGroup:
         try:
             proc = self._run_rg(args, cwd=safe_dir)
         except subprocess.TimeoutExpired:
-            return tool_error('grep', f'搜索超时（>{_RG_TIMEOUT}s）', error_type='Timeout')
+            return tool_error('grep', f'Search timed out (>{_RG_TIMEOUT}s)', error_type='Timeout')
 
         matches: List[Dict[str, Any]] = []
         for line in proc.stdout.splitlines():
@@ -193,7 +193,7 @@ class LocalFSToolGroup:
         try:
             regex = re.compile(pattern)
         except re.error as exc:
-            return tool_error('grep', f'无效的正则表达式: {exc}')
+            return tool_error('grep', f'Invalid regex: {exc}')
 
         matches: List[Dict[str, Any]] = []
         for root, _dirs, files in os.walk(safe_dir):
@@ -235,12 +235,12 @@ class LocalFSToolGroup:
         start_line: int = 0,
         max_lines: int = 500,
     ) -> Dict[str, Any]:
-        """读取允许范围内的文本文件内容。
+        """Read text file contents within allowed paths.
 
         Args:
-            filepath: 文件路径（必须在白名单内）。
-            start_line: 起始行号（0-based），默认 0。
-            max_lines: 最大读取行数，默认 500。
+            filepath: File path (must be within the whitelist).
+            start_line: Starting line number (0-based), default 0.
+            max_lines: Maximum lines to read, default 500.
 
         Returns:
             dict with ``filepath``, ``total_lines``, ``start_line``,
@@ -248,13 +248,13 @@ class LocalFSToolGroup:
         """
         safe_path = self._resolve(filepath)
         if not os.path.isfile(safe_path):
-            return tool_error('read', f'文件不存在: {filepath}')
+            return tool_error('read', f'File not found: {filepath}')
 
         try:
             with open(safe_path, 'r', encoding='utf-8', errors='replace') as fh:
                 lines = fh.readlines()
         except (OSError, PermissionError) as exc:
-            return tool_error('read', f'无法读取文件: {exc}')
+            return tool_error('read', f'Cannot read file: {exc}')
 
         total = len(lines)
         chunk = lines[start_line:start_line + max_lines]
@@ -271,10 +271,11 @@ class LocalFSToolGroup:
 
     @handle_tool_errors
     def info(self, path: Optional[str] = None) -> Dict[str, Any]:
-        """获取文件或目录的元信息。
+        """Get metadata for a file or directory.
 
         Args:
-            path: 路径（必须在白名单内），默认使用白名单中的第一个路径。
+            path: Path (must be within the whitelist); defaults to the first
+                allowed path.
 
         Returns:
             dict with ``path``, ``type``, ``size``, ``mtime``.
@@ -288,7 +289,7 @@ class LocalFSToolGroup:
         try:
             st = os.stat(safe_path)
         except OSError as exc:
-            return tool_error('info', f'无法获取文件信息: {exc}')
+            return tool_error('info', f'Cannot get file info: {exc}')
 
         return tool_success('info', {
             'path': safe_path,

--- a/algorithm/lazymind/chat/engine/tools/local_fs.py
+++ b/algorithm/lazymind/chat/engine/tools/local_fs.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2026 LazyAGI. All rights reserved.
 """Read-only local filesystem tool group.
 
-Activated only when ``tool_config`` includes a ``localfs`` path whitelist.
+Activated only when ``tool_config`` includes a ``localfs_paths`` whitelist.
 All operations are constrained to the whitelisted paths.
 
 Backend: prefers ripgrep_ (``rg``) for ``grep`` and ``glob`` when available;
@@ -34,7 +34,7 @@ _RG_TIMEOUT = 30
 class LocalFSToolGroup:
     """Read-only local filesystem tools.
 
-    Activated when ``tool_config`` contains ``{"localfs": ["/path1", ...]}``.
+    Activated when ``tool_config`` contains ``{"localfs_paths": ["/path1", ...]}``.
     The whitelist is stored in ``agentic_config['localfs_paths']`` and every
     operation validates the target path against it.
     """
@@ -42,7 +42,9 @@ class LocalFSToolGroup:
     __public_apis__ = ['glob', 'grep', 'read', 'info']
 
     def _get_allowed_paths(self) -> List[str]:
-        return lazyllm.globals['agentic_config'].get('localfs_paths', [])
+        config = lazyllm.globals.get('agentic_config') or {}
+        paths = config.get('localfs_paths') or []
+        return [paths] if isinstance(paths, str) else paths
 
     def __key_source__(self) -> Any:
         return self._get_allowed_paths()
@@ -54,11 +56,16 @@ class LocalFSToolGroup:
             PermissionError: if *target* is outside the allowed set.
         """
         allowed = self._get_allowed_paths()
-        target = os.path.abspath(target)
+        if not allowed:
+            raise PermissionError('No local filesystem paths are configured')
+        target = os.path.realpath(target)
         for base in allowed:
-            base = os.path.abspath(base)
-            if target == base or target.startswith(base + os.sep):
-                return target
+            base = os.path.realpath(base)
+            try:
+                if os.path.commonpath([base, target]) == base:
+                    return target
+            except ValueError:
+                continue
         raise PermissionError(f'Path {target} is not within allowed paths: {allowed}')
 
     def _resolve_dir(self, path: Optional[str]) -> str:
@@ -67,13 +74,15 @@ class LocalFSToolGroup:
         When *path* is ``None`` or ``"."``, falls back to the first allowed path
         that is a directory (or the first allowed path).
         """
+        allowed = self._get_allowed_paths()
+        if not allowed:
+            raise PermissionError('No local filesystem paths are configured')
         if path is None or str(path).strip() in ('', '.'):
-            allowed = self._get_allowed_paths()
             for base in allowed:
-                abs_base = os.path.abspath(base)
+                abs_base = os.path.realpath(base)
                 if os.path.isdir(abs_base):
                     return abs_base
-            return os.path.abspath(allowed[0])
+            return os.path.realpath(allowed[0])
         resolved = self._resolve(str(path))
         if not os.path.isdir(resolved):
             raise ValueError(f'Path is not a directory: {path}')
@@ -104,6 +113,8 @@ class LocalFSToolGroup:
         safe_dir = self._resolve_dir(path)
         if self._has_rg():
             proc = self._run_rg(['--files', '--glob', pattern], cwd=safe_dir)
+            if proc.returncode > 1:
+                return tool_error('glob', f'ripgrep glob failed: {proc.stderr.strip() or "unknown error"}')
             raw = [os.path.join(safe_dir, p) for p in proc.stdout.splitlines() if p.strip()]
         else:
             py_pattern = pattern if '**' in pattern else f'**/{pattern}'
@@ -149,6 +160,9 @@ class LocalFSToolGroup:
             proc = self._run_rg(args, cwd=safe_dir)
         except subprocess.TimeoutExpired:
             return tool_error('grep', f'Search timed out (>{_RG_TIMEOUT}s)', error_type='Timeout')
+
+        if proc.returncode > 1:
+            return tool_error('grep', f'ripgrep search failed: {proc.stderr.strip() or "unknown error"}')
 
         matches: List[Dict[str, Any]] = []
         for line in proc.stdout.splitlines():
@@ -242,12 +256,14 @@ class LocalFSToolGroup:
 
         try:
             with open(safe_path, 'r', encoding='utf-8', errors='replace') as fh:
-                lines = fh.readlines()
+                chunk: List[str] = []
+                total = 0
+                for index, line in enumerate(fh):
+                    total += 1
+                    if start_line <= index < start_line + max_lines:
+                        chunk.append(line)
         except OSError as exc:
             return tool_error('read', f'Cannot read file: {exc}')
-
-        total = len(lines)
-        chunk = lines[start_line:start_line + max_lines]
 
         return tool_success('read', {
             'filepath': safe_path,
@@ -270,7 +286,9 @@ class LocalFSToolGroup:
         """
         if path is None or str(path).strip() in ('', '.'):
             allowed = self._get_allowed_paths()
-            safe_path = os.path.abspath(allowed[0])
+            if not allowed:
+                raise PermissionError('No local filesystem paths are configured')
+            safe_path = os.path.realpath(allowed[0])
         else:
             safe_path = self._resolve(str(path))
 

--- a/algorithm/lazymind/chat/engine/tools/local_fs.py
+++ b/algorithm/lazymind/chat/engine/tools/local_fs.py
@@ -44,7 +44,7 @@ class LocalFSToolGroup:
     # ── activation / path helpers ───────────────────────────────────────
 
     def _get_allowed_paths(self) -> List[str]:
-        paths = lazyllm.globals['agentic_config']['localfs_paths']
+        paths = lazyllm.globals['agentic_config'].get('localfs_paths')
         return [paths] if isinstance(paths, str) else paths
 
     def __key_source__(self) -> Any:

--- a/algorithm/lazymind/chat/service/chat_service.py
+++ b/algorithm/lazymind/chat/service/chat_service.py
@@ -222,10 +222,21 @@ async def handle_chat(query: str, history: Optional[List[Dict[str, Any]]],
     agent_history = normalize_history_for_agent(raw_history)
     translator = AgentEventFrameTranslator(query=query)
 
+    # localfs is a path whitelist, not a credential — pop from tool_config
+    # so inject_tool_config never sees it, and store in agentic_config instead.
+    _localfs_paths: Optional[List[str]] = None
+    if tool_config and isinstance(tool_config, dict) and 'localfs' in tool_config:
+        raw = tool_config.pop('localfs')
+        if isinstance(raw, str):
+            _localfs_paths = [raw]
+        elif isinstance(raw, list):
+            _localfs_paths = [str(p) for p in raw if p]
+
     agentic_config = {
         'session_id': session_id,
         'filters': filters if RAG_MODE and filters else {},
         'files': resolved_files,
+        'localfs_paths': _localfs_paths or [],
         'priority': priority,
         'user_id': user_id or '',
         'use_memory': use_memory,

--- a/algorithm/lazymind/chat/service/chat_service.py
+++ b/algorithm/lazymind/chat/service/chat_service.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 import asyncio
 import json
+import os
 import re
 import time
 from typing import Any, Dict, List, Optional, Union
@@ -84,6 +85,22 @@ def _normalize_kb_id_filter(raw_kb_id: Any) -> str | list[str] | None:
         cleaned = [item.strip() for item in raw_kb_id if isinstance(item, str) and item.strip()]
         return cleaned[0] if len(cleaned) == 1 else (cleaned or None)
     return None
+
+
+def _normalize_localfs_paths(raw_paths: Any) -> list[str]:
+    if raw_paths is None:
+        return []
+    if isinstance(raw_paths, str):
+        items = [raw_paths]
+    elif isinstance(raw_paths, list):
+        items = [item for item in raw_paths if isinstance(item, str)]
+    else:
+        return []
+    return [
+        os.path.realpath(path)
+        for item in items
+        if (path := str(item).strip())
+    ]
 
 
 def check_sensitive_content(
@@ -222,21 +239,17 @@ async def handle_chat(query: str, history: Optional[List[Dict[str, Any]]],
     agent_history = normalize_history_for_agent(raw_history)
     translator = AgentEventFrameTranslator(query=query)
 
-    # localfs is a path whitelist, not a credential — pop from tool_config
-    # so inject_tool_config never sees it, and store in agentic_config instead.
-    _localfs_paths: Optional[List[str]] = None
-    if tool_config and isinstance(tool_config, dict) and 'localfs' in tool_config:
-        raw = tool_config.pop('localfs')
-        if isinstance(raw, str):
-            _localfs_paths = [raw]
-        elif isinstance(raw, list):
-            _localfs_paths = [str(p) for p in raw if p]
+    # localfs_paths is a path whitelist, not a credential. Keep it request-scoped
+    # in agentic_config and remove it before dynamic credential injection.
+    localfs_paths: list[str] = []
+    if tool_config and isinstance(tool_config, dict):
+        localfs_paths = _normalize_localfs_paths(tool_config.pop('localfs_paths', None))
 
     agentic_config = {
         'session_id': session_id,
         'filters': filters if RAG_MODE and filters else {},
         'files': resolved_files,
-        'localfs_paths': _localfs_paths or [],
+        'localfs_paths': localfs_paths,
         'priority': priority,
         'user_id': user_id or '',
         'use_memory': use_memory,

--- a/algorithm/lazymind/chat/service/component/tool_registry.py
+++ b/algorithm/lazymind/chat/service/component/tool_registry.py
@@ -19,6 +19,7 @@ from lazyllm.tools.tools.search import (
 
 from lazymind.chat.engine.tools import (
     KBToolGroup,
+    LocalFSToolGroup,
     TempKBToolGroup,
     calculator,
     image_editor,
@@ -153,6 +154,12 @@ DEFAULT_TOOLS: list[ToolGroupConfig] = [
         label='技能编辑',
         description='创建、修改和删除技能',
         instance=skill_editor,
+    ),
+    ToolGroupConfig(
+        name='local_fs',
+        label='本地文件',
+        description='在配置的本地路径内进行 glob 匹配、grep 搜索、文件读取（只读）',
+        instance=LocalFSToolGroup(),
     ),
     ToolGroupConfig(
         name='feishu',

--- a/algorithm/lazymind/chat/service/component/tool_rendering.py
+++ b/algorithm/lazymind/chat/service/component/tool_rendering.py
@@ -150,6 +150,7 @@ _TOOL_CALL_PREVIEW_TEMPLATES: dict[str, str] = {
     'FeishuWikiFS_move': 'Moving Feishu file from {value} to the target path.',
     'FeishuWikiFS_copy': 'Copying Feishu file from {value} to the target path.',
     'advance_step': 'Switching to step {value}.',
+    'regex:get_(.+)_methods': 'Expanding the {match} tool group.',
     'regex:trigger_(.+)_plugin': 'Loading the {match} plugin now.',
 }
 _TOOL_CALL_FALLBACK_TEMPLATE = 'Calling a tool to handle the request.'
@@ -203,6 +204,7 @@ _ZH_TOOL_CALL_PREVIEW_TEMPLATES: dict[str, str] = {
     'FeishuWikiFS_move': '正在将飞书文件从 {value} 移动到目标路径。',
     'FeishuWikiFS_copy': '正在将飞书文件从 {value} 复制到目标路径。',
     'advance_step': '正在切换到步骤 {value}...',
+    'regex:get_(.+)_methods': '正在展开{match}工具组。',
     'regex:trigger_(.+)_plugin': '正在加载 {match} 插件...',
 }
 _ZH_TOOL_CALL_FALLBACK_TEMPLATE = '正在调用工具处理请求...'
@@ -258,6 +260,7 @@ _TOOL_RESULT_PREVIEW_TEMPLATES: dict[str, str] = {
     'FeishuWikiFS_move': 'Feishu file was moved from {value} to the target path successfully.',
     'FeishuWikiFS_copy': 'Feishu file was copied from {value} to the target path successfully.',
     'advance_step': 'Plugin launched.',
+    'regex:get_(.+)_methods': 'The {match} tool group has been expanded.',
     'regex:trigger_(.+)_plugin': 'Plugin launched.',
 }
 
@@ -310,6 +313,7 @@ _ZH_TOOL_RESULT_PREVIEW_TEMPLATES: dict[str, str] = {
     'FeishuWikiFS_move': '已成功将飞书文件从 {value} 移动到目标路径。',
     'FeishuWikiFS_copy': '已成功将飞书文件从 {value} 复制到目标路径。',
     'advance_step': '插件已启动',
+    'regex:get_(.+)_methods': '已经展开{match}工具组。',
     'regex:trigger_(.+)_plugin': '插件已启动',
 }
 
@@ -362,6 +366,7 @@ _TOOL_RESULT_FAILURE_TEMPLATES: dict[str, str] = {
     'FeishuWikiFS_move': 'Feishu file could not be moved from {value} to the target path.',
     'FeishuWikiFS_copy': 'Feishu file could not be copied from {value} to the target path.',
     'advance_step': 'Step {value} could not be started.',
+    'regex:get_(.+)_methods': 'The {match} tool group could not be expanded.',
     'regex:trigger_(.+)_plugin': 'Failed to load the {match} plugin.',
 }
 
@@ -414,6 +419,7 @@ _ZH_TOOL_RESULT_FAILURE_TEMPLATES: dict[str, str] = {
     'FeishuWikiFS_move': '未能将飞书文件从 {value} 移动到目标路径。',
     'FeishuWikiFS_copy': '未能将飞书文件从 {value} 复制到目标路径。',
     'advance_step': '步骤 {value} 启动失败',
+    'regex:get_(.+)_methods': '未能展开{match}工具组。',
     'regex:trigger_(.+)_plugin': '{match} 插件加载失败',
 }
 

--- a/algorithm/lazymind/router/api/proxy_routes.py
+++ b/algorithm/lazymind/router/api/proxy_routes.py
@@ -31,6 +31,12 @@ async def proxy_chat_stream(request: Request):
     return await _select_and_forward(request, caller_algo_id)
 
 
+@router.post('/api/chat/tools', summary='Proxy: list chat tools (router mode)')
+async def proxy_chat_tools(request: Request):
+    caller_algo_id = await _parse_algo_id(request)
+    return await _select_and_forward(request, caller_algo_id)
+
+
 @router.post('/api/subagent/run', summary='Proxy: SubAgent execution (router mode)')
 async def proxy_subagent_run(request: Request):
     # SubAgent requests carry no algorithm_id; let the AB router resolve the default.

--- a/tests/algorithm/chat/test_local_fs_tool.py
+++ b/tests/algorithm/chat/test_local_fs_tool.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+import subprocess
+
+import lazymind.chat.engine.tools.local_fs as local_fs_mod
+from lazymind.chat.engine.tools.local_fs import LocalFSToolGroup
+from lazymind.chat.service.chat_service import _normalize_localfs_paths
+
+
+def _set_localfs_paths(monkeypatch, paths):
+    monkeypatch.setattr(local_fs_mod.lazyllm, 'globals', {
+        'agentic_config': {'localfs_paths': paths},
+    })
+
+
+def test_local_fs_key_source_is_empty_without_config(monkeypatch):
+    monkeypatch.setattr(local_fs_mod.lazyllm, 'globals', {})
+
+    assert LocalFSToolGroup().__key_source__() == []
+
+
+def test_normalize_localfs_paths_resolves_strings_and_lists(tmp_path):
+    root = tmp_path / 'root'
+    root.mkdir()
+
+    assert _normalize_localfs_paths(str(root)) == [str(root.resolve())]
+    assert _normalize_localfs_paths(['', str(root)]) == [str(root.resolve())]
+    assert _normalize_localfs_paths(None) == []
+
+
+def test_local_fs_rejects_symlink_escape(monkeypatch, tmp_path):
+    allowed = tmp_path / 'allowed'
+    outside = tmp_path / 'outside'
+    allowed.mkdir()
+    outside.mkdir()
+    secret = outside / 'secret.txt'
+    secret.write_text('secret', encoding='utf-8')
+    link = allowed / 'link.txt'
+    link.symlink_to(secret)
+    _set_localfs_paths(monkeypatch, [str(allowed.resolve())])
+
+    result = LocalFSToolGroup().read(str(link))
+
+    assert result['success'] is False
+    assert result['tool'] == 'read'
+    assert result['error']['type'] == 'PermissionError'
+
+
+def test_local_fs_read_keeps_pagination_behavior(monkeypatch, tmp_path):
+    allowed = tmp_path / 'allowed'
+    allowed.mkdir()
+    target = allowed / 'sample.txt'
+    target.write_text('a\nb\nc\nd\n', encoding='utf-8')
+    _set_localfs_paths(monkeypatch, [str(allowed.resolve())])
+
+    result = LocalFSToolGroup().read(str(target), start_line=1, max_lines=2)
+
+    assert result['success'] is True
+    assert result['result']['total_lines'] == 4
+    assert result['result']['start_line'] == 1
+    assert result['result']['end_line'] == 3
+    assert result['result']['content'] == 'b\nc\n'
+
+
+def test_local_fs_glob_returns_tool_error_when_rg_fails(monkeypatch, tmp_path):
+    allowed = tmp_path / 'allowed'
+    allowed.mkdir()
+    _set_localfs_paths(monkeypatch, [str(allowed.resolve())])
+    monkeypatch.setattr(LocalFSToolGroup, '_has_rg', staticmethod(lambda: True))
+    monkeypatch.setattr(
+        LocalFSToolGroup,
+        '_run_rg',
+        staticmethod(lambda _args, cwd: subprocess.CompletedProcess([], 2, '', 'bad glob')),
+    )
+
+    result = LocalFSToolGroup().glob('[')
+
+    assert result['success'] is False
+    assert result['tool'] == 'glob'
+    assert 'ripgrep glob failed' in result['error']['reason']
+
+
+def test_local_fs_grep_returns_tool_error_when_rg_fails(monkeypatch, tmp_path):
+    allowed = tmp_path / 'allowed'
+    allowed.mkdir()
+    _set_localfs_paths(monkeypatch, [str(allowed.resolve())])
+    monkeypatch.setattr(LocalFSToolGroup, '_has_rg', staticmethod(lambda: True))
+    monkeypatch.setattr(
+        LocalFSToolGroup,
+        '_run_rg',
+        staticmethod(lambda _args, cwd: subprocess.CompletedProcess([], 2, '', 'bad regex')),
+    )
+
+    result = LocalFSToolGroup().grep('[')
+
+    assert result['success'] is False
+    assert result['tool'] == 'grep'
+    assert 'ripgrep search failed' in result['error']['reason']

--- a/tests/backend/chat/test_tool_rendering.py
+++ b/tests/backend/chat/test_tool_rendering.py
@@ -1,0 +1,35 @@
+import json
+import sys
+from pathlib import Path
+
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[3] / 'algorithm'))
+
+from lazymind.chat.service.component.tool_rendering import (  # noqa: E402
+    _tool_call_frame_text,
+    _tool_result_frame_text,
+)
+
+
+def test_lazy_tool_group_gateway_uses_group_expansion_preview_in_chinese():
+    tool_call = {
+        'id': 'call_1',
+        'function': {
+            'name': 'get_KBToolGroup_methods',
+            'arguments': json.dumps({}),
+        },
+    }
+
+    call_text, preview_value = _tool_call_frame_text(tool_call, 'zh')
+    result_text = _tool_result_frame_text(
+        {
+            'id': 'call_1',
+            'name': 'get_KBToolGroup_methods',
+            'result': 'Activated tool group "KBToolGroup". Available tools: kb_search',
+        },
+        'zh',
+        preview_value,
+    )
+
+    assert '正在展开**KBToolGroup**工具组。' in call_text
+    assert '已经展开**KBToolGroup**工具组。' in result_text


### PR DESCRIPTION
## 主要变更

### local_fs 工具
新增 `LocalFSToolGroup`，提供 `glob`、`grep`、`read`、`info` 四个只读文件系统操作。工具仅在配置了 `localfs_paths` 白名单后激活，所有操作限制在白名单路径内。优先使用 ripgrep 作为后端，不可用时回退到 Python stdlib。

### /api/chat/tools 代理路由
新增 `/api/chat/tools` 路由代理，支持在路由模式下获取可用聊天工具列表。

### 工具调用展示
为 lazy 工具组 gateway（`get_<Group>_methods`）增加专门的 tool preview 文案，使工具组展开过程显示为“正在展开 xxx 工具组 / 已经展开 xxx 工具组”，避免落到默认工具调用模板。

### 配套变更
- Dockerfile 安装 `ripgrep` 以支持 local_fs 的 rg 后端
- guidance.py 新增 tool group discovery 指引，确保 LLM 在调用工具组方法前先获取方法列表
- 新增轻量单测覆盖 lazy 工具组展开的中文调用态和完成态渲染

## 验证

- `pytest tests/backend/chat/test_tool_rendering.py`
