### PR TITLE
remove evo from local mode

### DIFF
--- a/backend/core/common/error_catalog.go
+++ b/backend/core/common/error_catalog.go
@@ -117,6 +117,8 @@ var errorCatalog = map[string]*AppError{
 	"unauthorized": NewAppError(http.StatusUnauthorized, ErrCodeUnauthorized, "unauthorized"),
 	"forbidden":    NewAppError(http.StatusForbidden, ErrCodeForbidden, "forbidden"),
 
+	"feature disabled": NewAppError(http.StatusForbidden, ErrCodeForbidden, "feature disabled"),
+
 	// Additional bad request errors discovered from handlers.
 	"action_list must be a non-empty array":                       NewAppError(http.StatusBadRequest, 2000801, "action_list must be a non-empty array"),
 	"apply_id and filename required":                              NewAppError(http.StatusBadRequest, 2000802, "apply_id and filename required"),

--- a/backend/core/common/external_endpoints.go
+++ b/backend/core/common/external_endpoints.go
@@ -5,6 +5,27 @@ import (
 	"strings"
 )
 
+// EnvFlagEnabled returns the feature flag value for envName.
+// Empty or unrecognized values keep the supplied default.
+func EnvFlagEnabled(envName string, defaultValue bool) bool {
+	v := strings.TrimSpace(strings.ToLower(os.Getenv(envName)))
+	switch v {
+	case "":
+		return defaultValue
+	case "1", "true", "yes", "on":
+		return true
+	case "0", "false", "no", "off":
+		return false
+	default:
+		return defaultValue
+	}
+}
+
+// EvoEnabled reports whether dedicated Evo features may call evo-api.
+func EvoEnabled() bool {
+	return EnvFlagEnabled("LAZYMIND_EVO_ENABLED", true)
+}
+
 // ChatServiceEndpoint returns the base URL for the chat/generation service.
 func ChatServiceEndpoint() string {
 	if u := strings.TrimSpace(os.Getenv("LAZYMIND_CHAT_SERVICE_URL")); u != "" {

--- a/backend/core/common/external_endpoints_test.go
+++ b/backend/core/common/external_endpoints_test.go
@@ -23,3 +23,17 @@ func TestEvoServiceEndpointDoesNotFallBackToAlgoService(t *testing.T) {
 		t.Fatalf("expected evo service endpoint %q, got %q", want, got)
 	}
 }
+
+func TestEvoEnabledDefaultsToTrue(t *testing.T) {
+	if !EvoEnabled() {
+		t.Fatal("expected Evo to be enabled by default")
+	}
+}
+
+func TestEvoEnabledCanBeDisabled(t *testing.T) {
+	t.Setenv("LAZYMIND_EVO_ENABLED", "false")
+
+	if EvoEnabled() {
+		t.Fatal("expected Evo to be disabled")
+	}
+}

--- a/backend/core/memory/handler.go
+++ b/backend/core/memory/handler.go
@@ -144,9 +144,11 @@ func upsertManagedMemoryContent(r *http.Request, db *gorm.DB, userID, userName s
 	}
 	if req.AutoEvo != nil {
 		update["auto_evo"] = resolvedAutoEvo
-		update["auto_evo_generation"] = gorm.Expr("auto_evo_generation + 1")
 		update["auto_evo_apply_status"] = evolution.AutoEvoApplyStatusIdle
 		update["auto_evo_error"] = ""
+		if common.EvoEnabled() {
+			update["auto_evo_generation"] = gorm.Expr("auto_evo_generation + 1")
+		}
 		if resolvedAutoEvo {
 			update["auto_evo_finished_at"] = nil
 		} else {
@@ -187,7 +189,9 @@ func upsertManagedMemoryContent(r *http.Request, db *gorm.DB, userID, userName s
 	existing.Version++
 	if req.AutoEvo != nil {
 		existing.AutoEvo = resolvedAutoEvo
-		existing.AutoEvoGeneration++
+		if common.EvoEnabled() {
+			existing.AutoEvoGeneration++
+		}
 		existing.AutoEvoApplyStatus = evolution.AutoEvoApplyStatusIdle
 		existing.AutoEvoError = ""
 	}
@@ -265,6 +269,10 @@ func Upsert(w http.ResponseWriter, r *http.Request) {
 	if !hasMemoryUpsertField(req) {
 		common.ReplyErr(w, "content or auto_evo required", http.StatusBadRequest)
 		return
+	}
+	if !common.EvoEnabled() {
+		disabled := false
+		req.AutoEvo = &disabled
 	}
 	if req.Content != nil {
 		if err := validateManagedContentLength(*req.Content); err != nil {

--- a/backend/core/memory/handler_test.go
+++ b/backend/core/memory/handler_test.go
@@ -167,6 +167,36 @@ func TestUpsertCreatesThenUpdatesMemory(t *testing.T) {
 	}
 }
 
+func TestUpsertForcesMemoryAutoEvoDisabledWhenEvoFeatureOff(t *testing.T) {
+	t.Setenv("LAZYMIND_EVO_ENABLED", "false")
+
+	db := newMemoryTestDB(t)
+	store.Init(db.DB, nil, nil)
+	t.Cleanup(func() { store.Init(nil, nil, nil) })
+
+	req := httptest.NewRequest(http.MethodPut, "/api/core/memory", strings.NewReader(`{"content":"本地记忆内容","auto_evo":true}`))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-User-Id", "u1")
+	req.Header.Set("X-User-Name", "User 1")
+	rec := httptest.NewRecorder()
+
+	Upsert(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d body=%s", rec.Code, rec.Body.String())
+	}
+	var row orm.SystemMemory
+	if err := db.Where("user_id = ?", "u1").Take(&row).Error; err != nil {
+		t.Fatalf("query created memory: %v", err)
+	}
+	if row.AutoEvo {
+		t.Fatal("expected auto_evo=true request to persist auto_evo=false when Evo is disabled")
+	}
+	if row.AutoEvoGeneration != 0 {
+		t.Fatalf("expected auto_evo_generation to stay 0, got %d", row.AutoEvoGeneration)
+	}
+}
+
 func TestUpsertPreservesMemoryAutoEvoWhenOmitted(t *testing.T) {
 	db := newMemoryTestDB(t)
 	store.Init(db.DB, nil, nil)

--- a/backend/core/modelprovider/check.go
+++ b/backend/core/modelprovider/check.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"mime/multipart"
@@ -23,6 +24,8 @@ import (
 )
 
 const modelProviderCheckTimeout = 5 * time.Minute
+const modelProviderProbeTimeout = 30 * time.Second
+const maxModelProviderProbeModels = 10
 const cloudServiceCheckTimeout = 30 * time.Second
 
 const (
@@ -80,6 +83,7 @@ type modelCheckResponse struct {
 type CheckModelProviderData struct {
 	Success bool   `json:"success"`
 	Message string `json:"message,omitempty"`
+	Model   string `json:"model,omitempty"`
 }
 
 // doCheck calls the appropriate algorithm endpoint based on provider category and returns the result.
@@ -94,6 +98,9 @@ func doCheck(ctx context.Context, category, providerName, baseURL, apiKey string
 		checkEndpoint = "/api/model/check"
 	}
 	upstream := common.JoinURL(common.ChatServiceEndpoint(), checkEndpoint)
+	if strings.TrimSpace(category) == "model" {
+		return doModelProviderCheck(ctx, upstream, providerName, baseURL, apiKey)
+	}
 	body := algoModelCheckBody{
 		Source: providerName,
 		URL:    baseURL,
@@ -104,6 +111,191 @@ func doCheck(ctx context.Context, category, providerName, baseURL, apiKey string
 		return &result, err
 	}
 	return &result, nil
+}
+
+func doModelProviderCheck(ctx context.Context, upstream, providerName, baseURL, apiKey string) (*modelCheckResponse, error) {
+	candidates, err := defaultLLMProbeModels(ctx, providerName, maxModelProviderProbeModels)
+	if err != nil {
+		return &modelCheckResponse{Success: false, Message: err.Error(), Source: providerName, URL: baseURL}, nil
+	}
+	if len(candidates) == 0 {
+		return &modelCheckResponse{
+			Success: false,
+			Message: fmt.Sprintf("no default llm models found for provider %s", providerName),
+			Source:  providerName,
+			URL:     baseURL,
+		}, nil
+	}
+
+	failures := make([]string, 0, len(candidates))
+	for _, model := range candidates {
+		result, err := probeModelProvider(ctx, upstream, providerName, baseURL, apiKey, model)
+		if result == nil {
+			result = &modelCheckResponse{Source: providerName, URL: baseURL, Model: model}
+		}
+		if result.Model == "" {
+			result.Model = model
+		}
+		if err == nil && result.Success {
+			log.Logger.Info().
+				Str("provider_name", providerName).
+				Str("model", model).
+				Msg("model provider check succeeded")
+			return result, nil
+		}
+
+		reason := modelProbeFailureReason(model, result, err, apiKey)
+		failures = append(failures, reason)
+		if isTerminalModelProbeFailure(result, err) {
+			return &modelCheckResponse{
+				Success: false,
+				Message: fmt.Sprintf("model provider check failed after %d/%d model probes: %s", len(failures), len(candidates), reason),
+				Model:   model,
+				Source:  providerName,
+				URL:     baseURL,
+			}, nil
+		}
+	}
+
+	return &modelCheckResponse{
+		Success: false,
+		Message: aggregateModelProbeFailures(len(candidates), failures),
+		Source:  providerName,
+		URL:     baseURL,
+	}, nil
+}
+
+func defaultLLMProbeModels(ctx context.Context, providerName string, limit int) ([]string, error) {
+	db := store.DB()
+	if db == nil {
+		return nil, errors.New("store not initialized")
+	}
+
+	providerName = strings.TrimSpace(providerName)
+	var provider orm.DefaultModelProvider
+	if err := db.WithContext(ctx).
+		Where("name = ? AND category = ? AND deleted_at IS NULL", providerName, "model").
+		Take(&provider).Error; err != nil {
+		return nil, fmt.Errorf("default model provider not found: %s", providerName)
+	}
+
+	var rows []orm.DefaultModel
+	query := db.WithContext(ctx).
+		Where("default_model_provider_id = ? AND model_type = ? AND deleted_at IS NULL", provider.ID, "llm").
+		Order("id ASC")
+	if limit > 0 {
+		query = query.Limit(limit)
+	}
+	if err := query.Find(&rows).Error; err != nil {
+		return nil, fmt.Errorf("query default llm models: %w", err)
+	}
+
+	out := make([]string, 0, len(rows))
+	seen := map[string]struct{}{}
+	for _, row := range rows {
+		name := strings.TrimSpace(row.Name)
+		key := strings.ToLower(name)
+		if name == "" {
+			continue
+		}
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		out = append(out, name)
+	}
+	return out, nil
+}
+
+func probeModelProvider(ctx context.Context, upstream, providerName, baseURL, apiKey, model string) (*modelCheckResponse, error) {
+	body := algoModelCheckBody{
+		Model:  model,
+		Source: providerName,
+		URL:    baseURL,
+		APIKey: apiKey,
+	}
+	var result modelCheckResponse
+	if err := common.ApiPost(ctx, upstream, body, nil, &result, modelProviderProbeTimeout); err != nil {
+		return &result, err
+	}
+	return &result, nil
+}
+
+func modelProbeFailureReason(model string, result *modelCheckResponse, err error, apiKey string) string {
+	message := ""
+	if err != nil {
+		message = err.Error()
+	}
+	if result != nil && strings.TrimSpace(result.Message) != "" {
+		message = result.Message
+	}
+	message = safeCheckMessage(message, apiKey)
+	if message == "" {
+		message = "model check failed"
+	}
+	return fmt.Sprintf("%s: %s", model, message)
+}
+
+func aggregateModelProbeFailures(total int, failures []string) string {
+	if len(failures) == 0 {
+		return fmt.Sprintf("model provider check failed: tried %d llm models", total)
+	}
+	start := 0
+	if len(failures) > 3 {
+		start = len(failures) - 3
+	}
+	return fmt.Sprintf(
+		"model provider check failed: tried %d llm models; recent failures: %s",
+		total,
+		strings.Join(failures[start:], "; "),
+	)
+}
+
+func isTerminalModelProbeFailure(result *modelCheckResponse, err error) bool {
+	if err != nil {
+		var httpErr *common.HTTPError
+		if errors.As(err, &httpErr) {
+			if httpErr.StatusCode == http.StatusUnauthorized || httpErr.StatusCode == http.StatusForbidden {
+				return true
+			}
+			return looksLikeCredentialOrEndpointFailure(httpErr.Message)
+		}
+		return looksLikeCredentialOrEndpointFailure(err.Error())
+	}
+	if result == nil {
+		return false
+	}
+	return looksLikeCredentialOrEndpointFailure(result.Message)
+}
+
+func looksLikeCredentialOrEndpointFailure(message string) bool {
+	text := strings.ToLower(strings.TrimSpace(message))
+	if text == "" {
+		return false
+	}
+	signals := []string{
+		"unauthorized",
+		"forbidden",
+		"invalid token",
+		"invalid api key",
+		"invalid apikey",
+		"api key invalid",
+		"incorrect api key",
+		"token invalid",
+		"authentication",
+		"authorization",
+		"invalid base url",
+		"invalid url",
+		"unsupported protocol scheme",
+		"no such host",
+		"connection refused",
+	}
+	for _, signal := range signals {
+		if strings.Contains(text, signal) {
+			return true
+		}
+	}
+	return false
 }
 
 func doProviderGroupCheck(ctx context.Context, category, providerName, baseURL, apiKey string) (*modelCheckResponse, error) {
@@ -647,7 +839,7 @@ func CheckGroup(w http.ResponseWriter, r *http.Request) {
 			cacheKey := verifyCheckCacheKey(groupID, urlStr, apiKey)
 			recentVerifyCache.Store(cacheKey, time.Now().Add(5*time.Minute))
 		}
-		common.ReplyOK(w, CheckModelProviderData{Success: algo.Success, Message: algo.Message})
+		common.ReplyOK(w, CheckModelProviderData{Success: algo.Success, Message: algo.Message, Model: algo.Model})
 		return
 	}
 
@@ -669,5 +861,5 @@ func CheckGroup(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 	}
-	common.ReplyOK(w, CheckModelProviderData{Success: algo.Success, Message: algo.Message})
+	common.ReplyOK(w, CheckModelProviderData{Success: algo.Success, Message: algo.Message, Model: algo.Model})
 }

--- a/backend/core/modelprovider/check_test.go
+++ b/backend/core/modelprovider/check_test.go
@@ -1,0 +1,197 @@
+package modelprovider
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+
+	"lazymind/core/common/orm"
+	"lazymind/core/store"
+)
+
+func setupCheckProviderTestDB(t *testing.T) *gorm.DB {
+	t.Helper()
+
+	dbName := "check_provider_" + strings.ReplaceAll(t.Name(), "/", "_")
+	db, err := gorm.Open(sqlite.Open("file:"+dbName+"?mode=memory&cache=shared"), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	if err := db.AutoMigrate(
+		&orm.DefaultModelProvider{},
+		&orm.DefaultModel{},
+	); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	store.Init(db, db, nil)
+	return db
+}
+
+func seedCheckProviderCatalog(t *testing.T, db *gorm.DB, models []orm.DefaultModel) {
+	t.Helper()
+
+	now := time.Now()
+	provider := orm.DefaultModelProvider{
+		ID:          "provider-qwen",
+		Name:        "Qwen",
+		Description: "Qwen provider",
+		BaseURL:     "https://dashscope.aliyuncs.com/compatible-mode/v1",
+		Category:    "model",
+		CreatedAt:   now,
+		UpdatedAt:   now,
+	}
+	if err := db.Create(&provider).Error; err != nil {
+		t.Fatalf("create provider: %v", err)
+	}
+	for i := range models {
+		models[i].DefaultModelProviderID = provider.ID
+		models[i].ProviderName = provider.Name
+		models[i].CreatedAt = now
+		models[i].UpdatedAt = now
+	}
+	if err := db.Create(&models).Error; err != nil {
+		t.Fatalf("create models: %v", err)
+	}
+}
+
+func TestDoModelProviderCheckTriesDefaultLLMsInDBOrderAndStopsOnSuccess(t *testing.T) {
+	db := setupCheckProviderTestDB(t)
+	seedCheckProviderCatalog(t, db, []orm.DefaultModel{
+		{ID: "00-embed", Name: "text-embedding-v4", ModelType: "embed"},
+		{ID: "01-llm", Name: "qwen-disabled", ModelType: "llm"},
+		{ID: "02-llm", Name: "qwen-ready", ModelType: "llm"},
+		{ID: "03-llm", Name: "qwen-untouched", ModelType: "llm"},
+	})
+
+	var tried []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/model/check" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		var body algoModelCheckBody
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("decode body: %v", err)
+		}
+		tried = append(tried, body.Model)
+		w.Header().Set("Content-Type", "application/json")
+		if body.Model == "qwen-ready" {
+			_, _ = w.Write([]byte(`{"success":true,"message":"ok"}`))
+			return
+		}
+		_, _ = w.Write([]byte(`{"success":false,"message":"Model disabled"}`))
+	}))
+	defer server.Close()
+	t.Setenv("LAZYMIND_CHAT_SERVICE_URL", server.URL)
+
+	result, err := doCheck(t.Context(), "model", "Qwen", "https://example.test/v1", "test-key")
+	if err != nil {
+		t.Fatalf("doCheck error: %v", err)
+	}
+	if result == nil || !result.Success {
+		t.Fatalf("expected success, got %+v", result)
+	}
+	if result.Model != "qwen-ready" {
+		t.Fatalf("expected successful model to be reported, got %q", result.Model)
+	}
+	want := []string{"qwen-disabled", "qwen-ready"}
+	if !reflect.DeepEqual(tried, want) {
+		t.Fatalf("unexpected probe order: got %v want %v", tried, want)
+	}
+}
+
+func TestDoModelProviderCheckStopsOnCredentialFailure(t *testing.T) {
+	db := setupCheckProviderTestDB(t)
+	seedCheckProviderCatalog(t, db, []orm.DefaultModel{
+		{ID: "01-llm", Name: "qwen-one", ModelType: "llm"},
+		{ID: "02-llm", Name: "qwen-two", ModelType: "llm"},
+	})
+
+	var tried []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body algoModelCheckBody
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("decode body: %v", err)
+		}
+		tried = append(tried, body.Model)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte(`{"message":"invalid api key"}`))
+	}))
+	defer server.Close()
+	t.Setenv("LAZYMIND_CHAT_SERVICE_URL", server.URL)
+
+	result, err := doCheck(t.Context(), "model", "Qwen", "https://example.test/v1", "test-key")
+	if err != nil {
+		t.Fatalf("doCheck error: %v", err)
+	}
+	if result == nil || result.Success {
+		t.Fatalf("expected failure, got %+v", result)
+	}
+	if len(tried) != 1 || tried[0] != "qwen-one" {
+		t.Fatalf("expected credential failure to stop after first probe, got %v", tried)
+	}
+	if !strings.Contains(result.Message, "1/2") || !strings.Contains(result.Message, "qwen-one") {
+		t.Fatalf("unexpected failure message: %q", result.Message)
+	}
+}
+
+func TestDoModelProviderCheckAggregatesModelFailures(t *testing.T) {
+	db := setupCheckProviderTestDB(t)
+	seedCheckProviderCatalog(t, db, []orm.DefaultModel{
+		{ID: "01-llm", Name: "qwen-one", ModelType: "llm"},
+		{ID: "02-llm", Name: "qwen-two", ModelType: "llm"},
+		{ID: "03-llm", Name: "qwen-three", ModelType: "llm"},
+	})
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body algoModelCheckBody
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("decode body: %v", err)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"success":false,"message":"model not found: ` + body.Model + `"}`))
+	}))
+	defer server.Close()
+	t.Setenv("LAZYMIND_CHAT_SERVICE_URL", server.URL)
+
+	result, err := doCheck(t.Context(), "model", "Qwen", "https://example.test/v1", "test-key")
+	if err != nil {
+		t.Fatalf("doCheck error: %v", err)
+	}
+	if result == nil || result.Success {
+		t.Fatalf("expected failure, got %+v", result)
+	}
+	for _, want := range []string{"tried 3 llm models", "qwen-one", "qwen-two", "qwen-three"} {
+		if !strings.Contains(result.Message, want) {
+			t.Fatalf("expected message to contain %q, got %q", want, result.Message)
+		}
+	}
+}
+
+func TestDefaultLLMProbeModelsLimitsCandidates(t *testing.T) {
+	db := setupCheckProviderTestDB(t)
+	models := make([]orm.DefaultModel, 0, maxModelProviderProbeModels+2)
+	for i := 0; i < maxModelProviderProbeModels+2; i++ {
+		models = append(models, orm.DefaultModel{
+			ID:        "llm-" + string(rune('a'+i)),
+			Name:      "qwen-" + string(rune('a'+i)),
+			ModelType: "llm",
+		})
+	}
+	seedCheckProviderCatalog(t, db, models)
+
+	got, err := defaultLLMProbeModels(t.Context(), "Qwen", maxModelProviderProbeModels)
+	if err != nil {
+		t.Fatalf("defaultLLMProbeModels error: %v", err)
+	}
+	if len(got) != maxModelProviderProbeModels {
+		t.Fatalf("expected %d candidates, got %d: %v", maxModelProviderProbeModels, len(got), got)
+	}
+}

--- a/backend/core/preference/handler.go
+++ b/backend/core/preference/handler.go
@@ -167,9 +167,11 @@ func upsertManagedPreferenceContent(r *http.Request, db *gorm.DB, userID, userNa
 	}
 	if req.AutoEvo != nil {
 		update["auto_evo"] = resolvedAutoEvo
-		update["auto_evo_generation"] = gorm.Expr("auto_evo_generation + 1")
 		update["auto_evo_apply_status"] = evolution.AutoEvoApplyStatusIdle
 		update["auto_evo_error"] = ""
+		if common.EvoEnabled() {
+			update["auto_evo_generation"] = gorm.Expr("auto_evo_generation + 1")
+		}
 		if resolvedAutoEvo {
 			update["auto_evo_finished_at"] = nil
 		} else {
@@ -213,7 +215,9 @@ func upsertManagedPreferenceContent(r *http.Request, db *gorm.DB, userID, userNa
 	existing.Version++
 	if req.AutoEvo != nil {
 		existing.AutoEvo = resolvedAutoEvo
-		existing.AutoEvoGeneration++
+		if common.EvoEnabled() {
+			existing.AutoEvoGeneration++
+		}
 		existing.AutoEvoApplyStatus = evolution.AutoEvoApplyStatusIdle
 		existing.AutoEvoError = ""
 	}
@@ -291,6 +295,10 @@ func Upsert(w http.ResponseWriter, r *http.Request) {
 	if !hasPreferenceUpsertField(req) {
 		common.ReplyErr(w, "content, user_preference metadata, or auto_evo required", http.StatusBadRequest)
 		return
+	}
+	if !common.EvoEnabled() {
+		disabled := false
+		req.AutoEvo = &disabled
 	}
 	if req.Content != nil {
 		if err := validateManagedContentLength(*req.Content); err != nil {

--- a/backend/core/preference/handler_test.go
+++ b/backend/core/preference/handler_test.go
@@ -164,6 +164,36 @@ func TestUpsertCreatesThenUpdatesPreference(t *testing.T) {
 	}
 }
 
+func TestUpsertForcesPreferenceAutoEvoDisabledWhenEvoFeatureOff(t *testing.T) {
+	t.Setenv("LAZYMIND_EVO_ENABLED", "false")
+
+	db := newPreferenceTestDB(t)
+	store.Init(db.DB, nil, nil)
+	t.Cleanup(func() { store.Init(nil, nil, nil) })
+
+	req := httptest.NewRequest(http.MethodPut, "/api/core/user-preference", strings.NewReader(`{"content":"本地偏好内容","auto_evo":true}`))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-User-Id", "u1")
+	req.Header.Set("X-User-Name", "User 1")
+	rec := httptest.NewRecorder()
+
+	Upsert(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d body=%s", rec.Code, rec.Body.String())
+	}
+	var row orm.SystemUserPreference
+	if err := db.Where("user_id = ?", "u1").Take(&row).Error; err != nil {
+		t.Fatalf("query created preference: %v", err)
+	}
+	if row.AutoEvo {
+		t.Fatal("expected auto_evo=true request to persist auto_evo=false when Evo is disabled")
+	}
+	if row.AutoEvoGeneration != 0 {
+		t.Fatalf("expected auto_evo_generation to stay 0, got %d", row.AutoEvoGeneration)
+	}
+}
+
 func TestUpsertPreservesPreferenceAutoEvoWhenOmitted(t *testing.T) {
 	db := newPreferenceTestDB(t)
 	store.Init(db.DB, nil, nil)

--- a/backend/core/resourceupdate/resourceupdate_test.go
+++ b/backend/core/resourceupdate/resourceupdate_test.go
@@ -22,6 +22,18 @@ import (
 	"lazymind/core/store"
 )
 
+func TestEnabledFromEnvRequiresEvoEnabled(t *testing.T) {
+	t.Setenv("LAZYMIND_RESOURCE_UPDATE_ENABLED", "true")
+	if !EnabledFromEnv() {
+		t.Fatal("expected resource update to follow its own env when Evo is enabled")
+	}
+
+	t.Setenv("LAZYMIND_EVO_ENABLED", "false")
+	if EnabledFromEnv() {
+		t.Fatal("expected resource update to be disabled when Evo is disabled")
+	}
+}
+
 func TestCountSkillReviewHistoryStatsFiltersUserAndHalfOpenWindow(t *testing.T) {
 	db := newResourceUpdateTestDB(t)
 	ctx := context.Background()
@@ -1167,6 +1179,7 @@ func TestAcceptUserPreferenceReviewResultParsesFrontmatter(t *testing.T) {
 	resource.ContentHash = evolution.HashSystemUserPreference(resource)
 	insertPreferenceResource(t, db, resource)
 	reviewContent := "---\nagent_persona: 新角色\npreferred_name: 用户称谓\nresponse_style: 回复风格\n---\n\n新正文"
+	insertMemoryReviewResult(t, db, MemoryReviewResult{
 		ID:           "preference-accept",
 		UserID:       "user-1",
 		Target:       orm.ResourceUpdateResourceTypeUserPreference,

--- a/backend/core/resourceupdate/runtime.go
+++ b/backend/core/resourceupdate/runtime.go
@@ -3,11 +3,10 @@ package resourceupdate
 import (
 	"context"
 	"fmt"
-	"os"
-	"strings"
 	"time"
 
 	"gorm.io/gorm"
+	"lazymind/core/common"
 	"lazymind/core/state"
 )
 
@@ -38,8 +37,10 @@ func Start(ctx context.Context, db *gorm.DB, stateStore state.Store, cfg Config)
 }
 
 func EnabledFromEnv() bool {
-	v := strings.TrimSpace(strings.ToLower(os.Getenv("LAZYMIND_RESOURCE_UPDATE_ENABLED")))
-	return v == "1" || v == "true" || v == "yes"
+	if !common.EvoEnabled() {
+		return false
+	}
+	return common.EnvFlagEnabled("LAZYMIND_RESOURCE_UPDATE_ENABLED", false)
 }
 
 func runSchedulerLoop(ctx context.Context, scheduler *Scheduler, interval time.Duration) {

--- a/backend/core/routes.go
+++ b/backend/core/routes.go
@@ -1,9 +1,12 @@
 package main
 
 import (
+	"net/http"
+
 	"lazymind/core/acl"
 	"lazymind/core/agent"
 	"lazymind/core/chat"
+	"lazymind/core/common"
 	"lazymind/core/datasource"
 	"lazymind/core/doc"
 	"lazymind/core/evalset"
@@ -22,6 +25,16 @@ import (
 
 	"github.com/gorilla/mux"
 )
+
+func evoFeatureHandler(h http.HandlerFunc) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if !common.EvoEnabled() {
+			common.ReplyErr(w, "feature disabled", http.StatusForbidden)
+			return
+		}
+		h(w, r)
+	}
+}
 
 // registerAllRoutes text OpenAPI text（text Job），text handleAPI textPermissiontext（text extract_api_permissions.py text Kong RBAC）。
 func registerAllRoutes(r *mux.Router) {
@@ -139,37 +152,37 @@ func registerAllRoutes(r *mux.Router) {
 	handleAPI(r, "PUT", "/mcp_servers/{id}/tools", []string{"qa.write"}, mcp.UpdateTools)
 
 	// ----- Agent thread stream -----
-	handleAPI(r, "GET", "/agent/threads", []string{"qa.read"}, agent.ListThreads)
-	handleAPI(r, "POST", "/agent/threads", []string{"qa.write"}, agent.CreateThread)
-	handleAPI(r, "GET", "/agent/threads/{thread_id}:events", []string{"qa.read"}, agent.StreamThreadEvents)
-	handleAPI(r, "GET", "/agent/threads/{thread_id}/events/{step_id}", []string{"qa.read"}, agent.StreamThreadStepEvents)
-	handleAPI(r, "GET", "/agent/threads/{thread_id}/steps", []string{"qa.read"}, agent.ListThreadSteps)
-	handleAPI(r, "GET", "/agent/threads/{thread_id}/steps/{step_id}/records", []string{"qa.read"}, agent.ListThreadStepRecords)
-	handleAPI(r, "GET", "/agent/threads/{thread_id}", []string{"qa.read"}, agent.GetThread)
-	handleAPI(r, "GET", "/agent/threads/{thread_id}/history", []string{"qa.read"}, agent.GetThreadHistory)
-	handleAPI(r, "DELETE", "/agent/threads/{thread_id}:history", []string{"qa.write"}, agent.DeleteThreadHistory)
-	handleAPI(r, "GET", "/agent/threads/{thread_id}/rounds", []string{"qa.read"}, agent.ListThreadRounds)
-	handleAPI(r, "GET", "/agent/threads/{thread_id}/records", []string{"qa.read"}, agent.ListThreadRecords)
-	handleAPI(r, "GET", "/agent/threads/{thread_id}/results/datasets", []string{"qa.read"}, agent.GetThreadResultDatasets)
-	handleAPI(r, "GET", "/agent/threads/{thread_id}/results/eval-reports", []string{"qa.read"}, agent.GetThreadResultEvalReports)
-	handleAPI(r, "GET", "/agent/threads/{thread_id}/results/eval-reports/{report_id}/bad-cases", []string{"qa.read"}, agent.GetThreadEvalReportBadCases)
-	handleAPI(r, "GET", "/agent/threads/{thread_id}/results/analysis-reports", []string{"qa.read"}, agent.GetThreadResultAnalysisReports)
-	handleAPI(r, "GET", "/agent/threads/{thread_id}/results/diffs", []string{"qa.read"}, agent.GetThreadResultDiffs)
-	handleAPI(r, "GET", "/agent/threads/{thread_id}/results/abtests", []string{"qa.read"}, agent.GetThreadResultAbtests)
-	handleAPI(r, "GET", "/agent/threads/{thread_id}/results/abtests/{abtest_id}/case-details", []string{"qa.read"}, agent.GetThreadABTestCaseDetails)
-	handleAPI(r, "GET", "/agent/threads/{thread_id}/flow-status", []string{"qa.read"}, agent.GetThreadFlowStatus)
-	handleAPI(r, "GET", "/agent/threads/{thread_id}/artifacts/{artifact_id}", []string{"qa.read"}, agent.GetThreadArtifact)
-	handleAPI(r, "GET", "/agent/threads/{thread_id}/results/traces/{trace_id}", []string{"qa.read"}, agent.GetThreadResultTrace)
-	handleAPI(r, "GET", "/agent/threads/{thread_id}/results/traces-compare", []string{"qa.read"}, agent.GetThreadResultTraceCompare)
-	handleAPI(r, "POST", "/agent/threads/{thread_id}:messages", []string{"qa.write"}, agent.StreamThreadMessages)
-	handleAPI(r, "POST", "/agent/threads/{thread_id}:start", []string{"qa.write"}, agent.StartThread)
-	handleAPI(r, "POST", "/agent/threads/{thread_id}:pause", []string{"qa.write"}, agent.PauseThread)
-	handleAPI(r, "POST", "/agent/threads/{thread_id}:cancel", []string{"qa.write"}, agent.CancelThread)
-	handleAPI(r, "POST", "/agent/threads/{thread_id}:retry", []string{"qa.write"}, agent.RetryThread)
-	handleAPI(r, "POST", "/agent/threads/{thread_id}:continue", []string{"qa.write"}, agent.ContinueThread)
-	handleAPI(r, "GET", "/agent/reports/{report_id}:content", []string{"qa.read"}, agent.GetReportContent)
-	handleAPI(r, "GET", "/agent/diffs/{apply_id}/{filename:.*}", []string{"qa.read"}, agent.GetDiffContent)
-	handleAPI(r, "POST", "/agent/files:content", []string{"qa.read"}, agent.GetAgentFileContent)
+	handleAPI(r, "GET", "/agent/threads", []string{"qa.read"}, evoFeatureHandler(agent.ListThreads))
+	handleAPI(r, "POST", "/agent/threads", []string{"qa.write"}, evoFeatureHandler(agent.CreateThread))
+	handleAPI(r, "GET", "/agent/threads/{thread_id}:events", []string{"qa.read"}, evoFeatureHandler(agent.StreamThreadEvents))
+	handleAPI(r, "GET", "/agent/threads/{thread_id}/events/{step_id}", []string{"qa.read"}, evoFeatureHandler(agent.StreamThreadStepEvents))
+	handleAPI(r, "GET", "/agent/threads/{thread_id}/steps", []string{"qa.read"}, evoFeatureHandler(agent.ListThreadSteps))
+	handleAPI(r, "GET", "/agent/threads/{thread_id}/steps/{step_id}/records", []string{"qa.read"}, evoFeatureHandler(agent.ListThreadStepRecords))
+	handleAPI(r, "GET", "/agent/threads/{thread_id}", []string{"qa.read"}, evoFeatureHandler(agent.GetThread))
+	handleAPI(r, "GET", "/agent/threads/{thread_id}/history", []string{"qa.read"}, evoFeatureHandler(agent.GetThreadHistory))
+	handleAPI(r, "DELETE", "/agent/threads/{thread_id}:history", []string{"qa.write"}, evoFeatureHandler(agent.DeleteThreadHistory))
+	handleAPI(r, "GET", "/agent/threads/{thread_id}/rounds", []string{"qa.read"}, evoFeatureHandler(agent.ListThreadRounds))
+	handleAPI(r, "GET", "/agent/threads/{thread_id}/records", []string{"qa.read"}, evoFeatureHandler(agent.ListThreadRecords))
+	handleAPI(r, "GET", "/agent/threads/{thread_id}/results/datasets", []string{"qa.read"}, evoFeatureHandler(agent.GetThreadResultDatasets))
+	handleAPI(r, "GET", "/agent/threads/{thread_id}/results/eval-reports", []string{"qa.read"}, evoFeatureHandler(agent.GetThreadResultEvalReports))
+	handleAPI(r, "GET", "/agent/threads/{thread_id}/results/eval-reports/{report_id}/bad-cases", []string{"qa.read"}, evoFeatureHandler(agent.GetThreadEvalReportBadCases))
+	handleAPI(r, "GET", "/agent/threads/{thread_id}/results/analysis-reports", []string{"qa.read"}, evoFeatureHandler(agent.GetThreadResultAnalysisReports))
+	handleAPI(r, "GET", "/agent/threads/{thread_id}/results/diffs", []string{"qa.read"}, evoFeatureHandler(agent.GetThreadResultDiffs))
+	handleAPI(r, "GET", "/agent/threads/{thread_id}/results/abtests", []string{"qa.read"}, evoFeatureHandler(agent.GetThreadResultAbtests))
+	handleAPI(r, "GET", "/agent/threads/{thread_id}/results/abtests/{abtest_id}/case-details", []string{"qa.read"}, evoFeatureHandler(agent.GetThreadABTestCaseDetails))
+	handleAPI(r, "GET", "/agent/threads/{thread_id}/flow-status", []string{"qa.read"}, evoFeatureHandler(agent.GetThreadFlowStatus))
+	handleAPI(r, "GET", "/agent/threads/{thread_id}/artifacts/{artifact_id}", []string{"qa.read"}, evoFeatureHandler(agent.GetThreadArtifact))
+	handleAPI(r, "GET", "/agent/threads/{thread_id}/results/traces/{trace_id}", []string{"qa.read"}, evoFeatureHandler(agent.GetThreadResultTrace))
+	handleAPI(r, "GET", "/agent/threads/{thread_id}/results/traces-compare", []string{"qa.read"}, evoFeatureHandler(agent.GetThreadResultTraceCompare))
+	handleAPI(r, "POST", "/agent/threads/{thread_id}:messages", []string{"qa.write"}, evoFeatureHandler(agent.StreamThreadMessages))
+	handleAPI(r, "POST", "/agent/threads/{thread_id}:start", []string{"qa.write"}, evoFeatureHandler(agent.StartThread))
+	handleAPI(r, "POST", "/agent/threads/{thread_id}:pause", []string{"qa.write"}, evoFeatureHandler(agent.PauseThread))
+	handleAPI(r, "POST", "/agent/threads/{thread_id}:cancel", []string{"qa.write"}, evoFeatureHandler(agent.CancelThread))
+	handleAPI(r, "POST", "/agent/threads/{thread_id}:retry", []string{"qa.write"}, evoFeatureHandler(agent.RetryThread))
+	handleAPI(r, "POST", "/agent/threads/{thread_id}:continue", []string{"qa.write"}, evoFeatureHandler(agent.ContinueThread))
+	handleAPI(r, "GET", "/agent/reports/{report_id}:content", []string{"qa.read"}, evoFeatureHandler(agent.GetReportContent))
+	handleAPI(r, "GET", "/agent/diffs/{apply_id}/{filename:.*}", []string{"qa.read"}, evoFeatureHandler(agent.GetDiffContent))
+	handleAPI(r, "POST", "/agent/files:content", []string{"qa.read"}, evoFeatureHandler(agent.GetAgentFileContent))
 
 	// ----- Conversation -----
 	handleAPI(r, "POST", "/conversations:chat", []string{"qa.write"}, chat.ChatConversations)

--- a/backend/core/routes_test.go
+++ b/backend/core/routes_test.go
@@ -32,6 +32,25 @@ func TestAgentThreadEventsRouteWinsOverGenericThreadRoute(t *testing.T) {
 	}
 }
 
+func TestAgentRoutesReturnFeatureDisabledWhenEvoDisabled(t *testing.T) {
+	t.Setenv("LAZYMIND_EVO_ENABLED", "false")
+
+	r := mux.NewRouter()
+	r.UseEncodedPath()
+	registerAllRoutes(r)
+
+	req := httptest.NewRequest(http.MethodGet, "/agent/threads", nil)
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("expected status 403, got %d body=%s", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), "feature disabled") {
+		t.Fatalf("expected feature disabled response, got %s", rec.Body.String())
+	}
+}
+
 func TestAgentThreadStepEventsRouteWinsOverGenericThreadRoute(t *testing.T) {
 	r := mux.NewRouter()
 	r.UseEncodedPath()

--- a/backend/core/skill/management.go
+++ b/backend/core/skill/management.go
@@ -38,6 +38,28 @@ func payloadForLog(v any) string {
 	return string(b)
 }
 
+func localEvoDisabled() bool {
+	return !common.EvoEnabled()
+}
+
+func forceCreateSkillAutoEvoDisabled(req *createSkillRequest) {
+	if req == nil || !localEvoDisabled() {
+		return
+	}
+	req.AutoEvo = false
+	for i := range req.Children {
+		req.Children[i].AutoEvo = false
+	}
+}
+
+func forceUpdateSkillAutoEvoDisabled(req *updateSkillRequest) {
+	if req == nil || !localEvoDisabled() {
+		return
+	}
+	disabled := false
+	req.AutoEvo = &disabled
+}
+
 func normalizedSkillUpdateStatus(status string) string {
 	status = strings.TrimSpace(status)
 	if status == "" || status == "pending_confirm" {
@@ -283,6 +305,7 @@ func CreateManaged(w http.ResponseWriter, r *http.Request) {
 		common.ReplyErr(w, "invalid body", http.StatusBadRequest)
 		return
 	}
+	forceCreateSkillAutoEvoDisabled(&req)
 	req.Name = strings.TrimSpace(req.Name)
 	req.Description = strings.TrimSpace(req.Description)
 	req.Category = strings.TrimSpace(req.Category)
@@ -395,6 +418,7 @@ func UpdateManaged(w http.ResponseWriter, r *http.Request) {
 		common.ReplyErr(w, "invalid body", http.StatusBadRequest)
 		return
 	}
+	forceUpdateSkillAutoEvoDisabled(&req)
 	appLog.Logger.Warn().
 		Str("route", "PATCH /api/core/skills/{skill_id}").
 		Str("user_id", userID).
@@ -919,6 +943,7 @@ func createParentSkill(ctx context.Context, db *gorm.DB, userID, userName string
 }
 
 func createParentSkillWithContent(ctx context.Context, db *gorm.DB, userID, userName string, req createSkillRequest, fullContent, description string, source resourcechange.Source) error {
+	forceCreateSkillAutoEvoDisabled(&req)
 	relPath := parentRelativePath(req.Category, req.Name)
 	var count int64
 	if err := db.WithContext(ctx).
@@ -1064,6 +1089,7 @@ func resolveParentSkill(ctx context.Context, db *gorm.DB, userID, parentSkillID,
 }
 
 func createChildSkill(ctx context.Context, db *gorm.DB, userID, userName string, req createSkillRequest) (orm.SkillResource, error) {
+	forceCreateSkillAutoEvoDisabled(&req)
 	parent, err := resolveParentSkill(ctx, db, userID, req.ParentSkillID, req.Category, req.ParentSkillName)
 	if err != nil {
 		return orm.SkillResource{}, err
@@ -1120,6 +1146,7 @@ func createChildSkill(ctx context.Context, db *gorm.DB, userID, userName string,
 }
 
 func updateSkill(ctx context.Context, db *gorm.DB, userID, userName, skillID string, req updateSkillRequest) error {
+	forceUpdateSkillAutoEvoDisabled(&req)
 	var row orm.SkillResource
 	if err := db.WithContext(ctx).Where("id = ? AND owner_user_id = ?", skillID, userID).Take(&row).Error; err != nil {
 		return err
@@ -1367,7 +1394,9 @@ func updateParentSkill(ctx context.Context, db *gorm.DB, userID, userName string
 	}
 	if req.AutoEvo != nil {
 		update["auto_evo"] = *req.AutoEvo
-		update["auto_evo_generation"] = gorm.Expr("auto_evo_generation + 1")
+		if common.EvoEnabled() {
+			update["auto_evo_generation"] = gorm.Expr("auto_evo_generation + 1")
+		}
 		if *req.AutoEvo {
 			update["auto_evo_apply_status"] = evolution.AutoEvoApplyStatusIdle
 			update["auto_evo_error"] = ""
@@ -1547,7 +1576,9 @@ func updateChildSkill(ctx context.Context, db *gorm.DB, userID string, row *orm.
 	}
 	if req.AutoEvo != nil {
 		update["auto_evo"] = *req.AutoEvo
-		update["auto_evo_generation"] = gorm.Expr("auto_evo_generation + 1")
+		if common.EvoEnabled() {
+			update["auto_evo_generation"] = gorm.Expr("auto_evo_generation + 1")
+		}
 		if *req.AutoEvo {
 			update["auto_evo_apply_status"] = evolution.AutoEvoApplyStatusIdle
 			update["auto_evo_error"] = ""

--- a/backend/core/skill/management_test.go
+++ b/backend/core/skill/management_test.go
@@ -2655,6 +2655,67 @@ func TestCreateChildSkillPersistsDescription(t *testing.T) {
 	}
 }
 
+func TestSkillAutoEvoForcedDisabledWhenEvoFeatureOff(t *testing.T) {
+	t.Setenv("LAZYMIND_EVO_ENABLED", "false")
+
+	db := newSkillTestDB(t)
+
+	createReq := createSkillRequest{
+		Name:        "git-workflow",
+		Description: "Git workflow for local mode",
+		Category:    "coding",
+		Content:     "# Git Workflow\n\nKeep commit history clean.",
+		AutoEvo:     true,
+		Children: []childSkillInput{
+			{
+				Name:        "rules",
+				Description: "Branching rules",
+				Content:     "1. Rebase before review.",
+				FileExt:     "md",
+				AutoEvo:     true,
+			},
+		},
+	}
+	if err := createParentSkill(context.Background(), db.DB, "u1", "User 1", createReq); err != nil {
+		t.Fatalf("create parent skill: %v", err)
+	}
+
+	var parent orm.SkillResource
+	if err := db.Where("owner_user_id = ? AND node_type = ?", "u1", evolution.SkillNodeTypeParent).Take(&parent).Error; err != nil {
+		t.Fatalf("query parent skill: %v", err)
+	}
+	if parent.AutoEvo {
+		t.Fatal("expected parent auto_evo=true request to persist auto_evo=false when Evo is disabled")
+	}
+	if parent.AutoEvoGeneration != 0 {
+		t.Fatalf("expected parent auto_evo_generation to stay 0, got %d", parent.AutoEvoGeneration)
+	}
+
+	var child orm.SkillResource
+	if err := db.Where("owner_user_id = ? AND node_type = ?", "u1", evolution.SkillNodeTypeChild).Take(&child).Error; err != nil {
+		t.Fatalf("query child skill: %v", err)
+	}
+	if child.AutoEvo {
+		t.Fatal("expected child auto_evo=true request to persist auto_evo=false when Evo is disabled")
+	}
+
+	enableAutoEvo := true
+	if err := updateSkill(context.Background(), db.DB, "u1", "User 1", parent.ID, updateSkillRequest{AutoEvo: &enableAutoEvo}); err != nil {
+		t.Fatalf("update parent skill: %v", err)
+	}
+
+	var updated orm.SkillResource
+	if err := db.Where("id = ?", parent.ID).Take(&updated).Error; err != nil {
+		t.Fatalf("query updated parent skill: %v", err)
+	}
+	if updated.AutoEvo {
+		t.Fatal("expected update auto_evo=true request to persist auto_evo=false when Evo is disabled")
+	}
+	if updated.AutoEvoGeneration != parent.AutoEvoGeneration {
+		t.Fatalf("expected auto_evo_generation to stay %d, got %d", parent.AutoEvoGeneration, updated.AutoEvoGeneration)
+	}
+}
+
 func TestCreateParentSkillAllowsDuplicateParentNameAcrossCategories(t *testing.T) {
 	db := newSkillTestDB(t)
 

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -14,6 +14,8 @@ COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
 RUN pnpm install --frozen-lockfile
 
 COPY . .
+ARG VITE_HIDE_EVO=false
+ENV VITE_HIDE_EVO=${VITE_HIDE_EVO}
 RUN pnpm build
 
 FROM ${DOCKER_MIRROR}nginx:alpine

--- a/local/docker-compose.local.yml
+++ b/local/docker-compose.local.yml
@@ -82,6 +82,9 @@ x-lazymind-local:
     - redis
     - kong
     - evo-api
+  scale_disabled_container_services:
+    - redis
+    - kong
 
 volumes:
   sqlite-data:

--- a/local/docker-compose.local.yml
+++ b/local/docker-compose.local.yml
@@ -81,6 +81,7 @@ x-lazymind-local:
   disabled_container_services:
     - redis
     - kong
+    - evo-api
 
 volumes:
   sqlite-data:

--- a/local/docker-compose.local.yml
+++ b/local/docker-compose.local.yml
@@ -34,6 +34,8 @@ services:
       LAZYMIND_REDIS_URL: ""
       LAZYMIND_STATE_BACKEND: sqlite
       LAZYMIND_STATE_SQLITE_DIR: /data/sqlite
+      LAZYMIND_EVO_ENABLED: "false"
+      LAZYMIND_RESOURCE_UPDATE_ENABLED: "false"
     depends_on:
       redis:
         condition: service_healthy
@@ -46,6 +48,8 @@ services:
       LAZYMIND_REDIS_URL: ""
       LAZYMIND_STATE_BACKEND: sqlite
       LAZYMIND_STATE_SQLITE_DIR: /data/sqlite
+      LAZYMIND_EVO_ENABLED: "false"
+      LAZYMIND_RESOURCE_UPDATE_ENABLED: "false"
 
   lazyllm-parse-server:
     volumes:
@@ -70,6 +74,9 @@ services:
       - "127.0.0.1:${LAZYMIND_LOCAL_PROXY_EVO_HOST_PORT:-18047}:8047"
 
   frontend:
+    build:
+      args:
+        VITE_HIDE_EVO: "true"
     environment:
       FRONTEND_API_PROXY_PASS: "http://host.docker.internal:${LAZYMIND_LOCAL_PROXY_PORT:-5024}"
       FRONTEND_API_DOCS_PROXY_PASS: "http://host.docker.internal:${LAZYMIND_LOCAL_PROXY_PORT:-5024}"

--- a/local/local-proxy/configs/cloud-replace-kong.yaml
+++ b/local/local-proxy/configs/cloud-replace-kong.yaml
@@ -56,6 +56,6 @@ routes:
     prefix: "/api/evo"
     upstream: "http://127.0.0.1:${LAZYMIND_LOCAL_PROXY_EVO_HOST_PORT}"
     stripPath: true
-    enabled: true
+    enabled: false
     optional: true
     healthPath: "/healthz"

--- a/local/local-proxy/configs/local.yaml
+++ b/local/local-proxy/configs/local.yaml
@@ -54,6 +54,6 @@ routes:
     prefix: "/api/evo"
     upstream: "http://127.0.0.1:8047"
     stripPath: true
-    enabled: true
+    enabled: false
     optional: true
     healthPath: "/health"

--- a/local/local-proxy/internal/config/config.go
+++ b/local/local-proxy/internal/config/config.go
@@ -152,7 +152,7 @@ func defaultRoutes() []RouteConfig {
 			Prefix:     "/api/evo",
 			Upstream:   "http://127.0.0.1:8047",
 			StripPath:  true,
-			Enabled:    true,
+			Enabled:    false,
 			Optional:   true,
 			HealthPath: "/health",
 		},

--- a/local/local-proxy/internal/config/config_test.go
+++ b/local/local-proxy/internal/config/config_test.go
@@ -70,7 +70,7 @@ func TestLoadUsesDefaults(t *testing.T) {
 	wantRoute("chat-route", "/api/chat", "http://127.0.0.1:8046", "/health", false, false, true)
 	wantRoute("scan-route", "/api/scan", "http://127.0.0.1:18080", "/health", false, true, true)
 	wantRoute("core-route", "/api/core", "http://127.0.0.1:8001", "/health", true, false, true)
-	wantRoute("evo-route", "/api/evo", "http://127.0.0.1:8047", "/health", true, true, true)
+	wantRoute("evo-route", "/api/evo", "http://127.0.0.1:8047", "/health", true, true, false)
 }
 
 func TestLoadFromConfigFile(t *testing.T) {

--- a/local/local-proxy/internal/config/config_test.go
+++ b/local/local-proxy/internal/config/config_test.go
@@ -41,7 +41,7 @@ func TestLoadUsesDefaults(t *testing.T) {
 		routesByName[route.Name] = route
 	}
 
-	wantRoute := func(name, prefix, upstream, healthPath string, stripPath, optional bool) {
+	wantRoute := func(name, prefix, upstream, healthPath string, stripPath, optional, enabled bool) {
 		route, ok := routesByName[name]
 		if !ok {
 			t.Fatalf("route %q missing", name)
@@ -61,16 +61,16 @@ func TestLoadUsesDefaults(t *testing.T) {
 		if route.HealthPath != healthPath {
 			t.Fatalf("route %q healthPath = %q, want %q", name, route.HealthPath, healthPath)
 		}
-		if !route.Enabled {
-			t.Fatalf("route %q enabled = false, want true", name)
+		if route.Enabled != enabled {
+			t.Fatalf("route %q enabled = %v, want %v", name, route.Enabled, enabled)
 		}
 	}
 
-	wantRoute("authservice-route", "/api/authservice", "http://127.0.0.1:8000", "/health", false, false)
-	wantRoute("chat-route", "/api/chat", "http://127.0.0.1:8046", "/health", false, false)
-	wantRoute("scan-route", "/api/scan", "http://127.0.0.1:18080", "/health", false, true)
-	wantRoute("core-route", "/api/core", "http://127.0.0.1:8001", "/health", true, false)
-	wantRoute("evo-route", "/api/evo", "http://127.0.0.1:8047", "/health", true, true)
+	wantRoute("authservice-route", "/api/authservice", "http://127.0.0.1:8000", "/health", false, false, true)
+	wantRoute("chat-route", "/api/chat", "http://127.0.0.1:8046", "/health", false, false, true)
+	wantRoute("scan-route", "/api/scan", "http://127.0.0.1:18080", "/health", false, true, true)
+	wantRoute("core-route", "/api/core", "http://127.0.0.1:8001", "/health", true, false, true)
+	wantRoute("evo-route", "/api/evo", "http://127.0.0.1:8047", "/health", true, true, true)
 }
 
 func TestLoadFromConfigFile(t *testing.T) {
@@ -216,7 +216,7 @@ func TestLoadCloudReplaceKongConfigFile(t *testing.T) {
 		routesByName[route.Name] = route
 	}
 
-	wantRoute := func(name, prefix, upstream, healthPath string, stripPath, optional bool) {
+	wantRoute := func(name, prefix, upstream, healthPath string, stripPath, optional, enabled bool) {
 		route, ok := routesByName[name]
 		if !ok {
 			t.Fatalf("route %q missing", name)
@@ -236,13 +236,16 @@ func TestLoadCloudReplaceKongConfigFile(t *testing.T) {
 		if route.HealthPath != healthPath {
 			t.Fatalf("route %q healthPath = %q, want %q", name, route.HealthPath, healthPath)
 		}
+		if route.Enabled != enabled {
+			t.Fatalf("route %q enabled = %v, want %v", name, route.Enabled, enabled)
+		}
 	}
 
-	wantRoute("authservice-route", "/api/authservice", "http://127.0.0.1:18000", "/api/authservice/auth/health", false, false)
-	wantRoute("chat-route", "/api/chat", "http://127.0.0.1:18046", "/health", false, false)
-	wantRoute("scan-route", "/api/scan", "http://127.0.0.1:18080", "/healthz", false, true)
-	wantRoute("core-route", "/api/core", "http://127.0.0.1:18001", "/health", true, false)
-	wantRoute("evo-route", "/api/evo", "http://127.0.0.1:18047", "/healthz", true, true)
+	wantRoute("authservice-route", "/api/authservice", "http://127.0.0.1:18000", "/api/authservice/auth/health", false, false, true)
+	wantRoute("chat-route", "/api/chat", "http://127.0.0.1:18046", "/health", false, false, true)
+	wantRoute("scan-route", "/api/scan", "http://127.0.0.1:18080", "/healthz", false, true, true)
+	wantRoute("core-route", "/api/core", "http://127.0.0.1:18001", "/health", true, false, true)
+	wantRoute("evo-route", "/api/evo", "http://127.0.0.1:18047", "/healthz", true, true, false)
 }
 
 func TestLoadUsesCLIConfigPathOverEnv(t *testing.T) {

--- a/local/local-proxy/internal/server/routes_test.go
+++ b/local/local-proxy/internal/server/routes_test.go
@@ -57,14 +57,6 @@ func TestMatchRoute_DefaultRoutes(t *testing.T) {
 			targetPath: "/",
 			stripPath:  true,
 		},
-		{
-			name:       "evo strip nested path",
-			path:       "/api/evo/jobs",
-			upstream:   "http://127.0.0.1:8047",
-			targetPath: "/jobs",
-			optional:   true,
-			stripPath:  true,
-		},
 	}
 
 	for _, tc := range tests {
@@ -197,14 +189,7 @@ func TestMatchRoute_DisabledOptionalRoute(t *testing.T) {
 		t.Fatalf("Load(): %v", err)
 	}
 
-	routes := append([]config.RouteConfig{}, cfg.Routes...)
-	for i, route := range routes {
-		if route.Prefix == "/api/evo" {
-			routes[i].Enabled = false
-		}
-	}
-
-	_, err = MatchRoute(routes, "/api/evo/feature")
+	_, err = MatchRoute(cfg.Routes, "/api/evo/feature")
 	var routeErr RouteMatchError
 	if !errors.As(err, &routeErr) {
 		t.Fatalf("expected route error, got %v", err)

--- a/local/local-runtime-manager/compose.go
+++ b/local/local-runtime-manager/compose.go
@@ -158,11 +158,14 @@ func (m *ComposeManager) ComposeUp(ctx context.Context, repoRoot string, profile
 	if err != nil {
 		return err
 	}
+	if err := validateKnownServices(services, disabled.ScaleDisabledServices); err != nil {
+		return err
+	}
 	if len(remaining) == 0 {
 		_ = profile
 	}
 	args := append(m.composeArgs(repoRoot), "up", "--build")
-	for _, svc := range disabled.DisabledContainerTypes {
+	for _, svc := range disabled.ScaleDisabledServices {
 		if svc == "" {
 			continue
 		}
@@ -206,6 +209,22 @@ func filterRemainingServices(allServices []string, disabled []string) ([]string,
 		remaining = append(remaining, svc)
 	}
 	return remaining, nil
+}
+
+func validateKnownServices(allServices []string, services []string) error {
+	available := make(map[string]struct{}, len(allServices))
+	for _, svc := range allServices {
+		available[svc] = struct{}{}
+	}
+	for _, svc := range services {
+		if svc == "" {
+			continue
+		}
+		if _, ok := available[svc]; !ok {
+			return fmt.Errorf("unknown scale-disabled service: %s", svc)
+		}
+	}
+	return nil
 }
 
 func parseComposeStatusJSON(raw string) ([]ComposeServiceStatus, error) {

--- a/local/local-runtime-manager/compose_parser.go
+++ b/local/local-runtime-manager/compose_parser.go
@@ -10,6 +10,7 @@ import (
 type OverlayConfig struct {
 	Mode                   string   `yaml:"mode"`
 	DisabledContainerTypes []string `yaml:"disabled_container_services"`
+	ScaleDisabledServices  []string `yaml:"scale_disabled_container_services"`
 }
 
 type composeOverlayFile struct {

--- a/local/local-runtime-manager/manager_test.go
+++ b/local/local-runtime-manager/manager_test.go
@@ -205,14 +205,14 @@ func TestComposeUpScalesDisabledServicesToZero(t *testing.T) {
 	repo := t.TempDir()
 	writeComposeFixture(t, repo)
 	overlay := filepath.Join(repo, localComposeOverrideName)
-	if err := os.WriteFile(overlay, []byte("x-lazymind-local:\n  mode: local\n  disabled_container_services:\n    - redis\n"), 0o644); err != nil {
+	if err := os.WriteFile(overlay, []byte("x-lazymind-local:\n  mode: local\n  disabled_container_services:\n    - redis\n    - evo-api\n"), 0o644); err != nil {
 		t.Fatalf("write overlay: %v", err)
 	}
 
 	runner := &fakeRunner{t: t}
 	manager := NewRuntimeManager(runner, filepath.Join(repo, "lazymind-local"))
 	runner.handlers = append(runner.handlers, func(cmd Command) (CommandResult, error) {
-		return CommandResult{Stdout: "redis\nauth-service\ncore\n"}, nil
+		return CommandResult{Stdout: "redis\nevo-api\nauth-service\ncore\n"}, nil
 	}, func(cmd Command) (CommandResult, error) {
 		assertCommandContainsInOrder(t, cmd, "docker", []string{
 			"compose",
@@ -223,11 +223,12 @@ func TestComposeUpScalesDisabledServicesToZero(t *testing.T) {
 			"up",
 			"--build",
 			"--scale", "redis=0",
+			"--scale", "evo-api=0",
 			"auth-service", "core",
 		})
 		for _, arg := range cmd.Args {
-			if arg == "redis" {
-				t.Fatalf("disabled service redis should not be in explicit service list: %v", cmd.Args)
+			if arg == "redis" || arg == "evo-api" {
+				t.Fatalf("disabled service %s should not be in explicit service list: %v", arg, cmd.Args)
 			}
 		}
 		return CommandResult{}, nil

--- a/local/local-runtime-manager/manager_test.go
+++ b/local/local-runtime-manager/manager_test.go
@@ -201,11 +201,11 @@ func TestComposeUpCommandIsCanonical(t *testing.T) {
 	}
 }
 
-func TestComposeUpScalesDisabledServicesToZero(t *testing.T) {
+func TestComposeUpOmitsDisabledServices(t *testing.T) {
 	repo := t.TempDir()
 	writeComposeFixture(t, repo)
 	overlay := filepath.Join(repo, localComposeOverrideName)
-	if err := os.WriteFile(overlay, []byte("x-lazymind-local:\n  mode: local\n  disabled_container_services:\n    - redis\n    - evo-api\n"), 0o644); err != nil {
+	if err := os.WriteFile(overlay, []byte("x-lazymind-local:\n  mode: local\n  disabled_container_services:\n    - redis\n    - evo-api\n  scale_disabled_container_services:\n    - redis\n"), 0o644); err != nil {
 		t.Fatalf("write overlay: %v", err)
 	}
 
@@ -223,12 +223,14 @@ func TestComposeUpScalesDisabledServicesToZero(t *testing.T) {
 			"up",
 			"--build",
 			"--scale", "redis=0",
-			"--scale", "evo-api=0",
 			"auth-service", "core",
 		})
 		for _, arg := range cmd.Args {
 			if arg == "redis" || arg == "evo-api" {
 				t.Fatalf("disabled service %s should not be in explicit service list: %v", arg, cmd.Args)
+			}
+			if arg == "evo-api=0" {
+				t.Fatalf("non-dependency disabled service evo-api should not be scaled: %v", cmd.Args)
 			}
 		}
 		return CommandResult{}, nil


### PR DESCRIPTION
Local Runtime 默认裁剪 Evo：不启动 evo-api、不暴露 /api/evo，并通过功能门控让 core/前端在 Evo 缺失时正常工作，Cloud 默认行为不变。