### PR TITLE
local-runtime: combine Linux browser host runtime work

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -442,6 +442,7 @@ up-build:
 	fi
 
 up-build-local:
+	@$(MAKE) --no-print-directory compose-host-permissions
 	@if [ ! -x "$(PROCESS_COMPOSE_BIN)" ]; then \
 		mkdir -p "$(dir $(PROCESS_COMPOSE_BIN))"; \
 		GOBIN="$(CURDIR)/local/bin" $(GO) install "$(PROCESS_COMPOSE_PKG)"; \

--- a/Makefile
+++ b/Makefile
@@ -310,6 +310,11 @@ build:
 
 compose-host-permissions:
 	@echo "🔐 Ensuring compose bind mounts are readable by containers..."
+	@dir="$(CURDIR)"; \
+	while [ "$$dir" != "/" ] && [ "$$dir" != "$(HOME)" ]; do \
+		chmod a+x "$$dir" 2>/dev/null || true; \
+		dir="$$(dirname "$$dir")"; \
+	done
 	@chmod a+rx .
 	@for path in $(_COMPOSE_BIND_CRITICAL_READ_PATHS); do \
 		if [ -e "$$path" ]; then \
@@ -444,6 +449,7 @@ up-build-local:
 	@$(MAKE) --no-print-directory compose-host-permissions
 	@mkdir -p "$(LAZYMIND_LOCAL_GOCACHE)"
 	@cd local/local-runtime-manager && GOCACHE="$(LAZYMIND_LOCAL_GOCACHE)" $(GO) build -buildvcs=false -o lazymind-local .
+	@$(MAKE) --no-print-directory compose-host-permissions
 	@"$(LAZYMIND_LOCAL_BIN)" up --profile "$(LAZYMIND_LOCAL_PROFILE)"
 
 clear:

--- a/Makefile
+++ b/Makefile
@@ -441,6 +441,7 @@ up-build-local:
 		mkdir -p "$(dir $(PROCESS_COMPOSE_BIN))"; \
 		GOBIN="$(CURDIR)/local/bin" $(GO) install "$(PROCESS_COMPOSE_PKG)"; \
 	fi
+	@$(MAKE) --no-print-directory compose-host-permissions
 	@mkdir -p "$(LAZYMIND_LOCAL_GOCACHE)"
 	@cd local/local-runtime-manager && GOCACHE="$(LAZYMIND_LOCAL_GOCACHE)" $(GO) build -buildvcs=false -o lazymind-local .
 	@"$(LAZYMIND_LOCAL_BIN)" up --profile "$(LAZYMIND_LOCAL_PROFILE)"

--- a/algorithm/lazymind/config.py
+++ b/algorithm/lazymind/config.py
@@ -133,6 +133,8 @@ config.add('mineru_backend', str, 'pipeline', 'MINERU_BACKEND', description='Min
 config.add('mineru_server_port', int, 8000, 'MINERU_SERVER_PORT', description='MinerU server port.')
 config.add('ocr_cache_dir', str, os.path.join(config['shared_upload_dir'], '.image_cache'), 'OCR_CACHE_DIR',
            description='OCR cache root for parsed results and images.')
+config.add('document_parse_profile', str, 'cloud', 'DOCUMENT_PARSE_PROFILE',
+           description='Document parsing profile: cloud or local.')
 config.add('document_processor_url', str, 'http://localhost:8000', 'DOCUMENT_PROCESSOR_URL',
            description='Document processor service URL.')
 config.add('algo_server_port', int, 8000, 'ALGO_SERVER_PORT', description='Algorithm server port.')

--- a/backend/core/doc/task.go
+++ b/backend/core/doc/task.go
@@ -1331,6 +1331,11 @@ func startParseTasksInternal(r *http.Request, datasetID string, taskIDs []string
 		log.Printf("[startParseTasksInternal] failed to load ocr_config for user=%s: %v", userID, err)
 		ocrConfig = nil
 	}
+	parseProfile := resolveDocumentParseProfile()
+	applog.Logger.Info().
+		Str("document_parse_profile", string(parseProfile)).
+		Str("document_parse_strategy", documentParseStrategyName(parseProfile)).
+		Msg("resolved document parse profile")
 	resultsByTaskID := make(map[string]StartTaskResult, len(taskIDs))
 	orderedUniqueIDs := make([]string, 0, len(taskIDs))
 
@@ -1364,7 +1369,7 @@ func startParseTasksInternal(r *http.Request, datasetID string, taskIDs []string
 		}
 		candidate := startCandidate{task: taskRow, doc: docRow, docExt: dExt}
 		candidates = append(candidates, candidate)
-		if needsOfficeConvertBeforeParse(dExt, ocrConfig) {
+		if needsOfficeConvertBeforeParse(dExt, ocrConfig, parseProfile) {
 			officeCandidates = append(officeCandidates, candidate)
 		} else {
 			pdfCandidates = append(pdfCandidates, candidate)
@@ -1387,7 +1392,7 @@ func startParseTasksInternal(r *http.Request, datasetID string, taskIDs []string
 		baseDocExts := make([]documentExt, 0, len(pdfCandidates))
 		items := make([]addFileItem, 0, len(pdfCandidates))
 		for _, candidate := range pdfCandidates {
-			parsePath := parsePathForIngestion(candidate.docExt, ocrConfig)
+			parsePath := parsePathForIngestion(candidate.docExt, ocrConfig, parseProfile)
 			if strings.TrimSpace(parsePath) == "" {
 				resultsByTaskID[candidate.task.ID] = StartTaskResult{TaskID: candidate.task.ID, DocumentID: candidate.doc.ID, DisplayName: candidate.doc.DisplayName, Status: "FAILED", SubmitStatus: "REJECTED", Message: "parse file path is empty"}
 				continue
@@ -1438,8 +1443,16 @@ func startParseTasksInternal(r *http.Request, datasetID string, taskIDs []string
 				defer wg.Done()
 				defer func() { <-guard }()
 				dExt := cloneDocumentExt(candidate.docExt)
-				callOfficeConvertWithRetry(r.Context(), &dExt)
+				callOfficeConvertWithRetry(r.Context(), &dExt, parseProfile)
 				persistDocumentConvertState(r.Context(), datasetID, candidate.doc.ID, dExt)
+				if parseProfile == documentParseProfileLocal && strings.TrimSpace(dExt.ConvertStatus) == ConvertStatusFailed {
+					msg := strings.TrimSpace(dExt.ConvertError)
+					if msg == "" {
+						msg = officeConvertUserError(parseProfile, "local Office to PDF fallback failed")
+					}
+					outcomes[idx] = officeOutcome{task: candidate.task, doc: candidate.doc, docExt: dExt, result: StartTaskResult{TaskID: candidate.task.ID, DocumentID: candidate.doc.ID, DisplayName: candidate.doc.DisplayName, Status: "FAILED", SubmitStatus: "FAILED", Message: msg}}
+					return
+				}
 				parsePath := parsePathForAdd(dExt)
 				if strings.TrimSpace(parsePath) == "" {
 					outcomes[idx] = officeOutcome{task: candidate.task, doc: candidate.doc, docExt: dExt, result: StartTaskResult{TaskID: candidate.task.ID, DocumentID: candidate.doc.ID, DisplayName: candidate.doc.DisplayName, Status: "FAILED", SubmitStatus: "REJECTED", Message: "parse file path is empty"}}

--- a/backend/core/doc/task_convert.go
+++ b/backend/core/doc/task_convert.go
@@ -3,9 +3,12 @@ package doc
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strconv"
 	"strings"
 	"time"
@@ -27,12 +30,21 @@ const (
 )
 
 const convertProviderHTTP = "http"
+const convertProviderLibreOffice = "libreoffice"
 
 const officeConvertRetryCount = 2
 const defaultOfficeConvertWorkers = 4
 
-// env: LAZYMIND_OFFICE_CONVERT_URL — text URL，POST JSON {"source_path":"..."}，text {"pdf_path":"..."} text {"data":{"pdf_path":"..."}}
-// Office text tasks:start text；Failedtext，text。
+const documentParseProfileEnv = "LAZYMIND_DOCUMENT_PARSE_PROFILE"
+
+type documentParseProfile string
+
+const (
+	documentParseProfileCloud documentParseProfile = "cloud"
+	documentParseProfileLocal documentParseProfile = "local"
+)
+
+// Cloud profile uses LAZYMIND_OFFICE_CONVERT_URL. Local profile runs LibreOffice in the core process.
 
 func newDocumentExt(storedPath, storedName, originalFilename string, fileSize int64, contentType, relativePath string, tags []string) documentExt {
 	d := documentExt{StoredPath: storedPath, StoredName: storedName, OriginalFilename: originalFilename, FileSize: fileSize, ContentType: contentType, RelativePath: relativePath, Tags: append([]string(nil), tags...)}
@@ -144,10 +156,39 @@ func isOfficialMinerU(ocrConfig map[string]any) bool {
 	return url == "" || strings.Contains(url, "mineru.net")
 }
 
-// needsOfficeConvertBeforeParse decides whether office-convert-service runs before parsing.
+func resolveDocumentParseProfile() documentParseProfile {
+	raw := strings.TrimSpace(os.Getenv(documentParseProfileEnv))
+	profile, ok := normalizeDocumentParseProfile(raw)
+	if !ok {
+		log.Logger.Warn().Str("profile", raw).Str("fallback", string(documentParseProfileCloud)).Msg("unknown document parse profile, using cloud profile")
+	}
+	return profile
+}
+
+func normalizeDocumentParseProfile(raw string) (documentParseProfile, bool) {
+	switch strings.ToLower(strings.TrimSpace(raw)) {
+	case "", string(documentParseProfileCloud):
+		return documentParseProfileCloud, true
+	case string(documentParseProfileLocal):
+		return documentParseProfileLocal, true
+	default:
+		return documentParseProfileCloud, false
+	}
+}
+
+func documentParseStrategyName(profile documentParseProfile) string {
+	switch profile {
+	case documentParseProfileLocal:
+		return "ocr-first-with-local-office-fallback"
+	default:
+		return "office-preconvert"
+	}
+}
+
+// needsOfficeConvertBeforeParse decides whether Office-to-PDF conversion runs before parsing.
 // PPT/PPTX/PPTM skip conversion only when official MinerU (mineru.net) is configured so
 // DynamicPDFReader can route them to MineruPPTReader; self-hosted MinerU still converts to PDF.
-func needsOfficeConvertBeforeParse(d documentExt, ocrConfig map[string]any) bool {
+func needsOfficeConvertBeforeParse(d documentExt, ocrConfig map[string]any, profile documentParseProfile) bool {
 	if !d.ConvertRequired {
 		return false
 	}
@@ -155,6 +196,22 @@ func needsOfficeConvertBeforeParse(d documentExt, ocrConfig map[string]any) bool
 	if !isOfficeDocument(src, d.ContentType, d.OriginalFilename) {
 		return false
 	}
+	switch profile {
+	case documentParseProfileLocal:
+		return ocrFirstWithLocalOfficeFallbackNeedsConvert(src, d, ocrConfig)
+	default:
+		return officePreconvertNeedsConvert(src, d, ocrConfig)
+	}
+}
+
+func ocrFirstWithLocalOfficeFallbackNeedsConvert(src string, d documentExt, ocrConfig map[string]any) bool {
+	if isPresentationDocument(src, d.ContentType, d.OriginalFilename) && isOfficialMinerU(ocrConfig) {
+		return false
+	}
+	return true
+}
+
+func officePreconvertNeedsConvert(src string, d documentExt, ocrConfig map[string]any) bool {
 	if isPresentationDocument(src, d.ContentType, d.OriginalFilename) && isOfficialMinerU(ocrConfig) {
 		return false
 	}
@@ -162,8 +219,8 @@ func needsOfficeConvertBeforeParse(d documentExt, ocrConfig map[string]any) bool
 }
 
 // parsePathForIngestion returns the file path passed to the parsing service.
-func parsePathForIngestion(d documentExt, ocrConfig map[string]any) string {
-	if needsOfficeConvertBeforeParse(d, ocrConfig) {
+func parsePathForIngestion(d documentExt, ocrConfig map[string]any, profile documentParseProfile) string {
+	if needsOfficeConvertBeforeParse(d, ocrConfig, profile) {
 		return parsePathForAdd(d)
 	}
 	if isOfficeDocument(d.StoredPath, d.ContentType, d.OriginalFilename) {
@@ -207,7 +264,7 @@ func officeConvertWorkers() int {
 }
 
 // applyOfficeConversion text d text StoredPath/StoredName text；Failedtext ConvertStatus=FAILED，text error（UploadtextSuccess）。
-func applyOfficeConversion(ctx context.Context, d *documentExt) {
+func applyOfficeConversion(ctx context.Context, d *documentExt, profile documentParseProfile) {
 	src := strings.TrimSpace(d.StoredPath)
 	if src == "" {
 		return
@@ -226,7 +283,6 @@ func applyOfficeConversion(ctx context.Context, d *documentExt) {
 	outPath := expectedParseOutputPathByStoredName(src, d.StoredName)
 	d.ConvertStatus = ConvertStatusProcessing
 	d.ConvertError = ""
-	d.ConvertProvider = convertProviderHTTP
 
 	// text：text PDF text
 	if ok, sz := reuseExistingPDFIfFresh(src, outPath); ok {
@@ -237,18 +293,11 @@ func applyOfficeConversion(ctx context.Context, d *documentExt) {
 		return
 	}
 
-	url := strings.TrimSpace(os.Getenv("LAZYMIND_OFFICE_CONVERT_URL"))
-	if url == "" {
-		d.ConvertStatus = ConvertStatusFailed
-		d.ConvertError = "LAZYMIND_OFFICE_CONVERT_URL is not configured"
-		log.Logger.Warn().Str("source", src).Msg("office convert: service URL missing")
-		return
-	}
-
-	pdfPath, err := callOfficeConvertHTTP(ctx, url, src)
+	pdfPath, provider, err := convertOfficeToPDF(ctx, profile, src, outPath)
+	d.ConvertProvider = provider
 	if err != nil {
 		d.ConvertStatus = ConvertStatusFailed
-		d.ConvertError = err.Error()
+		d.ConvertError = officeConvertUserError(profile, err.Error())
 		log.Logger.Error().Err(err).Str("source", src).Msg("office convert failed")
 		return
 	}
@@ -259,13 +308,156 @@ func applyOfficeConversion(ctx context.Context, d *documentExt) {
 	st, err := os.Stat(pdfPath)
 	if err != nil || st.IsDir() {
 		d.ConvertStatus = ConvertStatusFailed
-		d.ConvertError = fmt.Sprintf("converted pdf not found: %v", err)
+		d.ConvertError = officeConvertUserError(profile, fmt.Sprintf("converted pdf not found: %v", err))
 		return
 	}
 	fillParseFields(d, pdfPath, st.Size())
 	d.ConvertStatus = ConvertStatusSucceeded
 	d.ConvertError = ""
 	log.Logger.Info().Str("source", src).Str("pdf", pdfPath).Int64("size", st.Size()).Msg("office convert succeeded")
+}
+
+func convertOfficeToPDF(ctx context.Context, profile documentParseProfile, sourcePath, targetPath string) (string, string, error) {
+	if profile == documentParseProfileLocal {
+		detected := detectLibreOffice()
+		if !detected.Found {
+			return "", convertProviderLibreOffice, errors.New(detected.Message)
+		}
+		if err := runLibreOfficeConvert(ctx, detected.Path, sourcePath, targetPath); err != nil {
+			return "", convertProviderLibreOffice, err
+		}
+		return targetPath, convertProviderLibreOffice, nil
+	}
+
+	url := strings.TrimSpace(os.Getenv("LAZYMIND_OFFICE_CONVERT_URL"))
+	if url == "" {
+		log.Logger.Warn().Str("source", sourcePath).Msg("office convert: service URL missing")
+		return "", convertProviderHTTP, fmt.Errorf("LAZYMIND_OFFICE_CONVERT_URL is not configured")
+	}
+	pdfPath, err := callOfficeConvertHTTP(ctx, url, sourcePath)
+	return pdfPath, convertProviderHTTP, err
+}
+
+type libreOfficeDetection struct {
+	Path    string
+	Found   bool
+	Message string
+	Source  string
+	OS      string
+}
+
+func detectLibreOffice() libreOfficeDetection {
+	if p := strings.TrimSpace(os.Getenv("LAZYMIND_LIBREOFFICE_PATH")); p != "" {
+		if executableFile(p) {
+			return libreOfficeDetection{Path: p, Found: true, Source: "LAZYMIND_LIBREOFFICE_PATH", OS: runtime.GOOS}
+		}
+		return libreOfficeDetection{Found: false, Source: "LAZYMIND_LIBREOFFICE_PATH", OS: runtime.GOOS, Message: "LAZYMIND_LIBREOFFICE_PATH does not point to an executable file"}
+	}
+
+	for _, candidate := range libreOfficePathCandidates(runtime.GOOS, os.Getenv) {
+		if executableFile(candidate) {
+			return libreOfficeDetection{Path: candidate, Found: true, Source: "default-path", OS: runtime.GOOS}
+		}
+	}
+	for _, name := range []string{"libreoffice", "soffice"} {
+		if p, err := exec.LookPath(name); err == nil && executableFile(p) {
+			return libreOfficeDetection{Path: p, Found: true, Source: "PATH", OS: runtime.GOOS}
+		}
+	}
+	return libreOfficeDetection{Found: false, OS: runtime.GOOS, Message: "LibreOffice was not found in the core runtime environment"}
+}
+
+func libreOfficePathCandidates(goos string, getenv func(string) string) []string {
+	switch goos {
+	case "darwin":
+		return []string{"/Applications/LibreOffice.app/Contents/MacOS/soffice"}
+	case "windows":
+		candidates := []string{}
+		for _, key := range []string{"ProgramFiles", "ProgramFiles(x86)"} {
+			if root := strings.TrimSpace(getenv(key)); root != "" {
+				candidates = append(candidates, filepath.Join(root, "LibreOffice", "program", "soffice.exe"))
+			}
+		}
+		return candidates
+	default:
+		return nil
+	}
+}
+
+func executableFile(p string) bool {
+	info, err := os.Stat(p)
+	if err != nil || info.IsDir() {
+		return false
+	}
+	if runtime.GOOS == "windows" {
+		return true
+	}
+	return info.Mode()&0o111 != 0
+}
+
+func libreOfficeProfileURI(profileDir string) string {
+	uriPath := strings.ReplaceAll(filepath.ToSlash(profileDir), `\`, `/`)
+	if strings.HasPrefix(uriPath, "/") {
+		return "file://" + uriPath
+	}
+	return "file:///" + uriPath
+}
+
+func runLibreOfficeConvert(ctx context.Context, libreOfficePath, sourcePath, targetPath string) error {
+	outputDir := filepath.Dir(targetPath)
+	if err := os.MkdirAll(outputDir, 0o755); err != nil {
+		return err
+	}
+	tmpOutputDir, err := os.MkdirTemp(outputDir, ".lo-out-")
+	if err != nil {
+		return err
+	}
+	defer os.RemoveAll(tmpOutputDir)
+	profileDir, err := os.MkdirTemp("", "lo-profile-")
+	if err != nil {
+		return err
+	}
+	defer os.RemoveAll(profileDir)
+
+	runCtx, cancel := context.WithTimeout(ctx, officeConvertTimeout())
+	defer cancel()
+	cmd := exec.CommandContext(runCtx, libreOfficePath,
+		"-env:UserInstallation="+libreOfficeProfileURI(profileDir),
+		"--headless",
+		"--nologo",
+		"--nofirststartwizard",
+		"--nolockcheck",
+		"--nodefault",
+		"--convert-to",
+		"pdf",
+		sourcePath,
+		"--outdir",
+		tmpOutputDir,
+	)
+	out, err := cmd.CombinedOutput()
+	if runCtx.Err() == context.DeadlineExceeded {
+		return fmt.Errorf("libreoffice convert timeout")
+	}
+	if err != nil {
+		return fmt.Errorf("libreoffice convert failed: %s", strings.TrimSpace(string(out)))
+	}
+	tmpPDF := filepath.Join(tmpOutputDir, strings.TrimSuffix(filepath.Base(sourcePath), filepath.Ext(sourcePath))+".pdf")
+	if st, err := os.Stat(tmpPDF); err != nil || st.IsDir() || st.Size() <= 0 {
+		return fmt.Errorf("converted pdf not found after libreoffice run: %s", strings.TrimSpace(string(out)))
+	}
+	_ = os.Remove(targetPath)
+	return os.Rename(tmpPDF, targetPath)
+}
+
+func officeConvertUserError(profile documentParseProfile, detail string) string {
+	detail = strings.TrimSpace(detail)
+	if profile != documentParseProfileLocal {
+		return detail
+	}
+	if detail == "" {
+		detail = "local Office to PDF fallback failed"
+	}
+	return detail + ". Configure MinerU/PaddleOCR online parsing service or install LibreOffice in the core runtime environment and set LAZYMIND_LIBREOFFICE_PATH for local fallback."
 }
 
 func fillParseFields(d *documentExt, pdfPath string, size int64) {
@@ -291,7 +483,7 @@ func reuseExistingPDFIfFresh(sourcePath, pdfPath string) (bool, int64) {
 	return true, pdfSt.Size()
 }
 
-func callOfficeConvertWithRetry(ctx context.Context, d *documentExt) {
+func callOfficeConvertWithRetry(ctx context.Context, d *documentExt, profile documentParseProfile) {
 	if d == nil {
 		return
 	}
@@ -304,7 +496,7 @@ func callOfficeConvertWithRetry(ctx context.Context, d *documentExt) {
 		return
 	}
 	for attempt := 0; attempt < officeConvertRetryCount; attempt++ {
-		applyOfficeConversion(ctx, d)
+		applyOfficeConversion(ctx, d, profile)
 		if strings.TrimSpace(d.ConvertStatus) == ConvertStatusSucceeded {
 			return
 		}

--- a/backend/core/doc/task_convert_test.go
+++ b/backend/core/doc/task_convert_test.go
@@ -1,6 +1,12 @@
 package doc
 
-import "testing"
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
 
 func TestNeedsOfficeConvertBeforeParse(t *testing.T) {
 	pptExt := documentExt{
@@ -45,7 +51,7 @@ func TestNeedsOfficeConvertBeforeParse(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := needsOfficeConvertBeforeParse(tt.doc, tt.ocrConfig); got != tt.want {
+			if got := needsOfficeConvertBeforeParse(tt.doc, tt.ocrConfig, documentParseProfileCloud); got != tt.want {
 				t.Fatalf("needsOfficeConvertBeforeParse() = %v, want %v", got, tt.want)
 			}
 		})
@@ -60,7 +66,7 @@ func TestParsePathForIngestionPresentationMineru(t *testing.T) {
 		ConvertRequired:  true,
 	}
 	cfg := map[string]any{"ocr_type": "mineru"}
-	if got := parsePathForIngestion(d, cfg); got != "/data/demo.pptx" {
+	if got := parsePathForIngestion(d, cfg, documentParseProfileCloud); got != "/data/demo.pptx" {
 		t.Fatalf("parsePathForIngestion() = %q, want original pptx path", got)
 	}
 }
@@ -82,7 +88,7 @@ func TestParsePathForIngestionSpreadsheet(t *testing.T) {
 		OriginalFilename: "demo.xlsx",
 		ConvertRequired:  true,
 	}
-	if got := parsePathForIngestion(d, nil); got != "/data/demo.pdf" {
+	if got := parsePathForIngestion(d, nil, documentParseProfileCloud); got != "/data/demo.pdf" {
 		t.Fatalf("parsePathForIngestion() = %q, want converted pdf path", got)
 	}
 }
@@ -95,7 +101,7 @@ func TestParsePathForIngestionPresentationPaddle(t *testing.T) {
 		ConvertRequired:  true,
 	}
 	cfg := map[string]any{"ocr_type": "paddleocr"}
-	if got := parsePathForIngestion(d, cfg); got != "/data/demo.pdf" {
+	if got := parsePathForIngestion(d, cfg, documentParseProfileCloud); got != "/data/demo.pdf" {
 		t.Fatalf("parsePathForIngestion() = %q, want converted pdf path", got)
 	}
 }
@@ -108,7 +114,170 @@ func TestParsePathForIngestionPresentationSelfHostedMineru(t *testing.T) {
 		ConvertRequired:  true,
 	}
 	cfg := map[string]any{"ocr_type": "mineru", "ocr_url": "http://local-mineru:8000/api/v1/pdf_parse"}
-	if got := parsePathForIngestion(d, cfg); got != "/data/demo.pdf" {
+	if got := parsePathForIngestion(d, cfg, documentParseProfileCloud); got != "/data/demo.pdf" {
 		t.Fatalf("parsePathForIngestion() = %q, want converted pdf path", got)
 	}
+}
+
+func TestLocalParseProfileOfficeWithOCRUsesFallbackForUnsupportedRawOffice(t *testing.T) {
+	d := documentExt{
+		StoredPath:       "/data/demo.docx",
+		ParseStoredPath:  "/data/demo.pdf",
+		OriginalFilename: "demo.docx",
+		ContentType:      "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+		ConvertRequired:  true,
+	}
+	for _, cfg := range []map[string]any{
+		{"ocr_type": "mineru", "ocr_url": "http://local-mineru:8000/api/v1/pdf_parse"},
+		{"ocr_type": "paddleocr", "ocr_url": "https://paddleocr.aistudio-app.com/api/v2/ocr/jobs"},
+	} {
+		if got := needsOfficeConvertBeforeParse(d, cfg, documentParseProfileLocal); !got {
+			t.Fatalf("needsOfficeConvertBeforeParse() = false for cfg %#v, want true", cfg)
+		}
+		if got := parsePathForIngestion(d, cfg, documentParseProfileLocal); got != "/data/demo.pdf" {
+			t.Fatalf("parsePathForIngestion() = %q, want converted pdf path", got)
+		}
+	}
+}
+
+func TestLocalParseProfileOfficialMinerUPresentationSkipsConvert(t *testing.T) {
+	d := documentExt{
+		StoredPath:       "/data/demo.pptx",
+		ParseStoredPath:  "/data/demo.pdf",
+		OriginalFilename: "demo.pptx",
+		ContentType:      "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+		ConvertRequired:  true,
+	}
+	cfg := map[string]any{"ocr_type": "mineru", "ocr_url": "https://mineru.net/api/v4/"}
+	if got := needsOfficeConvertBeforeParse(d, cfg, documentParseProfileLocal); got {
+		t.Fatal("needsOfficeConvertBeforeParse() = true, want false")
+	}
+	if got := parsePathForIngestion(d, cfg, documentParseProfileLocal); got != "/data/demo.pptx" {
+		t.Fatalf("parsePathForIngestion() = %q, want original pptx path", got)
+	}
+}
+
+func TestLocalParseProfileOfficeWithoutOCRUsesFallbackConvert(t *testing.T) {
+	d := documentExt{
+		StoredPath:       "/data/demo.xlsx",
+		ParseStoredPath:  "/data/demo.pdf",
+		OriginalFilename: "demo.xlsx",
+		ConvertRequired:  true,
+	}
+	if got := needsOfficeConvertBeforeParse(d, nil, documentParseProfileLocal); !got {
+		t.Fatal("needsOfficeConvertBeforeParse() = false, want local fallback convert")
+	}
+	if got := parsePathForIngestion(d, nil, documentParseProfileLocal); got != "/data/demo.pdf" {
+		t.Fatalf("parsePathForIngestion() = %q, want converted pdf path", got)
+	}
+}
+
+func TestLocalLibreOfficeFallbackUserErrorRecommendsOnlineParsing(t *testing.T) {
+	msg := officeConvertUserError(documentParseProfileLocal, "convert failed")
+	if !testStringContainsAll(msg, "convert failed", "MinerU/PaddleOCR", "LibreOffice") {
+		t.Fatalf("unexpected message: %q", msg)
+	}
+}
+
+func TestLocalConvertMissingLibreOfficeDoesNotRequireHTTPURL(t *testing.T) {
+	t.Setenv("LAZYMIND_LIBREOFFICE_PATH", filepath.Join(t.TempDir(), "missing-soffice"))
+	t.Setenv("LAZYMIND_OFFICE_CONVERT_URL", "")
+
+	_, provider, err := convertOfficeToPDF(context.Background(), documentParseProfileLocal, "/data/demo.docx", "/data/demo.pdf")
+	if err == nil {
+		t.Fatal("expected missing LibreOffice error")
+	}
+	if provider != convertProviderLibreOffice {
+		t.Fatalf("provider = %q, want %q", provider, convertProviderLibreOffice)
+	}
+	if !strings.Contains(err.Error(), "LAZYMIND_LIBREOFFICE_PATH") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestCloudConvertStillRequiresHTTPURL(t *testing.T) {
+	t.Setenv("LAZYMIND_OFFICE_CONVERT_URL", "")
+
+	_, provider, err := convertOfficeToPDF(context.Background(), documentParseProfileCloud, "/data/demo.docx", "/data/demo.pdf")
+	if err == nil {
+		t.Fatal("expected missing office convert URL error")
+	}
+	if provider != convertProviderHTTP {
+		t.Fatalf("provider = %q, want %q", provider, convertProviderHTTP)
+	}
+	if !strings.Contains(err.Error(), "LAZYMIND_OFFICE_CONVERT_URL") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestDetectLibreOfficeUsesEnvOverride(t *testing.T) {
+	dir := t.TempDir()
+	bin := filepath.Join(dir, "soffice")
+	if err := os.WriteFile(bin, []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatalf("write fake soffice: %v", err)
+	}
+	t.Setenv("LAZYMIND_LIBREOFFICE_PATH", bin)
+
+	detected := detectLibreOffice()
+	if !detected.Found || detected.Path != bin || detected.Source != "LAZYMIND_LIBREOFFICE_PATH" {
+		t.Fatalf("unexpected detection: %#v", detected)
+	}
+}
+
+func TestLibreOfficePathCandidatesCoverMacOSAndWindows(t *testing.T) {
+	mac := libreOfficePathCandidates("darwin", func(string) string { return "" })
+	if len(mac) != 1 || mac[0] != "/Applications/LibreOffice.app/Contents/MacOS/soffice" {
+		t.Fatalf("unexpected mac candidates: %v", mac)
+	}
+	win := libreOfficePathCandidates("windows", func(key string) string {
+		switch key {
+		case "ProgramFiles":
+			return `C:\Program Files`
+		case "ProgramFiles(x86)":
+			return `C:\Program Files (x86)`
+		default:
+			return ""
+		}
+	})
+	joined := strings.Join(win, "\n")
+	if !strings.Contains(joined, `C:\Program Files`) || !strings.Contains(joined, "soffice.exe") {
+		t.Fatalf("unexpected windows candidates: %v", win)
+	}
+}
+
+func TestLibreOfficeProfileURI(t *testing.T) {
+	tests := []struct {
+		name string
+		path string
+		want string
+	}{
+		{name: "unix absolute", path: "/tmp/lo-profile-123", want: "file:///tmp/lo-profile-123"},
+		{name: "windows drive", path: `C:\Users\me\AppData\Local\Temp\lo-profile-123`, want: "file:///C:/Users/me/AppData/Local/Temp/lo-profile-123"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := libreOfficeProfileURI(tt.path); got != tt.want {
+				t.Fatalf("libreOfficeProfileURI() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestUnknownDocumentParseProfileFallsBackToCloud(t *testing.T) {
+	profile, ok := normalizeDocumentParseProfile("surprise")
+	if ok {
+		t.Fatal("unknown profile should not be accepted")
+	}
+	if profile != documentParseProfileCloud {
+		t.Fatalf("profile = %q, want cloud", profile)
+	}
+}
+
+func testStringContainsAll(s string, parts ...string) bool {
+	for _, part := range parts {
+		if !strings.Contains(s, part) {
+			return false
+		}
+	}
+	return true
 }

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -4,6 +4,9 @@ WORKDIR /app
 
 ARG ALPINE_MIRROR=https://mirrors.aliyun.com/alpine
 ARG NPM_REGISTRY=https://registry.npmmirror.com
+ARG VITE_API_BASE_URL
+ARG VITE_LAZYMIND_MODE
+ARG VITE_HIDE_EVO
 ENV NPM_CONFIG_REGISTRY=${NPM_REGISTRY}
 
 RUN sed -i "s|https://dl-cdn.alpinelinux.org/alpine|${ALPINE_MIRROR}|g" /etc/apk/repositories \

--- a/frontend/src/components/auth.ts
+++ b/frontend/src/components/auth.ts
@@ -3,15 +3,10 @@
  * Compatible with AuthServiceApi login (token stored after username/password login).
  */
 import axios from "axios";
+import { authServiceApiUrl } from "@/runtime/apiBase";
 
 const STORAGE_KEY = "lazymind:user";
 export const AUTH_USER_CHANGE_EVENT = "lazymind:user-change";
-
-const BASE_URL =
-  (typeof import.meta !== "undefined" &&
-    (import.meta as any).env?.VITE_API_BASE_URL) ||
-  (typeof window !== "undefined" && window.location.origin) ||
-  "";
 
 function decodeBase64Url(value: string) {
   const normalized = value.replace(/-/g, "+").replace(/_/g, "/");
@@ -178,7 +173,7 @@ export const AgentAppsAuth = {
       throw new Error("No refresh token available");
     }
 
-    const refreshUrl = `${BASE_URL}/api/authservice/auth/refresh`;
+    const refreshUrl = authServiceApiUrl("auth/refresh");
     
     const refreshAxios = axios.create({
       timeout: 10000,

--- a/frontend/src/components/request.ts
+++ b/frontend/src/components/request.ts
@@ -3,12 +3,9 @@ import type { AxiosInstance, AxiosError, InternalAxiosRequestConfig } from "axio
 import { message } from "antd";
 import { AgentAppsAuth } from "@/components/auth";
 import i18n from "@/i18n";
+import { getApiBaseUrl } from "@/runtime/apiBase";
 
-export const BASE_URL =
-  (typeof import.meta !== "undefined" &&
-    (import.meta as any).env?.VITE_API_BASE_URL) ||
-  (typeof window !== "undefined" && window.location.origin) ||
-  "";
+export const BASE_URL = getApiBaseUrl();
 
 const axiosInstance: AxiosInstance = axios.create({
   timeout: 30000,

--- a/frontend/src/layouts/MainLayout.tsx
+++ b/frontend/src/layouts/MainLayout.tsx
@@ -41,6 +41,7 @@ import {
   CHAT_RESUME_CONVERSATION_KEY,
   CHAT_SELECT_CONVERSATION_EVENT,
 } from "@/modules/chat/constants/chat";
+import { runtimeFeatures } from "@/runtime/features";
 import "./index.scss";
 
 const { Content, Sider } = Layout;
@@ -122,12 +123,16 @@ export default function MainLayout() {
   const pathname = location.pathname || "/agent/chat";
 
   const settingsMenuItems = [
-    {
-      key: "/admin",
-      label: t("layout.systemManagement"),
-      icon: <TeamOutlined className="settings-popover-icon" />,
-    },
-    ...(isAdminUser
+    ...(!runtimeFeatures.hideCloudAdmin
+      ? [
+          {
+            key: "/admin",
+            label: t("layout.systemManagement"),
+            icon: <TeamOutlined className="settings-popover-icon" />,
+          },
+        ]
+      : []),
+    ...(isAdminUser && !runtimeFeatures.hideEvo
       ? [
           {
             key: "developer-toggle",
@@ -159,7 +164,7 @@ export default function MainLayout() {
       icon: <ApiOutlined />,
     },
   ];
-  const hideEvo = import.meta.env.VITE_HIDE_EVO === "true";
+  const hideEvo = runtimeFeatures.hideEvo;
   const aiEvolutionNavItems = [
     {
       key: "/memory-management",

--- a/frontend/src/modules/chat/utils/chunkUpload.ts
+++ b/frontend/src/modules/chat/utils/chunkUpload.ts
@@ -1,5 +1,6 @@
 import { axiosInstance } from "@/components/request";
 import i18n from "@/i18n";
+import { coreApiUrl } from "@/runtime/apiBase";
 import {
   InitUploadRequest,
   InitUploadResponse,
@@ -7,9 +8,6 @@ import {
   CompleteUploadResponse,
   UploadPartResponse,
 } from "@/api/generated/core-client";
-
-const BASE_URL = import.meta.env.VITE_BASE_URL || "";
-const coreApiBaseUrl = `${BASE_URL}/api/core`;
 
 const DEFAULT_CHUNK_SIZE = 5 * 1024 * 1024;
 
@@ -47,7 +45,7 @@ export async function uploadFileInChunks(
     };
 
     const initResponse = await axiosInstance.post<InitUploadResponse>(
-      `${coreApiBaseUrl}/temp/uploads:initUpload`,
+      coreApiUrl("temp/uploads:initUpload"),
       initRequest,
       { timeout },
     );
@@ -68,7 +66,7 @@ export async function uploadFileInChunks(
       const chunk = file.slice(start, end);
 
       await axiosInstance.put<UploadPartResponse>(
-        `${coreApiBaseUrl}/temp/uploads/${encodeURIComponent(upload_id)}/parts/${partNumber}`,
+        coreApiUrl(`temp/uploads/${encodeURIComponent(upload_id)}/parts/${partNumber}`),
         chunk,
         {
           headers: {
@@ -96,7 +94,7 @@ export async function uploadFileInChunks(
     };
 
     const completeResponse = await axiosInstance.post<CompleteUploadResponse>(
-      `${coreApiBaseUrl}/temp/uploads/${encodeURIComponent(upload_id)}:complete`,
+      coreApiUrl(`temp/uploads/${encodeURIComponent(upload_id)}:complete`),
       completeRequest,
       { timeout },
     );
@@ -117,7 +115,7 @@ export async function uploadFileInChunks(
 export async function abortUpload(uploadId: string): Promise<void> {
   try {
     await axiosInstance.post(
-      `${coreApiBaseUrl}/temp/uploads/${encodeURIComponent(uploadId)}:abort`,
+      coreApiUrl(`temp/uploads/${encodeURIComponent(uploadId)}:abort`),
       {},
     );
   } catch (error) {

--- a/frontend/src/modules/signin/pages/login/index.tsx
+++ b/frontend/src/modules/signin/pages/login/index.tsx
@@ -8,6 +8,7 @@ import {
 } from "@/modules/signin/utils/request";
 import { AgentAppsAuth } from "@/components/auth";
 import { useTranslation } from "react-i18next";
+import { runtimeFeatures } from "@/runtime/features";
 
 interface LoginForm {
   username: string;
@@ -143,9 +144,11 @@ const Login = () => {
           >
             {t("auth.login")}
           </Button>
-          <div style={{ textAlign: "center", marginTop: "16px", color: '#86909c' }}>
-            {t("auth.noAccount")} <a style={{ color: '#1677ff', fontWeight: 500 }} onClick={() => navigate("/register")}>{t("auth.registerNow")}</a>
-          </div>
+          {!runtimeFeatures.hideRegister && (
+            <div style={{ textAlign: "center", marginTop: "16px", color: '#86909c' }}>
+              {t("auth.noAccount")} <a style={{ color: '#1677ff', fontWeight: 500 }} onClick={() => navigate("/register")}>{t("auth.registerNow")}</a>
+            </div>
+          )}
         </Form.Item>
       </Form>
     </div>

--- a/frontend/src/modules/signin/utils/request.ts
+++ b/frontend/src/modules/signin/utils/request.ts
@@ -15,11 +15,12 @@ import {
   Configuration as AuthServiceConfiguration,
   UsersApiFactory,
 } from "@/api/generated/authservice-client";
-import { axiosInstance, BASE_URL } from "@/components/request";
+import { axiosInstance } from "@/components/request";
 import { AgentAppsAuth } from "@/components/auth";
+import { authServiceApiUrl, getApiBaseUrl } from "@/runtime/apiBase";
 
-const baseUrl = BASE_URL || window.location.origin;
-const authServiceBaseUrl = `${baseUrl}/api/authservice/v1`;
+const baseUrl = getApiBaseUrl();
+const authServiceBaseUrl = authServiceApiUrl("v1");
 
 const commonBaseOptions = {
   headers: { "Content-Type": "application/json" },
@@ -189,7 +190,7 @@ export async function logoutFromServer() {
   }
 
   try {
-    const logoutUrl = `${BASE_URL}/api/authservice/auth/logout`;
+    const logoutUrl = authServiceApiUrl("auth/logout");
 
     const logoutAxios = axios.create({
       timeout: 10000,

--- a/frontend/src/router/index.tsx
+++ b/frontend/src/router/index.tsx
@@ -37,6 +37,7 @@ import ExternalServicesPage from "@/modules/modelProvider/pages/ExternalServices
 import DefaultServicesPage from "@/modules/modelProvider/pages/DefaultServicesPage";
 import { SelfEvolutionHomePage, SelfEvolutionDetailPage, SelfEvolutionObservationPage } from "@/modules/selfEvolution";
 import { getAntdLocale } from "@/i18n/antdLocale";
+import { runtimeFeatures } from "@/runtime/features";
 
 export default function AppRouter() {
   const { i18n } = useTranslation();
@@ -47,9 +48,13 @@ export default function AppRouter() {
         <Route path="/login" element={<SigninDashboard />}>
           <Route index element={<SigninLogin />} />
         </Route>
-        <Route path="/register" element={<SigninDashboard />}>
-          <Route index element={<SigninRegister />} />
-        </Route>
+        {runtimeFeatures.hideRegister ? (
+          <Route path="/register" element={<Navigate to="/login" replace />} />
+        ) : (
+          <Route path="/register" element={<SigninDashboard />}>
+            <Route index element={<SigninRegister />} />
+          </Route>
+        )}
         <Route
           path="/oauth/feishu/callback"
           element={<DataSourceFeishuCallback />}
@@ -116,18 +121,28 @@ export default function AppRouter() {
               element={<MemoryReviewPage />}
             />
           </Route>
-          <Route path="self-evolution" element={<SelfEvolutionHomePage />} />
-          <Route path="self-evolution/detail/:threadId/observation/:kind" element={<SelfEvolutionObservationPage />} />
-          <Route path="self-evolution/detail/:threadId" element={<SelfEvolutionDetailPage />} />
-          <Route path="self-evolution/:threadId/observation/:kind" element={<SelfEvolutionObservationPage />} />
-          <Route path="self-evolution/:threadId" element={<SelfEvolutionDetailPage />} />
+          {runtimeFeatures.hideEvo ? (
+            <Route path="self-evolution/*" element={<Navigate to="/agent/chat" replace />} />
+          ) : (
+            <>
+              <Route path="self-evolution" element={<SelfEvolutionHomePage />} />
+              <Route path="self-evolution/detail/:threadId/observation/:kind" element={<SelfEvolutionObservationPage />} />
+              <Route path="self-evolution/detail/:threadId" element={<SelfEvolutionDetailPage />} />
+              <Route path="self-evolution/:threadId/observation/:kind" element={<SelfEvolutionObservationPage />} />
+              <Route path="self-evolution/:threadId" element={<SelfEvolutionDetailPage />} />
+            </>
+          )}
         </Route>
-        <Route path="/admin" element={<AdminLayout />}>
-          <Route index element={<Navigate to="groups" replace />} />
-          <Route path="users" element={<UserManagement />} />
-          <Route path="groups" element={<GroupManagement />} />
-          <Route path="groups/:id" element={<GroupDetail />} />
-        </Route>
+        {runtimeFeatures.hideCloudAdmin ? (
+          <Route path="/admin/*" element={<Navigate to="/agent/chat" replace />} />
+        ) : (
+          <Route path="/admin" element={<AdminLayout />}>
+            <Route index element={<Navigate to="groups" replace />} />
+            <Route path="users" element={<UserManagement />} />
+            <Route path="groups" element={<GroupManagement />} />
+            <Route path="groups/:id" element={<GroupDetail />} />
+          </Route>
+        )}
         <Route path="*" element={<Navigate to="/" replace />} />
       </Routes>
     </ConfigProvider>

--- a/frontend/src/runtime/apiBase.ts
+++ b/frontend/src/runtime/apiBase.ts
@@ -1,0 +1,72 @@
+export interface ApiBaseEnv {
+  VITE_API_BASE_URL?: string;
+}
+
+function readApiBaseEnv(): ApiBaseEnv {
+  return (
+    (typeof import.meta !== "undefined" &&
+      ((import.meta as unknown as { env?: ApiBaseEnv }).env || {})) ||
+    {}
+  );
+}
+
+function getWindowOrigin(): string {
+  return (typeof window !== "undefined" && window.location.origin) || "";
+}
+
+function trimTrailingSlashes(value: string): string {
+  return value.replace(/\/+$/, "");
+}
+
+function ensureLeadingSlash(path: string): string {
+  return path.startsWith("/") ? path : `/${path}`;
+}
+
+export function resolveApiBaseUrl(
+  env: ApiBaseEnv = readApiBaseEnv(),
+  origin = getWindowOrigin(),
+): string {
+  return trimTrailingSlashes(String(env.VITE_API_BASE_URL || origin || ""));
+}
+
+export function getApiBaseUrl(): string {
+  return resolveApiBaseUrl();
+}
+
+export function resolveApiUrl(
+  path: string,
+  env: ApiBaseEnv = readApiBaseEnv(),
+  origin = getWindowOrigin(),
+): string {
+  const baseUrl = resolveApiBaseUrl(env, origin);
+  const normalizedPath = ensureLeadingSlash(path);
+  return baseUrl ? `${baseUrl}${normalizedPath}` : normalizedPath;
+}
+
+export function resolveCoreApiUrl(
+  path: string,
+  env: ApiBaseEnv = readApiBaseEnv(),
+  origin = getWindowOrigin(),
+): string {
+  return resolveApiUrl(`/api/core/${path.replace(/^\/+/, "")}`, env, origin);
+}
+
+export function resolveAuthServiceApiUrl(
+  path: string,
+  env: ApiBaseEnv = readApiBaseEnv(),
+  origin = getWindowOrigin(),
+): string {
+  return resolveApiUrl(`/api/authservice/${path.replace(/^\/+/, "")}`, env, origin);
+}
+
+export function apiUrl(path: string): string {
+  return resolveApiUrl(path);
+}
+
+export function coreApiUrl(path: string): string {
+  return resolveCoreApiUrl(path);
+}
+
+export function authServiceApiUrl(path: string): string {
+  return resolveAuthServiceApiUrl(path);
+}

--- a/frontend/src/runtime/desktopBridge.ts
+++ b/frontend/src/runtime/desktopBridge.ts
@@ -1,0 +1,47 @@
+import { isDesktopRuntime } from "./mode";
+
+export type DesktopBridgeUnavailableReason = "unavailable" | "failed";
+
+export type DesktopBridgeResult =
+  | { ok: true }
+  | { ok: false; reason: DesktopBridgeUnavailableReason; error?: unknown };
+
+interface LazyMindDesktopBridge {
+  openLogsDir?: () => Promise<void> | void;
+  openDataDir?: () => Promise<void> | void;
+}
+
+function getDesktopBridge(): LazyMindDesktopBridge | undefined {
+  if (!isDesktopRuntime() || typeof window === "undefined") {
+    return undefined;
+  }
+
+  return (window as Window & { lazymindDesktop?: LazyMindDesktopBridge })
+    .lazymindDesktop;
+}
+
+async function callDesktopBridge(
+  method: keyof LazyMindDesktopBridge,
+): Promise<DesktopBridgeResult> {
+  const bridge = getDesktopBridge();
+  const handler = bridge?.[method];
+
+  if (!handler) {
+    return { ok: false, reason: "unavailable" };
+  }
+
+  try {
+    await handler.call(bridge);
+    return { ok: true };
+  } catch (error) {
+    return { ok: false, reason: "failed", error };
+  }
+}
+
+export function openLogsDir(): Promise<DesktopBridgeResult> {
+  return callDesktopBridge("openLogsDir");
+}
+
+export function openDataDir(): Promise<DesktopBridgeResult> {
+  return callDesktopBridge("openDataDir");
+}

--- a/frontend/src/runtime/features.ts
+++ b/frontend/src/runtime/features.ts
@@ -1,0 +1,61 @@
+import { resolveRuntimeMode, type RuntimeEnv, type RuntimeMode } from "./mode";
+
+export interface RuntimeFeatureEnv extends RuntimeEnv {
+  VITE_HIDE_EVO?: string;
+}
+
+export interface RuntimeFeatures {
+  hideEvo: boolean;
+  hideRegister: boolean;
+  hideCloudAdmin: boolean;
+  localAutoLogin: boolean;
+  allowFolderPicker: boolean;
+  allowOpenLogDir: boolean;
+  useLocalGateway: boolean;
+}
+
+function readRuntimeFeatureEnv(): RuntimeFeatureEnv {
+  return (
+    (typeof import.meta !== "undefined" &&
+      ((import.meta as unknown as { env?: RuntimeFeatureEnv }).env || {})) ||
+    {}
+  );
+}
+
+function parseBooleanFlag(value?: string): boolean | undefined {
+  const normalized = String(value ?? "")
+    .trim()
+    .toLowerCase();
+
+  if (["1", "true", "yes", "on"].includes(normalized)) {
+    return true;
+  }
+  if (["0", "false", "no", "off"].includes(normalized)) {
+    return false;
+  }
+  return undefined;
+}
+
+function isLocalLikeMode(mode: RuntimeMode): boolean {
+  return mode === "local" || mode === "desktop";
+}
+
+export function resolveRuntimeFeatures(
+  env: RuntimeFeatureEnv = readRuntimeFeatureEnv(),
+): RuntimeFeatures {
+  const mode = resolveRuntimeMode(env);
+  const isLocalLike = isLocalLikeMode(mode);
+  const explicitHideEvo = parseBooleanFlag(env.VITE_HIDE_EVO);
+
+  return {
+    hideEvo: explicitHideEvo ?? isLocalLike,
+    hideRegister: isLocalLike,
+    hideCloudAdmin: isLocalLike,
+    localAutoLogin: isLocalLike,
+    allowFolderPicker: mode === "desktop",
+    allowOpenLogDir: mode === "desktop",
+    useLocalGateway: isLocalLike,
+  };
+}
+
+export const runtimeFeatures = resolveRuntimeFeatures();

--- a/frontend/src/runtime/mode.ts
+++ b/frontend/src/runtime/mode.ts
@@ -1,0 +1,39 @@
+export type RuntimeMode = "cloud" | "local" | "desktop";
+
+export interface RuntimeEnv {
+  VITE_LAZYMIND_MODE?: string;
+}
+
+const RUNTIME_MODES = new Set<RuntimeMode>(["cloud", "local", "desktop"]);
+
+function readRuntimeEnv(): RuntimeEnv {
+  return (
+    (typeof import.meta !== "undefined" &&
+      ((import.meta as unknown as { env?: RuntimeEnv }).env || {})) ||
+    {}
+  );
+}
+
+export function resolveRuntimeMode(env: RuntimeEnv = readRuntimeEnv()): RuntimeMode {
+  const rawMode = String(env.VITE_LAZYMIND_MODE || "")
+    .trim()
+    .toLowerCase();
+
+  if (RUNTIME_MODES.has(rawMode as RuntimeMode)) {
+    return rawMode as RuntimeMode;
+  }
+
+  return "cloud";
+}
+
+export function getRuntimeMode(): RuntimeMode {
+  return resolveRuntimeMode();
+}
+
+export function isLocalRuntime(): boolean {
+  return getRuntimeMode() === "local";
+}
+
+export function isDesktopRuntime(): boolean {
+  return getRuntimeMode() === "desktop";
+}

--- a/frontend/src/vite-env.d.ts
+++ b/frontend/src/vite-env.d.ts
@@ -2,7 +2,10 @@
 
 interface ImportMetaEnv {
   readonly VITE_API_BASE_URL: string;
+  readonly VITE_LAZYMIND_MODE?: string;
   readonly VITE_HIDE_EVO?: string;
+  readonly VITE_APP_LOGO?: string;
+  readonly VITE_APP_CHAT_TITLE?: string;
 }
 
 interface ImportMeta {
@@ -12,6 +15,10 @@ interface ImportMeta {
 declare global {
   interface Window {
     BASENAME?: string;
+    lazymindDesktop?: {
+      openLogsDir?: () => Promise<void> | void;
+      openDataDir?: () => Promise<void> | void;
+    };
   }
 }
 

--- a/local/docker-compose.local.yml
+++ b/local/docker-compose.local.yml
@@ -82,17 +82,6 @@ services:
     ports:
       - "127.0.0.1:${LAZYMIND_LOCAL_PROXY_EVO_HOST_PORT:-18047}:8047"
 
-  frontend:
-    environment:
-      FRONTEND_API_PROXY_PASS: "http://host.docker.internal:${LAZYMIND_LOCAL_PROXY_PORT:-5024}"
-      FRONTEND_API_DOCS_PROXY_PASS: "http://host.docker.internal:${LAZYMIND_LOCAL_PROXY_PORT:-5024}"
-    extra_hosts:
-      - "host.docker.internal:host-gateway"
-    depends_on:
-      kong:
-        condition: service_started
-        required: false
-
 x-lazymind-local:
   mode: local
   disabled_container_services:
@@ -100,6 +89,7 @@ x-lazymind-local:
     - kong
     - auth-service
     - evo-api
+    - frontend
   scale_disabled_container_services:
     - redis
     - kong

--- a/local/docker-compose.local.yml
+++ b/local/docker-compose.local.yml
@@ -3,6 +3,14 @@ services:
     ports:
       - "127.0.0.1:${LAZYMIND_LOCAL_POSTGRES_PORT:-15432}:5432"
 
+  milvus:
+    ports:
+      - "127.0.0.1:${LAZYMIND_LOCAL_MILVUS_PORT:-19530}:19530"
+
+  opensearch:
+    ports:
+      - "127.0.0.1:${LAZYMIND_LOCAL_OPENSEARCH_PORT:-19200}:9200"
+
   scan-control-plane:
     ports:
       - "127.0.0.1:${LAZYMIND_LOCAL_PROXY_SCAN_HOST_PORT:-18080}:18080"
@@ -10,6 +18,7 @@ services:
       - "host.docker.internal:host-gateway"
     environment:
       LAZYMIND_SCAN_CONTROL_PLANE_AUTH_SERVICE_BASE_URL: "http://host.docker.internal:${LAZYMIND_LOCAL_PROXY_AUTH_HOST_PORT:-18000}"
+      LAZYMIND_SCAN_CONTROL_PLANE_CORE_BASE_URL: "http://core:8000"
       LAZYMIND_REDIS_URL: ""
       LAZYMIND_STATE_BACKEND: sqlite
       LAZYMIND_STATE_SQLITE_PATH: /tmp/scan-control-plane/state/scan_state.db
@@ -45,6 +54,11 @@ services:
       LAZYMIND_REDIS_URL: ""
       LAZYMIND_STATE_BACKEND: sqlite
       LAZYMIND_STATE_SQLITE_DIR: /data/sqlite
+      LAZYMIND_ALGO_SERVICE_URL: "http://host.docker.internal:${LAZYMIND_LOCAL_DOC_PORT:-18002}"
+      LAZYMIND_DOCUMENT_SERVICE_URL: "http://host.docker.internal:${LAZYMIND_LOCAL_DOC_PORT:-18002}"
+      LAZYMIND_PARSING_SERVICE_URL: "http://host.docker.internal:${LAZYMIND_LOCAL_PROCESSOR_PORT:-18003}"
+      LAZYMIND_CHAT_SERVICE_URL: "http://host.docker.internal:${LAZYMIND_LOCAL_CHAT_PORT:-${LAZYMIND_LOCAL_PROXY_CHAT_HOST_PORT:-18046}}"
+      LAZYMIND_EVO_SERVICE_URL: "http://host.docker.internal:${LAZYMIND_LOCAL_EVO_PORT:-${LAZYMIND_LOCAL_PROXY_EVO_HOST_PORT:-18047}}"
     depends_on:
       auth-service:
         condition: service_started
@@ -93,6 +107,12 @@ x-lazymind-local:
     - redis
     - kong
     - auth-service
+    - core-dev
+    - lazyllm-doc-server
+    - lazyllm-parse-server
+    - lazyllm-parse-worker
+    - lazyllm-algo
+    - chat
     - evo-api
     - frontend
     - office-convert-service

--- a/local/docker-compose.local.yml
+++ b/local/docker-compose.local.yml
@@ -41,6 +41,7 @@ services:
       - sqlite-data:/data/sqlite
     environment:
       LAZYMIND_AUTH_SERVICE_URL: "http://host.docker.internal:${LAZYMIND_LOCAL_PROXY_AUTH_HOST_PORT:-18000}/api/authservice"
+      LAZYMIND_DOCUMENT_PARSE_PROFILE: local
       LAZYMIND_REDIS_URL: ""
       LAZYMIND_STATE_BACKEND: sqlite
       LAZYMIND_STATE_SQLITE_DIR: /data/sqlite
@@ -56,6 +57,7 @@ services:
     volumes:
       - sqlite-data:/data/sqlite
     environment:
+      LAZYMIND_DOCUMENT_PARSE_PROFILE: local
       LAZYMIND_REDIS_URL: ""
       LAZYMIND_STATE_BACKEND: sqlite
       LAZYMIND_STATE_SQLITE_DIR: /data/sqlite
@@ -63,6 +65,8 @@ services:
   lazyllm-parse-server:
     volumes:
       - sqlite-data:/data/sqlite
+    environment:
+      LAZYMIND_DOCUMENT_PARSE_PROFILE: local
 
   lazyllm-parse-worker:
     volumes:
@@ -72,6 +76,7 @@ services:
     volumes:
       - sqlite-data:/data/sqlite
     environment:
+      LAZYMIND_DOCUMENT_PARSE_PROFILE: local
       LAZYLLM_ALGO_REGISTER_POLICY: force
 
   chat:
@@ -90,6 +95,7 @@ x-lazymind-local:
     - auth-service
     - evo-api
     - frontend
+    - office-convert-service
   scale_disabled_container_services:
     - redis
     - kong

--- a/local/local-runtime-manager/algorithm_service.go
+++ b/local/local-runtime-manager/algorithm_service.go
@@ -1,0 +1,656 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"syscall"
+	"time"
+)
+
+const (
+	algorithmHealthTimeout = 15 * time.Minute
+)
+
+type AlgorithmServiceSpec struct {
+	Name       string
+	Module     []string
+	Port       int
+	HealthPath string
+}
+
+type AlgorithmServiceManager struct {
+	runner CommandRunner
+}
+
+func NewAlgorithmServiceManager(r CommandRunner) *AlgorithmServiceManager {
+	return &AlgorithmServiceManager{runner: r}
+}
+
+func algorithmProcessSpecs(cfg AlgorithmConfig) []AlgorithmServiceSpec {
+	specs := []AlgorithmServiceSpec{
+		{Name: processorServerProcessName, Module: []string{"-m", "lazymind.processor.service.server"}, Port: cfg.ProcessorPort, HealthPath: "/health"},
+		{Name: processorWorkerProcessName, Module: []string{"-m", "lazymind.processor.service.worker"}, Port: cfg.WorkerPort, HealthPath: "/health"},
+		{Name: algoProcessName, Module: []string{"-m", "lazymind.parsing.app"}, Port: cfg.AlgoPort, HealthPath: "/docs"},
+		{Name: docServerProcessName, Module: []string{filepath.Join("backend", "core", "doc", "doc_server.py"), "--port", strconv.Itoa(cfg.DocPort), "--parser-url", fmt.Sprintf("http://127.0.0.1:%d", cfg.ProcessorPort)}, Port: cfg.DocPort, HealthPath: "/v1/health"},
+		{Name: chatProcessName, Module: []string{"-m", "lazymind.router.app", "--host", "0.0.0.0", "--port", strconv.Itoa(cfg.ChatPort)}, Port: cfg.ChatPort, HealthPath: "/health"},
+	}
+	if cfg.EnableEvo {
+		specs = append(specs, AlgorithmServiceSpec{
+			Name:       evoProcessName,
+			Module:     []string{"-m", "uvicorn", "evo.service.api:get_app", "--factory", "--host", "127.0.0.1", "--port", strconv.Itoa(cfg.EvoPort)},
+			Port:       cfg.EvoPort,
+			HealthPath: "/healthz",
+		})
+	}
+	return specs
+}
+
+func algorithmSpecByName(cfg AlgorithmConfig, name string) (AlgorithmServiceSpec, bool) {
+	for _, spec := range algorithmProcessSpecs(cfg) {
+		if spec.Name == name {
+			return spec, true
+		}
+	}
+	return AlgorithmServiceSpec{}, false
+}
+
+func algorithmLogPath(paths RuntimePaths, service string) string {
+	switch service {
+	case docServerProcessName:
+		return paths.DocServerLog
+	case processorServerProcessName:
+		return paths.ProcessorServerLog
+	case processorWorkerProcessName:
+		return paths.ProcessorWorkerLog
+	case algoProcessName:
+		return paths.AlgoLog
+	case chatProcessName:
+		return paths.ChatLog
+	case evoProcessName:
+		return paths.EvoLog
+	default:
+		return filepath.Join(paths.LogsDir, service+".log")
+	}
+}
+
+func (m *AlgorithmServiceManager) Run(ctx context.Context, cfg RuntimeConfig, paths RuntimePaths, service string) error {
+	spec, ok := algorithmSpecByName(cfg.Algorithm, service)
+	if !ok {
+		return fmt.Errorf("unknown algorithm service: %s", service)
+	}
+	if err := paths.EnsureAllDirs(); err != nil {
+		return err
+	}
+	if err := ensureAlgorithmDataDirs(paths); err != nil {
+		return err
+	}
+	if err := m.preparePython(ctx, paths, cfg.Algorithm.EnableEvo); err != nil {
+		return err
+	}
+	if err := m.waitForDependencies(ctx, cfg, spec.Name); err != nil {
+		return err
+	}
+
+	cmd := exec.CommandContext(ctx, paths.AlgorithmPython, spec.Module...)
+	cmd.Dir = paths.RepoRoot
+	cmd.Env = append(os.Environ(), algorithmServiceEnv(cfg, paths, spec.Name)...)
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Start(); err != nil {
+		return fmt.Errorf("start %s failed: %w", service, err)
+	}
+	pidFile := algorithmPIDFile(paths, service)
+	if err := os.WriteFile(pidFile, []byte(strconv.Itoa(cmd.Process.Pid)+"\n"), 0o600); err != nil {
+		_ = killAlgorithmProcess(cmd.Process)
+		return err
+	}
+
+	waitErr := make(chan error, 1)
+	go func() {
+		waitErr <- cmd.Wait()
+	}()
+	if err := waitForHTTPHealth(ctx, spec.Port, spec.HealthPath, service, algorithmHealthTimeout, waitErr); err != nil {
+		_ = killAlgorithmProcess(cmd.Process)
+		_ = os.Remove(pidFile)
+		return err
+	}
+	if service == algoProcessName {
+		if err := waitForAlgorithmRegistration(ctx, cfg.Algorithm.ProcessorPort, algorithmHealthTimeout); err != nil {
+			_ = killAlgorithmProcess(cmd.Process)
+			_ = os.Remove(pidFile)
+			return err
+		}
+	}
+
+	err := <-waitErr
+	_ = os.Remove(pidFile)
+	if ctx.Err() != nil {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("%s exited: %w", service, err)
+	}
+	return nil
+}
+
+func (m *AlgorithmServiceManager) Down(ctx context.Context, paths RuntimePaths, service string) error {
+	pidFile := algorithmPIDFile(paths, service)
+	raw, err := os.ReadFile(pidFile)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return err
+	}
+	pid, err := strconv.Atoi(strings.TrimSpace(string(raw)))
+	if err != nil || pid <= 0 {
+		_ = os.Remove(pidFile)
+		return nil
+	}
+	proc, err := os.FindProcess(pid)
+	if err != nil {
+		_ = os.Remove(pidFile)
+		return nil
+	}
+	if err := signalProcessGroup(pid, syscall.SIGINT); err != nil {
+		_ = proc.Signal(os.Interrupt)
+	}
+	if !processAlive(pid) {
+		_ = os.Remove(pidFile)
+		return nil
+	}
+	deadline := time.NewTimer(10 * time.Second)
+	defer deadline.Stop()
+	ticker := time.NewTicker(250 * time.Millisecond)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			_ = signalProcessGroup(pid, syscall.SIGKILL)
+			_ = proc.Kill()
+			return ctx.Err()
+		case <-deadline.C:
+			_ = signalProcessGroup(pid, syscall.SIGKILL)
+			_ = proc.Kill()
+			_ = os.Remove(pidFile)
+			return nil
+		case <-ticker.C:
+			if !processAlive(pid) {
+				_ = os.Remove(pidFile)
+				return nil
+			}
+		}
+	}
+}
+
+func signalProcessGroup(pid int, signal syscall.Signal) error {
+	if pid <= 0 {
+		return nil
+	}
+	return syscall.Kill(-pid, signal)
+}
+
+func killAlgorithmProcess(proc *os.Process) error {
+	if proc == nil {
+		return nil
+	}
+	_ = signalProcessGroup(proc.Pid, syscall.SIGKILL)
+	return proc.Kill()
+}
+
+func (m *AlgorithmServiceManager) preparePython(ctx context.Context, paths RuntimePaths, includeEvo bool) error {
+	if err := ensureLazyLLMSubmodule(paths.RepoRoot); err != nil {
+		return err
+	}
+	release, err := acquireAlgorithmPythonLock(ctx, paths)
+	if err != nil {
+		return err
+	}
+	defer release()
+	stamp := filepath.Join(filepath.Dir(paths.AlgorithmVenv), "algorithm.ready")
+	if includeEvo {
+		stamp = filepath.Join(filepath.Dir(paths.AlgorithmVenv), "algorithm-evo.ready")
+	}
+	if _, err := os.Stat(stamp); err == nil {
+		return nil
+	}
+	if _, err := os.Stat(paths.AlgorithmPython); os.IsNotExist(err) {
+		if err := m.createVenv(ctx, paths, false); err != nil {
+			return err
+		}
+	}
+	if err := m.ensurePip(ctx, paths); err != nil {
+		return err
+	}
+	pip := filepath.Join(paths.AlgorithmVenv, "bin", "pip")
+	lazyllm := filepath.Join(paths.AlgorithmVenv, "bin", "lazyllm")
+	installSteps := []Command{
+		{Name: paths.AlgorithmPython, Args: []string{"-m", "pip", "install", "--upgrade", "pip"}, Dir: paths.RepoRoot},
+		{Name: pip, Args: []string{"install", "lazyllm"}, Dir: paths.RepoRoot},
+		{Name: lazyllm, Args: []string{"install", "rag"}, Dir: paths.RepoRoot},
+		{Name: pip, Args: []string{"install", "-r", filepath.Join(paths.RepoRoot, "algorithm", "requirements.txt")}, Dir: paths.RepoRoot},
+	}
+	if includeEvo {
+		installSteps = append(installSteps, Command{Name: pip, Args: []string{"install", "-r", filepath.Join(paths.RepoRoot, "evo", "requirements.txt")}, Dir: paths.RepoRoot})
+	}
+	for _, step := range installSteps {
+		res, err := m.runner.Run(ctx, step)
+		if err != nil {
+			return fmt.Errorf("prepare algorithm python failed at %s %s: %w (%s)", step.Name, strings.Join(step.Args, " "), err, strings.TrimSpace(res.Stderr))
+		}
+	}
+	return os.WriteFile(stamp, []byte(time.Now().UTC().Format(time.RFC3339)+"\n"), 0o644)
+}
+
+func (m *AlgorithmServiceManager) createVenv(ctx context.Context, paths RuntimePaths, clear bool) error {
+	python := envText("PYTHON", "python3")
+	if uv, ok := uvCommand(); ok {
+		args := []string{"venv", "--seed", "--python", python}
+		if clear {
+			args = append(args, "--clear")
+		}
+		args = append(args, paths.AlgorithmVenv)
+		if res, err := m.runner.Run(ctx, Command{Name: uv, Args: args, Dir: paths.RepoRoot}); err != nil {
+			detail := strings.TrimSpace(res.Stderr)
+			if detail == "" {
+				detail = strings.TrimSpace(res.Stdout)
+			}
+			return fmt.Errorf("create algorithm venv with uv failed: %w (%s)", err, detail)
+		}
+		return nil
+	}
+	if res, err := m.runner.Run(ctx, Command{Name: python, Args: []string{"-m", "venv", paths.AlgorithmVenv}, Dir: paths.RepoRoot}); err != nil {
+		return fmt.Errorf("create algorithm venv failed: %w (%s)", err, strings.TrimSpace(res.Stderr))
+	}
+	return nil
+}
+
+func (m *AlgorithmServiceManager) ensurePip(ctx context.Context, paths RuntimePaths) error {
+	check := Command{Name: paths.AlgorithmPython, Args: []string{"-m", "pip", "--version"}, Dir: paths.RepoRoot}
+	if res, err := m.runner.Run(ctx, check); err == nil && strings.TrimSpace(res.Stdout+res.Stderr) != "" {
+		return nil
+	}
+	step := Command{Name: paths.AlgorithmPython, Args: []string{"-m", "ensurepip", "--upgrade"}, Dir: paths.RepoRoot}
+	if res, err := m.runner.Run(ctx, step); err != nil {
+		if uv, ok := uvCommand(); ok {
+			_ = uv
+			if createErr := m.createVenv(ctx, paths, true); createErr == nil {
+				return nil
+			}
+		}
+		detail := strings.TrimSpace(res.Stderr)
+		if detail == "" {
+			detail = strings.TrimSpace(res.Stdout)
+		}
+		return fmt.Errorf("bootstrap algorithm pip failed at %s %s: %w (%s)", step.Name, strings.Join(step.Args, " "), err, detail)
+	}
+	return nil
+}
+
+func uvCommand() (string, bool) {
+	if uv := strings.TrimSpace(os.Getenv("UV")); uv != "" {
+		return uv, true
+	}
+	if uv, err := exec.LookPath("uv"); err == nil {
+		return uv, true
+	}
+	const userUV = "/home/panyang/.local/bin/uv"
+	if info, err := os.Stat(userUV); err == nil && !info.IsDir() {
+		return userUV, true
+	}
+	return "", false
+}
+
+func acquireAlgorithmPythonLock(ctx context.Context, paths RuntimePaths) (func(), error) {
+	lockFile := filepath.Join(paths.RunDir, "algorithm-python.lock")
+	for {
+		f, err := os.OpenFile(lockFile, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0o600)
+		if err == nil {
+			_, _ = fmt.Fprintf(f, "%d\n", os.Getpid())
+			_ = f.Close()
+			return func() { _ = os.Remove(lockFile) }, nil
+		}
+		if !os.IsExist(err) {
+			return nil, err
+		}
+		alive, readErr := upLockProcessAlive(lockFile)
+		if readErr == nil && !alive {
+			_ = os.Remove(lockFile)
+			continue
+		}
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-time.After(500 * time.Millisecond):
+		}
+	}
+}
+
+func (m *AlgorithmServiceManager) waitForDependencies(ctx context.Context, cfg RuntimeConfig, service string) error {
+	switch service {
+	case processorServerProcessName:
+		return waitForTCP(ctx, "127.0.0.1", cfg.Algorithm.PostgresPort, "PostgreSQL", 3*time.Minute)
+	case processorWorkerProcessName:
+		return waitForHTTPOnly(ctx, cfg.Algorithm.ProcessorPort, "/health", "processor-server", 3*time.Minute)
+	case algoProcessName:
+		if err := waitForHTTPOnly(ctx, cfg.Algorithm.ProcessorPort, "/health", "processor-server", 3*time.Minute); err != nil {
+			return err
+		}
+		if isBuiltInServiceURI("LAZYMIND_MILVUS_URI", "http://milvus:19530") {
+			if err := waitForTCP(ctx, "127.0.0.1", cfg.Algorithm.MilvusPort, "Milvus", 5*time.Minute); err != nil {
+				return err
+			}
+		}
+		if isBuiltInServiceURI("LAZYMIND_OPENSEARCH_URI", "https://opensearch:9200") {
+			if err := waitForTCP(ctx, "127.0.0.1", cfg.Algorithm.OpenSearchPort, "OpenSearch", 5*time.Minute); err != nil {
+				return err
+			}
+		}
+	case docServerProcessName:
+		return waitForHTTPOnly(ctx, cfg.Algorithm.ProcessorPort, "/health", "processor-server", 3*time.Minute)
+	case chatProcessName:
+		if err := waitForHTTPOnly(ctx, cfg.Algorithm.AlgoPort, "/docs", "lazyllm-algo", 5*time.Minute); err != nil {
+			return err
+		}
+		if err := waitForAlgorithmRegistration(ctx, cfg.Algorithm.ProcessorPort, 5*time.Minute); err != nil {
+			return err
+		}
+		return waitForHTTPOnly(ctx, cfg.LocalProxy.CoreHostPort, "/health", "core", 5*time.Minute)
+	case evoProcessName:
+		return waitForHTTPOnly(ctx, cfg.Algorithm.ChatPort, "/health", "chat", 5*time.Minute)
+	}
+	return nil
+}
+
+func ensureAlgorithmDataDirs(paths RuntimePaths) error {
+	dirs := []string{
+		filepath.Join(paths.RepoRoot, "data", "core", "uploads"),
+		filepath.Join(paths.RepoRoot, "data", "traces"),
+		filepath.Join(paths.RepoRoot, "data", "evo"),
+		filepath.Join(paths.RepoRoot, "data", "subagent"),
+		filepath.Join(paths.AlgorithmHome, "agent_workspace"),
+		filepath.Join(paths.AlgorithmHome, "sqlite"),
+	}
+	for _, dir := range dirs {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func ensureLazyLLMSubmodule(repoRoot string) error {
+	required := filepath.Join(repoRoot, "algorithm", "lazyllm", "lazyllm")
+	if info, err := os.Stat(required); err == nil && info.IsDir() {
+		return nil
+	}
+	return fmt.Errorf("algorithm/lazyllm submodule is not checked out; run: git submodule update --init algorithm/lazyllm")
+}
+
+func algorithmServiceEnv(cfg RuntimeConfig, paths RuntimePaths, service string) []string {
+	uploads := filepath.Join(paths.RepoRoot, "data", "core", "uploads")
+	traces := filepath.Join(paths.RepoRoot, "data", "traces")
+	pythonPath := strings.Join([]string{
+		filepath.Join(paths.RepoRoot, "algorithm", "lazyllm"),
+		filepath.Join(paths.RepoRoot, "algorithm"),
+		paths.RepoRoot,
+	}, string(os.PathListSeparator))
+	dbURL := fmt.Sprintf("postgresql+psycopg://app:app@127.0.0.1:%d/app", cfg.Algorithm.PostgresPort)
+	noProxy := envText("no_proxy", "127.0.0.1,localhost,::1,core,chat,evo-api,doc-server,lazyllm-algo,parsing,milvus,opensearch,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16")
+	noProxyUpper := envText("NO_PROXY", noProxy)
+	env := []string{
+		"LAZYMIND_RUNTIME_MODE=local",
+		"PYTHONPATH=" + pythonPath,
+		"LAZYMIND_HOME=" + paths.AlgorithmHome,
+		"LAZYMIND_DATABASE_URL=" + dbURL,
+		"LAZYMIND_CORE_DATABASE_URL=" + fmt.Sprintf("postgresql+psycopg://root:123456@127.0.0.1:%d/core", cfg.Algorithm.PostgresPort),
+		"LAZYMIND_SHARED_UPLOAD_DIR=" + uploads,
+		"LAZYMIND_UPLOAD_DIR=" + uploads,
+		"LAZYMIND_UPLOAD_ROOT=" + uploads,
+		"LAZYMIND_DOCUMENT_SERVICE_STORAGE_DIR=" + uploads,
+		"http_proxy=" + envText("http_proxy", ""),
+		"https_proxy=" + envText("https_proxy", ""),
+		"HTTP_PROXY=" + envText("HTTP_PROXY", ""),
+		"HTTPS_PROXY=" + envText("HTTPS_PROXY", ""),
+		"no_proxy=" + noProxy,
+		"NO_PROXY=" + noProxyUpper,
+		"LAZYLLM_OPENAI_API_KEY=" + envText("LAZYLLM_OPENAI_API_KEY", ""),
+		"LAZYLLM_GLM_API_KEY=" + envText("LAZYLLM_GLM_API_KEY", ""),
+		"LAZYLLM_QWEN_API_KEY=" + envText("LAZYLLM_QWEN_API_KEY", ""),
+		"LAZYLLM_SENSENOVA_API_KEY=" + envText("LAZYLLM_SENSENOVA_API_KEY", ""),
+		"LAZYLLM_SENSENOVA_SECRET_KEY=" + envText("LAZYLLM_SENSENOVA_SECRET_KEY", ""),
+		"LAZYLLM_KIMI_API_KEY=" + envText("LAZYLLM_KIMI_API_KEY", ""),
+		"LAZYLLM_DEEPSEEK_API_KEY=" + envText("LAZYLLM_DEEPSEEK_API_KEY", ""),
+		"LAZYLLM_DOUBAO_API_KEY=" + envText("LAZYLLM_DOUBAO_API_KEY", ""),
+		"LAZYLLM_SILICONFLOW_API_KEY=" + envText("LAZYLLM_SILICONFLOW_API_KEY", ""),
+		"LAZYLLM_MINIMAX_API_KEY=" + envText("LAZYLLM_MINIMAX_API_KEY", ""),
+		"LAZYLLM_AIPING_API_KEY=" + envText("LAZYLLM_AIPING_API_KEY", ""),
+		"LAZYMIND_MAAS_API_KEY=" + envText("LAZYMIND_MAAS_API_KEY", ""),
+		"LAZYLLM_TEMP_DIR=" + filepath.Join(uploads, ".lazyllm_temp"),
+		"LAZYMIND_OCR_CACHE_DIR=" + filepath.Join(uploads, ".image_cache"),
+		"LAZYMIND_MOUNT_BASE_DIR=" + uploads,
+		"TZ=" + envText("TZ", "Asia/Shanghai"),
+		"LANGFUSE_HOST=" + envText("LANGFUSE_HOST", ""),
+		"LANGFUSE_BASE_URL=" + envText("LANGFUSE_BASE_URL", ""),
+		"LANGFUSE_PUBLIC_KEY=" + envText("LANGFUSE_PUBLIC_KEY", ""),
+		"LANGFUSE_SECRET_KEY=" + envText("LANGFUSE_SECRET_KEY", ""),
+		"LAZYLLM_TRACE_ENABLED=" + envText("LAZYLLM_TRACE_ENABLED", "1"),
+		"LAZYLLM_TRACE_LOCAL_STORAGE_DIR=" + traces,
+		"LAZYLLM_TRACE_CONSUME_BACKEND=local",
+		"LAZYLLM_TRACE_BACKEND=local",
+		"OTEL_EXPORTER_OTLP_TIMEOUT=" + envText("OTEL_EXPORTER_OTLP_TIMEOUT", "60"),
+		"OTEL_EXPORTER_OTLP_TRACES_TIMEOUT=" + envText("OTEL_EXPORTER_OTLP_TRACES_TIMEOUT", "60"),
+		"LAZYMIND_LANGFUSE_FORCE_FLUSH_TIMEOUT_MS=" + envText("LAZYMIND_LANGFUSE_FORCE_FLUSH_TIMEOUT_MS", "70000"),
+		"LAZYMIND_OCR_SERVER_URL=" + envText("LAZYMIND_OCR_SERVER_URL", ""),
+		"LAZYMIND_MINERU_BACKEND=" + envText("LAZYMIND_MINERU_BACKEND", "pipeline"),
+		"LAZYMIND_MINERU_SERVER_PORT=" + envText("LAZYMIND_MINERU_SERVER_PORT", "8000"),
+		"LAZYLLM_MINERU_BACKEND=" + envText("LAZYLLM_MINERU_BACKEND", envText("LAZYMIND_MINERU_BACKEND", "pipeline")),
+		"LAZYLLM_MINERU_API_KEY=" + envText("LAZYLLM_MINERU_API_KEY", ""),
+		"LAZYLLM_PADDLE_API_KEY=" + envText("LAZYLLM_PADDLE_API_KEY", ""),
+		"LAZYLLM_INIT_DOC=True",
+		"LAZYLLM_EXPECTED_LOG_MODULES=all",
+		"LAZYMIND_MODEL_CONFIG_PATH=" + envText("LAZYMIND_MODEL_CONFIG_PATH", "dynamic"),
+		"LAZYMIND_DOCUMENT_PROCESSOR_URL=" + fmt.Sprintf("http://127.0.0.1:%d", cfg.Algorithm.ProcessorPort),
+		"LAZYMIND_DOCUMENT_PROCESSOR_PORT=" + strconv.Itoa(cfg.Algorithm.ProcessorPort),
+		"LAZYMIND_DOCUMENT_WORKER_PORT=" + strconv.Itoa(cfg.Algorithm.WorkerPort),
+		"LAZYMIND_DOCUMENT_WORKER_NUM_WORKERS=" + envText("LAZYMIND_DOCUMENT_WORKER_NUM_WORKERS", "1"),
+		"LAZYMIND_DOCUMENT_WORKER_LEASE_DURATION=" + envText("LAZYMIND_DOCUMENT_WORKER_LEASE_DURATION", "300"),
+		"LAZYMIND_DOCUMENT_WORKER_LEASE_RENEW_INTERVAL=" + envText("LAZYMIND_DOCUMENT_WORKER_LEASE_RENEW_INTERVAL", "60"),
+		"LAZYMIND_DOCUMENT_WORKER_HIGH_PRIORITY_TASK_TYPES=" + envText("LAZYMIND_DOCUMENT_WORKER_HIGH_PRIORITY_TASK_TYPES", ""),
+		"LAZYMIND_DOCUMENT_WORKER_HIGH_PRIORITY_ONLY=" + envText("LAZYMIND_DOCUMENT_WORKER_HIGH_PRIORITY_ONLY", "false"),
+		"LAZYMIND_DOCUMENT_WORKER_POLL_MODE=" + envText("LAZYMIND_DOCUMENT_WORKER_POLL_MODE", "direct"),
+		"LAZYMIND_DOCUMENT_SERVICE_PORT=" + strconv.Itoa(cfg.Algorithm.DocPort),
+		"LAZYMIND_ALGO_SERVER_PORT=" + strconv.Itoa(cfg.Algorithm.AlgoPort),
+		"LAZYLLM_ALGO_REGISTER_POLICY=" + envText("LAZYLLM_ALGO_REGISTER_POLICY", "force"),
+		"LAZYMIND_USE_INNER_MODEL=true",
+		"LAZYMIND_RESET_ALGO_ON_STARTUP=" + envText("LAZYMIND_RESET_ALGO_ON_STARTUP", "false"),
+		"LAZYMIND_RESET_ALL_ON_STARTUP=" + envText("LAZYMIND_RESET_ALL_ON_STARTUP", "false"),
+		"LAZYMIND_MILVUS_URI=" + fmt.Sprintf("http://127.0.0.1:%d", cfg.Algorithm.MilvusPort),
+		"LAZYMIND_OPENSEARCH_URI=" + envText("LAZYMIND_OPENSEARCH_URI", fmt.Sprintf("https://127.0.0.1:%d", cfg.Algorithm.OpenSearchPort)),
+		"LAZYMIND_OPENSEARCH_USER=" + envText("LAZYMIND_OPENSEARCH_USER", "admin"),
+		"LAZYMIND_OPENSEARCH_PASSWORD=" + envText("LAZYMIND_OPENSEARCH_PASSWORD", "LazyRAG_OpenSearch123!"),
+		"LAZYMIND_SEGMENT_STORE_TYPE=" + envText("LAZYMIND_SEGMENT_STORE_TYPE", "opensearch"),
+		"LAZYMIND_SEGMENT_STORE_URI_OR_PATH=" + envText("LAZYMIND_SEGMENT_STORE_URI_OR_PATH", fmt.Sprintf("https://127.0.0.1:%d", cfg.Algorithm.OpenSearchPort)),
+		"LAZYMIND_SEGMENT_STORE_USER=" + envText("LAZYMIND_SEGMENT_STORE_USER", "admin"),
+		"LAZYMIND_SEGMENT_STORE_PASSWORD=" + envText("LAZYMIND_SEGMENT_STORE_PASSWORD", "LazyRAG_OpenSearch123!"),
+		"LAZYMIND_DOCUMENT_SERVER_URL=" + fmt.Sprintf("http://127.0.0.1:%d,general_algo", cfg.Algorithm.AlgoPort),
+		"LAZYMIND_DEFAULT_CHAT_DATASET=algo",
+		"LAZYMIND_CORE_API_URL=" + fmt.Sprintf("http://127.0.0.1:%d", cfg.LocalProxy.CoreHostPort),
+		"LAZYMIND_CORE_SERVICE_URL=" + fmt.Sprintf("http://127.0.0.1:%d", cfg.LocalProxy.CoreHostPort),
+		"LAZYMIND_FILE_URL_SIGN_SECRET=" + envText("LAZYMIND_FILE_URL_SIGN_SECRET", "changeme-in-production"),
+		"LAZYMIND_FILE_URL_EXPIRE_SECONDS=" + envText("LAZYMIND_FILE_URL_EXPIRE_SECONDS", "3600"),
+		"LAZYMIND_MAX_RETRIES=" + envText("LAZYMIND_MAX_RETRIES", "20"),
+		"LAZYMIND_REVIEW_MAX_RETRIES=" + envText("LAZYMIND_REVIEW_MAX_RETRIES", "5"),
+		"LAZYMIND_SKILL_REVIEW_DEBUG=" + envText("LAZYMIND_SKILL_REVIEW_DEBUG", "false"),
+		"LAZYMIND_MAX_CONCURRENCY=" + envText("LAZYMIND_MAX_CONCURRENCY", "10"),
+		"LAZYMIND_LLM_PRIORITY=" + envText("LAZYMIND_LLM_PRIORITY", "0"),
+		"LAZYMIND_ENABLE_ROUTER=" + envText("LAZYMIND_ENABLE_ROUTER", "true"),
+		"LAZYMIND_ROUTER_PORT_POOL_START=18100",
+		"LAZYMIND_ROUTER_PORT_POOL_END=18999",
+		"LAZYMIND_ROUTER_PORTS_PER_INSTANCE=100",
+		"LAZYMIND_ROUTER_DEFAULT_ALGO_PATH=" + filepath.Join(paths.RepoRoot, "algorithm", "lazymind", "chat"),
+		"LAZYMIND_ROUTER_DEFAULT_INSTANCE_COUNT=1",
+		"LAZYMIND_PLUGINS_DIR=" + filepath.Join(paths.RepoRoot, "plugins"),
+		"LAZYMIND_AGENTIC_WORKSPACE=" + filepath.Join(paths.AlgorithmHome, "agent_workspace"),
+		"LAZYMIND_SUBAGENT_WORKSPACE=" + filepath.Join(paths.RepoRoot, "data", "subagent"),
+		"LAZYMIND_EVO_API_PORT=" + strconv.Itoa(cfg.Algorithm.EvoPort),
+		"LAZYMIND_EVO_BASE_DIR=" + filepath.Join(paths.RepoRoot, "data", "evo"),
+		"LAZYMIND_EVO_CHAT_SOURCE=" + filepath.Join(paths.RepoRoot, "algorithm", "lazymind", "chat"),
+		"LAZYMIND_EVO_CODE_TIMEOUT_S=" + envText("LAZYMIND_EVO_CODE_TIMEOUT_S", "900"),
+		"LAZYMIND_EVO_LLM_ROLE=" + envText("LAZYMIND_EVO_LLM_ROLE", "evo_llm"),
+		"LAZYMIND_EVO_KB_BASE_URL=" + fmt.Sprintf("http://127.0.0.1:%d", cfg.Algorithm.DocPort),
+		"LAZYMIND_EVO_CHUNK_BASE_URL=" + fmt.Sprintf("http://127.0.0.1:%d", cfg.Algorithm.DocPort),
+		"LAZYMIND_EVO_TARGET_CHAT_URL=" + fmt.Sprintf("http://127.0.0.1:%d/api/chat/stream", cfg.Algorithm.ChatPort),
+		"LAZYMIND_WORD_GROUP_APPLY_URL=" + envText("LAZYMIND_WORD_GROUP_APPLY_URL", ""),
+	}
+	if service == docServerProcessName {
+		env = append(env, "LAZYMIND_DOCUMENT_SERVICE_CALLBACK_URL=http://127.0.0.1:"+strconv.Itoa(cfg.Algorithm.DocPort)+"/v1/internal/callbacks/tasks")
+	}
+	return env
+}
+
+func algorithmPIDFile(paths RuntimePaths, service string) string {
+	return filepath.Join(paths.AlgorithmPIDDir, service+".pid")
+}
+
+func waitForHostAlgorithmReadiness(ctx context.Context, cfg RuntimeConfig) error {
+	for _, spec := range algorithmProcessSpecs(cfg.Algorithm) {
+		if err := waitForHTTPOnly(ctx, spec.Port, spec.HealthPath, spec.Name, algorithmHealthTimeout); err != nil {
+			return err
+		}
+	}
+	return waitForAlgorithmRegistration(ctx, cfg.Algorithm.ProcessorPort, algorithmHealthTimeout)
+}
+
+func waitForAlgorithmRegistration(ctx context.Context, processorPort int, timeout time.Duration) error {
+	deadline := time.NewTimer(timeout)
+	defer deadline.Stop()
+	ticker := time.NewTicker(500 * time.Millisecond)
+	defer ticker.Stop()
+	url := fmt.Sprintf("http://127.0.0.1:%d/algo/list", processorPort)
+	for {
+		if algorithmRegistered(ctx, url) {
+			return nil
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-deadline.C:
+			return fmt.Errorf("timed out waiting for algorithm registration at %s", url)
+		case <-ticker.C:
+		}
+	}
+}
+
+func algorithmRegistered(ctx context.Context, url string) bool {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return false
+	}
+	client := http.Client{Timeout: 3 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		return false
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return false
+	}
+	var payload struct {
+		Data []struct {
+			AlgoID string `json:"algo_id"`
+		} `json:"data"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+		return false
+	}
+	for _, item := range payload.Data {
+		if item.AlgoID == "general_algo" {
+			return true
+		}
+	}
+	return false
+}
+
+func waitForHTTPOnly(ctx context.Context, port int, path string, label string, timeout time.Duration) error {
+	return waitForHTTPHealth(ctx, port, path, label, timeout, nil)
+}
+
+func waitForHTTPHealth(ctx context.Context, port int, path string, label string, timeout time.Duration, waitErr <-chan error) error {
+	deadline := time.NewTimer(timeout)
+	defer deadline.Stop()
+	ticker := time.NewTicker(500 * time.Millisecond)
+	defer ticker.Stop()
+	url := fmt.Sprintf("http://127.0.0.1:%d%s", port, path)
+	for {
+		if httpOK(ctx, url, 3*time.Second) {
+			return nil
+		}
+		select {
+		case err := <-waitErr:
+			if err != nil {
+				return fmt.Errorf("%s exited before becoming healthy: %w", label, err)
+			}
+			return fmt.Errorf("%s exited before becoming healthy", label)
+		default:
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-deadline.C:
+			return fmt.Errorf("timed out waiting for %s at %s", label, url)
+		case <-ticker.C:
+		}
+	}
+}
+
+func httpOK(ctx context.Context, url string, timeout time.Duration) bool {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return false
+	}
+	client := http.Client{Timeout: timeout}
+	resp, err := client.Do(req)
+	if err != nil {
+		return false
+	}
+	defer resp.Body.Close()
+	return resp.StatusCode >= 200 && resp.StatusCode < 500
+}
+
+func waitForTCP(ctx context.Context, host string, port int, label string, timeout time.Duration) error {
+	address := net.JoinHostPort(host, strconv.Itoa(port))
+	deadline := time.NewTimer(timeout)
+	defer deadline.Stop()
+	ticker := time.NewTicker(500 * time.Millisecond)
+	defer ticker.Stop()
+	dialer := net.Dialer{Timeout: time.Second}
+	for {
+		conn, err := dialer.DialContext(ctx, "tcp", address)
+		if err == nil {
+			_ = conn.Close()
+			return nil
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-deadline.C:
+			return fmt.Errorf("timed out waiting for %s at %s", label, address)
+		case <-ticker.C:
+		}
+	}
+}
+
+func processAlive(pid int) bool {
+	err := syscall.Kill(pid, 0)
+	return err == nil || err == syscall.EPERM
+}

--- a/local/local-runtime-manager/algorithm_service.go
+++ b/local/local-runtime-manager/algorithm_service.go
@@ -303,7 +303,11 @@ func uvCommand() (string, bool) {
 	if uv, err := exec.LookPath("uv"); err == nil {
 		return uv, true
 	}
-	const userUV = "/home/panyang/.local/bin/uv"
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", false
+	}
+	userUV := filepath.Join(home, ".local", "bin", "uv")
 	if info, err := os.Stat(userUV); err == nil && !info.IsDir() {
 		return userUV, true
 	}

--- a/local/local-runtime-manager/compose.go
+++ b/local/local-runtime-manager/compose.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"sort"
 	"strconv"
 	"strings"
 )
@@ -190,17 +189,10 @@ type composeConfigJSON struct {
 }
 
 type composeConfigService struct {
-	Image string              `json:"image"`
 	Build *composeBuildConfig `json:"build"`
 }
 
-type composeBuildConfig struct {
-	Context    string            `json:"context"`
-	Dockerfile string            `json:"dockerfile"`
-	Args       map[string]string `json:"args"`
-	Network    string            `json:"network"`
-	Target     string            `json:"target"`
-}
+type composeBuildConfig struct{}
 
 func (m *ComposeManager) BuildEnabledServices(ctx context.Context, repoRoot string, services []string) error {
 	if len(services) == 0 {
@@ -212,31 +204,34 @@ func (m *ComposeManager) BuildEnabledServices(ctx context.Context, repoRoot stri
 	}
 
 	seen := map[string]struct{}{}
+	buildServices := []string{}
 	for _, serviceName := range services {
 		service, ok := config.Services[serviceName]
 		if !ok || service.Build == nil {
 			continue
 		}
-		args, err := dockerBuildArgs(service)
-		if err != nil {
-			return fmt.Errorf("build config for %s: %w", serviceName, err)
-		}
-		key := strings.Join(args, "\x00")
-		if _, ok := seen[key]; ok {
+		if _, ok := seen[serviceName]; ok {
 			continue
 		}
-		seen[key] = struct{}{}
-		cmd := Command{Name: "docker", Args: args, Dir: repoRoot}
-		if streamer, ok := m.runner.(CommandStreamer); ok {
-			if err := streamer.Stream(ctx, cmd, os.Stdout, os.Stderr); err != nil {
-				return fmt.Errorf("docker build %s failed: %w", serviceName, err)
-			}
-			continue
+		seen[serviceName] = struct{}{}
+		buildServices = append(buildServices, serviceName)
+	}
+	if len(buildServices) == 0 {
+		return nil
+	}
+
+	args := append(m.composeArgs(repoRoot), "build")
+	args = append(args, buildServices...)
+	cmd := Command{Name: "docker", Args: args, Dir: repoRoot}
+	if streamer, ok := m.runner.(CommandStreamer); ok {
+		if err := streamer.Stream(ctx, cmd, os.Stdout, os.Stderr); err != nil {
+			return fmt.Errorf("docker compose build failed: %w", err)
 		}
-		res, err := m.runner.Run(ctx, cmd)
-		if err != nil {
-			return fmt.Errorf("docker build %s failed: %w (%s)", serviceName, err, strings.TrimSpace(res.Stderr))
-		}
+		return nil
+	}
+	res, err := m.runner.Run(ctx, cmd)
+	if err != nil {
+		return fmt.Errorf("docker compose build failed: %w (%s)", err, strings.TrimSpace(res.Stderr))
 	}
 	return nil
 }
@@ -252,39 +247,6 @@ func (m *ComposeManager) ComposeConfigJSON(ctx context.Context, repoRoot string)
 		return composeConfigJSON{}, fmt.Errorf("parse docker compose config json: %w", err)
 	}
 	return config, nil
-}
-
-func dockerBuildArgs(service composeConfigService) ([]string, error) {
-	if service.Build == nil {
-		return nil, fmt.Errorf("missing build config")
-	}
-	contextDir := strings.TrimSpace(service.Build.Context)
-	if contextDir == "" {
-		return nil, fmt.Errorf("missing build context")
-	}
-	args := []string{"build"}
-	if image := strings.TrimSpace(service.Image); image != "" {
-		args = append(args, "-t", image)
-	}
-	if dockerfile := strings.TrimSpace(service.Build.Dockerfile); dockerfile != "" {
-		args = append(args, "-f", filepath.Join(contextDir, dockerfile))
-	}
-	if target := strings.TrimSpace(service.Build.Target); target != "" {
-		args = append(args, "--target", target)
-	}
-	if network := strings.TrimSpace(service.Build.Network); network != "" {
-		args = append(args, "--network", network)
-	}
-	keys := make([]string, 0, len(service.Build.Args))
-	for key := range service.Build.Args {
-		keys = append(keys, key)
-	}
-	sort.Strings(keys)
-	for _, key := range keys {
-		args = append(args, "--build-arg", key+"="+service.Build.Args[key])
-	}
-	args = append(args, contextDir)
-	return args, nil
 }
 
 func localComposeEnv(cfg RuntimeConfig) []string {

--- a/local/local-runtime-manager/compose.go
+++ b/local/local-runtime-manager/compose.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"strconv"
 	"strings"
 )
 
@@ -145,7 +146,8 @@ func (m *ComposeManager) ComposeHasContainers(ctx context.Context, repoRoot stri
 	return len(statuses) > 0, nil
 }
 
-func (m *ComposeManager) ComposeUp(ctx context.Context, repoRoot string, profile string) error {
+func (m *ComposeManager) ComposeUp(ctx context.Context, cfg RuntimeConfig, paths RuntimePaths) error {
+	repoRoot := paths.RepoRoot
 	services, err := m.ComposeServices(ctx, repoRoot)
 	if err != nil {
 		return err
@@ -160,35 +162,23 @@ func (m *ComposeManager) ComposeUp(ctx context.Context, repoRoot string, profile
 		return err
 	}
 	if len(remaining) == 0 {
-		_ = profile
+		_ = cfg.Profile
 	}
 	if err := m.BuildEnabledServices(ctx, repoRoot, remaining); err != nil {
 		return err
 	}
 
-	args := append(m.composeArgs(repoRoot), "up", "--no-build")
-	scaleDisabled := disabled.ScaleDisabledContainerTypes
-	if len(scaleDisabled) == 0 {
-		scaleDisabled = disabled.DisabledContainerTypes
-	}
-	if _, err := validateKnownServices(services, scaleDisabled, "scale disabled service"); err != nil {
-		return err
-	}
-	for _, svc := range scaleDisabled {
-		if svc == "" {
-			continue
-		}
-		args = append(args, "--scale", svc+"=0")
-	}
+	args := append(m.composeArgs(repoRoot), "up", "--no-build", "--detach", "--no-deps")
 	args = append(args, remaining...)
+	env := localComposeEnv(cfg)
 	if streamer, ok := m.runner.(CommandStreamer); ok {
-		err := streamer.Stream(ctx, Command{Name: "docker", Args: args, Dir: repoRoot}, os.Stdout, os.Stderr)
+		err := streamer.Stream(ctx, Command{Name: "docker", Args: args, Dir: repoRoot, Env: env}, os.Stdout, os.Stderr)
 		if err != nil {
 			return fmt.Errorf("docker compose up failed: %w", err)
 		}
 		return nil
 	}
-	res, err := m.runner.Run(ctx, Command{Name: "docker", Args: args, Dir: repoRoot})
+	res, err := m.runner.Run(ctx, Command{Name: "docker", Args: args, Dir: repoRoot, Env: env})
 	if err != nil {
 		return fmt.Errorf("docker compose up failed: %w (%s)", err, strings.TrimSpace(res.Stderr))
 	}
@@ -295,6 +285,27 @@ func dockerBuildArgs(service composeConfigService) ([]string, error) {
 	}
 	args = append(args, contextDir)
 	return args, nil
+}
+
+func localComposeEnv(cfg RuntimeConfig) []string {
+	return []string{
+		"LAZYMIND_FRONTEND_PORT=" + strconv.Itoa(cfg.FrontendPort),
+		"LAZYMIND_LOCAL_PROXY_PORT=" + strconv.Itoa(cfg.LocalProxy.Port),
+		"LAZYMIND_LOCAL_PROXY_AUTH_HOST_PORT=" + strconv.Itoa(cfg.LocalProxy.AuthHostPort),
+		"LAZYMIND_LOCAL_PROXY_CORE_HOST_PORT=" + strconv.Itoa(cfg.LocalProxy.CoreHostPort),
+		"LAZYMIND_LOCAL_PROXY_CHAT_HOST_PORT=" + strconv.Itoa(cfg.LocalProxy.ChatHostPort),
+		"LAZYMIND_LOCAL_PROXY_SCAN_HOST_PORT=" + strconv.Itoa(cfg.LocalProxy.ScanHostPort),
+		"LAZYMIND_LOCAL_PROXY_EVO_HOST_PORT=" + strconv.Itoa(cfg.LocalProxy.EvoHostPort),
+		"LAZYMIND_LOCAL_POSTGRES_PORT=" + strconv.Itoa(cfg.Algorithm.PostgresPort),
+		"LAZYMIND_LOCAL_DOC_PORT=" + strconv.Itoa(cfg.Algorithm.DocPort),
+		"LAZYMIND_LOCAL_PROCESSOR_PORT=" + strconv.Itoa(cfg.Algorithm.ProcessorPort),
+		"LAZYMIND_LOCAL_ALGO_PORT=" + strconv.Itoa(cfg.Algorithm.AlgoPort),
+		"LAZYMIND_LOCAL_WORKER_PORT=" + strconv.Itoa(cfg.Algorithm.WorkerPort),
+		"LAZYMIND_LOCAL_CHAT_PORT=" + strconv.Itoa(cfg.Algorithm.ChatPort),
+		"LAZYMIND_LOCAL_EVO_PORT=" + strconv.Itoa(cfg.Algorithm.EvoPort),
+		"LAZYMIND_LOCAL_MILVUS_PORT=" + strconv.Itoa(cfg.Algorithm.MilvusPort),
+		"LAZYMIND_LOCAL_OPENSEARCH_PORT=" + strconv.Itoa(cfg.Algorithm.OpenSearchPort),
+	}
 }
 
 func filterRemainingServices(allServices []string, disabled []string) ([]string, error) {

--- a/local/local-runtime-manager/compose.go
+++ b/local/local-runtime-manager/compose.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 )
 
@@ -161,7 +162,11 @@ func (m *ComposeManager) ComposeUp(ctx context.Context, repoRoot string, profile
 	if len(remaining) == 0 {
 		_ = profile
 	}
-	args := append(m.composeArgs(repoRoot), "up", "--build")
+	if err := m.BuildEnabledServices(ctx, repoRoot, remaining); err != nil {
+		return err
+	}
+
+	args := append(m.composeArgs(repoRoot), "up", "--no-build")
 	scaleDisabled := disabled.ScaleDisabledContainerTypes
 	if len(scaleDisabled) == 0 {
 		scaleDisabled = disabled.DisabledContainerTypes
@@ -188,6 +193,108 @@ func (m *ComposeManager) ComposeUp(ctx context.Context, repoRoot string, profile
 		return fmt.Errorf("docker compose up failed: %w (%s)", err, strings.TrimSpace(res.Stderr))
 	}
 	return nil
+}
+
+type composeConfigJSON struct {
+	Services map[string]composeConfigService `json:"services"`
+}
+
+type composeConfigService struct {
+	Image string              `json:"image"`
+	Build *composeBuildConfig `json:"build"`
+}
+
+type composeBuildConfig struct {
+	Context    string            `json:"context"`
+	Dockerfile string            `json:"dockerfile"`
+	Args       map[string]string `json:"args"`
+	Network    string            `json:"network"`
+	Target     string            `json:"target"`
+}
+
+func (m *ComposeManager) BuildEnabledServices(ctx context.Context, repoRoot string, services []string) error {
+	if len(services) == 0 {
+		return nil
+	}
+	config, err := m.ComposeConfigJSON(ctx, repoRoot)
+	if err != nil {
+		return err
+	}
+
+	seen := map[string]struct{}{}
+	for _, serviceName := range services {
+		service, ok := config.Services[serviceName]
+		if !ok || service.Build == nil {
+			continue
+		}
+		args, err := dockerBuildArgs(service)
+		if err != nil {
+			return fmt.Errorf("build config for %s: %w", serviceName, err)
+		}
+		key := strings.Join(args, "\x00")
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		cmd := Command{Name: "docker", Args: args, Dir: repoRoot}
+		if streamer, ok := m.runner.(CommandStreamer); ok {
+			if err := streamer.Stream(ctx, cmd, os.Stdout, os.Stderr); err != nil {
+				return fmt.Errorf("docker build %s failed: %w", serviceName, err)
+			}
+			continue
+		}
+		res, err := m.runner.Run(ctx, cmd)
+		if err != nil {
+			return fmt.Errorf("docker build %s failed: %w (%s)", serviceName, err, strings.TrimSpace(res.Stderr))
+		}
+	}
+	return nil
+}
+
+func (m *ComposeManager) ComposeConfigJSON(ctx context.Context, repoRoot string) (composeConfigJSON, error) {
+	args := append(m.composeArgs(repoRoot), "config", "--format", "json")
+	res, err := m.runner.Run(ctx, Command{Name: "docker", Args: args, Dir: repoRoot})
+	if err != nil {
+		return composeConfigJSON{}, fmt.Errorf("docker compose config --format json failed: %w (%s)", err, strings.TrimSpace(res.Stderr))
+	}
+	var config composeConfigJSON
+	if err := json.Unmarshal([]byte(res.Stdout), &config); err != nil {
+		return composeConfigJSON{}, fmt.Errorf("parse docker compose config json: %w", err)
+	}
+	return config, nil
+}
+
+func dockerBuildArgs(service composeConfigService) ([]string, error) {
+	if service.Build == nil {
+		return nil, fmt.Errorf("missing build config")
+	}
+	contextDir := strings.TrimSpace(service.Build.Context)
+	if contextDir == "" {
+		return nil, fmt.Errorf("missing build context")
+	}
+	args := []string{"build"}
+	if image := strings.TrimSpace(service.Image); image != "" {
+		args = append(args, "-t", image)
+	}
+	if dockerfile := strings.TrimSpace(service.Build.Dockerfile); dockerfile != "" {
+		args = append(args, "-f", filepath.Join(contextDir, dockerfile))
+	}
+	if target := strings.TrimSpace(service.Build.Target); target != "" {
+		args = append(args, "--target", target)
+	}
+	if network := strings.TrimSpace(service.Build.Network); network != "" {
+		args = append(args, "--network", network)
+	}
+	keys := make([]string, 0, len(service.Build.Args))
+	for key := range service.Build.Args {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	for _, key := range keys {
+		args = append(args, "--build-arg", key+"="+service.Build.Args[key])
+	}
+	args = append(args, contextDir)
+	return args, nil
 }
 
 func filterRemainingServices(allServices []string, disabled []string) ([]string, error) {

--- a/local/local-runtime-manager/config.go
+++ b/local/local-runtime-manager/config.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"net"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -20,13 +21,22 @@ const (
 	localProxyChatHostPortEnvVar  = "LAZYMIND_LOCAL_PROXY_CHAT_HOST_PORT"
 	localProxyScanHostPortEnvVar  = "LAZYMIND_LOCAL_PROXY_SCAN_HOST_PORT"
 	localProxyEvoHostPortEnvVar   = "LAZYMIND_LOCAL_PROXY_EVO_HOST_PORT"
+	localPostgresPortEnvVar       = "LAZYMIND_LOCAL_POSTGRES_PORT"
+	localDocPortEnvVar            = "LAZYMIND_LOCAL_DOC_PORT"
+	localProcessorPortEnvVar      = "LAZYMIND_LOCAL_PROCESSOR_PORT"
+	localAlgoPortEnvVar           = "LAZYMIND_LOCAL_ALGO_PORT"
+	localWorkerPortEnvVar         = "LAZYMIND_LOCAL_WORKER_PORT"
+	localChatPortEnvVar           = "LAZYMIND_LOCAL_CHAT_PORT"
+	localEvoPortEnvVar            = "LAZYMIND_LOCAL_EVO_PORT"
+	localMilvusPortEnvVar         = "LAZYMIND_LOCAL_MILVUS_PORT"
+	localOpenSearchPortEnvVar     = "LAZYMIND_LOCAL_OPENSEARCH_PORT"
+	localEnableEvoEnvVar          = "LAZYMIND_LOCAL_ENABLE_EVO"
 	frontendPortEnvVar            = "LAZYMIND_FRONTEND_PORT"
 	authServicePortEnvVar         = "LAZYMIND_AUTH_SERVICE_PORT"
 	authServicePythonEnvVar       = "LAZYMIND_AUTH_SERVICE_PYTHON"
 	authServiceUVEnvVar           = "LAZYMIND_AUTH_SERVICE_UV"
 	authServiceDatabaseURLEnvVar  = "LAZYMIND_AUTH_SERVICE_DATABASE_URL"
 	authServiceInstallDepsEnvVar  = "LAZYMIND_AUTH_SERVICE_INSTALL_DEPS"
-	localPostgresPortEnvVar       = "LAZYMIND_LOCAL_POSTGRES_PORT"
 	caddyBinEnvVar                = "LAZYMIND_CADDY_BIN"
 	caddyVersionEnvVar            = "LAZYMIND_CADDY_VERSION"
 	defaultProfile                = "linux-browser"
@@ -44,6 +54,12 @@ const (
 	defaultLocalProxyScanHostPort = 18080
 	defaultLocalProxyEvoHostPort  = 18047
 	defaultLocalPostgresPort      = 15432
+	defaultLocalDocPort           = 18002
+	defaultLocalProcessorPort     = 18003
+	defaultLocalAlgoPort          = 18004
+	defaultLocalWorkerPort        = 18005
+	defaultLocalMilvusPort        = 19530
+	defaultLocalOpenSearchPort    = 19200
 	stateFileName                 = "runtime-state.json"
 	composeGeneratedFileName      = "process-compose.generated.yaml"
 	tokenFileName                 = "pc-token"
@@ -63,6 +79,12 @@ const (
 	localProxyProcessName         = "local-proxy"
 	authServiceProcessName        = "auth-service"
 	frontendProcessName           = "frontend"
+	docServerProcessName          = "lazyllm-doc-server"
+	processorServerProcessName    = "lazyllm-parse-server"
+	processorWorkerProcessName    = "lazyllm-parse-worker"
+	algoProcessName               = "lazyllm-algo"
+	chatProcessName               = "chat"
+	evoProcessName                = "evo-api"
 )
 
 type RuntimePaths struct {
@@ -83,12 +105,22 @@ type RuntimePaths struct {
 	AuthServiceVenvDir   string
 	AuthServiceStateDir  string
 	FrontendLog          string
+	DocServerLog         string
+	ProcessorServerLog   string
+	ProcessorWorkerLog   string
+	AlgoLog              string
+	ChatLog              string
+	EvoLog               string
 	LocalProxyBin        string
 	CaddyBin             string
 	LocalProxyConfig     string
 	LocalProxyStopScript string
 	CaddyConfig          string
 	GeneratedConfig      string
+	AlgorithmVenv        string
+	AlgorithmPython      string
+	AlgorithmHome        string
+	AlgorithmPIDDir      string
 }
 
 type RuntimeConfig struct {
@@ -100,6 +132,7 @@ type RuntimeConfig struct {
 	LocalProxy         LocalProxyConfig
 	AuthService        AuthServiceConfig
 	CaddyVersion       string
+	Algorithm          AlgorithmConfig
 }
 
 type LocalProxyConfig struct {
@@ -119,6 +152,19 @@ type AuthServiceConfig struct {
 	InstallDeps bool
 }
 
+type AlgorithmConfig struct {
+	PostgresPort   int
+	DocPort        int
+	ProcessorPort  int
+	AlgoPort       int
+	WorkerPort     int
+	ChatPort       int
+	EvoPort        int
+	MilvusPort     int
+	OpenSearchPort int
+	EnableEvo      bool
+}
+
 func defaultProfileValue() string {
 	if v := os.Getenv(defaultProfileEnvVar); v != "" {
 		return v
@@ -127,7 +173,91 @@ func defaultProfileValue() string {
 }
 
 func defaultProcessComposePortValue() int {
-	return envPort(processComposePortEnvVar, defaultProcessComposePort)
+	if strings.TrimSpace(os.Getenv(processComposePortEnvVar)) != "" {
+		return envPort(processComposePortEnvVar, defaultProcessComposePort)
+	}
+	return firstAvailableLocalPort(defaultProcessComposePort, 100)
+}
+
+func defaultLocalProxyPortValue() int {
+	if strings.TrimSpace(os.Getenv(localProxyPortEnvVar)) != "" {
+		return envPort(localProxyPortEnvVar, defaultLocalProxyPort)
+	}
+	return firstAvailableLocalPort(defaultLocalProxyPort, 100)
+}
+
+func firstAvailableLocalPort(start int, attempts int) int {
+	for port := start; port < start+attempts && port < 65536; port++ {
+		if localPortAvailable(port) {
+			return port
+		}
+	}
+	return start
+}
+
+type localPortAllocator struct {
+	used map[int]struct{}
+}
+
+func newLocalPortAllocator() *localPortAllocator {
+	return &localPortAllocator{used: map[int]struct{}{}}
+}
+
+func (a *localPortAllocator) reserve(port int) int {
+	if port > 0 && port < 65536 {
+		a.used[port] = struct{}{}
+	}
+	return port
+}
+
+func (a *localPortAllocator) envOrAvailable(envName string, fallback int) int {
+	if strings.TrimSpace(os.Getenv(envName)) != "" {
+		return a.reserve(envPort(envName, fallback))
+	}
+	return a.availableFrom(fallback, 500)
+}
+
+func (a *localPortAllocator) envOrAvailableDefaultCanMove(envName string, fallback int) int {
+	raw := strings.TrimSpace(os.Getenv(envName))
+	if raw == "" {
+		return a.availableFrom(fallback, 500)
+	}
+	port := envPort(envName, fallback)
+	if port != fallback || localPortAvailable(port) {
+		return a.reserve(port)
+	}
+	return a.availableFrom(fallback, 500)
+}
+
+func (a *localPortAllocator) firstEnvOrAvailable(envNames []string, fallback int) int {
+	for _, envName := range envNames {
+		if strings.TrimSpace(os.Getenv(envName)) != "" {
+			return a.reserve(envPort(envName, fallback))
+		}
+	}
+	return a.availableFrom(fallback, 500)
+}
+
+func (a *localPortAllocator) availableFrom(start int, attempts int) int {
+	for port := start; port < start+attempts && port < 65536; port++ {
+		if _, ok := a.used[port]; ok {
+			continue
+		}
+		if !localPortAvailable(port) {
+			continue
+		}
+		return a.reserve(port)
+	}
+	return a.reserve(start)
+}
+
+func localPortAvailable(port int) bool {
+	ln, err := net.Listen("tcp", net.JoinHostPort("127.0.0.1", strconv.Itoa(port)))
+	if err != nil {
+		return false
+	}
+	_ = ln.Close()
+	return true
 }
 
 func envPort(name string, fallback int) int {
@@ -182,12 +312,14 @@ func defaultLocalProxyAuthHostPortValue() int {
 	return defaultLocalProxyAuthHostPort
 }
 
-func defaultAuthServiceDatabaseURL() string {
+func authServiceDatabaseURL(postgresPort int) string {
 	if v := strings.TrimSpace(os.Getenv(authServiceDatabaseURLEnvVar)); v != "" {
 		return v
 	}
-	port := envPort(localPostgresPortEnvVar, defaultLocalPostgresPort)
-	return "postgresql+psycopg://root:123456@127.0.0.1:" + strconv.Itoa(port) + "/authservice"
+	if postgresPort <= 0 {
+		postgresPort = defaultLocalPostgresPort
+	}
+	return "postgresql+psycopg://root:123456@127.0.0.1:" + strconv.Itoa(postgresPort) + "/authservice"
 }
 
 func resolveRepoRoot(start string) (string, error) {
@@ -242,33 +374,71 @@ func NewRuntimeConfig(profile, repoRootHint string) (RuntimeConfig, RuntimePaths
 		AuthServiceVenvDir:   filepath.Join(runtimeRoot, "venvs", "auth-service"),
 		AuthServiceStateDir:  filepath.Join(runtimeRoot, "stores", "sqlite", "auth-state"),
 		FrontendLog:          filepath.Join(runtimeRoot, "logs", frontendLogFileName),
+		DocServerLog:         filepath.Join(runtimeRoot, "logs", docServerProcessName+".log"),
+		ProcessorServerLog:   filepath.Join(runtimeRoot, "logs", processorServerProcessName+".log"),
+		ProcessorWorkerLog:   filepath.Join(runtimeRoot, "logs", processorWorkerProcessName+".log"),
+		AlgoLog:              filepath.Join(runtimeRoot, "logs", algoProcessName+".log"),
+		ChatLog:              filepath.Join(runtimeRoot, "logs", chatProcessName+".log"),
+		EvoLog:               filepath.Join(runtimeRoot, "logs", evoProcessName+".log"),
 		LocalProxyBin:        filepath.Join(runtimeRoot, "bin", "local-proxy"),
 		CaddyBin:             filepath.Join(runtimeRoot, "bin", "caddy"),
 		LocalProxyConfig:     filepath.Join(root, localProxyConfigName),
 		LocalProxyStopScript: filepath.Join(root, localProxyScriptDirName, "stop.sh"),
 		CaddyConfig:          filepath.Join(runtimeRoot, "generated", "Caddyfile"),
 		GeneratedConfig:      filepath.Join(runtimeRoot, "generated", composeGeneratedFileName),
+		AlgorithmVenv:        filepath.Join(runtimeRoot, "python", ".venv"),
+		AlgorithmPython:      filepath.Join(runtimeRoot, "python", ".venv", "bin", "python"),
+		AlgorithmHome:        filepath.Join(runtimeRoot, "home"),
+		AlgorithmPIDDir:      filepath.Join(runtimeRoot, "run", "algorithm"),
 	}
+	ports := newLocalPortAllocator()
+	processComposePort := ports.envOrAvailable(processComposePortEnvVar, defaultProcessComposePort)
+	frontendPort := ports.envOrAvailableDefaultCanMove(frontendPortEnvVar, defaultFrontendPort)
+	localProxyPort := ports.envOrAvailable(localProxyPortEnvVar, defaultLocalProxyPort)
+	authHostPort := ports.envOrAvailable(localProxyAuthHostPortEnvVar, defaultLocalProxyAuthHostPort)
+	coreHostPort := ports.envOrAvailable(localProxyCoreHostPortEnvVar, defaultLocalProxyCoreHostPort)
+	scanHostPort := ports.envOrAvailable(localProxyScanHostPortEnvVar, defaultLocalProxyScanHostPort)
+	postgresPort := ports.envOrAvailable(localPostgresPortEnvVar, defaultLocalPostgresPort)
+	docPort := ports.envOrAvailable(localDocPortEnvVar, defaultLocalDocPort)
+	processorPort := ports.envOrAvailable(localProcessorPortEnvVar, defaultLocalProcessorPort)
+	algoPort := ports.envOrAvailable(localAlgoPortEnvVar, defaultLocalAlgoPort)
+	workerPort := ports.envOrAvailable(localWorkerPortEnvVar, defaultLocalWorkerPort)
+	milvusPort := ports.envOrAvailable(localMilvusPortEnvVar, defaultLocalMilvusPort)
+	openSearchPort := ports.envOrAvailable(localOpenSearchPortEnvVar, defaultLocalOpenSearchPort)
+	chatPort := ports.firstEnvOrAvailable([]string{localChatPortEnvVar, localProxyChatHostPortEnvVar}, defaultLocalProxyChatHostPort)
+	evoPort := ports.firstEnvOrAvailable([]string{localEvoPortEnvVar, localProxyEvoHostPortEnvVar}, defaultLocalProxyEvoHostPort)
 	return RuntimeConfig{
 		Profile:            profile,
 		RepoRoot:           p.RepoRoot,
 		RuntimeRoot:        runtimeRoot,
-		ProcessComposePort: defaultProcessComposePortValue(),
-		FrontendPort:       envPort(frontendPortEnvVar, defaultFrontendPort),
+		ProcessComposePort: processComposePort,
+		FrontendPort:       frontendPort,
 		CaddyVersion:       envText(caddyVersionEnvVar, defaultCaddyVersion),
 		LocalProxy: LocalProxyConfig{
 			Address:      envText(localProxyAddressEnvVar, defaultLocalProxyAddress),
-			Port:         envPort(localProxyPortEnvVar, defaultLocalProxyPort),
-			AuthHostPort: defaultLocalProxyAuthHostPortValue(),
-			CoreHostPort: envPort(localProxyCoreHostPortEnvVar, defaultLocalProxyCoreHostPort),
-			ChatHostPort: envPort(localProxyChatHostPortEnvVar, defaultLocalProxyChatHostPort),
-			ScanHostPort: envPort(localProxyScanHostPortEnvVar, defaultLocalProxyScanHostPort),
-			EvoHostPort:  envPort(localProxyEvoHostPortEnvVar, defaultLocalProxyEvoHostPort),
+			Port:         localProxyPort,
+			AuthHostPort: authHostPort,
+			CoreHostPort: coreHostPort,
+			ChatHostPort: chatPort,
+			ScanHostPort: scanHostPort,
+			EvoHostPort:  evoPort,
+		},
+		Algorithm: AlgorithmConfig{
+			PostgresPort:   postgresPort,
+			DocPort:        docPort,
+			ProcessorPort:  processorPort,
+			AlgoPort:       algoPort,
+			WorkerPort:     workerPort,
+			ChatPort:       chatPort,
+			EvoPort:        evoPort,
+			MilvusPort:     milvusPort,
+			OpenSearchPort: openSearchPort,
+			EnableEvo:      envBool(localEnableEvoEnvVar, false),
 		},
 		AuthService: AuthServiceConfig{
-			Port:        defaultAuthServicePortValue(),
+			Port:        authHostPort,
 			Python:      envText(authServicePythonEnvVar, "python3"),
-			DatabaseURL: defaultAuthServiceDatabaseURL(),
+			DatabaseURL: authServiceDatabaseURL(postgresPort),
 			InstallDeps: envBool(authServiceInstallDepsEnvVar, true),
 		},
 	}, p, nil
@@ -284,6 +454,9 @@ func (p RuntimePaths) EnsureAllDirs() error {
 		filepath.Dir(p.AuthServicePIDFile),
 		p.AuthServiceStateDir,
 		p.AuthServiceVenvDir,
+		filepath.Dir(p.AlgorithmVenv),
+		p.AlgorithmHome,
+		p.AlgorithmPIDDir,
 	}
 	for _, d := range dirs {
 		if err := os.MkdirAll(d, 0o755); err != nil {

--- a/local/local-runtime-manager/config.go
+++ b/local/local-runtime-manager/config.go
@@ -11,6 +11,7 @@ import (
 
 const (
 	defaultProfileEnvVar          = "LAZYMIND_LOCAL_PROFILE"
+	localPortsPinnedEnvVar        = "LAZYMIND_LOCAL_PORTS_PINNED"
 	processComposePortEnvVar      = "LAZYMIND_PROCESS_COMPOSE_PORT"
 	localUpTimeoutEnvVar          = "LAZYMIND_LOCAL_UP_TIMEOUT"
 	localDownTimeoutEnvVar        = "LAZYMIND_LOCAL_DOWN_TIMEOUT"
@@ -223,6 +224,9 @@ func (a *localPortAllocator) envOrAvailableDefaultCanMove(envName string, fallba
 		return a.availableFrom(fallback, 500)
 	}
 	port := envPort(envName, fallback)
+	if envBool(localPortsPinnedEnvVar, false) {
+		return a.reserve(port)
+	}
 	if port != fallback || localPortAvailable(port) {
 		return a.reserve(port)
 	}

--- a/local/local-runtime-manager/config.go
+++ b/local/local-runtime-manager/config.go
@@ -27,8 +27,11 @@ const (
 	authServiceDatabaseURLEnvVar  = "LAZYMIND_AUTH_SERVICE_DATABASE_URL"
 	authServiceInstallDepsEnvVar  = "LAZYMIND_AUTH_SERVICE_INSTALL_DEPS"
 	localPostgresPortEnvVar       = "LAZYMIND_LOCAL_POSTGRES_PORT"
+	caddyBinEnvVar                = "LAZYMIND_CADDY_BIN"
+	caddyVersionEnvVar            = "LAZYMIND_CADDY_VERSION"
 	defaultProfile                = "linux-browser"
-	processComposeVersion         = 1
+	processComposeVersion         = 2
+	defaultCaddyVersion           = "2.10.2"
 	defaultProcessComposePort     = 19080
 	defaultLocalUpTimeout         = 30 * 60
 	defaultLocalDownTimeout       = 2 * 60
@@ -48,6 +51,7 @@ const (
 	logFileName                   = "docker-stack.log"
 	localProxyLogFileName         = "local-proxy.log"
 	authServiceLogFileName        = "auth-service.log"
+	frontendLogFileName           = "frontend.log"
 	repoComposeFileName           = "docker-compose.yml"
 	localComposeOverrideName      = "local/docker-compose.local.yml"
 	localProcessComposeBin        = "local/bin/process-compose"
@@ -58,6 +62,7 @@ const (
 	processComposeServiceName     = "docker-stack"
 	localProxyProcessName         = "local-proxy"
 	authServiceProcessName        = "auth-service"
+	frontendProcessName           = "frontend"
 )
 
 type RuntimePaths struct {
@@ -77,9 +82,12 @@ type RuntimePaths struct {
 	AuthServicePIDFile   string
 	AuthServiceVenvDir   string
 	AuthServiceStateDir  string
+	FrontendLog          string
 	LocalProxyBin        string
+	CaddyBin             string
 	LocalProxyConfig     string
 	LocalProxyStopScript string
+	CaddyConfig          string
 	GeneratedConfig      string
 }
 
@@ -91,6 +99,7 @@ type RuntimeConfig struct {
 	FrontendPort       int
 	LocalProxy         LocalProxyConfig
 	AuthService        AuthServiceConfig
+	CaddyVersion       string
 }
 
 type LocalProxyConfig struct {
@@ -232,9 +241,12 @@ func NewRuntimeConfig(profile, repoRootHint string) (RuntimeConfig, RuntimePaths
 		AuthServicePIDFile:   filepath.Join(runtimeRoot, "run", "auth-service.pid"),
 		AuthServiceVenvDir:   filepath.Join(runtimeRoot, "venvs", "auth-service"),
 		AuthServiceStateDir:  filepath.Join(runtimeRoot, "stores", "sqlite", "auth-state"),
+		FrontendLog:          filepath.Join(runtimeRoot, "logs", frontendLogFileName),
 		LocalProxyBin:        filepath.Join(runtimeRoot, "bin", "local-proxy"),
+		CaddyBin:             filepath.Join(runtimeRoot, "bin", "caddy"),
 		LocalProxyConfig:     filepath.Join(root, localProxyConfigName),
 		LocalProxyStopScript: filepath.Join(root, localProxyScriptDirName, "stop.sh"),
+		CaddyConfig:          filepath.Join(runtimeRoot, "generated", "Caddyfile"),
 		GeneratedConfig:      filepath.Join(runtimeRoot, "generated", composeGeneratedFileName),
 	}
 	return RuntimeConfig{
@@ -243,6 +255,7 @@ func NewRuntimeConfig(profile, repoRootHint string) (RuntimeConfig, RuntimePaths
 		RuntimeRoot:        runtimeRoot,
 		ProcessComposePort: defaultProcessComposePortValue(),
 		FrontendPort:       envPort(frontendPortEnvVar, defaultFrontendPort),
+		CaddyVersion:       envText(caddyVersionEnvVar, defaultCaddyVersion),
 		LocalProxy: LocalProxyConfig{
 			Address:      envText(localProxyAddressEnvVar, defaultLocalProxyAddress),
 			Port:         envPort(localProxyPortEnvVar, defaultLocalProxyPort),

--- a/local/local-runtime-manager/frontend.go
+++ b/local/local-runtime-manager/frontend.go
@@ -1,0 +1,218 @@
+package main
+
+import (
+	"archive/tar"
+	"compress/gzip"
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"strings"
+)
+
+type FrontendManager struct {
+	runner CommandRunner
+}
+
+func NewFrontendManager(r CommandRunner) *FrontendManager {
+	return &FrontendManager{runner: r}
+}
+
+func (m *FrontendManager) Run(ctx context.Context, cfg RuntimeConfig, paths RuntimePaths) error {
+	if err := paths.EnsureAllDirs(); err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(paths.CaddyBin), 0o755); err != nil {
+		return err
+	}
+
+	frontendDir := filepath.Join(paths.RepoRoot, "frontend")
+	install := Command{Name: "pnpm", Args: []string{"install", "--frozen-lockfile"}, Dir: frontendDir}
+	if res, err := m.runner.Run(ctx, install); err != nil {
+		return fmt.Errorf("frontend dependency install failed: %w (%s)", err, strings.TrimSpace(res.Stderr))
+	}
+
+	build := Command{
+		Name: "pnpm",
+		Args: []string{"build"},
+		Dir:  frontendDir,
+		Env:  frontendBuildEnv(),
+	}
+	if res, err := m.runner.Run(ctx, build); err != nil {
+		return fmt.Errorf("frontend build failed: %w (%s)", err, strings.TrimSpace(res.Stderr))
+	}
+
+	if err := writeCaddyfile(paths, cfg); err != nil {
+		return err
+	}
+	caddyBin, err := m.ensureCaddy(ctx, cfg, paths)
+	if err != nil {
+		return err
+	}
+
+	run := Command{
+		Name: caddyBin,
+		Args: []string{"run", "--config", paths.CaddyConfig, "--adapter", "caddyfile"},
+		Dir:  paths.RepoRoot,
+	}
+	if res, err := m.runner.Run(ctx, run); err != nil {
+		return fmt.Errorf("frontend caddy exited: %w (%s)", err, strings.TrimSpace(res.Stderr))
+	}
+	return nil
+}
+
+func (m *FrontendManager) Down(ctx context.Context, cfg RuntimeConfig, paths RuntimePaths) error {
+	if err := paths.EnsureAllDirs(); err != nil {
+		return err
+	}
+	script := `
+port="$1"
+config="$2"
+if command -v lsof >/dev/null 2>&1; then
+  for pid in $(lsof -t -nP -iTCP:"$port" -sTCP:LISTEN 2>/dev/null | sort -u); do
+    cmd="$(ps -p "$pid" -o command= 2>/dev/null || true)"
+    case "$cmd" in
+      *caddy*"$config"*|*caddy*)
+        echo "Stopping frontend Caddy on :$port ($pid)..."
+        kill "$pid" 2>/dev/null || true
+        ;;
+    esac
+  done
+fi
+exit 0
+`
+	res, err := m.runner.Run(ctx, Command{
+		Name: "sh",
+		Args: []string{"-c", script, "frontend-down", strconv.Itoa(cfg.FrontendPort), paths.CaddyConfig},
+		Dir:  paths.RepoRoot,
+	})
+	if err != nil {
+		return fmt.Errorf("stop frontend failed: %w (%s)", err, strings.TrimSpace(res.Stderr))
+	}
+	return nil
+}
+
+func frontendBuildEnv() []string {
+	mode := strings.TrimSpace(os.Getenv("VITE_LAZYMIND_MODE"))
+	if mode == "" {
+		mode = "local"
+	}
+	return []string{"VITE_LAZYMIND_MODE=" + mode}
+}
+
+func writeCaddyfile(paths RuntimePaths, cfg RuntimeConfig) error {
+	distRoot := filepath.Join(paths.RepoRoot, "frontend", "dist")
+	proxy := "http://127.0.0.1:" + strconv.Itoa(cfg.LocalProxy.Port)
+	content := fmt.Sprintf(`{
+	admin off
+	auto_https off
+}
+
+http://localhost:%d, http://127.0.0.1:%d {
+	bind 127.0.0.1
+	root * %s
+	encode gzip
+
+	handle /api/* {
+		reverse_proxy %s {
+			flush_interval -1
+		}
+	}
+
+	handle /api-docs/* {
+		reverse_proxy %s {
+			flush_interval -1
+		}
+	}
+
+	handle {
+		try_files {path} /index.html
+		file_server
+	}
+}
+`, cfg.FrontendPort, cfg.FrontendPort, strconv.Quote(distRoot), proxy, proxy)
+	return os.WriteFile(paths.CaddyConfig, []byte(content), 0o644)
+}
+
+func (m *FrontendManager) ensureCaddy(ctx context.Context, cfg RuntimeConfig, paths RuntimePaths) (string, error) {
+	if explicit := strings.TrimSpace(os.Getenv(caddyBinEnvVar)); explicit != "" {
+		return explicit, nil
+	}
+	if info, err := os.Stat(paths.CaddyBin); err == nil && !info.IsDir() {
+		return paths.CaddyBin, nil
+	}
+	if runtime.GOOS != "linux" {
+		return "", fmt.Errorf("automatic Caddy download is only supported on linux in this local profile; set %s", caddyBinEnvVar)
+	}
+	switch runtime.GOARCH {
+	case "amd64", "arm64":
+	default:
+		return "", fmt.Errorf("automatic Caddy download does not support %s/%s; set %s", runtime.GOOS, runtime.GOARCH, caddyBinEnvVar)
+	}
+	if err := downloadCaddy(ctx, cfg.CaddyVersion, runtime.GOOS, runtime.GOARCH, paths.CaddyBin); err != nil {
+		return "", err
+	}
+	return paths.CaddyBin, nil
+}
+
+func caddyArchiveURL(version, goos, goarch string) string {
+	return fmt.Sprintf("https://github.com/caddyserver/caddy/releases/download/v%s/caddy_%s_%s_%s.tar.gz", version, version, goos, goarch)
+}
+
+func downloadCaddy(ctx context.Context, version, goos, goarch, dest string) error {
+	url := caddyArchiveURL(version, goos, goarch)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return err
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("download Caddy %s failed: %w", version, err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("download Caddy %s failed: HTTP %d from %s", version, resp.StatusCode, url)
+	}
+
+	gzr, err := gzip.NewReader(resp.Body)
+	if err != nil {
+		return fmt.Errorf("read Caddy archive: %w", err)
+	}
+	defer gzr.Close()
+
+	tr := tar.NewReader(gzr)
+	tmp := dest + ".tmp"
+	defer os.Remove(tmp)
+	for {
+		hdr, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return fmt.Errorf("extract Caddy archive: %w", err)
+		}
+		if filepath.Base(hdr.Name) != "caddy" || hdr.FileInfo().IsDir() {
+			continue
+		}
+		out, err := os.OpenFile(tmp, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o755)
+		if err != nil {
+			return err
+		}
+		if _, err := io.Copy(out, tr); err != nil {
+			_ = out.Close()
+			return fmt.Errorf("write Caddy binary: %w", err)
+		}
+		if err := out.Close(); err != nil {
+			return err
+		}
+		if err := os.Rename(tmp, dest); err != nil {
+			return err
+		}
+		return os.Chmod(dest, 0o755)
+	}
+	return fmt.Errorf("Caddy archive did not contain caddy binary")
+}

--- a/local/local-runtime-manager/frontend.go
+++ b/local/local-runtime-manager/frontend.go
@@ -101,11 +101,17 @@ func frontendBuildEnv() []string {
 	if mode == "" {
 		mode = "local"
 	}
-	return []string{"VITE_LAZYMIND_MODE=" + mode}
+	env := []string{"VITE_LAZYMIND_MODE=" + mode}
+	for _, key := range []string{"VITE_HIDE_EVO", "VITE_API_BASE_URL", "VITE_APP_LOGO", "VITE_APP_CHAT_TITLE"} {
+		if value := strings.TrimSpace(os.Getenv(key)); value != "" {
+			env = append(env, key+"="+value)
+		}
+	}
+	return env
 }
 
 func writeCaddyfile(paths RuntimePaths, cfg RuntimeConfig) error {
-	distRoot := filepath.Join(paths.RepoRoot, "frontend", "dist")
+	distRoot := filepath.ToSlash(filepath.Join(paths.RepoRoot, "frontend", "dist"))
 	proxy := "http://127.0.0.1:" + strconv.Itoa(cfg.LocalProxy.Port)
 	content := fmt.Sprintf(`{
 	admin off

--- a/local/local-runtime-manager/local_proxy.go
+++ b/local/local-runtime-manager/local_proxy.go
@@ -66,7 +66,19 @@ func (m *LocalProxyManager) Down(ctx context.Context, cfg RuntimeConfig, paths R
 }
 
 func localProxyEnv(cfg RuntimeConfig, paths RuntimePaths) []string {
+	env := append([]string{}, localRuntimeEnv(cfg)...)
+	env = append(env,
+		"LAZYMIND_LOCAL_PROXY_BASE_ROOT="+filepath.Join(paths.RuntimeRoot, "local-proxy"),
+		"LAZYMIND_LOCAL_PROXY_BIN="+paths.LocalProxyBin,
+		"LAZYMIND_LOCAL_PROXY_CONFIG="+paths.LocalProxyConfig,
+		"LAZYMIND_LOCAL_PROXY_LOG_FILE="+paths.LocalProxyLog,
+	)
+	return env
+}
+
+func localRuntimeEnv(cfg RuntimeConfig) []string {
 	return []string{
+		processComposePortEnvVar + "=" + strconv.Itoa(cfg.ProcessComposePort),
 		frontendPortEnvVar + "=" + strconv.Itoa(cfg.FrontendPort),
 		localProxyAddressEnvVar + "=" + cfg.LocalProxy.Address,
 		localProxyPortEnvVar + "=" + strconv.Itoa(cfg.LocalProxy.Port),
@@ -75,9 +87,5 @@ func localProxyEnv(cfg RuntimeConfig, paths RuntimePaths) []string {
 		localProxyChatHostPortEnvVar + "=" + strconv.Itoa(cfg.LocalProxy.ChatHostPort),
 		localProxyScanHostPortEnvVar + "=" + strconv.Itoa(cfg.LocalProxy.ScanHostPort),
 		localProxyEvoHostPortEnvVar + "=" + strconv.Itoa(cfg.LocalProxy.EvoHostPort),
-		"LAZYMIND_LOCAL_PROXY_BASE_ROOT=" + filepath.Join(paths.RuntimeRoot, "local-proxy"),
-		"LAZYMIND_LOCAL_PROXY_BIN=" + paths.LocalProxyBin,
-		"LAZYMIND_LOCAL_PROXY_CONFIG=" + paths.LocalProxyConfig,
-		"LAZYMIND_LOCAL_PROXY_LOG_FILE=" + paths.LocalProxyLog,
 	}
 }

--- a/local/local-runtime-manager/main.go
+++ b/local/local-runtime-manager/main.go
@@ -128,6 +128,10 @@ func (c *CLI) runInternal(ctx context.Context, manager *RuntimeManager, args []s
 		return manager.authService.Run(ctx, cfg, paths)
 	case "auth-service-down":
 		return manager.authService.Down(ctx, cfg, paths)
+	case "frontend-run":
+		return manager.frontend.Run(ctx, cfg, paths)
+	case "frontend-down":
+		return manager.frontend.Down(ctx, cfg, paths)
 	default:
 		return fmt.Errorf("unknown internal command: %s", sub)
 	}
@@ -167,5 +171,5 @@ func (c *CLI) usage() {
 	_, _ = io.WriteString(c.out, "  lazymind-local up --profile <profile>\n")
 	_, _ = io.WriteString(c.out, "  lazymind-local down --profile <profile>\n")
 	_, _ = io.WriteString(c.out, "  lazymind-local status --json\n")
-	_, _ = io.WriteString(c.out, "  lazymind-local internal compose-up|compose-down|compose-services|local-proxy-run|local-proxy-down|auth-service-run|auth-service-down --profile <profile>\n")
+	_, _ = io.WriteString(c.out, "  lazymind-local internal compose-up|compose-down|compose-services|local-proxy-run|local-proxy-down|auth-service-run|auth-service-down|frontend-run|frontend-down --profile <profile>\n")
 }

--- a/local/local-runtime-manager/main.go
+++ b/local/local-runtime-manager/main.go
@@ -97,6 +97,20 @@ func (c *CLI) runInternal(ctx context.Context, manager *RuntimeManager, args []s
 
 	sub := args[0]
 	subArgs := args[1:]
+	if sub == "algorithm-run" || sub == "algorithm-down" {
+		service, profile, repoRoot, err := parseAlgorithmInternalArgs(sub, subArgs, c.errOut)
+		if err != nil {
+			return err
+		}
+		cfg, paths, err := NewRuntimeConfig(profile, repoRoot)
+		if err != nil {
+			return err
+		}
+		if sub == "algorithm-run" {
+			return manager.algorithm.Run(ctx, cfg, paths, service)
+		}
+		return manager.algorithm.Down(ctx, paths, service)
+	}
 	profile, repoRoot, err := parseCommonArgs("internal", subArgs, c.errOut)
 	if err != nil {
 		return err
@@ -108,7 +122,7 @@ func (c *CLI) runInternal(ctx context.Context, manager *RuntimeManager, args []s
 
 	switch sub {
 	case "compose-up":
-		return manager.compose.ComposeUp(ctx, paths.RepoRoot, cfg.Profile)
+		return manager.compose.ComposeUp(ctx, cfg, paths)
 	case "compose-down":
 		return manager.compose.ComposeDown(ctx, paths.RepoRoot, cfg.Profile)
 	case "compose-services":
@@ -135,6 +149,24 @@ func (c *CLI) runInternal(ctx context.Context, manager *RuntimeManager, args []s
 	default:
 		return fmt.Errorf("unknown internal command: %s", sub)
 	}
+}
+
+func parseAlgorithmInternalArgs(name string, args []string, out io.Writer) (string, string, string, error) {
+	fs := flag.NewFlagSet(name, flag.ContinueOnError)
+	fs.SetOutput(out)
+	service := fs.String("service", "", "")
+	profile := fs.String("profile", defaultProfileValue(), "")
+	repoRoot := fs.String("repo-root", "", "")
+	if err := fs.Parse(args); err != nil {
+		return "", "", "", err
+	}
+	if len(fs.Args()) != 0 {
+		return "", "", "", fmt.Errorf("unexpected positional args: %v", fs.Args())
+	}
+	if *service == "" {
+		return "", "", "", fmt.Errorf("--service is required")
+	}
+	return *service, *profile, *repoRoot, nil
 }
 
 func parseCommonArgs(name string, args []string, out io.Writer) (string, string, error) {
@@ -171,5 +203,5 @@ func (c *CLI) usage() {
 	_, _ = io.WriteString(c.out, "  lazymind-local up --profile <profile>\n")
 	_, _ = io.WriteString(c.out, "  lazymind-local down --profile <profile>\n")
 	_, _ = io.WriteString(c.out, "  lazymind-local status --json\n")
-	_, _ = io.WriteString(c.out, "  lazymind-local internal compose-up|compose-down|compose-services|local-proxy-run|local-proxy-down|auth-service-run|auth-service-down|frontend-run|frontend-down --profile <profile>\n")
+	_, _ = io.WriteString(c.out, "  lazymind-local internal compose-up|compose-down|compose-services|local-proxy-run|local-proxy-down|auth-service-run|auth-service-down|frontend-run|frontend-down|algorithm-run|algorithm-down --profile <profile>\n")
 }

--- a/local/local-runtime-manager/manager.go
+++ b/local/local-runtime-manager/manager.go
@@ -7,9 +7,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"net"
-	"net/http"
 	"os"
+	"regexp"
 	"strconv"
 	"strings"
 	"syscall"
@@ -24,7 +23,8 @@ type RuntimeManager struct {
 	errOut         io.Writer
 	probeAPI       func(port int, timeout time.Duration) bool
 	probeAuth      func(port int, timeout time.Duration) bool
-	portAvailable  func(port int) bool
+	waitHostReady  func(context.Context, RuntimeConfig) error
+	runtimeReady   func(context.Context, RuntimeConfig, RuntimePaths) bool
 	pollInterval   time.Duration
 	upTimeout      time.Duration
 	downTimeout    time.Duration
@@ -33,7 +33,7 @@ type RuntimeManager struct {
 	localProxy     *LocalProxyManager
 	authService    *AuthServiceManager
 	frontend       *FrontendManager
-	probeURL       func(url string, timeout time.Duration) bool
+	algorithm      *AlgorithmServiceManager
 }
 
 func NewRuntimeManager(r CommandRunner, execPath string) *RuntimeManager {
@@ -46,7 +46,8 @@ func NewRuntimeManager(r CommandRunner, execPath string) *RuntimeManager {
 		errOut:         io.Discard,
 		probeAPI:       processCompose.ProbeAPI,
 		probeAuth:      authServiceHealthAlive,
-		portAvailable:  isLoopbackPortAvailable,
+		waitHostReady:  waitForHostAlgorithmReadiness,
+		runtimeReady:   nil,
 		pollInterval:   2 * time.Second,
 		upTimeout:      envDuration(localUpTimeoutEnvVar, time.Duration(defaultLocalUpTimeout)*time.Second),
 		downTimeout:    envDuration(localDownTimeoutEnvVar, time.Duration(defaultLocalDownTimeout)*time.Second),
@@ -55,7 +56,7 @@ func NewRuntimeManager(r CommandRunner, execPath string) *RuntimeManager {
 		localProxy:     NewLocalProxyManager(r),
 		authService:    NewAuthServiceManager(r),
 		frontend:       NewFrontendManager(r),
-		probeURL:       probeHTTPStatusOK,
+		algorithm:      NewAlgorithmServiceManager(r),
 	}
 }
 
@@ -79,6 +80,7 @@ func randomHexToken() (string, error) {
 }
 
 func (m *RuntimeManager) Up(ctx context.Context, cfg RuntimeConfig, paths RuntimePaths) error {
+	freshCfg := cfg
 	if err := paths.EnsureAllDirs(); err != nil {
 		return err
 	}
@@ -89,8 +91,12 @@ func (m *RuntimeManager) Up(ctx context.Context, cfg RuntimeConfig, paths Runtim
 	if err != nil {
 		return err
 	}
-	if m.isExistingRuntimeRunning(ctx, state, paths) {
+	stateCfg := applyStateConfig(freshCfg, state)
+	if m.isExistingRuntimeRunning(ctx, state, stateCfg, paths) {
 		return m.reportExistingRuntime(ctx, state, paths)
+	}
+	if err := m.stopStaleRuntimeIfNeeded(ctx, state, stateCfg, paths); err != nil {
+		return err
 	}
 
 	releaseLock, err := acquireUpLock(paths)
@@ -103,22 +109,14 @@ func (m *RuntimeManager) Up(ctx context.Context, cfg RuntimeConfig, paths Runtim
 	if err != nil {
 		return err
 	}
-	if m.isExistingRuntimeRunning(ctx, state, paths) {
+	stateCfg = applyStateConfig(freshCfg, state)
+	if m.isExistingRuntimeRunning(ctx, state, stateCfg, paths) {
 		return m.reportExistingRuntime(ctx, state, paths)
 	}
-	if err := m.stopStaleRuntimeIfNeeded(ctx, cfg, paths, state); err != nil {
+	if err := m.stopStaleRuntimeIfNeeded(ctx, state, stateCfg, paths); err != nil {
 		return err
 	}
-	if os.Getenv(processComposePortEnvVar) == "" {
-		port, err := m.selectAvailableProcessComposePort(cfg.ProcessComposePort)
-		if err != nil {
-			return err
-		}
-		cfg.ProcessComposePort = port
-	}
-	if err := m.selectAvailableLocalPorts(&cfg); err != nil {
-		return err
-	}
+	cfg = freshCfg
 
 	token, err := randomHexToken()
 	if err != nil {
@@ -132,18 +130,7 @@ func (m *RuntimeManager) Up(ctx context.Context, cfg RuntimeConfig, paths Runtim
 	if err != nil {
 		return err
 	}
-	if err := m.processCompose.WriteGeneratedConfig(
-		generatedFile,
-		paths.RepoRoot,
-		cfg.Profile,
-		paths.LogFilePath,
-		paths.LocalProxyLog,
-		paths.AuthServiceLog,
-		paths.FrontendLog,
-		paths.RunDirTokenFile,
-		cfg.ProcessComposePort,
-		localRuntimeEnv(cfg),
-	); err != nil {
+	if err := m.processCompose.WriteGeneratedConfig(generatedFile, paths.RepoRoot, cfg.Profile, paths, cfg, paths.RunDirTokenFile, cfg.ProcessComposePort); err != nil {
 		_ = generatedFile.Close()
 		return err
 	}
@@ -154,10 +141,10 @@ func (m *RuntimeManager) Up(ctx context.Context, cfg RuntimeConfig, paths Runtim
 	state.Profile = cfg.Profile
 	state.RepoRoot = cfg.RepoRoot
 	state.RuntimeRoot = cfg.RuntimeRoot
-	state.Version = processComposeVersion
 	state.ProcessCompose.APIPort = cfg.ProcessComposePort
 	state.ProcessCompose.APIRoot = "http://127.0.0.1:" + strconv.Itoa(cfg.ProcessComposePort)
 	state.ProcessCompose.TokenFile = paths.RunDirTokenFile
+	state.Config = snapshotRuntimeConfig(cfg)
 	state = newStateWithServiceStatus(state, "starting")
 	if err := writeRuntimeState(paths.StateFile, state); err != nil {
 		return err
@@ -204,11 +191,17 @@ func (m *RuntimeManager) Up(ctx context.Context, cfg RuntimeConfig, paths Runtim
 		}
 		return waitErr
 	}
-	if err := m.waitForHostProcessesReady(ctx, cfg, paths); err != nil {
+	if err := m.waitForAuthServiceHealthy(ctx, cfg.AuthService.Port, m.upTimeout, paths.AuthServicePIDFile); err != nil {
 		state = newStateWithServiceStatus(state, "failed")
 		state.OverallStatus = "failed"
 		_ = writeRuntimeState(paths.StateFile, state)
 		return err
+	}
+	if waitErr := m.waitHostReady(ctx, cfg); waitErr != nil {
+		state = newStateWithServiceStatus(state, "failed")
+		state.OverallStatus = "failed"
+		_ = writeRuntimeState(paths.StateFile, state)
+		return waitErr
 	}
 
 	state = newStateWithServiceStatus(state, "running")
@@ -221,6 +214,35 @@ func (m *RuntimeManager) Up(ctx context.Context, cfg RuntimeConfig, paths Runtim
 	return nil
 }
 
+func (m *RuntimeManager) waitForAuthServiceHealthy(ctx context.Context, port int, timeout time.Duration, pidFile string) error {
+	deadline := time.NewTimer(timeout)
+	defer deadline.Stop()
+	ticker := time.NewTicker(500 * time.Millisecond)
+	defer ticker.Stop()
+	sawPIDFile := false
+	for {
+		if m.probeAuth(port, time.Second) {
+			return nil
+		}
+		alive, err := upLockProcessAlive(pidFile)
+		if err == nil {
+			sawPIDFile = true
+			if !alive {
+				return fmt.Errorf("auth-service process exited before becoming healthy")
+			}
+		} else if sawPIDFile && os.IsNotExist(err) {
+			return fmt.Errorf("auth-service process exited before becoming healthy")
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-deadline.C:
+			return fmt.Errorf("auth-service health check timed out on port %d", port)
+		case <-ticker.C:
+		}
+	}
+}
+
 func (m *RuntimeManager) Down(ctx context.Context, cfg RuntimeConfig, paths RuntimePaths) error {
 	if err := paths.EnsureAllDirs(); err != nil {
 		return err
@@ -229,24 +251,26 @@ func (m *RuntimeManager) Down(ctx context.Context, cfg RuntimeConfig, paths Runt
 	if err != nil {
 		return err
 	}
+	cfg = applyStateConfig(cfg, state)
 	if state.ProcessCompose.APIPort > 0 {
 		cfg.ProcessComposePort = state.ProcessCompose.APIPort
 	}
 	var downErr error
 	apiAlive := m.probeAPI(cfg.ProcessComposePort, 500*time.Millisecond)
 	if apiAlive {
-		downErr = m.processCompose.Down(ctx, cfg, paths)
+		downCtx, cancel := context.WithTimeout(ctx, m.downTimeout)
+		defer cancel()
+		downErr = m.processCompose.Down(downCtx, cfg, paths)
 	}
 	if downErr != nil || !apiAlive {
-		var hostDownErr error
-		if err := m.frontend.Down(ctx, cfg, paths); err != nil {
-			hostDownErr = err
+		if downErr != nil {
+			_ = m.killStaleRuntimeProcesses(context.Background(), paths.RepoRoot)
 		}
-		if err := m.localProxy.Down(ctx, cfg, paths); err != nil && hostDownErr == nil {
-			hostDownErr = err
+		if err := m.frontend.Down(ctx, cfg, paths); err != nil && downErr == nil {
+			downErr = err
 		}
-		if err := m.authService.Down(ctx, cfg, paths); err != nil && hostDownErr == nil {
-			hostDownErr = err
+		if err := m.localProxy.Down(ctx, cfg, paths); err != nil && downErr == nil {
+			downErr = err
 		}
 		if fallbackErr := m.compose.ComposeDown(ctx, paths.RepoRoot, cfg.Profile); fallbackErr != nil {
 			state = newStateWithServiceStatus(state, "failed")
@@ -255,17 +279,23 @@ func (m *RuntimeManager) Down(ctx context.Context, cfg RuntimeConfig, paths Runt
 			if downErr != nil {
 				return fmt.Errorf("process-compose down failed: %w; docker compose down fallback failed: %v", downErr, fallbackErr)
 			}
-			if hostDownErr != nil {
-				return fmt.Errorf("host process down failed: %w; docker compose down fallback failed: %v", hostDownErr, fallbackErr)
-			}
 			return fallbackErr
 		}
-		if hostDownErr != nil {
-			state = newStateWithServiceStatus(state, "failed")
-			state.OverallStatus = "failed"
-			_ = writeRuntimeState(paths.StateFile, state)
-			return hostDownErr
+		downErr = nil
+	}
+	for _, spec := range algorithmProcessSpecs(cfg.Algorithm) {
+		if err := m.algorithm.Down(ctx, paths, spec.Name); err != nil && downErr == nil {
+			downErr = err
 		}
+	}
+	if downErr != nil {
+		state = newStateWithServiceStatus(state, "failed")
+		state.OverallStatus = "failed"
+		_ = writeRuntimeState(paths.StateFile, state)
+		return downErr
+	}
+	if err := m.authService.Down(ctx, cfg, paths); err != nil {
+		return err
 	}
 	if err := m.waitForRuntimeStopped(ctx, cfg, paths); err != nil {
 		if ps, psErr := m.compose.ComposePS(context.Background(), paths.RepoRoot); psErr == nil && strings.TrimSpace(ps) != "" {
@@ -286,49 +316,73 @@ func (m *RuntimeManager) Down(ctx context.Context, cfg RuntimeConfig, paths Runt
 	return nil
 }
 
-func (m *RuntimeManager) isExistingRuntimeRunning(ctx context.Context, state RuntimeState, paths RuntimePaths) bool {
-	if !stateClaimsRuntimeActive(state) || state.Version != processComposeVersion || state.ProcessCompose.APIPort <= 0 {
-		return false
-	}
-	if !m.probeAPI(state.ProcessCompose.APIPort, 500*time.Millisecond) {
-		return false
-	}
-	cfg := RuntimeConfig{ProcessComposePort: state.ProcessCompose.APIPort}
-	statuses, err := m.processCompose.List(ctx, cfg, paths)
-	if err != nil {
-		return false
-	}
-	readiness, _ := classifyHostProcessReadiness(statuses)
-	if readiness != composeReadinessReady {
-		return false
-	}
-	composeStatuses, err := m.compose.ComposeStatus(ctx, paths.RepoRoot)
-	if err != nil {
-		return false
-	}
-	composeReadiness, _ := classifyComposeReadiness(composeStatuses)
-	return composeReadiness == composeReadinessReady
+func (m *RuntimeManager) isExistingRuntimeRunning(ctx context.Context, state RuntimeState, cfg RuntimeConfig, paths RuntimePaths) bool {
+	return claimsRuntimeRunning(state) && state.ProcessCompose.APIPort > 0 &&
+		m.probeAPI(state.ProcessCompose.APIPort, 500*time.Millisecond) &&
+		m.checkRuntimeReady(ctx, cfg, paths)
 }
 
-func (m *RuntimeManager) stopStaleRuntimeIfNeeded(ctx context.Context, cfg RuntimeConfig, paths RuntimePaths, state RuntimeState) error {
-	if !stateClaimsRuntimeActive(state) {
+func (m *RuntimeManager) stopStaleRuntimeIfNeeded(ctx context.Context, state RuntimeState, cfg RuntimeConfig, paths RuntimePaths) error {
+	if !claimsRuntimeRunning(state) {
 		return nil
 	}
 	if state.ProcessCompose.APIPort <= 0 || !m.probeAPI(state.ProcessCompose.APIPort, 500*time.Millisecond) {
 		return nil
 	}
+	if m.checkRuntimeReady(ctx, cfg, paths) {
+		return nil
+	}
 	staleCfg := cfg
 	staleCfg.ProcessComposePort = state.ProcessCompose.APIPort
-	if err := m.processCompose.Down(ctx, staleCfg, paths); err != nil {
-		return fmt.Errorf("stop stale local runtime failed: %w", err)
-	}
-	if err := m.waitForRuntimeStopped(ctx, staleCfg, paths); err != nil {
-		return fmt.Errorf("wait for stale local runtime to stop failed: %w", err)
+	downCtx, cancel := context.WithTimeout(ctx, 20*time.Second)
+	defer cancel()
+	err := m.processCompose.Down(downCtx, staleCfg, paths)
+	if err != nil {
+		_ = m.killStaleRuntimeProcesses(context.Background(), paths.RepoRoot)
 	}
 	return nil
 }
 
-func stateClaimsRuntimeActive(state RuntimeState) bool {
+func (m *RuntimeManager) killStaleRuntimeProcesses(ctx context.Context, repoRoot string) error {
+	pattern := regexp.QuoteMeta(repoRoot) + "/(local/bin/process-compose|\\.lazymind-local/bin/local-proxy|\\.lazymind-local/python/\\.venv/bin/python|\\.lazymind-local/venvs/auth-service/bin/python|local/local-runtime-manager/lazymind-local internal)"
+	_, err := m.runner.Run(ctx, Command{Name: "pkill", Args: []string{"-f", pattern}, Dir: repoRoot})
+	if err != nil {
+		return nil
+	}
+	time.Sleep(time.Second)
+	return nil
+}
+
+func (m *RuntimeManager) checkRuntimeReady(ctx context.Context, cfg RuntimeConfig, paths RuntimePaths) bool {
+	if m.runtimeReady != nil {
+		return m.runtimeReady(ctx, cfg, paths)
+	}
+	statuses, err := m.compose.ComposeStatus(ctx, paths.RepoRoot)
+	if err != nil {
+		return false
+	}
+	state, _ := classifyComposeReadiness(statuses)
+	if state != composeReadinessReady {
+		return false
+	}
+	if !httpOK(ctx, fmt.Sprintf("http://127.0.0.1:%d/_local/healthz", cfg.LocalProxy.Port), 500*time.Millisecond) {
+		return false
+	}
+	if !httpOK(ctx, fmt.Sprintf("http://127.0.0.1:%d/", cfg.FrontendPort), 500*time.Millisecond) {
+		return false
+	}
+	if !m.probeAuth(cfg.AuthService.Port, 500*time.Millisecond) {
+		return false
+	}
+	for _, spec := range algorithmProcessSpecs(cfg.Algorithm) {
+		if !httpOK(ctx, fmt.Sprintf("http://127.0.0.1:%d%s", spec.Port, spec.HealthPath), 500*time.Millisecond) {
+			return false
+		}
+	}
+	return true
+}
+
+func claimsRuntimeRunning(state RuntimeState) bool {
 	svc := state.Services[processComposeServiceName]
 	return state.OverallStatus == "ready" || state.OverallStatus == "running" || state.OverallStatus == "starting" ||
 		svc.Status == "running" || svc.Status == "starting"
@@ -366,92 +420,6 @@ func (m *RuntimeManager) waitForProcessComposeAPI(ctx context.Context, port int,
 		case <-time.After(250 * time.Millisecond):
 		}
 	}
-}
-
-func (m *RuntimeManager) selectAvailableProcessComposePort(preferred int) (int, error) {
-	if preferred <= 0 {
-		preferred = defaultProcessComposePort
-	}
-	return m.selectAvailablePort(preferred, map[int]struct{}{})
-}
-
-func (m *RuntimeManager) selectAvailableLocalPorts(cfg *RuntimeConfig) error {
-	reserved := map[int]struct{}{cfg.ProcessComposePort: {}}
-	var err error
-	if os.Getenv(frontendPortEnvVar) == "" {
-		cfg.FrontendPort, err = m.selectAvailablePort(cfg.FrontendPort, reserved)
-		if err != nil {
-			return fmt.Errorf("select frontend port: %w", err)
-		}
-		reserved[cfg.FrontendPort] = struct{}{}
-	}
-	if os.Getenv(localProxyPortEnvVar) == "" {
-		cfg.LocalProxy.Port, err = m.selectAvailablePort(cfg.LocalProxy.Port, reserved)
-		if err != nil {
-			return fmt.Errorf("select local proxy port: %w", err)
-		}
-		reserved[cfg.LocalProxy.Port] = struct{}{}
-	}
-	if os.Getenv(localProxyAuthHostPortEnvVar) == "" {
-		cfg.LocalProxy.AuthHostPort, err = m.selectAvailablePort(cfg.LocalProxy.AuthHostPort, reserved)
-		if err != nil {
-			return fmt.Errorf("select auth host port: %w", err)
-		}
-		reserved[cfg.LocalProxy.AuthHostPort] = struct{}{}
-	}
-	if os.Getenv(localProxyCoreHostPortEnvVar) == "" {
-		cfg.LocalProxy.CoreHostPort, err = m.selectAvailablePort(cfg.LocalProxy.CoreHostPort, reserved)
-		if err != nil {
-			return fmt.Errorf("select core host port: %w", err)
-		}
-		reserved[cfg.LocalProxy.CoreHostPort] = struct{}{}
-	}
-	if os.Getenv(localProxyChatHostPortEnvVar) == "" {
-		cfg.LocalProxy.ChatHostPort, err = m.selectAvailablePort(cfg.LocalProxy.ChatHostPort, reserved)
-		if err != nil {
-			return fmt.Errorf("select chat host port: %w", err)
-		}
-		reserved[cfg.LocalProxy.ChatHostPort] = struct{}{}
-	}
-	if os.Getenv(localProxyScanHostPortEnvVar) == "" {
-		cfg.LocalProxy.ScanHostPort, err = m.selectAvailablePort(cfg.LocalProxy.ScanHostPort, reserved)
-		if err != nil {
-			return fmt.Errorf("select scan host port: %w", err)
-		}
-		reserved[cfg.LocalProxy.ScanHostPort] = struct{}{}
-	}
-	if os.Getenv(localProxyEvoHostPortEnvVar) == "" {
-		cfg.LocalProxy.EvoHostPort, err = m.selectAvailablePort(cfg.LocalProxy.EvoHostPort, reserved)
-		if err != nil {
-			return fmt.Errorf("select evo host port: %w", err)
-		}
-		reserved[cfg.LocalProxy.EvoHostPort] = struct{}{}
-	}
-	return nil
-}
-
-func (m *RuntimeManager) selectAvailablePort(preferred int, reserved map[int]struct{}) (int, error) {
-	if preferred <= 0 {
-		return 0, fmt.Errorf("invalid preferred port %d", preferred)
-	}
-	for port := preferred; port < preferred+100 && port < 65536; port++ {
-		if _, ok := reserved[port]; ok {
-			continue
-		}
-		if m.portAvailable(port) {
-			return port, nil
-		}
-	}
-	return 0, fmt.Errorf("no available port found starting at %d", preferred)
-}
-
-func isLoopbackPortAvailable(port int) bool {
-	ln, err := net.Listen("tcp", net.JoinHostPort("127.0.0.1", strconv.Itoa(port)))
-	if err != nil {
-		return false
-	}
-	_ = ln.Close()
-	return true
 }
 
 func (m *RuntimeManager) waitForComposeTerminalState(ctx context.Context, cfg RuntimeConfig, paths RuntimePaths) error {
@@ -495,102 +463,6 @@ func (m *RuntimeManager) waitForComposeTerminalState(ctx context.Context, cfg Ru
 		case <-ticker.C:
 		}
 	}
-}
-
-func (m *RuntimeManager) waitForHostProcessesReady(ctx context.Context, cfg RuntimeConfig, paths RuntimePaths) error {
-	timeout := m.upTimeout
-	if timeout <= 0 {
-		timeout = time.Duration(defaultLocalUpTimeout) * time.Second
-	}
-	deadline := time.NewTimer(timeout)
-	defer deadline.Stop()
-	ticker := time.NewTicker(m.pollInterval)
-	defer ticker.Stop()
-
-	localProxyURL := fmt.Sprintf("http://127.0.0.1:%d/_local/healthz", cfg.LocalProxy.Port)
-	frontendURL := fmt.Sprintf("http://127.0.0.1:%d/", cfg.FrontendPort)
-	var lastReason string
-	var lastReport time.Time
-	for {
-		statuses, err := m.processCompose.List(ctx, cfg, paths)
-		if err != nil {
-			lastReason = err.Error()
-		} else {
-			state, reason := classifyHostProcessReadiness(statuses)
-			lastReason = reason
-			switch state {
-			case composeReadinessReady:
-				if !m.probeAuth(cfg.AuthService.Port, 500*time.Millisecond) {
-					lastReason = "auth-service health is not ready"
-				} else if !m.probeURL(localProxyURL, 500*time.Millisecond) {
-					lastReason = "local-proxy health is not ready"
-				} else if !m.probeURL(frontendURL, 500*time.Millisecond) {
-					lastReason = "frontend HTTP is not ready"
-				} else {
-					return nil
-				}
-			case composeReadinessFailed:
-				return fmt.Errorf("%s; see %s, %s, and %s", reason, paths.AuthServiceLog, paths.LocalProxyLog, paths.FrontendLog)
-			}
-		}
-		if !m.probeAPI(cfg.ProcessComposePort, 500*time.Millisecond) {
-			return fmt.Errorf("process-compose API stopped before host processes became ready: %s", lastReason)
-		}
-		if lastReport.IsZero() || time.Since(lastReport) >= 15*time.Second {
-			_, _ = fmt.Fprintf(m.errOut, "waiting for host processes: %s\n", lastReason)
-			lastReport = time.Now()
-		}
-		select {
-		case <-ctx.Done():
-			return ctx.Err()
-		case <-deadline.C:
-			return fmt.Errorf("timed out after %s waiting for host processes: %s", timeout, lastReason)
-		case <-ticker.C:
-		}
-	}
-}
-
-func classifyHostProcessReadiness(statuses []ProcessComposeProcessStatus) (composeReadinessState, string) {
-	if len(statuses) == 0 {
-		return composeReadinessPending, "no process-compose processes reported yet"
-	}
-	statusByName := map[string]ProcessComposeProcessStatus{}
-	for _, st := range statuses {
-		statusByName[st.Name] = st
-	}
-	for _, name := range []string{authServiceProcessName, localProxyProcessName, frontendProcessName} {
-		st, ok := statusByName[name]
-		if !ok {
-			return composeReadinessPending, "process " + name + " is missing"
-		}
-		if st.IsRunning || st.Status == "running" {
-			continue
-		}
-		if st.ExitCode != 0 {
-			return composeReadinessFailed, fmt.Sprintf("process %s exited with code %d", name, st.ExitCode)
-		}
-		if st.Status == "completed" || st.Status == "exited" || st.Status == "error" || st.Status == "failed" {
-			return composeReadinessFailed, fmt.Sprintf("process %s is %s", name, st.Status)
-		}
-		return composeReadinessPending, fmt.Sprintf("process %s is %s", name, st.Status)
-	}
-	return composeReadinessReady, "host processes running"
-}
-
-func probeHTTPStatusOK(url string, timeout time.Duration) bool {
-	req, err := http.NewRequest(http.MethodGet, url, nil)
-	if err != nil {
-		return false
-	}
-	_ctx, cancel := context.WithTimeout(context.Background(), timeout)
-	defer cancel()
-	req = req.WithContext(_ctx)
-	resp, err := http.DefaultClient.Do(req)
-	if err != nil {
-		return false
-	}
-	defer resp.Body.Close()
-	return resp.StatusCode >= 200 && resp.StatusCode < 500
 }
 
 func (m *RuntimeManager) waitForRuntimeStopped(ctx context.Context, cfg RuntimeConfig, paths RuntimePaths) error {
@@ -709,10 +581,12 @@ func envDuration(name string, fallback time.Duration) time.Duration {
 }
 
 func (m *RuntimeManager) Status(ctx context.Context, cfg RuntimeConfig, paths RuntimePaths, asJSON bool) (string, error) {
+	_ = ctx
 	state, err := readOrNewState(paths, cfg)
 	if err != nil {
 		return "", err
 	}
+	cfg = applyStateConfig(cfg, state)
 	if state.Profile == "" {
 		state.Profile = cfg.Profile
 	}
@@ -759,32 +633,61 @@ func (m *RuntimeManager) Status(ctx context.Context, cfg RuntimeConfig, paths Ru
 			Status: "unknown",
 		}
 	}
+	for _, spec := range algorithmProcessSpecs(cfg.Algorithm) {
+		if _, ok := resp.Services[spec.Name]; !ok {
+			resp.Services[spec.Name] = RuntimeServiceState{
+				Kind:   "host-process",
+				Status: "unknown",
+			}
+		}
+	}
 
 	if m.probeAPI(state.ProcessCompose.APIPort, 500*time.Millisecond) {
-		listCfg := cfg
-		listCfg.ProcessComposePort = state.ProcessCompose.APIPort
-		statuses, err := m.processCompose.List(ctx, listCfg, paths)
-		readiness, _ := classifyHostProcessReadiness(statuses)
-		composeStatuses, composeErr := m.compose.ComposeStatus(ctx, paths.RepoRoot)
-		composeReadiness, _ := classifyComposeReadiness(composeStatuses)
-		if err == nil && composeErr == nil && state.Version == processComposeVersion && readiness == composeReadinessReady && composeReadiness == composeReadinessReady {
-			resp.OverallStatus = "ready"
-			for name, kind := range map[string]string{
-				processComposeServiceName: "docker-compose",
-				authServiceProcessName:    "host-process",
-				localProxyProcessName:     "host-process",
-				frontendProcessName:       "host-process",
-			} {
-				resp.Services[name] = RuntimeServiceState{Kind: kind, Status: "running"}
-			}
+		resp.OverallStatus = "ready"
+		s := resp.Services[processComposeServiceName]
+		s.Status = "running"
+		resp.Services[processComposeServiceName] = s
+		hostHealthy := true
+		lp := resp.Services[localProxyProcessName]
+		lp.Kind = "host-process"
+		if httpOK(ctx, fmt.Sprintf("http://127.0.0.1:%d/_local/healthz", cfg.LocalProxy.Port), 500*time.Millisecond) {
+			lp.Status = "running"
 		} else {
-			resp.OverallStatus = "stale"
-			for name, svc := range resp.Services {
-				if svc.Status == "running" || svc.Status == "starting" || svc.Status == "unknown" || svc.Status == "" {
-					svc.Status = "stale"
-					resp.Services[name] = svc
-				}
+			hostHealthy = false
+		}
+		resp.Services[localProxyProcessName] = lp
+		auth := resp.Services[authServiceProcessName]
+		auth.Kind = "host-process"
+		if m.probeAuth(cfg.AuthService.Port, 500*time.Millisecond) {
+			auth.Status = "running"
+		} else {
+			hostHealthy = false
+		}
+		resp.Services[authServiceProcessName] = auth
+		frontend := resp.Services[frontendProcessName]
+		frontend.Kind = "host-process"
+		if httpOK(ctx, fmt.Sprintf("http://127.0.0.1:%d/", cfg.FrontendPort), 500*time.Millisecond) {
+			frontend.Status = "running"
+		} else {
+			hostHealthy = false
+		}
+		resp.Services[frontendProcessName] = frontend
+		for _, spec := range algorithmProcessSpecs(cfg.Algorithm) {
+			svc := resp.Services[spec.Name]
+			svc.Kind = "host-process"
+			if httpOK(ctx, fmt.Sprintf("http://127.0.0.1:%d%s", spec.Port, spec.HealthPath), 500*time.Millisecond) {
+				svc.Status = "running"
+			} else if svc.Status == "running" || svc.Status == "starting" {
+				svc.Status = "stale"
+				hostHealthy = false
+			} else if svc.Status == "" || svc.Status == "unknown" {
+				svc.Status = "stopped"
+				hostHealthy = false
 			}
+			resp.Services[spec.Name] = svc
+		}
+		if !hostHealthy {
+			resp.OverallStatus = "stale"
 		}
 	} else {
 		if resp.OverallStatus == "ready" || resp.OverallStatus == "running" || resp.OverallStatus == "starting" {

--- a/local/local-runtime-manager/manager.go
+++ b/local/local-runtime-manager/manager.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"os"
 	"strconv"
@@ -23,6 +24,7 @@ type RuntimeManager struct {
 	errOut         io.Writer
 	probeAPI       func(port int, timeout time.Duration) bool
 	probeAuth      func(port int, timeout time.Duration) bool
+	portAvailable  func(port int) bool
 	pollInterval   time.Duration
 	upTimeout      time.Duration
 	downTimeout    time.Duration
@@ -44,6 +46,7 @@ func NewRuntimeManager(r CommandRunner, execPath string) *RuntimeManager {
 		errOut:         io.Discard,
 		probeAPI:       processCompose.ProbeAPI,
 		probeAuth:      authServiceHealthAlive,
+		portAvailable:  isLoopbackPortAvailable,
 		pollInterval:   2 * time.Second,
 		upTimeout:      envDuration(localUpTimeoutEnvVar, time.Duration(defaultLocalUpTimeout)*time.Second),
 		downTimeout:    envDuration(localDownTimeoutEnvVar, time.Duration(defaultLocalDownTimeout)*time.Second),
@@ -79,6 +82,9 @@ func (m *RuntimeManager) Up(ctx context.Context, cfg RuntimeConfig, paths Runtim
 	if err := paths.EnsureAllDirs(); err != nil {
 		return err
 	}
+	if err := ensureComposeBindPermissions(paths.RepoRoot); err != nil {
+		return err
+	}
 	state, err := readOrNewState(paths, cfg)
 	if err != nil {
 		return err
@@ -103,6 +109,16 @@ func (m *RuntimeManager) Up(ctx context.Context, cfg RuntimeConfig, paths Runtim
 	if err := m.stopStaleRuntimeIfNeeded(ctx, cfg, paths, state); err != nil {
 		return err
 	}
+	if os.Getenv(processComposePortEnvVar) == "" {
+		port, err := m.selectAvailableProcessComposePort(cfg.ProcessComposePort)
+		if err != nil {
+			return err
+		}
+		cfg.ProcessComposePort = port
+	}
+	if err := m.selectAvailableLocalPorts(&cfg); err != nil {
+		return err
+	}
 
 	token, err := randomHexToken()
 	if err != nil {
@@ -116,7 +132,18 @@ func (m *RuntimeManager) Up(ctx context.Context, cfg RuntimeConfig, paths Runtim
 	if err != nil {
 		return err
 	}
-	if err := m.processCompose.WriteGeneratedConfig(generatedFile, paths.RepoRoot, cfg.Profile, paths.LogFilePath, paths.LocalProxyLog, paths.AuthServiceLog, paths.FrontendLog, paths.RunDirTokenFile, cfg.ProcessComposePort); err != nil {
+	if err := m.processCompose.WriteGeneratedConfig(
+		generatedFile,
+		paths.RepoRoot,
+		cfg.Profile,
+		paths.LogFilePath,
+		paths.LocalProxyLog,
+		paths.AuthServiceLog,
+		paths.FrontendLog,
+		paths.RunDirTokenFile,
+		cfg.ProcessComposePort,
+		localRuntimeEnv(cfg),
+	); err != nil {
 		_ = generatedFile.Close()
 		return err
 	}
@@ -339,6 +366,92 @@ func (m *RuntimeManager) waitForProcessComposeAPI(ctx context.Context, port int,
 		case <-time.After(250 * time.Millisecond):
 		}
 	}
+}
+
+func (m *RuntimeManager) selectAvailableProcessComposePort(preferred int) (int, error) {
+	if preferred <= 0 {
+		preferred = defaultProcessComposePort
+	}
+	return m.selectAvailablePort(preferred, map[int]struct{}{})
+}
+
+func (m *RuntimeManager) selectAvailableLocalPorts(cfg *RuntimeConfig) error {
+	reserved := map[int]struct{}{cfg.ProcessComposePort: {}}
+	var err error
+	if os.Getenv(frontendPortEnvVar) == "" {
+		cfg.FrontendPort, err = m.selectAvailablePort(cfg.FrontendPort, reserved)
+		if err != nil {
+			return fmt.Errorf("select frontend port: %w", err)
+		}
+		reserved[cfg.FrontendPort] = struct{}{}
+	}
+	if os.Getenv(localProxyPortEnvVar) == "" {
+		cfg.LocalProxy.Port, err = m.selectAvailablePort(cfg.LocalProxy.Port, reserved)
+		if err != nil {
+			return fmt.Errorf("select local proxy port: %w", err)
+		}
+		reserved[cfg.LocalProxy.Port] = struct{}{}
+	}
+	if os.Getenv(localProxyAuthHostPortEnvVar) == "" {
+		cfg.LocalProxy.AuthHostPort, err = m.selectAvailablePort(cfg.LocalProxy.AuthHostPort, reserved)
+		if err != nil {
+			return fmt.Errorf("select auth host port: %w", err)
+		}
+		reserved[cfg.LocalProxy.AuthHostPort] = struct{}{}
+	}
+	if os.Getenv(localProxyCoreHostPortEnvVar) == "" {
+		cfg.LocalProxy.CoreHostPort, err = m.selectAvailablePort(cfg.LocalProxy.CoreHostPort, reserved)
+		if err != nil {
+			return fmt.Errorf("select core host port: %w", err)
+		}
+		reserved[cfg.LocalProxy.CoreHostPort] = struct{}{}
+	}
+	if os.Getenv(localProxyChatHostPortEnvVar) == "" {
+		cfg.LocalProxy.ChatHostPort, err = m.selectAvailablePort(cfg.LocalProxy.ChatHostPort, reserved)
+		if err != nil {
+			return fmt.Errorf("select chat host port: %w", err)
+		}
+		reserved[cfg.LocalProxy.ChatHostPort] = struct{}{}
+	}
+	if os.Getenv(localProxyScanHostPortEnvVar) == "" {
+		cfg.LocalProxy.ScanHostPort, err = m.selectAvailablePort(cfg.LocalProxy.ScanHostPort, reserved)
+		if err != nil {
+			return fmt.Errorf("select scan host port: %w", err)
+		}
+		reserved[cfg.LocalProxy.ScanHostPort] = struct{}{}
+	}
+	if os.Getenv(localProxyEvoHostPortEnvVar) == "" {
+		cfg.LocalProxy.EvoHostPort, err = m.selectAvailablePort(cfg.LocalProxy.EvoHostPort, reserved)
+		if err != nil {
+			return fmt.Errorf("select evo host port: %w", err)
+		}
+		reserved[cfg.LocalProxy.EvoHostPort] = struct{}{}
+	}
+	return nil
+}
+
+func (m *RuntimeManager) selectAvailablePort(preferred int, reserved map[int]struct{}) (int, error) {
+	if preferred <= 0 {
+		return 0, fmt.Errorf("invalid preferred port %d", preferred)
+	}
+	for port := preferred; port < preferred+100 && port < 65536; port++ {
+		if _, ok := reserved[port]; ok {
+			continue
+		}
+		if m.portAvailable(port) {
+			return port, nil
+		}
+	}
+	return 0, fmt.Errorf("no available port found starting at %d", preferred)
+}
+
+func isLoopbackPortAvailable(port int) bool {
+	ln, err := net.Listen("tcp", net.JoinHostPort("127.0.0.1", strconv.Itoa(port)))
+	if err != nil {
+		return false
+	}
+	_ = ln.Close()
+	return true
 }
 
 func (m *RuntimeManager) waitForComposeTerminalState(ctx context.Context, cfg RuntimeConfig, paths RuntimePaths) error {

--- a/local/local-runtime-manager/manager.go
+++ b/local/local-runtime-manager/manager.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"net/http"
 	"os"
 	"strconv"
 	"strings"
@@ -29,6 +30,8 @@ type RuntimeManager struct {
 	processCompose *ProcessComposeManager
 	localProxy     *LocalProxyManager
 	authService    *AuthServiceManager
+	frontend       *FrontendManager
+	probeURL       func(url string, timeout time.Duration) bool
 }
 
 func NewRuntimeManager(r CommandRunner, execPath string) *RuntimeManager {
@@ -48,6 +51,8 @@ func NewRuntimeManager(r CommandRunner, execPath string) *RuntimeManager {
 		processCompose: processCompose,
 		localProxy:     NewLocalProxyManager(r),
 		authService:    NewAuthServiceManager(r),
+		frontend:       NewFrontendManager(r),
+		probeURL:       probeHTTPStatusOK,
 	}
 }
 
@@ -74,9 +79,6 @@ func (m *RuntimeManager) Up(ctx context.Context, cfg RuntimeConfig, paths Runtim
 	if err := paths.EnsureAllDirs(); err != nil {
 		return err
 	}
-	if err := ensureComposeBindPermissions(paths.RepoRoot); err != nil {
-		return err
-	}
 	state, err := readOrNewState(paths, cfg)
 	if err != nil {
 		return err
@@ -98,6 +100,9 @@ func (m *RuntimeManager) Up(ctx context.Context, cfg RuntimeConfig, paths Runtim
 	if m.isExistingRuntimeRunning(ctx, state, paths) {
 		return m.reportExistingRuntime(ctx, state, paths)
 	}
+	if err := m.stopStaleRuntimeIfNeeded(ctx, cfg, paths, state); err != nil {
+		return err
+	}
 
 	token, err := randomHexToken()
 	if err != nil {
@@ -111,16 +116,7 @@ func (m *RuntimeManager) Up(ctx context.Context, cfg RuntimeConfig, paths Runtim
 	if err != nil {
 		return err
 	}
-	if err := m.processCompose.WriteGeneratedConfig(
-		generatedFile,
-		paths.RepoRoot,
-		cfg.Profile,
-		paths.LogFilePath,
-		paths.LocalProxyLog,
-		paths.AuthServiceLog,
-		paths.RunDirTokenFile,
-		cfg.ProcessComposePort,
-	); err != nil {
+	if err := m.processCompose.WriteGeneratedConfig(generatedFile, paths.RepoRoot, cfg.Profile, paths.LogFilePath, paths.LocalProxyLog, paths.AuthServiceLog, paths.FrontendLog, paths.RunDirTokenFile, cfg.ProcessComposePort); err != nil {
 		_ = generatedFile.Close()
 		return err
 	}
@@ -131,6 +127,7 @@ func (m *RuntimeManager) Up(ctx context.Context, cfg RuntimeConfig, paths Runtim
 	state.Profile = cfg.Profile
 	state.RepoRoot = cfg.RepoRoot
 	state.RuntimeRoot = cfg.RuntimeRoot
+	state.Version = processComposeVersion
 	state.ProcessCompose.APIPort = cfg.ProcessComposePort
 	state.ProcessCompose.APIRoot = "http://127.0.0.1:" + strconv.Itoa(cfg.ProcessComposePort)
 	state.ProcessCompose.TokenFile = paths.RunDirTokenFile
@@ -180,7 +177,7 @@ func (m *RuntimeManager) Up(ctx context.Context, cfg RuntimeConfig, paths Runtim
 		}
 		return waitErr
 	}
-	if err := m.waitForAuthServiceHealthy(ctx, cfg.AuthService.Port, m.upTimeout, paths.AuthServicePIDFile); err != nil {
+	if err := m.waitForHostProcessesReady(ctx, cfg, paths); err != nil {
 		state = newStateWithServiceStatus(state, "failed")
 		state.OverallStatus = "failed"
 		_ = writeRuntimeState(paths.StateFile, state)
@@ -195,35 +192,6 @@ func (m *RuntimeManager) Up(ctx context.Context, cfg RuntimeConfig, paths Runtim
 	}
 	m.printReadySummary(cfg)
 	return nil
-}
-
-func (m *RuntimeManager) waitForAuthServiceHealthy(ctx context.Context, port int, timeout time.Duration, pidFile string) error {
-	deadline := time.NewTimer(timeout)
-	defer deadline.Stop()
-	ticker := time.NewTicker(500 * time.Millisecond)
-	defer ticker.Stop()
-	sawPIDFile := false
-	for {
-		if m.probeAuth(port, time.Second) {
-			return nil
-		}
-		alive, err := upLockProcessAlive(pidFile)
-		if err == nil {
-			sawPIDFile = true
-			if !alive {
-				return fmt.Errorf("auth-service process exited before becoming healthy")
-			}
-		} else if sawPIDFile && os.IsNotExist(err) {
-			return fmt.Errorf("auth-service process exited before becoming healthy")
-		}
-		select {
-		case <-ctx.Done():
-			return ctx.Err()
-		case <-deadline.C:
-			return fmt.Errorf("auth-service health check timed out on port %d", port)
-		case <-ticker.C:
-		}
-	}
 }
 
 func (m *RuntimeManager) Down(ctx context.Context, cfg RuntimeConfig, paths RuntimePaths) error {
@@ -243,6 +211,16 @@ func (m *RuntimeManager) Down(ctx context.Context, cfg RuntimeConfig, paths Runt
 		downErr = m.processCompose.Down(ctx, cfg, paths)
 	}
 	if downErr != nil || !apiAlive {
+		var hostDownErr error
+		if err := m.frontend.Down(ctx, cfg, paths); err != nil {
+			hostDownErr = err
+		}
+		if err := m.localProxy.Down(ctx, cfg, paths); err != nil && hostDownErr == nil {
+			hostDownErr = err
+		}
+		if err := m.authService.Down(ctx, cfg, paths); err != nil && hostDownErr == nil {
+			hostDownErr = err
+		}
 		if fallbackErr := m.compose.ComposeDown(ctx, paths.RepoRoot, cfg.Profile); fallbackErr != nil {
 			state = newStateWithServiceStatus(state, "failed")
 			state.OverallStatus = "failed"
@@ -250,11 +228,17 @@ func (m *RuntimeManager) Down(ctx context.Context, cfg RuntimeConfig, paths Runt
 			if downErr != nil {
 				return fmt.Errorf("process-compose down failed: %w; docker compose down fallback failed: %v", downErr, fallbackErr)
 			}
+			if hostDownErr != nil {
+				return fmt.Errorf("host process down failed: %w; docker compose down fallback failed: %v", hostDownErr, fallbackErr)
+			}
 			return fallbackErr
 		}
-	}
-	if err := m.authService.Down(ctx, cfg, paths); err != nil {
-		return err
+		if hostDownErr != nil {
+			state = newStateWithServiceStatus(state, "failed")
+			state.OverallStatus = "failed"
+			_ = writeRuntimeState(paths.StateFile, state)
+			return hostDownErr
+		}
 	}
 	if err := m.waitForRuntimeStopped(ctx, cfg, paths); err != nil {
 		if ps, psErr := m.compose.ComposePS(context.Background(), paths.RepoRoot); psErr == nil && strings.TrimSpace(ps) != "" {
@@ -276,12 +260,51 @@ func (m *RuntimeManager) Down(ctx context.Context, cfg RuntimeConfig, paths Runt
 }
 
 func (m *RuntimeManager) isExistingRuntimeRunning(ctx context.Context, state RuntimeState, paths RuntimePaths) bool {
-	_ = ctx
-	_ = paths
+	if !stateClaimsRuntimeActive(state) || state.Version != processComposeVersion || state.ProcessCompose.APIPort <= 0 {
+		return false
+	}
+	if !m.probeAPI(state.ProcessCompose.APIPort, 500*time.Millisecond) {
+		return false
+	}
+	cfg := RuntimeConfig{ProcessComposePort: state.ProcessCompose.APIPort}
+	statuses, err := m.processCompose.List(ctx, cfg, paths)
+	if err != nil {
+		return false
+	}
+	readiness, _ := classifyHostProcessReadiness(statuses)
+	if readiness != composeReadinessReady {
+		return false
+	}
+	composeStatuses, err := m.compose.ComposeStatus(ctx, paths.RepoRoot)
+	if err != nil {
+		return false
+	}
+	composeReadiness, _ := classifyComposeReadiness(composeStatuses)
+	return composeReadiness == composeReadinessReady
+}
+
+func (m *RuntimeManager) stopStaleRuntimeIfNeeded(ctx context.Context, cfg RuntimeConfig, paths RuntimePaths, state RuntimeState) error {
+	if !stateClaimsRuntimeActive(state) {
+		return nil
+	}
+	if state.ProcessCompose.APIPort <= 0 || !m.probeAPI(state.ProcessCompose.APIPort, 500*time.Millisecond) {
+		return nil
+	}
+	staleCfg := cfg
+	staleCfg.ProcessComposePort = state.ProcessCompose.APIPort
+	if err := m.processCompose.Down(ctx, staleCfg, paths); err != nil {
+		return fmt.Errorf("stop stale local runtime failed: %w", err)
+	}
+	if err := m.waitForRuntimeStopped(ctx, staleCfg, paths); err != nil {
+		return fmt.Errorf("wait for stale local runtime to stop failed: %w", err)
+	}
+	return nil
+}
+
+func stateClaimsRuntimeActive(state RuntimeState) bool {
 	svc := state.Services[processComposeServiceName]
-	claimsRunning := state.OverallStatus == "ready" || state.OverallStatus == "running" || state.OverallStatus == "starting" ||
+	return state.OverallStatus == "ready" || state.OverallStatus == "running" || state.OverallStatus == "starting" ||
 		svc.Status == "running" || svc.Status == "starting"
-	return claimsRunning && state.ProcessCompose.APIPort > 0 && m.probeAPI(state.ProcessCompose.APIPort, 500*time.Millisecond)
 }
 
 func (m *RuntimeManager) reportExistingRuntime(ctx context.Context, state RuntimeState, paths RuntimePaths) error {
@@ -359,6 +382,102 @@ func (m *RuntimeManager) waitForComposeTerminalState(ctx context.Context, cfg Ru
 		case <-ticker.C:
 		}
 	}
+}
+
+func (m *RuntimeManager) waitForHostProcessesReady(ctx context.Context, cfg RuntimeConfig, paths RuntimePaths) error {
+	timeout := m.upTimeout
+	if timeout <= 0 {
+		timeout = time.Duration(defaultLocalUpTimeout) * time.Second
+	}
+	deadline := time.NewTimer(timeout)
+	defer deadline.Stop()
+	ticker := time.NewTicker(m.pollInterval)
+	defer ticker.Stop()
+
+	localProxyURL := fmt.Sprintf("http://127.0.0.1:%d/_local/healthz", cfg.LocalProxy.Port)
+	frontendURL := fmt.Sprintf("http://127.0.0.1:%d/", cfg.FrontendPort)
+	var lastReason string
+	var lastReport time.Time
+	for {
+		statuses, err := m.processCompose.List(ctx, cfg, paths)
+		if err != nil {
+			lastReason = err.Error()
+		} else {
+			state, reason := classifyHostProcessReadiness(statuses)
+			lastReason = reason
+			switch state {
+			case composeReadinessReady:
+				if !m.probeAuth(cfg.AuthService.Port, 500*time.Millisecond) {
+					lastReason = "auth-service health is not ready"
+				} else if !m.probeURL(localProxyURL, 500*time.Millisecond) {
+					lastReason = "local-proxy health is not ready"
+				} else if !m.probeURL(frontendURL, 500*time.Millisecond) {
+					lastReason = "frontend HTTP is not ready"
+				} else {
+					return nil
+				}
+			case composeReadinessFailed:
+				return fmt.Errorf("%s; see %s, %s, and %s", reason, paths.AuthServiceLog, paths.LocalProxyLog, paths.FrontendLog)
+			}
+		}
+		if !m.probeAPI(cfg.ProcessComposePort, 500*time.Millisecond) {
+			return fmt.Errorf("process-compose API stopped before host processes became ready: %s", lastReason)
+		}
+		if lastReport.IsZero() || time.Since(lastReport) >= 15*time.Second {
+			_, _ = fmt.Fprintf(m.errOut, "waiting for host processes: %s\n", lastReason)
+			lastReport = time.Now()
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-deadline.C:
+			return fmt.Errorf("timed out after %s waiting for host processes: %s", timeout, lastReason)
+		case <-ticker.C:
+		}
+	}
+}
+
+func classifyHostProcessReadiness(statuses []ProcessComposeProcessStatus) (composeReadinessState, string) {
+	if len(statuses) == 0 {
+		return composeReadinessPending, "no process-compose processes reported yet"
+	}
+	statusByName := map[string]ProcessComposeProcessStatus{}
+	for _, st := range statuses {
+		statusByName[st.Name] = st
+	}
+	for _, name := range []string{authServiceProcessName, localProxyProcessName, frontendProcessName} {
+		st, ok := statusByName[name]
+		if !ok {
+			return composeReadinessPending, "process " + name + " is missing"
+		}
+		if st.IsRunning || st.Status == "running" {
+			continue
+		}
+		if st.ExitCode != 0 {
+			return composeReadinessFailed, fmt.Sprintf("process %s exited with code %d", name, st.ExitCode)
+		}
+		if st.Status == "completed" || st.Status == "exited" || st.Status == "error" || st.Status == "failed" {
+			return composeReadinessFailed, fmt.Sprintf("process %s is %s", name, st.Status)
+		}
+		return composeReadinessPending, fmt.Sprintf("process %s is %s", name, st.Status)
+	}
+	return composeReadinessReady, "host processes running"
+}
+
+func probeHTTPStatusOK(url string, timeout time.Duration) bool {
+	req, err := http.NewRequest(http.MethodGet, url, nil)
+	if err != nil {
+		return false
+	}
+	_ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	req = req.WithContext(_ctx)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return false
+	}
+	defer resp.Body.Close()
+	return resp.StatusCode >= 200 && resp.StatusCode < 500
 }
 
 func (m *RuntimeManager) waitForRuntimeStopped(ctx context.Context, cfg RuntimeConfig, paths RuntimePaths) error {
@@ -477,7 +596,6 @@ func envDuration(name string, fallback time.Duration) time.Duration {
 }
 
 func (m *RuntimeManager) Status(ctx context.Context, cfg RuntimeConfig, paths RuntimePaths, asJSON bool) (string, error) {
-	_ = ctx
 	state, err := readOrNewState(paths, cfg)
 	if err != nil {
 		return "", err
@@ -510,12 +628,51 @@ func (m *RuntimeManager) Status(ctx context.Context, cfg RuntimeConfig, paths Ru
 			Status: "unknown",
 		}
 	}
+	if _, ok := resp.Services[localProxyProcessName]; !ok {
+		resp.Services[localProxyProcessName] = RuntimeServiceState{
+			Kind:   "host-process",
+			Status: "unknown",
+		}
+	}
+	if _, ok := resp.Services[authServiceProcessName]; !ok {
+		resp.Services[authServiceProcessName] = RuntimeServiceState{
+			Kind:   "host-process",
+			Status: "unknown",
+		}
+	}
+	if _, ok := resp.Services[frontendProcessName]; !ok {
+		resp.Services[frontendProcessName] = RuntimeServiceState{
+			Kind:   "host-process",
+			Status: "unknown",
+		}
+	}
 
 	if m.probeAPI(state.ProcessCompose.APIPort, 500*time.Millisecond) {
-		resp.OverallStatus = "ready"
-		s := resp.Services[processComposeServiceName]
-		s.Status = "running"
-		resp.Services[processComposeServiceName] = s
+		listCfg := cfg
+		listCfg.ProcessComposePort = state.ProcessCompose.APIPort
+		statuses, err := m.processCompose.List(ctx, listCfg, paths)
+		readiness, _ := classifyHostProcessReadiness(statuses)
+		composeStatuses, composeErr := m.compose.ComposeStatus(ctx, paths.RepoRoot)
+		composeReadiness, _ := classifyComposeReadiness(composeStatuses)
+		if err == nil && composeErr == nil && state.Version == processComposeVersion && readiness == composeReadinessReady && composeReadiness == composeReadinessReady {
+			resp.OverallStatus = "ready"
+			for name, kind := range map[string]string{
+				processComposeServiceName: "docker-compose",
+				authServiceProcessName:    "host-process",
+				localProxyProcessName:     "host-process",
+				frontendProcessName:       "host-process",
+			} {
+				resp.Services[name] = RuntimeServiceState{Kind: kind, Status: "running"}
+			}
+		} else {
+			resp.OverallStatus = "stale"
+			for name, svc := range resp.Services {
+				if svc.Status == "running" || svc.Status == "starting" || svc.Status == "unknown" || svc.Status == "" {
+					svc.Status = "stale"
+					resp.Services[name] = svc
+				}
+			}
+		}
 	} else {
 		if resp.OverallStatus == "ready" || resp.OverallStatus == "running" || resp.OverallStatus == "starting" {
 			resp.OverallStatus = "stale"

--- a/local/local-runtime-manager/manager_test.go
+++ b/local/local-runtime-manager/manager_test.go
@@ -5,8 +5,10 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"net"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strconv"
 	"strings"
 	"testing"
@@ -92,6 +94,204 @@ func TestRuntimePathsEnsureAllDirsCreatesOnlyV1Directories(t *testing.T) {
 	}
 }
 
+func TestRuntimeConfigAllocatesAvailableLocalPorts(t *testing.T) {
+	for _, envName := range []string{
+		processComposePortEnvVar,
+		frontendPortEnvVar,
+		localProxyPortEnvVar,
+		localProxyAuthHostPortEnvVar,
+		localProxyCoreHostPortEnvVar,
+		localPostgresPortEnvVar,
+	} {
+		t.Setenv(envName, "")
+	}
+	listeners := occupyLocalPorts(t,
+		defaultProcessComposePort,
+		defaultFrontendPort,
+		defaultLocalProxyPort,
+		defaultLocalProxyAuthHostPort,
+		defaultLocalProxyCoreHostPort,
+		defaultLocalPostgresPort,
+	)
+	defer func() {
+		for _, ln := range listeners {
+			_ = ln.Close()
+		}
+	}()
+
+	repo := t.TempDir()
+	writeComposeFixture(t, repo)
+	cfg, _, err := NewRuntimeConfig(defaultProfileValue(), repo)
+	if err != nil {
+		t.Fatalf("runtime config: %v", err)
+	}
+	if cfg.ProcessComposePort == defaultProcessComposePort {
+		t.Fatalf("expected process-compose port to avoid occupied default")
+	}
+	if cfg.FrontendPort == defaultFrontendPort {
+		t.Fatalf("expected frontend port to avoid occupied default")
+	}
+	if cfg.LocalProxy.Port == defaultLocalProxyPort {
+		t.Fatalf("expected local proxy port to avoid occupied default")
+	}
+	if cfg.LocalProxy.AuthHostPort == defaultLocalProxyAuthHostPort {
+		t.Fatalf("expected auth host port to avoid occupied default")
+	}
+	if cfg.LocalProxy.CoreHostPort == defaultLocalProxyCoreHostPort {
+		t.Fatalf("expected core host port to avoid occupied default")
+	}
+	if cfg.Algorithm.PostgresPort == defaultLocalPostgresPort {
+		t.Fatalf("expected postgres host port to avoid occupied default")
+	}
+	env := strings.Join(localComposeEnv(cfg), "\n")
+	for _, want := range []string{
+		"LAZYMIND_LOCAL_PROXY_PORT=" + strconv.Itoa(cfg.LocalProxy.Port),
+		"LAZYMIND_FRONTEND_PORT=" + strconv.Itoa(cfg.FrontendPort),
+		"LAZYMIND_LOCAL_PROXY_CORE_HOST_PORT=" + strconv.Itoa(cfg.LocalProxy.CoreHostPort),
+		"LAZYMIND_LOCAL_POSTGRES_PORT=" + strconv.Itoa(cfg.Algorithm.PostgresPort),
+	} {
+		if !strings.Contains(env, want) {
+			t.Fatalf("compose env missing %q in %s", want, env)
+		}
+	}
+}
+
+func TestRuntimeConfigMovesDefaultFrontendPortWhenOccupied(t *testing.T) {
+	t.Setenv(frontendPortEnvVar, strconv.Itoa(defaultFrontendPort))
+	ln := occupyLocalPorts(t, defaultFrontendPort)
+	defer func() {
+		for _, existing := range ln {
+			_ = existing.Close()
+		}
+	}()
+
+	repo := t.TempDir()
+	writeComposeFixture(t, repo)
+	cfg, _, err := NewRuntimeConfig(defaultProfileValue(), repo)
+	if err != nil {
+		t.Fatalf("runtime config: %v", err)
+	}
+	if cfg.FrontendPort == defaultFrontendPort {
+		t.Fatalf("expected Makefile default frontend port to move when occupied")
+	}
+	if !strings.Contains(strings.Join(localComposeEnv(cfg), "\n"), "LAZYMIND_FRONTEND_PORT="+strconv.Itoa(cfg.FrontendPort)) {
+		t.Fatalf("compose env missing frontend port")
+	}
+}
+
+func TestAlgorithmServiceEnvIncludesCloudParityDefaults(t *testing.T) {
+	for _, name := range []string{
+		"TZ",
+		"LANGFUSE_HOST",
+		"LANGFUSE_BASE_URL",
+		"LANGFUSE_PUBLIC_KEY",
+		"LANGFUSE_SECRET_KEY",
+		"LAZYLLM_TRACE_ENABLED",
+		"OTEL_EXPORTER_OTLP_TIMEOUT",
+		"OTEL_EXPORTER_OTLP_TRACES_TIMEOUT",
+		"LAZYMIND_LANGFUSE_FORCE_FLUSH_TIMEOUT_MS",
+		"LAZYMIND_OCR_SERVER_URL",
+		"LAZYMIND_MINERU_BACKEND",
+		"LAZYMIND_MINERU_SERVER_PORT",
+		"LAZYLLM_MINERU_BACKEND",
+		"LAZYLLM_MINERU_API_KEY",
+		"LAZYLLM_PADDLE_API_KEY",
+		"LAZYMIND_RESET_ALGO_ON_STARTUP",
+		"LAZYMIND_RESET_ALL_ON_STARTUP",
+		"LAZYMIND_MAX_RETRIES",
+		"LAZYMIND_REVIEW_MAX_RETRIES",
+		"LAZYMIND_SKILL_REVIEW_DEBUG",
+		"LAZYMIND_WORD_GROUP_APPLY_URL",
+		"http_proxy",
+		"https_proxy",
+		"HTTP_PROXY",
+		"HTTPS_PROXY",
+		"no_proxy",
+		"NO_PROXY",
+		"LAZYLLM_OPENAI_API_KEY",
+		"LAZYLLM_GLM_API_KEY",
+		"LAZYLLM_QWEN_API_KEY",
+		"LAZYLLM_SENSENOVA_API_KEY",
+		"LAZYLLM_SENSENOVA_SECRET_KEY",
+		"LAZYLLM_KIMI_API_KEY",
+		"LAZYLLM_DEEPSEEK_API_KEY",
+		"LAZYLLM_DOUBAO_API_KEY",
+		"LAZYLLM_SILICONFLOW_API_KEY",
+		"LAZYLLM_MINIMAX_API_KEY",
+		"LAZYLLM_AIPING_API_KEY",
+		"LAZYMIND_MAAS_API_KEY",
+		"LAZYMIND_OPENSEARCH_URI",
+		"LAZYMIND_OPENSEARCH_USER",
+		"LAZYMIND_OPENSEARCH_PASSWORD",
+		"LAZYMIND_EVO_CODE_TIMEOUT_S",
+		"LAZYMIND_EVO_LLM_ROLE",
+	} {
+		t.Setenv(name, "")
+	}
+	repo := t.TempDir()
+	writeComposeFixture(t, repo)
+	cfg, paths, err := NewRuntimeConfig(defaultProfileValue(), repo)
+	if err != nil {
+		t.Fatalf("runtime config: %v", err)
+	}
+
+	env := algorithmServiceEnv(cfg, paths, algoProcessName)
+	uploads := filepath.Join(paths.RepoRoot, "data", "core", "uploads")
+	noProxy := "127.0.0.1,localhost,::1,core,chat,evo-api,doc-server,lazyllm-algo,parsing,milvus,opensearch,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16"
+	for _, want := range []string{
+		"LAZYLLM_INIT_DOC=True",
+		"LAZYMIND_MOUNT_BASE_DIR=" + uploads,
+		"http_proxy=",
+		"https_proxy=",
+		"HTTP_PROXY=",
+		"HTTPS_PROXY=",
+		"no_proxy=" + noProxy,
+		"NO_PROXY=" + noProxy,
+		"LAZYLLM_OPENAI_API_KEY=",
+		"LAZYLLM_GLM_API_KEY=",
+		"LAZYLLM_QWEN_API_KEY=",
+		"LAZYLLM_SENSENOVA_API_KEY=",
+		"LAZYLLM_SENSENOVA_SECRET_KEY=",
+		"LAZYLLM_KIMI_API_KEY=",
+		"LAZYLLM_DEEPSEEK_API_KEY=",
+		"LAZYLLM_DOUBAO_API_KEY=",
+		"LAZYLLM_SILICONFLOW_API_KEY=",
+		"LAZYLLM_MINIMAX_API_KEY=",
+		"LAZYLLM_AIPING_API_KEY=",
+		"LAZYMIND_MAAS_API_KEY=",
+		"TZ=Asia/Shanghai",
+		"LANGFUSE_HOST=",
+		"LANGFUSE_BASE_URL=",
+		"LANGFUSE_PUBLIC_KEY=",
+		"LANGFUSE_SECRET_KEY=",
+		"LAZYLLM_TRACE_ENABLED=1",
+		"OTEL_EXPORTER_OTLP_TIMEOUT=60",
+		"OTEL_EXPORTER_OTLP_TRACES_TIMEOUT=60",
+		"LAZYMIND_LANGFUSE_FORCE_FLUSH_TIMEOUT_MS=70000",
+		"LAZYMIND_OCR_SERVER_URL=",
+		"LAZYMIND_MINERU_BACKEND=pipeline",
+		"LAZYMIND_MINERU_SERVER_PORT=8000",
+		"LAZYLLM_MINERU_BACKEND=pipeline",
+		"LAZYLLM_MINERU_API_KEY=",
+		"LAZYLLM_PADDLE_API_KEY=",
+		"LAZYMIND_RESET_ALGO_ON_STARTUP=false",
+		"LAZYMIND_RESET_ALL_ON_STARTUP=false",
+		"LAZYMIND_MAX_RETRIES=20",
+		"LAZYMIND_REVIEW_MAX_RETRIES=5",
+		"LAZYMIND_SKILL_REVIEW_DEBUG=false",
+		"LAZYMIND_OPENSEARCH_URI=https://127.0.0.1:" + strconv.Itoa(cfg.Algorithm.OpenSearchPort),
+		"LAZYMIND_OPENSEARCH_USER=admin",
+		"LAZYMIND_OPENSEARCH_PASSWORD=LazyRAG_OpenSearch123!",
+		"LAZYMIND_EVO_CODE_TIMEOUT_S=900",
+		"LAZYMIND_EVO_LLM_ROLE=evo_llm",
+		"LAZYMIND_WORD_GROUP_APPLY_URL=",
+	} {
+		if !containsString(env, want) {
+			t.Fatalf("algorithm env missing %q in %v", want, env)
+		}
+	}
+}
+
 func TestAcquireUpLockRemovesStaleLock(t *testing.T) {
 	repo := t.TempDir()
 	writeComposeFixture(t, repo)
@@ -132,6 +332,53 @@ func TestAcquireUpLockKeepsLiveLock(t *testing.T) {
 
 	if _, err := acquireUpLock(paths); err == nil {
 		t.Fatal("expected live lock to block acquire")
+	}
+}
+
+func TestAcquireAlgorithmPythonLockRemovesStaleLock(t *testing.T) {
+	repo := t.TempDir()
+	writeComposeFixture(t, repo)
+	_, paths, err := NewRuntimeConfig(defaultProfileValue(), repo)
+	if err != nil {
+		t.Fatalf("runtime config: %v", err)
+	}
+	if err := paths.EnsureAllDirs(); err != nil {
+		t.Fatalf("ensure dirs: %v", err)
+	}
+	lockFile := filepath.Join(paths.RunDir, "algorithm-python.lock")
+	if err := os.WriteFile(lockFile, []byte("-1\n"), 0o600); err != nil {
+		t.Fatalf("write stale lock: %v", err)
+	}
+
+	release, err := acquireAlgorithmPythonLock(context.Background(), paths)
+	if err != nil {
+		t.Fatalf("acquire stale algorithm lock: %v", err)
+	}
+	release()
+	if _, err := os.Stat(lockFile); !os.IsNotExist(err) {
+		t.Fatalf("expected algorithm lock to be released, err=%v", err)
+	}
+}
+
+func TestAcquireAlgorithmPythonLockWaitsForLiveLock(t *testing.T) {
+	repo := t.TempDir()
+	writeComposeFixture(t, repo)
+	_, paths, err := NewRuntimeConfig(defaultProfileValue(), repo)
+	if err != nil {
+		t.Fatalf("runtime config: %v", err)
+	}
+	if err := paths.EnsureAllDirs(); err != nil {
+		t.Fatalf("ensure dirs: %v", err)
+	}
+	lockFile := filepath.Join(paths.RunDir, "algorithm-python.lock")
+	if err := os.WriteFile(lockFile, []byte(strconv.Itoa(os.Getpid())+"\n"), 0o600); err != nil {
+		t.Fatalf("write live lock: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Millisecond)
+	defer cancel()
+	if _, err := acquireAlgorithmPythonLock(ctx, paths); err == nil {
+		t.Fatal("expected live algorithm lock to block until context cancellation")
 	}
 }
 
@@ -189,15 +436,7 @@ func TestComposeUpCommandIsCanonical(t *testing.T) {
 			"--profile", "opensearch",
 			"config", "--format", "json",
 		)
-		return CommandResult{Stdout: composeConfigJSONFixture(repo)}, nil
-	}, func(cmd Command) (CommandResult, error) {
-		call++
-		assertCommandContainsInOrder(t, cmd, "docker", []string{
-			"build",
-			"-t", "core-image",
-			"-f", filepath.Join(repo, "backend", "core/Dockerfile"),
-		})
-		return CommandResult{}, nil
+		return CommandResult{Stdout: composeConfigJSONNoBuildFixture()}, nil
 	}, func(cmd Command) (CommandResult, error) {
 		call++
 		assertCommandContainsInOrder(t, cmd, "docker", []string{
@@ -208,6 +447,8 @@ func TestComposeUpCommandIsCanonical(t *testing.T) {
 			"--profile", "opensearch",
 			"up",
 			"--no-build",
+			"--detach",
+			"--no-deps",
 			"auth-service", "core", "web",
 		})
 		return CommandResult{}, nil
@@ -217,26 +458,26 @@ func TestComposeUpCommandIsCanonical(t *testing.T) {
 	if err != nil {
 		t.Fatalf("runtime config: %v", err)
 	}
-	if err := manager.compose.ComposeUp(context.Background(), paths.RepoRoot, cfg.Profile); err != nil {
+	if err := manager.compose.ComposeUp(context.Background(), cfg, paths); err != nil {
 		t.Fatalf("compose up: %v", err)
 	}
-	if call != 4 {
-		t.Fatalf("expected 4 compose calls got %d", call)
+	if call != 3 {
+		t.Fatalf("expected 3 compose calls got %d", call)
 	}
 }
 
-func TestComposeUpExcludesDisabledServicesAndScalesDependencyServices(t *testing.T) {
+func TestComposeUpOmitsDisabledServices(t *testing.T) {
 	repo := t.TempDir()
 	writeComposeFixture(t, repo)
 	overlay := filepath.Join(repo, localComposeOverrideName)
-	if err := os.WriteFile(overlay, []byte("x-lazymind-local:\n  mode: local\n  disabled_container_services:\n    - redis\n    - auth-service\n    - evo-api\n    - frontend\n  scale_disabled_container_services:\n    - redis\n    - auth-service\n"), 0o644); err != nil {
+	if err := os.WriteFile(overlay, []byte("x-lazymind-local:\n  mode: local\n  disabled_container_services:\n    - redis\n    - auth-service\n    - evo-api\n  scale_disabled_container_services:\n    - redis\n    - auth-service\n"), 0o644); err != nil {
 		t.Fatalf("write overlay: %v", err)
 	}
 
 	runner := &fakeRunner{t: t}
 	manager := NewRuntimeManager(runner, filepath.Join(repo, "lazymind-local"))
 	runner.handlers = append(runner.handlers, func(cmd Command) (CommandResult, error) {
-		return CommandResult{Stdout: "redis\nevo-api\nfrontend\nauth-service\ncore\n"}, nil
+		return CommandResult{Stdout: "redis\nevo-api\nauth-service\ncore\n"}, nil
 	}, func(cmd Command) (CommandResult, error) {
 		assertCommandContainsInOrder(t, cmd, "docker", []string{
 			"compose",
@@ -256,21 +497,21 @@ func TestComposeUpExcludesDisabledServicesAndScalesDependencyServices(t *testing
 			"--profile", "opensearch",
 			"up",
 			"--no-build",
-			"--scale", "redis=0",
-			"--scale", "auth-service=0",
+			"--detach",
+			"--no-deps",
 			"core",
 		})
 		for i, arg := range cmd.Args {
 			if arg == "--scale" && i+1 < len(cmd.Args) && cmd.Args[i+1] == "evo-api=0" {
 				t.Fatalf("evo-api should not be scale guarded when omitted from scale_disabled_container_services: %v", cmd.Args)
 			}
-			if arg == "--scale" && i+1 < len(cmd.Args) && cmd.Args[i+1] == "frontend=0" {
-				t.Fatalf("frontend should be excluded by explicit service list, not scaled: %v", cmd.Args)
-			}
 		}
 		for _, arg := range cmd.Args {
-			if arg == "redis" || arg == "auth-service" || arg == "evo-api" || arg == "frontend" {
+			if arg == "redis" || arg == "auth-service" || arg == "evo-api" {
 				t.Fatalf("disabled service %s should not be in explicit service list: %v", arg, cmd.Args)
+			}
+			if arg == "--scale" {
+				t.Fatalf("disabled services should be omitted instead of scaled: %v", cmd.Args)
 			}
 		}
 		return CommandResult{}, nil
@@ -280,7 +521,7 @@ func TestComposeUpExcludesDisabledServicesAndScalesDependencyServices(t *testing
 	if err != nil {
 		t.Fatalf("runtime config: %v", err)
 	}
-	if err := manager.compose.ComposeUp(context.Background(), paths.RepoRoot, cfg.Profile); err != nil {
+	if err := manager.compose.ComposeUp(context.Background(), cfg, paths); err != nil {
 		t.Fatalf("compose up: %v", err)
 	}
 }
@@ -291,19 +532,19 @@ func TestWriteGeneratedComposeConfig(t *testing.T) {
 	var b strings.Builder
 	profile := "linux-browser"
 	repo := t.TempDir()
-	logPath := filepath.Join(repo, "run.log")
-	tokenPath := filepath.Join(repo, "token")
+	writeComposeFixture(t, repo)
+	cfg, paths, err := NewRuntimeConfig(profile, repo)
+	if err != nil {
+		t.Fatalf("runtime config: %v", err)
+	}
 	if err := m.processCompose.WriteGeneratedConfig(
 		&builderWriter{builder: &b},
 		repo,
 		profile,
-		logPath,
-		filepath.Join(repo, "local-proxy.log"),
-		filepath.Join(repo, "auth-service.log"),
-		filepath.Join(repo, "frontend.log"),
-		tokenPath,
-		defaultProcessComposePort,
-		[]string{localProxyPortEnvVar + "=5028"},
+		paths,
+		cfg,
+		paths.RunDirTokenFile,
+		cfg.ProcessComposePort,
 	); err != nil {
 		t.Fatalf("write generated config: %v", err)
 	}
@@ -325,13 +566,16 @@ func TestWriteGeneratedComposeConfig(t *testing.T) {
 	if !strings.Contains(proc.Command, "internal compose-up --profile "+profile) {
 		t.Fatalf("missing compose-up command: %q", proc.Command)
 	}
+	if !strings.Contains(proc.Command, "LAZYMIND_FRONTEND_PORT="+strconv.Itoa(cfg.FrontendPort)) {
+		t.Fatalf("compose command missing frontend env: %q", proc.Command)
+	}
 	if !strings.Contains(proc.Shutdown.Command, "internal compose-down --profile "+profile) {
 		t.Fatalf("missing compose-down command: %q", proc.Shutdown.Command)
 	}
 	if proc.Shutdown.TimeoutSeconds != 60 {
 		t.Fatalf("unexpected shutdown timeout %d", proc.Shutdown.TimeoutSeconds)
 	}
-	if proc.LogLocation != logPath {
+	if proc.LogLocation != paths.LogFilePath {
 		t.Fatalf("unexpected log location %q", proc.LogLocation)
 	}
 	if proc.Namespace != "container" {
@@ -344,8 +588,8 @@ func TestWriteGeneratedComposeConfig(t *testing.T) {
 	if !strings.Contains(localProxy.Command, "internal local-proxy-run --profile "+profile) {
 		t.Fatalf("missing local-proxy-run command: %q", localProxy.Command)
 	}
-	if !strings.Contains(localProxy.Command, localProxyPortEnvVar+"=5028") {
-		t.Fatalf("missing selected local proxy port env: %q", localProxy.Command)
+	if !strings.Contains(localProxy.Command, "LAZYMIND_LOCAL_PROXY_PORT="+strconv.Itoa(cfg.LocalProxy.Port)) {
+		t.Fatalf("local-proxy command missing proxy env: %q", localProxy.Command)
 	}
 	if !strings.Contains(localProxy.Shutdown.Command, "internal local-proxy-down --profile "+profile) {
 		t.Fatalf("missing local-proxy-down command: %q", localProxy.Shutdown.Command)
@@ -360,78 +604,36 @@ func TestWriteGeneratedComposeConfig(t *testing.T) {
 	if !strings.Contains(authService.Command, "internal auth-service-run --profile "+profile) {
 		t.Fatalf("missing auth-service-run command: %q", authService.Command)
 	}
+	if !strings.Contains(authService.Command, "LAZYMIND_AUTH_SERVICE_PORT="+strconv.Itoa(cfg.AuthService.Port)) {
+		t.Fatalf("auth-service command missing auth env: %q", authService.Command)
+	}
 	if !strings.Contains(authService.Shutdown.Command, "internal auth-service-down --profile "+profile) {
 		t.Fatalf("missing auth-service-down command: %q", authService.Shutdown.Command)
+	}
+	if authService.LogLocation != paths.AuthServiceLog {
+		t.Fatalf("unexpected auth-service log location %q", authService.LogLocation)
 	}
 	if authService.Namespace != "host" {
 		t.Fatalf("unexpected auth-service namespace %q", authService.Namespace)
 	}
-	frontend, ok := parsed.Processes[frontendProcessName]
-	if !ok {
-		t.Fatal("missing frontend process")
-	}
-	if !strings.Contains(frontend.Command, "internal frontend-run --profile "+profile) {
-		t.Fatalf("missing frontend-run command: %q", frontend.Command)
-	}
-	if !strings.Contains(frontend.Shutdown.Command, "internal frontend-down --profile "+profile) {
-		t.Fatalf("missing frontend-down command: %q", frontend.Shutdown.Command)
-	}
-	if frontend.Namespace != "host" {
-		t.Fatalf("unexpected frontend namespace %q", frontend.Namespace)
+	for _, service := range []string{docServerProcessName, processorServerProcessName, processorWorkerProcessName, algoProcessName, chatProcessName} {
+		proc, ok := parsed.Processes[service]
+		if !ok {
+			t.Fatalf("missing algorithm process %s", service)
+		}
+		if !strings.Contains(proc.Command, "internal algorithm-run --service "+service+" --profile "+profile) {
+			t.Fatalf("missing algorithm-run command for %s: %q", service, proc.Command)
+		}
+		if !strings.Contains(proc.Shutdown.Command, "internal algorithm-down --service "+service+" --profile "+profile) {
+			t.Fatalf("missing algorithm-down command for %s: %q", service, proc.Shutdown.Command)
+		}
+		if proc.Namespace != "host" {
+			t.Fatalf("unexpected namespace for %s: %q", service, proc.Namespace)
+		}
 	}
 	if strings.Contains(out, "readiness_probe:") {
 		t.Fatal("generated config should not include process-compose readiness_probe")
 	}
-}
-
-func TestWriteCaddyfileIncludesFrontendAndProxyRoutes(t *testing.T) {
-	repo := t.TempDir()
-	writeComposeFixture(t, repo)
-	cfg, paths, err := NewRuntimeConfig(defaultProfileValue(), repo)
-	if err != nil {
-		t.Fatalf("runtime config: %v", err)
-	}
-	cfg.FrontendPort = 18090
-	cfg.LocalProxy.Port = 15024
-	if err := paths.EnsureAllDirs(); err != nil {
-		t.Fatalf("ensure dirs: %v", err)
-	}
-	if err := writeCaddyfile(paths, cfg); err != nil {
-		t.Fatalf("write caddyfile: %v", err)
-	}
-	raw, err := os.ReadFile(paths.CaddyConfig)
-	if err != nil {
-		t.Fatalf("read caddyfile: %v", err)
-	}
-	out := string(raw)
-	for _, want := range []string{
-		"http://localhost:18090, http://127.0.0.1:18090",
-		"bind 127.0.0.1",
-		"root * " + strconv.Quote(filepath.Join(repo, "frontend", "dist")),
-		"handle /api/*",
-		"handle /api-docs/*",
-		"reverse_proxy http://127.0.0.1:15024",
-		"flush_interval -1",
-		"try_files {path} /index.html",
-		"file_server",
-	} {
-		if !strings.Contains(out, want) {
-			t.Fatalf("missing %q in caddyfile:\n%s", want, out)
-		}
-	}
-}
-
-func TestFrontendBuildEnvDefaultsRuntimeModeAndPreservesHideEvo(t *testing.T) {
-	t.Setenv("VITE_LAZYMIND_MODE", "")
-	t.Setenv("VITE_HIDE_EVO", "false")
-	env := frontendBuildEnv()
-	assertStringSlicesEqual(t, env, []string{"VITE_LAZYMIND_MODE=local"})
-}
-
-func TestFrontendBuildEnvKeepsExplicitRuntimeMode(t *testing.T) {
-	t.Setenv("VITE_LAZYMIND_MODE", "desktop")
-	env := frontendBuildEnv()
-	assertStringSlicesEqual(t, env, []string{"VITE_LAZYMIND_MODE=desktop"})
 }
 
 func TestDerivedComposeProfilesUseBuiltInStoresByDefault(t *testing.T) {
@@ -492,6 +694,8 @@ func TestComposeUpStreamsDockerComposeLogsWhenSupported(t *testing.T) {
 			"--profile", "opensearch",
 			"up",
 			"--no-build",
+			"--detach",
+			"--no-deps",
 			"auth-service",
 			"core",
 		})
@@ -502,7 +706,7 @@ func TestComposeUpStreamsDockerComposeLogsWhenSupported(t *testing.T) {
 	if err != nil {
 		t.Fatalf("runtime config: %v", err)
 	}
-	if err := manager.compose.ComposeUp(context.Background(), paths.RepoRoot, cfg.Profile); err != nil {
+	if err := manager.compose.ComposeUp(context.Background(), cfg, paths); err != nil {
 		t.Fatalf("compose up: %v", err)
 	}
 	if len(runner.streamCalls) != 1 {
@@ -517,8 +721,7 @@ func TestManagerUpWritesStateAndStartsProcessCompose(t *testing.T) {
 	manager := NewRuntimeManager(runner, filepath.Join(repo, "lazymind-local"))
 	manager.probeAPI = func(port int, timeout time.Duration) bool { return true }
 	manager.probeAuth = func(port int, timeout time.Duration) bool { return true }
-	manager.probeURL = func(url string, timeout time.Duration) bool { return true }
-	manager.portAvailable = func(port int) bool { return true }
+	manager.waitHostReady = func(context.Context, RuntimeConfig) error { return nil }
 	manager.pollInterval = time.Millisecond
 	manager.upTimeout = time.Second
 	cfg, paths, err := NewRuntimeConfig(defaultProfileValue(), repo)
@@ -532,7 +735,7 @@ func TestManagerUpWritesStateAndStartsProcessCompose(t *testing.T) {
 		assertContains(t, cmd.Args, "-D")
 		assertContains(t, cmd.Args, "--ordered-shutdown")
 		assertContains(t, cmd.Args, "-t=false")
-		assertStringArgAfter(t, cmd.Args, "-p", strconv.Itoa(defaultProcessComposePort))
+		assertStringArgAfter(t, cmd.Args, "-p", strconv.Itoa(cfg.ProcessComposePort))
 		return CommandResult{}, nil
 	}, func(cmd Command) (CommandResult, error) {
 		assertCommandContainsInOrder(t, cmd, "docker", []string{
@@ -547,15 +750,6 @@ func TestManagerUpWritesStateAndStartsProcessCompose(t *testing.T) {
 			"json",
 		})
 		return CommandResult{Stdout: readyComposeStatusJSON()}, nil
-	}, func(cmd Command) (CommandResult, error) {
-		assertCommandContainsInOrder(t, cmd, "process-compose", []string{
-			"-p", strconv.Itoa(defaultProcessComposePort),
-			"--token-file", paths.RunDirTokenFile,
-			"list",
-			"-o",
-			"json",
-		})
-		return CommandResult{Stdout: readyProcessComposeListJSON()}, nil
 	})
 	if err := manager.Up(context.Background(), cfg, paths); err != nil {
 		t.Fatalf("up: %v", err)
@@ -574,19 +768,93 @@ func TestManagerUpWritesStateAndStartsProcessCompose(t *testing.T) {
 	if dockerStack.Status != "running" {
 		t.Fatalf("unexpected docker-stack status: %s", dockerStack.Status)
 	}
-	authService, ok := st.Services[authServiceProcessName]
-	if !ok {
-		t.Fatalf("state missing auth-service service")
+}
+
+func TestWaitForAuthServiceHealthyFailsFastWhenPIDIsDead(t *testing.T) {
+	repo := t.TempDir()
+	writeComposeFixture(t, repo)
+	runner := &fakeRunner{t: t}
+	manager := NewRuntimeManager(runner, filepath.Join(repo, "lazymind-local"))
+	manager.probeAuth = func(port int, timeout time.Duration) bool { return false }
+
+	_, paths, err := NewRuntimeConfig(defaultProfileValue(), repo)
+	if err != nil {
+		t.Fatalf("runtime config: %v", err)
 	}
-	if authService.Kind != "host-process" || authService.Status != "running" {
-		t.Fatalf("unexpected auth-service state: %#v", authService)
+	if err := paths.EnsureAllDirs(); err != nil {
+		t.Fatalf("prepare dirs: %v", err)
 	}
-	frontend, ok := st.Services[frontendProcessName]
-	if !ok {
-		t.Fatalf("state missing frontend service")
+	if err := os.WriteFile(paths.AuthServicePIDFile, []byte("-1\n"), 0o600); err != nil {
+		t.Fatalf("write auth pid: %v", err)
 	}
-	if frontend.Kind != "host-process" || frontend.Status != "running" {
-		t.Fatalf("unexpected frontend state: %#v", frontend)
+
+	start := time.Now()
+	err = manager.waitForAuthServiceHealthy(context.Background(), defaultLocalProxyAuthHostPort, time.Minute, paths.AuthServicePIDFile)
+	if err == nil {
+		t.Fatal("expected auth-service process failure")
+	}
+	if !strings.Contains(err.Error(), "auth-service process exited") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if elapsed := time.Since(start); elapsed > time.Second {
+		t.Fatalf("expected fail-fast, took %s", elapsed)
+	}
+}
+
+func TestWaitForAuthServiceHealthyIgnoresMissingPIDUntilTimeout(t *testing.T) {
+	repo := t.TempDir()
+	writeComposeFixture(t, repo)
+	runner := &fakeRunner{t: t}
+	manager := NewRuntimeManager(runner, filepath.Join(repo, "lazymind-local"))
+	manager.probeAuth = func(port int, timeout time.Duration) bool { return false }
+
+	_, paths, err := NewRuntimeConfig(defaultProfileValue(), repo)
+	if err != nil {
+		t.Fatalf("runtime config: %v", err)
+	}
+	if err := paths.EnsureAllDirs(); err != nil {
+		t.Fatalf("prepare dirs: %v", err)
+	}
+
+	err = manager.waitForAuthServiceHealthy(context.Background(), defaultLocalProxyAuthHostPort, time.Millisecond, paths.AuthServicePIDFile)
+	if err == nil {
+		t.Fatal("expected auth-service health timeout")
+	}
+	if !strings.Contains(err.Error(), "health check timed out") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestRuntimeManagerUpFailsWhenHostAlgorithmsDoNotBecomeReady(t *testing.T) {
+	repo := t.TempDir()
+	writeComposeFixture(t, repo)
+	runner := &fakeRunner{t: t}
+	manager := NewRuntimeManager(runner, filepath.Join(repo, "lazymind-local"))
+	manager.probeAPI = func(port int, timeout time.Duration) bool { return true }
+	manager.probeAuth = func(port int, timeout time.Duration) bool { return true }
+	manager.waitHostReady = func(context.Context, RuntimeConfig) error {
+		return fmt.Errorf("host algorithm not ready")
+	}
+	manager.pollInterval = time.Millisecond
+	manager.upTimeout = time.Second
+	runner.handlers = append(runner.handlers, func(cmd Command) (CommandResult, error) {
+		return CommandResult{}, nil
+	}, func(cmd Command) (CommandResult, error) {
+		return CommandResult{Stdout: readyComposeStatusJSON()}, nil
+	})
+	cfg, paths, err := NewRuntimeConfig(defaultProfileValue(), repo)
+	if err != nil {
+		t.Fatalf("runtime config: %v", err)
+	}
+	if err := manager.Up(context.Background(), cfg, paths); err == nil {
+		t.Fatalf("expected up failure")
+	}
+	state, err := readRuntimeState(paths.StateFile)
+	if err != nil {
+		t.Fatalf("read state: %v", err)
+	}
+	if state.OverallStatus != "failed" {
+		t.Fatalf("expected failed state got %s", state.OverallStatus)
 	}
 }
 
@@ -600,6 +868,7 @@ func TestRuntimeManagerUpReusesRunningProcessCompose(t *testing.T) {
 		probeCalls++
 		return probeCalls == 1
 	}
+	manager.runtimeReady = func(context.Context, RuntimeConfig, RuntimePaths) bool { return true }
 	cfg, paths, err := NewRuntimeConfig(defaultProfileValue(), repo)
 	if err != nil {
 		t.Fatalf("runtime config: %v", err)
@@ -607,35 +876,13 @@ func TestRuntimeManagerUpReusesRunningProcessCompose(t *testing.T) {
 	if err := paths.EnsureAllDirs(); err != nil {
 		t.Fatalf("prepare dirs: %v", err)
 	}
-	state := defaultRuntimeState(cfg, defaultProcessComposePort, paths.RunDirTokenFile)
+	state := defaultRuntimeState(cfg, cfg.ProcessComposePort, paths.RunDirTokenFile)
 	state.OverallStatus = "ready"
 	state.Services[processComposeServiceName] = RuntimeServiceState{Kind: "docker-compose", Status: "running"}
 	if err := writeRuntimeState(paths.StateFile, state); err != nil {
 		t.Fatalf("write state: %v", err)
 	}
 	runner.handlers = append(runner.handlers, func(cmd Command) (CommandResult, error) {
-		assertCommandContainsInOrder(t, cmd, "process-compose", []string{
-			"-p", strconv.Itoa(defaultProcessComposePort),
-			"--token-file", paths.RunDirTokenFile,
-			"list",
-			"-o",
-			"json",
-		})
-		return CommandResult{Stdout: readyProcessComposeListJSON()}, nil
-	}, func(cmd Command) (CommandResult, error) {
-		assertCommandContainsInOrder(t, cmd, "docker", []string{
-			"compose",
-			"-f", filepath.Join(repo, repoComposeFileName),
-			"-f", filepath.Join(repo, localComposeOverrideName),
-			"--profile", "milvus",
-			"--profile", "opensearch",
-			"ps",
-			"-a",
-			"--format",
-			"json",
-		})
-		return CommandResult{Stdout: readyComposeStatusJSON()}, nil
-	}, func(cmd Command) (CommandResult, error) {
 		assertCommandContainsInOrder(t, cmd, "docker", []string{
 			"compose",
 			"-f", filepath.Join(repo, repoComposeFileName),
@@ -651,8 +898,8 @@ func TestRuntimeManagerUpReusesRunningProcessCompose(t *testing.T) {
 	if err := manager.Up(context.Background(), cfg, paths); err != nil {
 		t.Fatalf("up: %v", err)
 	}
-	if len(runner.calls) != 3 {
-		t.Fatalf("expected only process-compose list and docker ps calls, got %d calls", len(runner.calls))
+	if len(runner.calls) != 1 {
+		t.Fatalf("expected only docker ps call, got %d calls", len(runner.calls))
 	}
 }
 
@@ -662,6 +909,7 @@ func TestRuntimeManagerUpFailsOnExitedService(t *testing.T) {
 	runner := &fakeRunner{t: t}
 	manager := NewRuntimeManager(runner, filepath.Join(repo, "lazymind-local"))
 	manager.probeAPI = func(port int, timeout time.Duration) bool { return true }
+	manager.probeAuth = func(port int, timeout time.Duration) bool { return true }
 	manager.pollInterval = time.Millisecond
 	manager.upTimeout = time.Second
 	cfg, paths, err := NewRuntimeConfig(defaultProfileValue(), repo)
@@ -718,7 +966,6 @@ func TestProcessComposeManagerDownCommandIncludesPortAndTokenFile(t *testing.T) 
 	writeComposeFixture(t, repo)
 	runner := &fakeRunner{t: t}
 	manager := NewRuntimeManager(runner, filepath.Join("/tmp", "lazymind-local"))
-	manager.probeAPI = func(port int, timeout time.Duration) bool { return false }
 	cfg, paths, err := NewRuntimeConfig(defaultProfileValue(), repo)
 	if err != nil {
 		t.Fatalf("runtime config: %v", err)
@@ -729,7 +976,7 @@ func TestProcessComposeManagerDownCommandIncludesPortAndTokenFile(t *testing.T) 
 
 	runner.handlers = append(runner.handlers, func(cmd Command) (CommandResult, error) {
 		assertCommand(t, cmd, "process-compose",
-			"-p", strconv.Itoa(defaultProcessComposePort),
+			"-p", strconv.Itoa(cfg.ProcessComposePort),
 			"--token-file", paths.RunDirTokenFile,
 			"down",
 		)
@@ -753,6 +1000,7 @@ func TestRuntimeManagerDownFallsBackToComposeDownOnProcessComposeFailure(t *test
 		probeCalls++
 		return probeCalls == 1
 	}
+	manager.probeAuth = func(port int, timeout time.Duration) bool { return false }
 	manager.pollInterval = time.Millisecond
 	manager.downTimeout = time.Second
 	cfg, paths, err := NewRuntimeConfig(defaultProfileValue(), repo)
@@ -772,11 +1020,15 @@ func TestRuntimeManagerDownFallsBackToComposeDownOnProcessComposeFailure(t *test
 	runner.handlers = append(runner.handlers,
 		func(cmd Command) (CommandResult, error) {
 			assertCommandContainsInOrder(t, cmd, "process-compose", []string{
-				"-p", strconv.Itoa(defaultProcessComposePort),
+				"-p", strconv.Itoa(cfg.ProcessComposePort),
 				"--token-file", paths.RunDirTokenFile,
 				"down",
 			})
 			return CommandResult{}, fmt.Errorf("process-compose failure")
+		},
+		func(cmd Command) (CommandResult, error) {
+			assertCommand(t, cmd, "pkill", "-f", regexp.QuoteMeta(repo)+"/(local/bin/process-compose|\\.lazymind-local/bin/local-proxy|\\.lazymind-local/python/\\.venv/bin/python|\\.lazymind-local/venvs/auth-service/bin/python|local/local-runtime-manager/lazymind-local internal)")
+			return CommandResult{}, nil
 		},
 		func(cmd Command) (CommandResult, error) {
 			assertCommandContainsInOrder(t, cmd, "sh", []string{"-c"})
@@ -829,8 +1081,8 @@ func TestRuntimeManagerDownFallsBackToComposeDownOnProcessComposeFailure(t *test
 	if got := state.Services[processComposeServiceName].Status; got != "stopped" {
 		t.Fatalf("unexpected service status %s", got)
 	}
-	if len(runner.calls) != 5 {
-		t.Fatalf("expected 5 commands got %d", len(runner.calls))
+	if len(runner.calls) != 6 {
+		t.Fatalf("expected 6 commands got %d", len(runner.calls))
 	}
 }
 
@@ -839,24 +1091,20 @@ func TestStatusJSONContainsDockerStackService(t *testing.T) {
 	manager := NewRuntimeManager(runner, filepath.Join("/tmp", "lazymind-local"))
 	repo := t.TempDir()
 	writeComposeFixture(t, repo)
-	_, paths, err := NewRuntimeConfig(defaultProfileValue(), repo)
+	cfg, paths, err := NewRuntimeConfig(defaultProfileValue(), repo)
 	if err != nil {
 		t.Fatalf("runtime config: %v", err)
 	}
 	if err := paths.EnsureAllDirs(); err != nil {
 		t.Fatalf("prepare dirs: %v", err)
 	}
-	state := defaultRuntimeState(RuntimeConfig{
-		Profile:     defaultProfileValue(),
-		RepoRoot:    paths.RepoRoot,
-		RuntimeRoot: paths.RuntimeRoot,
-	}, defaultProcessComposePort, filepath.Join(paths.RunDir, tokenFileName))
+	state := defaultRuntimeState(cfg, cfg.ProcessComposePort, filepath.Join(paths.RunDir, tokenFileName))
 	state.Services["docker-stack"] = RuntimeServiceState{Kind: "docker-compose", Status: "running"}
 	if err := writeRuntimeState(paths.StateFile, state); err != nil {
 		t.Fatalf("write state: %v", err)
 	}
 
-	out, err := manager.Status(context.Background(), RuntimeConfig{Profile: defaultProfileValue(), RepoRoot: repo, RuntimeRoot: paths.RuntimeRoot}, paths, true)
+	out, err := manager.Status(context.Background(), cfg, paths, true)
 	if err != nil {
 		t.Fatalf("status: %v", err)
 	}
@@ -873,12 +1121,6 @@ func TestStatusJSONContainsDockerStackService(t *testing.T) {
 	if _, ok := resp.Services[processComposeServiceName]; !ok {
 		t.Fatalf("missing docker-stack service")
 	}
-	if svc, ok := resp.Services[frontendProcessName]; !ok || svc.Kind != "host-process" {
-		t.Fatalf("missing frontend host-process service: %#v", resp.Services[frontendProcessName])
-	}
-	if svc, ok := resp.Services[authServiceProcessName]; !ok || svc.Kind != "host-process" {
-		t.Fatalf("missing auth-service host-process service: %#v", resp.Services[authServiceProcessName])
-	}
 }
 
 func TestStatusMarksStaleStateWhenProcessComposeAPIIsDown(t *testing.T) {
@@ -894,7 +1136,7 @@ func TestStatusMarksStaleStateWhenProcessComposeAPIIsDown(t *testing.T) {
 	if err := paths.EnsureAllDirs(); err != nil {
 		t.Fatalf("prepare dirs: %v", err)
 	}
-	state := defaultRuntimeState(cfg, defaultProcessComposePort, paths.RunDirTokenFile)
+	state := defaultRuntimeState(cfg, cfg.ProcessComposePort, paths.RunDirTokenFile)
 	state.OverallStatus = "ready"
 	state.Services[processComposeServiceName] = RuntimeServiceState{Kind: "docker-compose", Status: "running"}
 	if err := writeRuntimeState(paths.StateFile, state); err != nil {
@@ -975,22 +1217,28 @@ func writeComposeFixture(t *testing.T, repo string) {
 	}
 }
 
-func composeConfigJSONFixture(repo string) string {
-	return fmt.Sprintf(`{
-  "services": {
-    "auth-service": {"image": "auth-image"},
-    "core": {
-      "image": "core-image",
-      "build": {
-        "context": %q,
-        "dockerfile": "core/Dockerfile",
-        "args": {"GOPROXY": "https://goproxy.cn,direct"}
-      }
-    },
-    "web": {"image": "web-image"},
-    "redis": {"image": "redis-image"}
-  }
-}`, filepath.Join(repo, "backend"))
+func occupyLocalPorts(t *testing.T, ports ...int) []net.Listener {
+	t.Helper()
+	listeners := make([]net.Listener, 0, len(ports))
+	for _, port := range ports {
+		ln, err := net.Listen("tcp", net.JoinHostPort("127.0.0.1", strconv.Itoa(port)))
+		if err != nil {
+			for _, existing := range listeners {
+				_ = existing.Close()
+			}
+			t.Skipf("port %d is already in use on this test host: %v", port, err)
+		}
+		listeners = append(listeners, ln)
+	}
+	return listeners
+}
+
+func readyComposeStatusJSON() string {
+	return `[
+{"Name":"auth","Service":"auth-service","State":"running","Health":"healthy","ExitCode":0},
+{"Name":"core","Service":"core","State":"running","Health":"","ExitCode":0},
+{"Name":"db","Service":"db-bootstrap","State":"exited","Health":"","ExitCode":0}
+]`
 }
 
 func composeConfigJSONNoBuildFixture() string {
@@ -1004,23 +1252,6 @@ func composeConfigJSONNoBuildFixture() string {
     "frontend": {"image": "frontend-image"}
   }
 }`
-}
-
-func readyComposeStatusJSON() string {
-	return `[
-{"Name":"auth","Service":"auth-service","State":"running","Health":"healthy","ExitCode":0},
-{"Name":"core","Service":"core","State":"running","Health":"","ExitCode":0},
-{"Name":"db","Service":"db-bootstrap","State":"exited","Health":"","ExitCode":0}
-]`
-}
-
-func readyProcessComposeListJSON() string {
-	return `[
-{"name":"docker-stack","status":"Completed","is_running":false,"exit_code":0},
-{"name":"auth-service","status":"Running","is_running":true,"exit_code":0},
-{"name":"local-proxy","status":"Running","is_running":true,"exit_code":0},
-{"name":"frontend","status":"Running","is_running":true,"exit_code":0}
-]`
 }
 
 func assertCommand(t *testing.T, cmd Command, name string, args ...string) {
@@ -1070,6 +1301,15 @@ func assertContains(t *testing.T, args []string, want string) {
 		}
 	}
 	t.Fatalf("missing arg %s in %v", want, args)
+}
+
+func containsString(items []string, want string) bool {
+	for _, item := range items {
+		if item == want {
+			return true
+		}
+	}
+	return false
 }
 
 func assertStringArgAfter(t *testing.T, args []string, flag string, want string) {

--- a/local/local-runtime-manager/manager_test.go
+++ b/local/local-runtime-manager/manager_test.go
@@ -206,18 +206,18 @@ func TestComposeUpCommandIsCanonical(t *testing.T) {
 	}
 }
 
-func TestComposeUpScalesDisabledServicesToZero(t *testing.T) {
+func TestComposeUpExcludesDisabledServicesAndScalesDependencyServices(t *testing.T) {
 	repo := t.TempDir()
 	writeComposeFixture(t, repo)
 	overlay := filepath.Join(repo, localComposeOverrideName)
-	if err := os.WriteFile(overlay, []byte("x-lazymind-local:\n  mode: local\n  disabled_container_services:\n    - redis\n    - auth-service\n    - evo-api\n  scale_disabled_container_services:\n    - redis\n    - auth-service\n"), 0o644); err != nil {
+	if err := os.WriteFile(overlay, []byte("x-lazymind-local:\n  mode: local\n  disabled_container_services:\n    - redis\n    - auth-service\n    - evo-api\n    - frontend\n  scale_disabled_container_services:\n    - redis\n    - auth-service\n"), 0o644); err != nil {
 		t.Fatalf("write overlay: %v", err)
 	}
 
 	runner := &fakeRunner{t: t}
 	manager := NewRuntimeManager(runner, filepath.Join(repo, "lazymind-local"))
 	runner.handlers = append(runner.handlers, func(cmd Command) (CommandResult, error) {
-		return CommandResult{Stdout: "redis\nevo-api\nauth-service\ncore\n"}, nil
+		return CommandResult{Stdout: "redis\nevo-api\nfrontend\nauth-service\ncore\n"}, nil
 	}, func(cmd Command) (CommandResult, error) {
 		assertCommandContainsInOrder(t, cmd, "docker", []string{
 			"compose",
@@ -235,9 +235,12 @@ func TestComposeUpScalesDisabledServicesToZero(t *testing.T) {
 			if arg == "--scale" && i+1 < len(cmd.Args) && cmd.Args[i+1] == "evo-api=0" {
 				t.Fatalf("evo-api should not be scale guarded when omitted from scale_disabled_container_services: %v", cmd.Args)
 			}
+			if arg == "--scale" && i+1 < len(cmd.Args) && cmd.Args[i+1] == "frontend=0" {
+				t.Fatalf("frontend should be excluded by explicit service list, not scaled: %v", cmd.Args)
+			}
 		}
 		for _, arg := range cmd.Args {
-			if arg == "redis" || arg == "auth-service" || arg == "evo-api" {
+			if arg == "redis" || arg == "auth-service" || arg == "evo-api" || arg == "frontend" {
 				t.Fatalf("disabled service %s should not be in explicit service list: %v", arg, cmd.Args)
 			}
 		}
@@ -268,6 +271,7 @@ func TestWriteGeneratedComposeConfig(t *testing.T) {
 		logPath,
 		filepath.Join(repo, "local-proxy.log"),
 		filepath.Join(repo, "auth-service.log"),
+		filepath.Join(repo, "frontend.log"),
 		tokenPath,
 		defaultProcessComposePort,
 	); err != nil {
@@ -326,15 +330,75 @@ func TestWriteGeneratedComposeConfig(t *testing.T) {
 	if !strings.Contains(authService.Shutdown.Command, "internal auth-service-down --profile "+profile) {
 		t.Fatalf("missing auth-service-down command: %q", authService.Shutdown.Command)
 	}
-	if authService.LogLocation != filepath.Join(repo, "auth-service.log") {
-		t.Fatalf("unexpected auth-service log location %q", authService.LogLocation)
-	}
 	if authService.Namespace != "host" {
 		t.Fatalf("unexpected auth-service namespace %q", authService.Namespace)
+	}
+	frontend, ok := parsed.Processes[frontendProcessName]
+	if !ok {
+		t.Fatal("missing frontend process")
+	}
+	if !strings.Contains(frontend.Command, "internal frontend-run --profile "+profile) {
+		t.Fatalf("missing frontend-run command: %q", frontend.Command)
+	}
+	if !strings.Contains(frontend.Shutdown.Command, "internal frontend-down --profile "+profile) {
+		t.Fatalf("missing frontend-down command: %q", frontend.Shutdown.Command)
+	}
+	if frontend.Namespace != "host" {
+		t.Fatalf("unexpected frontend namespace %q", frontend.Namespace)
 	}
 	if strings.Contains(out, "readiness_probe:") {
 		t.Fatal("generated config should not include process-compose readiness_probe")
 	}
+}
+
+func TestWriteCaddyfileIncludesFrontendAndProxyRoutes(t *testing.T) {
+	repo := t.TempDir()
+	writeComposeFixture(t, repo)
+	cfg, paths, err := NewRuntimeConfig(defaultProfileValue(), repo)
+	if err != nil {
+		t.Fatalf("runtime config: %v", err)
+	}
+	cfg.FrontendPort = 18090
+	cfg.LocalProxy.Port = 15024
+	if err := paths.EnsureAllDirs(); err != nil {
+		t.Fatalf("ensure dirs: %v", err)
+	}
+	if err := writeCaddyfile(paths, cfg); err != nil {
+		t.Fatalf("write caddyfile: %v", err)
+	}
+	raw, err := os.ReadFile(paths.CaddyConfig)
+	if err != nil {
+		t.Fatalf("read caddyfile: %v", err)
+	}
+	out := string(raw)
+	for _, want := range []string{
+		"http://localhost:18090, http://127.0.0.1:18090",
+		"bind 127.0.0.1",
+		"root * " + strconv.Quote(filepath.Join(repo, "frontend", "dist")),
+		"handle /api/*",
+		"handle /api-docs/*",
+		"reverse_proxy http://127.0.0.1:15024",
+		"flush_interval -1",
+		"try_files {path} /index.html",
+		"file_server",
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("missing %q in caddyfile:\n%s", want, out)
+		}
+	}
+}
+
+func TestFrontendBuildEnvDefaultsRuntimeModeAndPreservesHideEvo(t *testing.T) {
+	t.Setenv("VITE_LAZYMIND_MODE", "")
+	t.Setenv("VITE_HIDE_EVO", "false")
+	env := frontendBuildEnv()
+	assertStringSlicesEqual(t, env, []string{"VITE_LAZYMIND_MODE=local"})
+}
+
+func TestFrontendBuildEnvKeepsExplicitRuntimeMode(t *testing.T) {
+	t.Setenv("VITE_LAZYMIND_MODE", "desktop")
+	env := frontendBuildEnv()
+	assertStringSlicesEqual(t, env, []string{"VITE_LAZYMIND_MODE=desktop"})
 }
 
 func TestDerivedComposeProfilesUseBuiltInStoresByDefault(t *testing.T) {
@@ -410,8 +474,13 @@ func TestManagerUpWritesStateAndStartsProcessCompose(t *testing.T) {
 	manager := NewRuntimeManager(runner, filepath.Join(repo, "lazymind-local"))
 	manager.probeAPI = func(port int, timeout time.Duration) bool { return true }
 	manager.probeAuth = func(port int, timeout time.Duration) bool { return true }
+	manager.probeURL = func(url string, timeout time.Duration) bool { return true }
 	manager.pollInterval = time.Millisecond
 	manager.upTimeout = time.Second
+	cfg, paths, err := NewRuntimeConfig(defaultProfileValue(), repo)
+	if err != nil {
+		t.Fatalf("runtime config: %v", err)
+	}
 	runner.handlers = append(runner.handlers, func(cmd Command) (CommandResult, error) {
 		if cmd.Name != "process-compose" {
 			t.Fatalf("expected process-compose got %s", cmd.Name)
@@ -434,11 +503,16 @@ func TestManagerUpWritesStateAndStartsProcessCompose(t *testing.T) {
 			"json",
 		})
 		return CommandResult{Stdout: readyComposeStatusJSON()}, nil
+	}, func(cmd Command) (CommandResult, error) {
+		assertCommandContainsInOrder(t, cmd, "process-compose", []string{
+			"-p", strconv.Itoa(defaultProcessComposePort),
+			"--token-file", paths.RunDirTokenFile,
+			"list",
+			"-o",
+			"json",
+		})
+		return CommandResult{Stdout: readyProcessComposeListJSON()}, nil
 	})
-	cfg, paths, err := NewRuntimeConfig(defaultProfileValue(), repo)
-	if err != nil {
-		t.Fatalf("runtime config: %v", err)
-	}
 	if err := manager.Up(context.Background(), cfg, paths); err != nil {
 		t.Fatalf("up: %v", err)
 	}
@@ -456,60 +530,19 @@ func TestManagerUpWritesStateAndStartsProcessCompose(t *testing.T) {
 	if dockerStack.Status != "running" {
 		t.Fatalf("unexpected docker-stack status: %s", dockerStack.Status)
 	}
-}
-
-func TestWaitForAuthServiceHealthyFailsFastWhenPIDIsDead(t *testing.T) {
-	repo := t.TempDir()
-	writeComposeFixture(t, repo)
-	runner := &fakeRunner{t: t}
-	manager := NewRuntimeManager(runner, filepath.Join(repo, "lazymind-local"))
-	manager.probeAuth = func(port int, timeout time.Duration) bool { return false }
-
-	_, paths, err := NewRuntimeConfig(defaultProfileValue(), repo)
-	if err != nil {
-		t.Fatalf("runtime config: %v", err)
+	authService, ok := st.Services[authServiceProcessName]
+	if !ok {
+		t.Fatalf("state missing auth-service service")
 	}
-	if err := paths.EnsureAllDirs(); err != nil {
-		t.Fatalf("prepare dirs: %v", err)
+	if authService.Kind != "host-process" || authService.Status != "running" {
+		t.Fatalf("unexpected auth-service state: %#v", authService)
 	}
-	if err := os.WriteFile(paths.AuthServicePIDFile, []byte("-1\n"), 0o600); err != nil {
-		t.Fatalf("write auth pid: %v", err)
+	frontend, ok := st.Services[frontendProcessName]
+	if !ok {
+		t.Fatalf("state missing frontend service")
 	}
-
-	start := time.Now()
-	err = manager.waitForAuthServiceHealthy(context.Background(), defaultLocalProxyAuthHostPort, time.Minute, paths.AuthServicePIDFile)
-	if err == nil {
-		t.Fatal("expected auth-service process failure")
-	}
-	if !strings.Contains(err.Error(), "auth-service process exited") {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if elapsed := time.Since(start); elapsed > time.Second {
-		t.Fatalf("expected fail-fast, took %s", elapsed)
-	}
-}
-
-func TestWaitForAuthServiceHealthyIgnoresMissingPIDUntilTimeout(t *testing.T) {
-	repo := t.TempDir()
-	writeComposeFixture(t, repo)
-	runner := &fakeRunner{t: t}
-	manager := NewRuntimeManager(runner, filepath.Join(repo, "lazymind-local"))
-	manager.probeAuth = func(port int, timeout time.Duration) bool { return false }
-
-	_, paths, err := NewRuntimeConfig(defaultProfileValue(), repo)
-	if err != nil {
-		t.Fatalf("runtime config: %v", err)
-	}
-	if err := paths.EnsureAllDirs(); err != nil {
-		t.Fatalf("prepare dirs: %v", err)
-	}
-
-	err = manager.waitForAuthServiceHealthy(context.Background(), defaultLocalProxyAuthHostPort, time.Millisecond, paths.AuthServicePIDFile)
-	if err == nil {
-		t.Fatal("expected auth-service health timeout")
-	}
-	if !strings.Contains(err.Error(), "health check timed out") {
-		t.Fatalf("unexpected error: %v", err)
+	if frontend.Kind != "host-process" || frontend.Status != "running" {
+		t.Fatalf("unexpected frontend state: %#v", frontend)
 	}
 }
 
@@ -537,6 +570,28 @@ func TestRuntimeManagerUpReusesRunningProcessCompose(t *testing.T) {
 		t.Fatalf("write state: %v", err)
 	}
 	runner.handlers = append(runner.handlers, func(cmd Command) (CommandResult, error) {
+		assertCommandContainsInOrder(t, cmd, "process-compose", []string{
+			"-p", strconv.Itoa(defaultProcessComposePort),
+			"--token-file", paths.RunDirTokenFile,
+			"list",
+			"-o",
+			"json",
+		})
+		return CommandResult{Stdout: readyProcessComposeListJSON()}, nil
+	}, func(cmd Command) (CommandResult, error) {
+		assertCommandContainsInOrder(t, cmd, "docker", []string{
+			"compose",
+			"-f", filepath.Join(repo, repoComposeFileName),
+			"-f", filepath.Join(repo, localComposeOverrideName),
+			"--profile", "milvus",
+			"--profile", "opensearch",
+			"ps",
+			"-a",
+			"--format",
+			"json",
+		})
+		return CommandResult{Stdout: readyComposeStatusJSON()}, nil
+	}, func(cmd Command) (CommandResult, error) {
 		assertCommandContainsInOrder(t, cmd, "docker", []string{
 			"compose",
 			"-f", filepath.Join(repo, repoComposeFileName),
@@ -552,8 +607,8 @@ func TestRuntimeManagerUpReusesRunningProcessCompose(t *testing.T) {
 	if err := manager.Up(context.Background(), cfg, paths); err != nil {
 		t.Fatalf("up: %v", err)
 	}
-	if len(runner.calls) != 1 {
-		t.Fatalf("expected only docker ps call, got %d calls", len(runner.calls))
+	if len(runner.calls) != 3 {
+		t.Fatalf("expected only process-compose list and docker ps calls, got %d calls", len(runner.calls))
 	}
 }
 
@@ -563,7 +618,6 @@ func TestRuntimeManagerUpFailsOnExitedService(t *testing.T) {
 	runner := &fakeRunner{t: t}
 	manager := NewRuntimeManager(runner, filepath.Join(repo, "lazymind-local"))
 	manager.probeAPI = func(port int, timeout time.Duration) bool { return true }
-	manager.probeAuth = func(port int, timeout time.Duration) bool { return true }
 	manager.pollInterval = time.Millisecond
 	manager.upTimeout = time.Second
 	cfg, paths, err := NewRuntimeConfig(defaultProfileValue(), repo)
@@ -620,6 +674,7 @@ func TestProcessComposeManagerDownCommandIncludesPortAndTokenFile(t *testing.T) 
 	writeComposeFixture(t, repo)
 	runner := &fakeRunner{t: t}
 	manager := NewRuntimeManager(runner, filepath.Join("/tmp", "lazymind-local"))
+	manager.probeAPI = func(port int, timeout time.Duration) bool { return false }
 	cfg, paths, err := NewRuntimeConfig(defaultProfileValue(), repo)
 	if err != nil {
 		t.Fatalf("runtime config: %v", err)
@@ -630,7 +685,6 @@ func TestProcessComposeManagerDownCommandIncludesPortAndTokenFile(t *testing.T) 
 
 	runner.handlers = append(runner.handlers, func(cmd Command) (CommandResult, error) {
 		assertCommand(t, cmd, "process-compose",
-			"--config", filepath.ToSlash(paths.GeneratedConfig),
 			"-p", strconv.Itoa(defaultProcessComposePort),
 			"--token-file", paths.RunDirTokenFile,
 			"down",
@@ -655,7 +709,6 @@ func TestRuntimeManagerDownFallsBackToComposeDownOnProcessComposeFailure(t *test
 		probeCalls++
 		return probeCalls == 1
 	}
-	manager.probeAuth = func(port int, timeout time.Duration) bool { return false }
 	manager.pollInterval = time.Millisecond
 	manager.downTimeout = time.Second
 	cfg, paths, err := NewRuntimeConfig(defaultProfileValue(), repo)
@@ -675,12 +728,21 @@ func TestRuntimeManagerDownFallsBackToComposeDownOnProcessComposeFailure(t *test
 	runner.handlers = append(runner.handlers,
 		func(cmd Command) (CommandResult, error) {
 			assertCommandContainsInOrder(t, cmd, "process-compose", []string{
-				"--config", filepath.ToSlash(paths.GeneratedConfig),
 				"-p", strconv.Itoa(defaultProcessComposePort),
 				"--token-file", paths.RunDirTokenFile,
 				"down",
 			})
 			return CommandResult{}, fmt.Errorf("process-compose failure")
+		},
+		func(cmd Command) (CommandResult, error) {
+			assertCommandContainsInOrder(t, cmd, "sh", []string{"-c"})
+			return CommandResult{}, nil
+		},
+		func(cmd Command) (CommandResult, error) {
+			if cmd.Name != paths.LocalProxyStopScript {
+				t.Fatalf("expected local-proxy stop script got %s", cmd.Name)
+			}
+			return CommandResult{}, nil
 		},
 		func(cmd Command) (CommandResult, error) {
 			assertCommandContainsInOrder(t, cmd, "docker", []string{
@@ -723,8 +785,8 @@ func TestRuntimeManagerDownFallsBackToComposeDownOnProcessComposeFailure(t *test
 	if got := state.Services[processComposeServiceName].Status; got != "stopped" {
 		t.Fatalf("unexpected service status %s", got)
 	}
-	if len(runner.calls) != 3 {
-		t.Fatalf("expected 3 commands got %d", len(runner.calls))
+	if len(runner.calls) != 5 {
+		t.Fatalf("expected 5 commands got %d", len(runner.calls))
 	}
 }
 
@@ -766,6 +828,12 @@ func TestStatusJSONContainsDockerStackService(t *testing.T) {
 	}
 	if _, ok := resp.Services[processComposeServiceName]; !ok {
 		t.Fatalf("missing docker-stack service")
+	}
+	if svc, ok := resp.Services[frontendProcessName]; !ok || svc.Kind != "host-process" {
+		t.Fatalf("missing frontend host-process service: %#v", resp.Services[frontendProcessName])
+	}
+	if svc, ok := resp.Services[authServiceProcessName]; !ok || svc.Kind != "host-process" {
+		t.Fatalf("missing auth-service host-process service: %#v", resp.Services[authServiceProcessName])
 	}
 }
 
@@ -868,6 +936,15 @@ func readyComposeStatusJSON() string {
 {"Name":"auth","Service":"auth-service","State":"running","Health":"healthy","ExitCode":0},
 {"Name":"core","Service":"core","State":"running","Health":"","ExitCode":0},
 {"Name":"db","Service":"db-bootstrap","State":"exited","Health":"","ExitCode":0}
+]`
+}
+
+func readyProcessComposeListJSON() string {
+	return `[
+{"name":"docker-stack","status":"Completed","is_running":false,"exit_code":0},
+{"name":"auth-service","status":"Running","is_running":true,"exit_code":0},
+{"name":"local-proxy","status":"Running","is_running":true,"exit_code":0},
+{"name":"frontend","status":"Running","is_running":true,"exit_code":0}
 ]`
 }
 

--- a/local/local-runtime-manager/manager_test.go
+++ b/local/local-runtime-manager/manager_test.go
@@ -181,6 +181,25 @@ func TestComposeUpCommandIsCanonical(t *testing.T) {
 		return CommandResult{Stdout: "auth-service\ncore\nweb\n"}, nil
 	}, func(cmd Command) (CommandResult, error) {
 		call++
+		assertCommand(t, cmd, "docker",
+			"compose",
+			"-f", filepath.Join(repo, repoComposeFileName),
+			"-f", filepath.Join(repo, localComposeOverrideName),
+			"--profile", "milvus",
+			"--profile", "opensearch",
+			"config", "--format", "json",
+		)
+		return CommandResult{Stdout: composeConfigJSONFixture(repo)}, nil
+	}, func(cmd Command) (CommandResult, error) {
+		call++
+		assertCommandContainsInOrder(t, cmd, "docker", []string{
+			"build",
+			"-t", "core-image",
+			"-f", filepath.Join(repo, "backend", "core/Dockerfile"),
+		})
+		return CommandResult{}, nil
+	}, func(cmd Command) (CommandResult, error) {
+		call++
 		assertCommandContainsInOrder(t, cmd, "docker", []string{
 			"compose",
 			"-f", filepath.Join(repo, repoComposeFileName),
@@ -188,7 +207,7 @@ func TestComposeUpCommandIsCanonical(t *testing.T) {
 			"--profile", "milvus",
 			"--profile", "opensearch",
 			"up",
-			"--build",
+			"--no-build",
 			"auth-service", "core", "web",
 		})
 		return CommandResult{}, nil
@@ -201,8 +220,8 @@ func TestComposeUpCommandIsCanonical(t *testing.T) {
 	if err := manager.compose.ComposeUp(context.Background(), paths.RepoRoot, cfg.Profile); err != nil {
 		t.Fatalf("compose up: %v", err)
 	}
-	if call != 2 {
-		t.Fatalf("expected 2 compose calls got %d", call)
+	if call != 4 {
+		t.Fatalf("expected 4 compose calls got %d", call)
 	}
 }
 
@@ -225,8 +244,18 @@ func TestComposeUpExcludesDisabledServicesAndScalesDependencyServices(t *testing
 			"-f", filepath.Join(repo, localComposeOverrideName),
 			"--profile", "milvus",
 			"--profile", "opensearch",
+			"config", "--format", "json",
+		})
+		return CommandResult{Stdout: composeConfigJSONNoBuildFixture()}, nil
+	}, func(cmd Command) (CommandResult, error) {
+		assertCommandContainsInOrder(t, cmd, "docker", []string{
+			"compose",
+			"-f", filepath.Join(repo, repoComposeFileName),
+			"-f", filepath.Join(repo, localComposeOverrideName),
+			"--profile", "milvus",
+			"--profile", "opensearch",
 			"up",
-			"--build",
+			"--no-build",
 			"--scale", "redis=0",
 			"--scale", "auth-service=0",
 			"core",
@@ -274,6 +303,7 @@ func TestWriteGeneratedComposeConfig(t *testing.T) {
 		filepath.Join(repo, "frontend.log"),
 		tokenPath,
 		defaultProcessComposePort,
+		[]string{localProxyPortEnvVar + "=5028"},
 	); err != nil {
 		t.Fatalf("write generated config: %v", err)
 	}
@@ -313,6 +343,9 @@ func TestWriteGeneratedComposeConfig(t *testing.T) {
 	}
 	if !strings.Contains(localProxy.Command, "internal local-proxy-run --profile "+profile) {
 		t.Fatalf("missing local-proxy-run command: %q", localProxy.Command)
+	}
+	if !strings.Contains(localProxy.Command, localProxyPortEnvVar+"=5028") {
+		t.Fatalf("missing selected local proxy port env: %q", localProxy.Command)
 	}
 	if !strings.Contains(localProxy.Shutdown.Command, "internal local-proxy-down --profile "+profile) {
 		t.Fatalf("missing local-proxy-down command: %q", localProxy.Shutdown.Command)
@@ -439,6 +472,16 @@ func TestComposeUpStreamsDockerComposeLogsWhenSupported(t *testing.T) {
 			"config", "--services",
 		)
 		return CommandResult{Stdout: "auth-service\ncore\n"}, nil
+	}, func(cmd Command) (CommandResult, error) {
+		assertCommand(t, cmd, "docker",
+			"compose",
+			"-f", filepath.Join(repo, repoComposeFileName),
+			"-f", filepath.Join(repo, localComposeOverrideName),
+			"--profile", "milvus",
+			"--profile", "opensearch",
+			"config", "--format", "json",
+		)
+		return CommandResult{Stdout: composeConfigJSONNoBuildFixture()}, nil
 	})
 	runner.streamHandlers = append(runner.streamHandlers, func(cmd Command) error {
 		assertCommandContainsInOrder(t, cmd, "docker", []string{
@@ -448,7 +491,7 @@ func TestComposeUpStreamsDockerComposeLogsWhenSupported(t *testing.T) {
 			"--profile", "milvus",
 			"--profile", "opensearch",
 			"up",
-			"--build",
+			"--no-build",
 			"auth-service",
 			"core",
 		})
@@ -475,6 +518,7 @@ func TestManagerUpWritesStateAndStartsProcessCompose(t *testing.T) {
 	manager.probeAPI = func(port int, timeout time.Duration) bool { return true }
 	manager.probeAuth = func(port int, timeout time.Duration) bool { return true }
 	manager.probeURL = func(url string, timeout time.Duration) bool { return true }
+	manager.portAvailable = func(port int) bool { return true }
 	manager.pollInterval = time.Millisecond
 	manager.upTimeout = time.Second
 	cfg, paths, err := NewRuntimeConfig(defaultProfileValue(), repo)
@@ -929,6 +973,37 @@ func writeComposeFixture(t *testing.T, repo string) {
 	if err := os.WriteFile(overlay, []byte("# Local Runtime override file\nx-lazymind-local:\n  mode: local\n  disabled_container_services: []\n"), 0o644); err != nil {
 		t.Fatalf("write overlay: %v", err)
 	}
+}
+
+func composeConfigJSONFixture(repo string) string {
+	return fmt.Sprintf(`{
+  "services": {
+    "auth-service": {"image": "auth-image"},
+    "core": {
+      "image": "core-image",
+      "build": {
+        "context": %q,
+        "dockerfile": "core/Dockerfile",
+        "args": {"GOPROXY": "https://goproxy.cn,direct"}
+      }
+    },
+    "web": {"image": "web-image"},
+    "redis": {"image": "redis-image"}
+  }
+}`, filepath.Join(repo, "backend"))
+}
+
+func composeConfigJSONNoBuildFixture() string {
+	return `{
+  "services": {
+    "auth-service": {"image": "auth-image"},
+    "core": {"image": "core-image"},
+    "web": {"image": "web-image"},
+    "redis": {"image": "redis-image"},
+    "evo-api": {"image": "evo-image"},
+    "frontend": {"image": "frontend-image"}
+  }
+}`
 }
 
 func readyComposeStatusJSON() string {

--- a/local/local-runtime-manager/manager_test.go
+++ b/local/local-runtime-manager/manager_test.go
@@ -179,6 +179,22 @@ func TestRuntimeConfigMovesDefaultFrontendPortWhenOccupied(t *testing.T) {
 	}
 }
 
+func TestFrontendBuildEnvIncludesLocalViteOverrides(t *testing.T) {
+	t.Setenv("VITE_LAZYMIND_MODE", "")
+	t.Setenv("VITE_HIDE_EVO", "true")
+	t.Setenv("VITE_API_BASE_URL", "http://127.0.0.1:5024")
+	t.Setenv("VITE_APP_LOGO", "/logo.svg")
+	t.Setenv("VITE_APP_CHAT_TITLE", "Local Chat")
+
+	assertStringSlicesEqual(t, frontendBuildEnv(), []string{
+		"VITE_LAZYMIND_MODE=local",
+		"VITE_HIDE_EVO=true",
+		"VITE_API_BASE_URL=http://127.0.0.1:5024",
+		"VITE_APP_LOGO=/logo.svg",
+		"VITE_APP_CHAT_TITLE=Local Chat",
+	})
+}
+
 func TestAlgorithmServiceEnvIncludesCloudParityDefaults(t *testing.T) {
 	for _, name := range []string{
 		"TZ",
@@ -382,6 +398,29 @@ func TestAcquireAlgorithmPythonLockWaitsForLiveLock(t *testing.T) {
 	}
 }
 
+func TestUVCommandFindsUserLocalInstall(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("UV", "")
+	t.Setenv("PATH", t.TempDir())
+	t.Setenv("HOME", home)
+
+	uv := filepath.Join(home, ".local", "bin", "uv")
+	if err := os.MkdirAll(filepath.Dir(uv), 0o755); err != nil {
+		t.Fatalf("mkdir uv dir: %v", err)
+	}
+	if err := os.WriteFile(uv, []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatalf("write uv: %v", err)
+	}
+
+	got, ok := uvCommand()
+	if !ok {
+		t.Fatal("expected uv command from user local install")
+	}
+	if got != uv {
+		t.Fatalf("expected %s got %s", uv, got)
+	}
+}
+
 func TestFilterRemainingServices(t *testing.T) {
 	services := []string{"auth-service", "core", "web"}
 	remaining, err := filterRemainingServices(services, []string{"core"})
@@ -394,6 +433,46 @@ func TestFilterRemainingServices(t *testing.T) {
 	if _, err := filterRemainingServices(services, []string{"does-not-exist"}); err == nil {
 		t.Fatalf("expected error for unknown disabled service")
 	}
+}
+
+func TestBuildEnabledServicesUsesDockerComposeBuild(t *testing.T) {
+	repo := t.TempDir()
+	writeComposeFixture(t, repo)
+	runner := &fakeRunner{t: t}
+	manager := NewRuntimeManager(runner, filepath.Join(repo, "lazymind-local"))
+	runner.handlers = append(runner.handlers, func(cmd Command) (CommandResult, error) {
+		assertCommand(t, cmd, "docker",
+			"compose",
+			"-f", filepath.Join(repo, repoComposeFileName),
+			"-f", filepath.Join(repo, localComposeOverrideName),
+			"--profile", "milvus",
+			"--profile", "opensearch",
+			"config", "--format", "json",
+		)
+		return CommandResult{Stdout: `{
+  "services": {
+    "auth-service": {"build": {"context": "./backend/auth"}},
+    "core": {"image": "core-image"},
+    "web": {"build": {"context": "./frontend"}}
+  }
+}`}, nil
+	}, func(cmd Command) (CommandResult, error) {
+		assertCommand(t, cmd, "docker",
+			"compose",
+			"-f", filepath.Join(repo, repoComposeFileName),
+			"-f", filepath.Join(repo, localComposeOverrideName),
+			"--profile", "milvus",
+			"--profile", "opensearch",
+			"build",
+			"auth-service",
+			"web",
+		)
+		return CommandResult{}, nil
+	})
+	if err := manager.compose.BuildEnabledServices(context.Background(), repo, []string{"auth-service", "core", "web"}); err != nil {
+		t.Fatalf("build enabled services: %v", err)
+	}
+	runner.assertCommandCount(2)
 }
 
 func TestClassifyComposeReadinessReportsFatalBeforePending(t *testing.T) {

--- a/local/local-runtime-manager/manager_test.go
+++ b/local/local-runtime-manager/manager_test.go
@@ -179,6 +179,27 @@ func TestRuntimeConfigMovesDefaultFrontendPortWhenOccupied(t *testing.T) {
 	}
 }
 
+func TestRuntimeConfigKeepsPinnedFrontendPortWhenOccupied(t *testing.T) {
+	t.Setenv(frontendPortEnvVar, strconv.Itoa(defaultFrontendPort))
+	t.Setenv(localPortsPinnedEnvVar, "1")
+	ln := occupyLocalPorts(t, defaultFrontendPort)
+	defer func() {
+		for _, existing := range ln {
+			_ = existing.Close()
+		}
+	}()
+
+	repo := t.TempDir()
+	writeComposeFixture(t, repo)
+	cfg, _, err := NewRuntimeConfig(defaultProfileValue(), repo)
+	if err != nil {
+		t.Fatalf("runtime config: %v", err)
+	}
+	if cfg.FrontendPort != defaultFrontendPort {
+		t.Fatalf("expected pinned frontend port %d got %d", defaultFrontendPort, cfg.FrontendPort)
+	}
+}
+
 func TestFrontendBuildEnvIncludesLocalViteOverrides(t *testing.T) {
 	t.Setenv("VITE_LAZYMIND_MODE", "")
 	t.Setenv("VITE_HIDE_EVO", "true")
@@ -647,6 +668,9 @@ func TestWriteGeneratedComposeConfig(t *testing.T) {
 	}
 	if !strings.Contains(proc.Command, "LAZYMIND_FRONTEND_PORT="+strconv.Itoa(cfg.FrontendPort)) {
 		t.Fatalf("compose command missing frontend env: %q", proc.Command)
+	}
+	if !strings.Contains(proc.Command, localPortsPinnedEnvVar+"=1") {
+		t.Fatalf("compose command missing pinned port env: %q", proc.Command)
 	}
 	if !strings.Contains(proc.Shutdown.Command, "internal compose-down --profile "+profile) {
 		t.Fatalf("missing compose-down command: %q", proc.Shutdown.Command)

--- a/local/local-runtime-manager/processcompose.go
+++ b/local/local-runtime-manager/processcompose.go
@@ -141,6 +141,7 @@ func commandWithEnv(env []string, command string) string {
 func runtimeCommandEnv(cfg RuntimeConfig) []string {
 	env := append([]string{}, localComposeEnv(cfg)...)
 	env = append(env,
+		localPortsPinnedEnvVar+"=1",
 		processComposePortEnvVar+"="+strconv.Itoa(cfg.ProcessComposePort),
 		authServicePortEnvVar+"="+strconv.Itoa(cfg.AuthService.Port),
 	)

--- a/local/local-runtime-manager/processcompose.go
+++ b/local/local-runtime-manager/processcompose.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
@@ -44,18 +43,18 @@ type processComposeShutdown struct {
 	TimeoutSeconds int    `yaml:"timeout_seconds"`
 }
 
-func (m *ProcessComposeManager) WriteGeneratedConfig(w io.Writer, repoRoot string, profile string, logPath string, localProxyLogPath string, authServiceLogPath string, frontendLogPath string, tokenPath string, apiPort int, runtimeEnv []string) error {
-	envPrefix := shellEnvPrefix(runtimeEnv)
-	commandForComposeUp := envPrefix + quoteShellArg(m.execPath) + " internal compose-up --profile " + profile
-	commandForComposeDown := envPrefix + quoteShellArg(m.execPath) + " internal compose-down --profile " + profile
-	commandForLocalProxyRun := envPrefix + quoteShellArg(m.execPath) + " internal local-proxy-run --profile " + profile
-	commandForLocalProxyDown := envPrefix + quoteShellArg(m.execPath) + " internal local-proxy-down --profile " + profile
-	commandForAuthServiceRun := envPrefix + quoteShellArg(m.execPath) + " internal auth-service-run --profile " + profile
-	commandForAuthServiceDown := envPrefix + quoteShellArg(m.execPath) + " internal auth-service-down --profile " + profile
-	commandForFrontendRun := envPrefix + quoteShellArg(m.execPath) + " internal frontend-run --profile " + profile
-	commandForFrontendDown := envPrefix + quoteShellArg(m.execPath) + " internal frontend-down --profile " + profile
+func (m *ProcessComposeManager) WriteGeneratedConfig(w io.Writer, repoRoot string, profile string, paths RuntimePaths, cfg RuntimeConfig, tokenPath string, apiPort int) error {
+	commandEnv := runtimeCommandEnv(cfg)
+	commandForComposeUp := commandWithEnv(commandEnv, quoteShellArg(m.execPath)+" internal compose-up --profile "+profile)
+	commandForComposeDown := commandWithEnv(commandEnv, quoteShellArg(m.execPath)+" internal compose-down --profile "+profile)
+	commandForLocalProxyRun := commandWithEnv(commandEnv, quoteShellArg(m.execPath)+" internal local-proxy-run --profile "+profile)
+	commandForLocalProxyDown := commandWithEnv(commandEnv, quoteShellArg(m.execPath)+" internal local-proxy-down --profile "+profile)
+	commandForAuthServiceRun := commandWithEnv(commandEnv, quoteShellArg(m.execPath)+" internal auth-service-run --profile "+profile)
+	commandForAuthServiceDown := commandWithEnv(commandEnv, quoteShellArg(m.execPath)+" internal auth-service-down --profile "+profile)
+	commandForFrontendRun := commandWithEnv(commandEnv, quoteShellArg(m.execPath)+" internal frontend-run --profile "+profile)
+	commandForFrontendDown := commandWithEnv(commandEnv, quoteShellArg(m.execPath)+" internal frontend-down --profile "+profile)
 
-	cfg := processComposeConfig{
+	pcCfg := processComposeConfig{
 		Version:         "0.5",
 		IsStrict:        true,
 		OrderedShutdown: true,
@@ -67,7 +66,7 @@ func (m *ProcessComposeManager) WriteGeneratedConfig(w io.Writer, repoRoot strin
 					Command:        commandForComposeDown,
 					TimeoutSeconds: 60,
 				},
-				LogLocation: logPath,
+				LogLocation: paths.LogFilePath,
 				Namespace:   "container",
 			},
 			localProxyProcessName: {
@@ -77,7 +76,7 @@ func (m *ProcessComposeManager) WriteGeneratedConfig(w io.Writer, repoRoot strin
 					Command:        commandForLocalProxyDown,
 					TimeoutSeconds: 15,
 				},
-				LogLocation: localProxyLogPath,
+				LogLocation: paths.LocalProxyLog,
 				Namespace:   "host",
 			},
 			authServiceProcessName: {
@@ -87,7 +86,7 @@ func (m *ProcessComposeManager) WriteGeneratedConfig(w io.Writer, repoRoot strin
 					Command:        commandForAuthServiceDown,
 					TimeoutSeconds: 15,
 				},
-				LogLocation: authServiceLogPath,
+				LogLocation: paths.AuthServiceLog,
 				Namespace:   "host",
 			},
 			frontendProcessName: {
@@ -97,14 +96,28 @@ func (m *ProcessComposeManager) WriteGeneratedConfig(w io.Writer, repoRoot strin
 					Command:        commandForFrontendDown,
 					TimeoutSeconds: 15,
 				},
-				LogLocation: frontendLogPath,
+				LogLocation: paths.FrontendLog,
 				Namespace:   "host",
 			},
 		},
 	}
+	for _, svc := range algorithmProcessSpecs(cfg.Algorithm) {
+		run := commandWithEnv(commandEnv, quoteShellArg(m.execPath)+" internal algorithm-run --service "+svc.Name+" --profile "+profile)
+		down := commandWithEnv(commandEnv, quoteShellArg(m.execPath)+" internal algorithm-down --service "+svc.Name+" --profile "+profile)
+		pcCfg.Processes[svc.Name] = processComposeProcess{
+			WorkingDir: repoRoot,
+			Command:    run,
+			Shutdown: processComposeShutdown{
+				Command:        down,
+				TimeoutSeconds: 20,
+			},
+			LogLocation: algorithmLogPath(paths, svc.Name),
+			Namespace:   "host",
+		}
+	}
 	_ = tokenPath
 	_ = apiPort
-	out, err := yaml.Marshal(cfg)
+	out, err := yaml.Marshal(pcCfg)
 	if err != nil {
 		return err
 	}
@@ -112,11 +125,26 @@ func (m *ProcessComposeManager) WriteGeneratedConfig(w io.Writer, repoRoot strin
 	return err
 }
 
-type ProcessComposeProcessStatus struct {
-	Name      string
-	Status    string
-	IsRunning bool
-	ExitCode  int
+func commandWithEnv(env []string, command string) string {
+	if len(env) == 0 {
+		return command
+	}
+	parts := make([]string, 0, len(env)+2)
+	parts = append(parts, "env")
+	for _, item := range env {
+		parts = append(parts, quoteShellArg(item))
+	}
+	parts = append(parts, command)
+	return strings.Join(parts, " ")
+}
+
+func runtimeCommandEnv(cfg RuntimeConfig) []string {
+	env := append([]string{}, localComposeEnv(cfg)...)
+	env = append(env,
+		processComposePortEnvVar+"="+strconv.Itoa(cfg.ProcessComposePort),
+		authServicePortEnvVar+"="+strconv.Itoa(cfg.AuthService.Port),
+	)
+	return env
 }
 
 func (m *ProcessComposeManager) Up(ctx context.Context, cfg RuntimeConfig, paths RuntimePaths) error {
@@ -174,46 +202,6 @@ func (m *ProcessComposeManager) Down(ctx context.Context, cfg RuntimeConfig, pat
 	return nil
 }
 
-func (m *ProcessComposeManager) List(ctx context.Context, cfg RuntimeConfig, paths RuntimePaths) ([]ProcessComposeProcessStatus, error) {
-	args := []string{
-		"-p", strconv.Itoa(cfg.ProcessComposePort),
-		"--token-file", paths.RunDirTokenFile,
-		"list",
-		"-o", "json",
-	}
-	res, err := m.runner.Run(ctx, Command{Name: processComposeCommand(paths.RepoRoot), Args: args, Dir: paths.RepoRoot})
-	if err != nil {
-		return nil, fmt.Errorf("process-compose list failed: %w (%s)", err, strings.TrimSpace(res.Stderr))
-	}
-	return parseProcessComposeListJSON(res.Stdout)
-}
-
-func parseProcessComposeListJSON(raw string) ([]ProcessComposeProcessStatus, error) {
-	raw = strings.TrimSpace(raw)
-	if raw == "" {
-		return nil, nil
-	}
-	var rows []struct {
-		Name      string `json:"name"`
-		Status    string `json:"status"`
-		IsRunning bool   `json:"is_running"`
-		ExitCode  int    `json:"exit_code"`
-	}
-	if err := json.Unmarshal([]byte(raw), &rows); err != nil {
-		return nil, err
-	}
-	statuses := make([]ProcessComposeProcessStatus, 0, len(rows))
-	for _, row := range rows {
-		statuses = append(statuses, ProcessComposeProcessStatus{
-			Name:      row.Name,
-			Status:    strings.ToLower(row.Status),
-			IsRunning: row.IsRunning,
-			ExitCode:  row.ExitCode,
-		})
-	}
-	return statuses, nil
-}
-
 func (m *ProcessComposeManager) ProbeAPI(port int, timeout time.Duration) bool {
 	url := "http://127.0.0.1:" + strconv.Itoa(port) + "/api/v1/processes"
 	req, err := http.NewRequest(http.MethodGet, url, nil)
@@ -249,22 +237,4 @@ func processComposeCommand(repoRoot string) string {
 		return candidate
 	}
 	return "process-compose"
-}
-
-func shellEnvPrefix(env []string) string {
-	if len(env) == 0 {
-		return ""
-	}
-	parts := make([]string, 0, len(env))
-	for _, item := range env {
-		key, value, ok := strings.Cut(item, "=")
-		if !ok || key == "" {
-			continue
-		}
-		parts = append(parts, key+"="+quoteShellArg(value))
-	}
-	if len(parts) == 0 {
-		return ""
-	}
-	return strings.Join(parts, " ") + " "
 }

--- a/local/local-runtime-manager/processcompose.go
+++ b/local/local-runtime-manager/processcompose.go
@@ -44,15 +44,16 @@ type processComposeShutdown struct {
 	TimeoutSeconds int    `yaml:"timeout_seconds"`
 }
 
-func (m *ProcessComposeManager) WriteGeneratedConfig(w io.Writer, repoRoot string, profile string, logPath string, localProxyLogPath string, authServiceLogPath string, frontendLogPath string, tokenPath string, apiPort int) error {
-	commandForComposeUp := quoteShellArg(m.execPath) + " internal compose-up --profile " + profile
-	commandForComposeDown := quoteShellArg(m.execPath) + " internal compose-down --profile " + profile
-	commandForLocalProxyRun := quoteShellArg(m.execPath) + " internal local-proxy-run --profile " + profile
-	commandForLocalProxyDown := quoteShellArg(m.execPath) + " internal local-proxy-down --profile " + profile
-	commandForAuthServiceRun := quoteShellArg(m.execPath) + " internal auth-service-run --profile " + profile
-	commandForAuthServiceDown := quoteShellArg(m.execPath) + " internal auth-service-down --profile " + profile
-	commandForFrontendRun := quoteShellArg(m.execPath) + " internal frontend-run --profile " + profile
-	commandForFrontendDown := quoteShellArg(m.execPath) + " internal frontend-down --profile " + profile
+func (m *ProcessComposeManager) WriteGeneratedConfig(w io.Writer, repoRoot string, profile string, logPath string, localProxyLogPath string, authServiceLogPath string, frontendLogPath string, tokenPath string, apiPort int, runtimeEnv []string) error {
+	envPrefix := shellEnvPrefix(runtimeEnv)
+	commandForComposeUp := envPrefix + quoteShellArg(m.execPath) + " internal compose-up --profile " + profile
+	commandForComposeDown := envPrefix + quoteShellArg(m.execPath) + " internal compose-down --profile " + profile
+	commandForLocalProxyRun := envPrefix + quoteShellArg(m.execPath) + " internal local-proxy-run --profile " + profile
+	commandForLocalProxyDown := envPrefix + quoteShellArg(m.execPath) + " internal local-proxy-down --profile " + profile
+	commandForAuthServiceRun := envPrefix + quoteShellArg(m.execPath) + " internal auth-service-run --profile " + profile
+	commandForAuthServiceDown := envPrefix + quoteShellArg(m.execPath) + " internal auth-service-down --profile " + profile
+	commandForFrontendRun := envPrefix + quoteShellArg(m.execPath) + " internal frontend-run --profile " + profile
+	commandForFrontendDown := envPrefix + quoteShellArg(m.execPath) + " internal frontend-down --profile " + profile
 
 	cfg := processComposeConfig{
 		Version:         "0.5",
@@ -248,4 +249,22 @@ func processComposeCommand(repoRoot string) string {
 		return candidate
 	}
 	return "process-compose"
+}
+
+func shellEnvPrefix(env []string) string {
+	if len(env) == 0 {
+		return ""
+	}
+	parts := make([]string, 0, len(env))
+	for _, item := range env {
+		key, value, ok := strings.Cut(item, "=")
+		if !ok || key == "" {
+			continue
+		}
+		parts = append(parts, key+"="+quoteShellArg(value))
+	}
+	if len(parts) == 0 {
+		return ""
+	}
+	return strings.Join(parts, " ") + " "
 }

--- a/local/local-runtime-manager/processcompose.go
+++ b/local/local-runtime-manager/processcompose.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
@@ -43,13 +44,15 @@ type processComposeShutdown struct {
 	TimeoutSeconds int    `yaml:"timeout_seconds"`
 }
 
-func (m *ProcessComposeManager) WriteGeneratedConfig(w io.Writer, repoRoot string, profile string, logPath string, localProxyLogPath string, authServiceLogPath string, tokenPath string, apiPort int) error {
+func (m *ProcessComposeManager) WriteGeneratedConfig(w io.Writer, repoRoot string, profile string, logPath string, localProxyLogPath string, authServiceLogPath string, frontendLogPath string, tokenPath string, apiPort int) error {
 	commandForComposeUp := quoteShellArg(m.execPath) + " internal compose-up --profile " + profile
 	commandForComposeDown := quoteShellArg(m.execPath) + " internal compose-down --profile " + profile
 	commandForLocalProxyRun := quoteShellArg(m.execPath) + " internal local-proxy-run --profile " + profile
 	commandForLocalProxyDown := quoteShellArg(m.execPath) + " internal local-proxy-down --profile " + profile
 	commandForAuthServiceRun := quoteShellArg(m.execPath) + " internal auth-service-run --profile " + profile
 	commandForAuthServiceDown := quoteShellArg(m.execPath) + " internal auth-service-down --profile " + profile
+	commandForFrontendRun := quoteShellArg(m.execPath) + " internal frontend-run --profile " + profile
+	commandForFrontendDown := quoteShellArg(m.execPath) + " internal frontend-down --profile " + profile
 
 	cfg := processComposeConfig{
 		Version:         "0.5",
@@ -86,6 +89,16 @@ func (m *ProcessComposeManager) WriteGeneratedConfig(w io.Writer, repoRoot strin
 				LogLocation: authServiceLogPath,
 				Namespace:   "host",
 			},
+			frontendProcessName: {
+				WorkingDir: repoRoot,
+				Command:    commandForFrontendRun,
+				Shutdown: processComposeShutdown{
+					Command:        commandForFrontendDown,
+					TimeoutSeconds: 15,
+				},
+				LogLocation: frontendLogPath,
+				Namespace:   "host",
+			},
 		},
 	}
 	_ = tokenPath
@@ -96,6 +109,13 @@ func (m *ProcessComposeManager) WriteGeneratedConfig(w io.Writer, repoRoot strin
 	}
 	_, err = w.Write(out)
 	return err
+}
+
+type ProcessComposeProcessStatus struct {
+	Name      string
+	Status    string
+	IsRunning bool
+	ExitCode  int
 }
 
 func (m *ProcessComposeManager) Up(ctx context.Context, cfg RuntimeConfig, paths RuntimePaths) error {
@@ -141,17 +161,56 @@ func (m *ProcessComposeManager) FollowLogs(ctx context.Context, cfg RuntimeConfi
 }
 
 func (m *ProcessComposeManager) Down(ctx context.Context, cfg RuntimeConfig, paths RuntimePaths) error {
-	args := []string{"--config", filepath.ToSlash(paths.GeneratedConfig)}
-	args = append(args,
+	args := []string{
 		"-p", strconv.Itoa(cfg.ProcessComposePort),
 		"--token-file", paths.RunDirTokenFile,
 		"down",
-	)
+	}
 	res, err := m.runner.Run(ctx, Command{Name: processComposeCommand(paths.RepoRoot), Args: args, Dir: paths.RepoRoot})
 	if err != nil {
 		return fmt.Errorf("process-compose down failed: %w (%s)", err, strings.TrimSpace(res.Stderr))
 	}
 	return nil
+}
+
+func (m *ProcessComposeManager) List(ctx context.Context, cfg RuntimeConfig, paths RuntimePaths) ([]ProcessComposeProcessStatus, error) {
+	args := []string{
+		"-p", strconv.Itoa(cfg.ProcessComposePort),
+		"--token-file", paths.RunDirTokenFile,
+		"list",
+		"-o", "json",
+	}
+	res, err := m.runner.Run(ctx, Command{Name: processComposeCommand(paths.RepoRoot), Args: args, Dir: paths.RepoRoot})
+	if err != nil {
+		return nil, fmt.Errorf("process-compose list failed: %w (%s)", err, strings.TrimSpace(res.Stderr))
+	}
+	return parseProcessComposeListJSON(res.Stdout)
+}
+
+func parseProcessComposeListJSON(raw string) ([]ProcessComposeProcessStatus, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return nil, nil
+	}
+	var rows []struct {
+		Name      string `json:"name"`
+		Status    string `json:"status"`
+		IsRunning bool   `json:"is_running"`
+		ExitCode  int    `json:"exit_code"`
+	}
+	if err := json.Unmarshal([]byte(raw), &rows); err != nil {
+		return nil, err
+	}
+	statuses := make([]ProcessComposeProcessStatus, 0, len(rows))
+	for _, row := range rows {
+		statuses = append(statuses, ProcessComposeProcessStatus{
+			Name:      row.Name,
+			Status:    strings.ToLower(row.Status),
+			IsRunning: row.IsRunning,
+			ExitCode:  row.ExitCode,
+		})
+	}
+	return statuses, nil
 }
 
 func (m *ProcessComposeManager) ProbeAPI(port int, timeout time.Duration) bool {

--- a/local/local-runtime-manager/state.go
+++ b/local/local-runtime-manager/state.go
@@ -15,6 +15,7 @@ type RuntimeState struct {
 	RepoRoot       string                         `json:"repoRoot"`
 	RuntimeRoot    string                         `json:"runtimeRoot"`
 	ProcessCompose ProcessComposeState            `json:"processCompose"`
+	Config         RuntimeConfigSnapshot          `json:"config,omitempty"`
 	Services       map[string]RuntimeServiceState `json:"services"`
 	OverallStatus  string                         `json:"overallStatus,omitempty"`
 	UpdatedAt      string                         `json:"updatedAt"`
@@ -25,6 +26,14 @@ type ProcessComposeState struct {
 	APIRoot   string `json:"api"`
 	TokenFile string `json:"apiTokenFile"`
 	PID       int    `json:"pid"`
+}
+
+type RuntimeConfigSnapshot struct {
+	FrontendPort       int               `json:"frontendPort,omitempty"`
+	LocalProxy         LocalProxyConfig  `json:"localProxy,omitempty"`
+	AuthService        AuthServiceConfig `json:"authService,omitempty"`
+	Algorithm          AlgorithmConfig   `json:"algorithm,omitempty"`
+	ProcessComposePort int               `json:"processComposePort,omitempty"`
 }
 
 type RuntimeServiceState struct {
@@ -75,6 +84,7 @@ func defaultRuntimeState(cfg RuntimeConfig, apiPort int, tokenPath string) Runti
 			TokenFile: tokenPath,
 			PID:       0,
 		},
+		Config: snapshotRuntimeConfig(cfg),
 		Services: map[string]RuntimeServiceState{
 			processComposeServiceName: {
 				Kind:   "docker-compose",
@@ -92,10 +102,59 @@ func defaultRuntimeState(cfg RuntimeConfig, apiPort int, tokenPath string) Runti
 				Kind:   "host-process",
 				Status: "stopped",
 			},
+			docServerProcessName: {
+				Kind:   "host-process",
+				Status: "stopped",
+			},
+			processorServerProcessName: {
+				Kind:   "host-process",
+				Status: "stopped",
+			},
+			processorWorkerProcessName: {
+				Kind:   "host-process",
+				Status: "stopped",
+			},
+			algoProcessName: {
+				Kind:   "host-process",
+				Status: "stopped",
+			},
+			chatProcessName: {
+				Kind:   "host-process",
+				Status: "stopped",
+			},
 		},
 		OverallStatus: "unknown",
 		UpdatedAt:     time.Now().UTC().Format(time.RFC3339),
 	}
+}
+
+func snapshotRuntimeConfig(cfg RuntimeConfig) RuntimeConfigSnapshot {
+	return RuntimeConfigSnapshot{
+		FrontendPort:       cfg.FrontendPort,
+		LocalProxy:         cfg.LocalProxy,
+		AuthService:        cfg.AuthService,
+		Algorithm:          cfg.Algorithm,
+		ProcessComposePort: cfg.ProcessComposePort,
+	}
+}
+
+func applyStateConfig(cfg RuntimeConfig, state RuntimeState) RuntimeConfig {
+	if state.Config.ProcessComposePort > 0 {
+		cfg.ProcessComposePort = state.Config.ProcessComposePort
+	}
+	if state.Config.FrontendPort > 0 {
+		cfg.FrontendPort = state.Config.FrontendPort
+	}
+	if state.Config.LocalProxy.Port > 0 {
+		cfg.LocalProxy = state.Config.LocalProxy
+	}
+	if state.Config.AuthService.Port > 0 {
+		cfg.AuthService = state.Config.AuthService
+	}
+	if state.Config.Algorithm.DocPort > 0 {
+		cfg.Algorithm = state.Config.Algorithm
+	}
+	return cfg
 }
 
 func itoa(v int) string {
@@ -120,6 +179,18 @@ func newStateWithServiceStatus(state RuntimeState, serviceStatus string) Runtime
 	fe.Kind = "host-process"
 	fe.Status = serviceStatus
 	state.Services[frontendProcessName] = fe
+	for _, name := range []string{
+		docServerProcessName,
+		processorServerProcessName,
+		processorWorkerProcessName,
+		algoProcessName,
+		chatProcessName,
+	} {
+		svc := state.Services[name]
+		svc.Kind = "host-process"
+		svc.Status = serviceStatus
+		state.Services[name] = svc
+	}
 	state.UpdatedAt = time.Now().UTC().Format(time.RFC3339)
 	return state
 }
@@ -183,6 +254,24 @@ func normalizeRuntimeServices(services map[string]RuntimeServiceState) map[strin
 		svc := services[frontendProcessName]
 		svc.Kind = "host-process"
 		normalized[frontendProcessName] = svc
+	}
+	for _, name := range []string{
+		docServerProcessName,
+		processorServerProcessName,
+		processorWorkerProcessName,
+		algoProcessName,
+		chatProcessName,
+	} {
+		if _, ok := services[name]; !ok {
+			normalized[name] = RuntimeServiceState{
+				Kind:   "host-process",
+				Status: "unknown",
+			}
+		} else {
+			svc := services[name]
+			svc.Kind = "host-process"
+			normalized[name] = svc
+		}
 	}
 	return normalized
 }

--- a/local/local-runtime-manager/state.go
+++ b/local/local-runtime-manager/state.go
@@ -88,6 +88,10 @@ func defaultRuntimeState(cfg RuntimeConfig, apiPort int, tokenPath string) Runti
 				Kind:   "host-process",
 				Status: "stopped",
 			},
+			frontendProcessName: {
+				Kind:   "host-process",
+				Status: "stopped",
+			},
 		},
 		OverallStatus: "unknown",
 		UpdatedAt:     time.Now().UTC().Format(time.RFC3339),
@@ -114,6 +118,10 @@ func newStateWithServiceStatus(state RuntimeState, serviceStatus string) Runtime
 	auth.Kind = "host-process"
 	auth.Status = serviceStatus
 	state.Services[authServiceProcessName] = auth
+	fe := state.Services[frontendProcessName]
+	fe.Kind = "host-process"
+	fe.Status = serviceStatus
+	state.Services[frontendProcessName] = fe
 	state.UpdatedAt = time.Now().UTC().Format(time.RFC3339)
 	return state
 }
@@ -146,6 +154,12 @@ func readOrNewState(paths RuntimePaths, cfg RuntimeConfig) (RuntimeState, error)
 	}
 	if _, ok := st.Services[authServiceProcessName]; !ok {
 		st.Services[authServiceProcessName] = RuntimeServiceState{
+			Kind:   "host-process",
+			Status: "unknown",
+		}
+	}
+	if _, ok := st.Services[frontendProcessName]; !ok {
+		st.Services[frontendProcessName] = RuntimeServiceState{
 			Kind:   "host-process",
 			Status: "unknown",
 		}

--- a/local/local-runtime-manager/state.go
+++ b/local/local-runtime-manager/state.go
@@ -103,9 +103,7 @@ func itoa(v int) string {
 }
 
 func newStateWithServiceStatus(state RuntimeState, serviceStatus string) RuntimeState {
-	if state.Services == nil {
-		state.Services = map[string]RuntimeServiceState{}
-	}
+	state.Services = normalizeRuntimeServices(state.Services)
 	ds := state.Services[processComposeServiceName]
 	ds.Kind = "docker-compose"
 	ds.Status = serviceStatus
@@ -137,32 +135,54 @@ func readOrNewState(paths RuntimePaths, cfg RuntimeConfig) (RuntimeState, error)
 	if st.ProcessCompose.APIPort == 0 {
 		st.ProcessCompose.APIPort = cfg.ProcessComposePort
 	}
-	if st.Services == nil {
-		st.Services = map[string]RuntimeServiceState{}
+	st.Services = normalizeRuntimeServices(st.Services)
+	return st, nil
+}
+
+func normalizeRuntimeServices(services map[string]RuntimeServiceState) map[string]RuntimeServiceState {
+	if services == nil {
+		services = map[string]RuntimeServiceState{}
 	}
-	if _, ok := st.Services[processComposeServiceName]; !ok {
-		st.Services[processComposeServiceName] = RuntimeServiceState{
+	normalized := map[string]RuntimeServiceState{}
+	if _, ok := services[processComposeServiceName]; !ok {
+		normalized[processComposeServiceName] = RuntimeServiceState{
 			Kind:   "docker-compose",
 			Status: "unknown",
 		}
+	} else {
+		svc := services[processComposeServiceName]
+		svc.Kind = "docker-compose"
+		normalized[processComposeServiceName] = svc
 	}
-	if _, ok := st.Services[localProxyProcessName]; !ok {
-		st.Services[localProxyProcessName] = RuntimeServiceState{
+	if _, ok := services[localProxyProcessName]; !ok {
+		normalized[localProxyProcessName] = RuntimeServiceState{
 			Kind:   "host-process",
 			Status: "unknown",
 		}
+	} else {
+		svc := services[localProxyProcessName]
+		svc.Kind = "host-process"
+		normalized[localProxyProcessName] = svc
 	}
-	if _, ok := st.Services[authServiceProcessName]; !ok {
-		st.Services[authServiceProcessName] = RuntimeServiceState{
+	if _, ok := services[authServiceProcessName]; !ok {
+		normalized[authServiceProcessName] = RuntimeServiceState{
 			Kind:   "host-process",
 			Status: "unknown",
 		}
+	} else {
+		svc := services[authServiceProcessName]
+		svc.Kind = "host-process"
+		normalized[authServiceProcessName] = svc
 	}
-	if _, ok := st.Services[frontendProcessName]; !ok {
-		st.Services[frontendProcessName] = RuntimeServiceState{
+	if _, ok := services[frontendProcessName]; !ok {
+		normalized[frontendProcessName] = RuntimeServiceState{
 			Kind:   "host-process",
 			Status: "unknown",
 		}
+	} else {
+		svc := services[frontendProcessName]
+		svc.Kind = "host-process"
+		normalized[frontendProcessName] = svc
 	}
-	return st, nil
+	return normalized
 }

--- a/tests/frontend/app.test.js
+++ b/tests/frontend/app.test.js
@@ -1,9 +1,17 @@
 import { describe, expect, it } from 'vitest';
 import {
   formRulesSource,
+  frontendDockerfileSource,
   indexHtml,
+  localComposeSource,
+  loginSource,
+  mainLayoutSource,
   mainEntry,
   routePaths,
+  runtimeApiBaseSource,
+  runtimeDesktopBridgeSource,
+  runtimeFeaturesSource,
+  runtimeModeSource,
   routerSource,
 } from './setup.js';
 
@@ -43,6 +51,38 @@ describe('router contract', () => {
 
   it('keeps fallback navigation wired to the app root', () => {
     expect(routerSource).toContain('<Route path="*" element={<Navigate to="/" replace />} />');
+  });
+});
+
+describe('runtime facade contract', () => {
+  it('keeps runtime facade modules present', () => {
+    expect(runtimeModeSource).toContain('export type RuntimeMode');
+    expect(runtimeFeaturesSource).toContain('export const runtimeFeatures');
+    expect(runtimeApiBaseSource).toContain('export function getApiBaseUrl');
+    expect(runtimeDesktopBridgeSource).toContain('export function openLogsDir');
+    expect(runtimeDesktopBridgeSource).toContain('export function openDataDir');
+    expect(runtimeDesktopBridgeSource).toContain('handler.call(bridge)');
+    expect(runtimeDesktopBridgeSource).not.toContain('diagnostics');
+    expect(runtimeDesktopBridgeSource).not.toContain('serviceStatus');
+  });
+
+  it('routes runtime mode checks through the facade', () => {
+    expect(routerSource).toContain('runtimeFeatures.hideRegister');
+    expect(routerSource).toContain('runtimeFeatures.hideCloudAdmin');
+    expect(routerSource).toContain('runtimeFeatures.hideEvo');
+    expect(mainLayoutSource).toContain('runtimeFeatures.hideEvo');
+    expect(loginSource).toContain('runtimeFeatures.hideRegister');
+    expect(mainLayoutSource).not.toContain('VITE_HIDE_EVO');
+    expect(routerSource).not.toContain('VITE_HIDE_EVO');
+    expect(loginSource).not.toContain('VITE_HIDE_EVO');
+  });
+
+  it('keeps frontend Docker build args available while local mode disables the frontend container', () => {
+    expect(frontendDockerfileSource).toContain('ARG VITE_API_BASE_URL');
+    expect(frontendDockerfileSource).toContain('ARG VITE_LAZYMIND_MODE');
+    expect(frontendDockerfileSource).toContain('ARG VITE_HIDE_EVO');
+    expect(localComposeSource).toMatch(/disabled_container_services:[\s\S]*-\s*frontend/);
+    expect(localComposeSource).not.toMatch(/frontend:[\s\S]*VITE_LAZYMIND_MODE:\s*local/);
   });
 });
 

--- a/tests/frontend/runtime.test.js
+++ b/tests/frontend/runtime.test.js
@@ -1,0 +1,87 @@
+import { describe, expect, it } from 'vitest';
+import {
+  resolveRuntimeMode,
+} from '../../frontend/src/runtime/mode.ts';
+import {
+  resolveRuntimeFeatures,
+} from '../../frontend/src/runtime/features.ts';
+import {
+  resolveApiBaseUrl,
+  resolveApiUrl,
+  resolveAuthServiceApiUrl,
+  resolveCoreApiUrl,
+} from '../../frontend/src/runtime/apiBase.ts';
+
+describe('runtime mode facade', () => {
+  it('defaults to cloud mode when unset or unknown', () => {
+    expect(resolveRuntimeMode({})).toBe('cloud');
+    expect(resolveRuntimeMode({ VITE_LAZYMIND_MODE: 'unknown' })).toBe('cloud');
+  });
+
+  it('accepts local and desktop modes explicitly', () => {
+    expect(resolveRuntimeMode({ VITE_LAZYMIND_MODE: 'local' })).toBe('local');
+    expect(resolveRuntimeMode({ VITE_LAZYMIND_MODE: 'desktop' })).toBe('desktop');
+  });
+});
+
+describe('runtime feature facade', () => {
+  it('keeps cloud features visible by default', () => {
+    expect(resolveRuntimeFeatures({})).toMatchObject({
+      hideEvo: false,
+      hideRegister: false,
+      hideCloudAdmin: false,
+      localAutoLogin: false,
+      useLocalGateway: false,
+    });
+  });
+
+  it('enables local presentation defaults for local and desktop', () => {
+    expect(resolveRuntimeFeatures({ VITE_LAZYMIND_MODE: 'local' })).toMatchObject({
+      hideEvo: true,
+      hideRegister: true,
+      hideCloudAdmin: true,
+      localAutoLogin: true,
+      allowFolderPicker: false,
+      allowOpenLogDir: false,
+      useLocalGateway: true,
+    });
+    expect(resolveRuntimeFeatures({ VITE_LAZYMIND_MODE: 'desktop' })).toMatchObject({
+      hideEvo: true,
+      hideRegister: true,
+      hideCloudAdmin: true,
+      localAutoLogin: true,
+      allowFolderPicker: true,
+      allowOpenLogDir: true,
+      useLocalGateway: true,
+    });
+  });
+
+  it('lets VITE_HIDE_EVO explicitly override mode defaults', () => {
+    expect(resolveRuntimeFeatures({ VITE_HIDE_EVO: 'true' }).hideEvo).toBe(true);
+    expect(resolveRuntimeFeatures({
+      VITE_LAZYMIND_MODE: 'local',
+      VITE_HIDE_EVO: 'false',
+    }).hideEvo).toBe(false);
+  });
+});
+
+describe('runtime API base facade', () => {
+  it('normalizes API base URL trailing slashes', () => {
+    expect(resolveApiBaseUrl(
+      { VITE_API_BASE_URL: 'http://127.0.0.1:8090///' },
+      'http://localhost:5173',
+    )).toBe('http://127.0.0.1:8090');
+  });
+
+  it('normalizes API paths with a single separator', () => {
+    const env = { VITE_API_BASE_URL: 'http://127.0.0.1:8090/' };
+    expect(resolveApiUrl('/api/healthz', env, '')).toBe('http://127.0.0.1:8090/api/healthz');
+    expect(resolveApiUrl('api/healthz', env, '')).toBe('http://127.0.0.1:8090/api/healthz');
+    expect(resolveCoreApiUrl('/temp/uploads:initUpload', env, '')).toBe(
+      'http://127.0.0.1:8090/api/core/temp/uploads:initUpload',
+    );
+    expect(resolveAuthServiceApiUrl('auth/refresh', env, '')).toBe(
+      'http://127.0.0.1:8090/api/authservice/auth/refresh',
+    );
+  });
+});

--- a/tests/frontend/setup.js
+++ b/tests/frontend/setup.js
@@ -3,15 +3,27 @@ import { dirname, join } from 'path';
 import { fileURLToPath } from 'url';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
+const repoRoot = join(__dirname, '../..');
 const frontendRoot = join(__dirname, '../../frontend');
 
 export const readFrontendFile = (...parts) =>
   readFileSync(join(frontendRoot, ...parts), 'utf-8');
 
+export const readRepoFile = (...parts) =>
+  readFileSync(join(repoRoot, ...parts), 'utf-8');
+
+export const frontendDockerfileSource = readFrontendFile('Dockerfile');
 export const indexHtml = readFrontendFile('index.html');
+export const localComposeSource = readRepoFile('local/docker-compose.local.yml');
 export const mainEntry = readFrontendFile('src/main.tsx');
 export const routerSource = readFrontendFile('src/router/index.tsx');
+export const mainLayoutSource = readFrontendFile('src/layouts/MainLayout.tsx');
+export const loginSource = readFrontendFile('src/modules/signin/pages/login/index.tsx');
 export const formRulesSource = readFrontendFile('src/modules/signin/utils/formRules.ts');
+export const runtimeModeSource = readFrontendFile('src/runtime/mode.ts');
+export const runtimeFeaturesSource = readFrontendFile('src/runtime/features.ts');
+export const runtimeApiBaseSource = readFrontendFile('src/runtime/apiBase.ts');
+export const runtimeDesktopBridgeSource = readFrontendFile('src/runtime/desktopBridge.ts');
 
 export const routePaths = Array.from(
   routerSource.matchAll(/<Route\s+[^>]*path=["']([^"']+)["']/g),


### PR DESCRIPTION
## Summary

This combines the Linux browser Local Runtime work that was previously split across three upstream PRs:

- Supersedes https://github.com/LazyAGI/LazyMind/pull/233
- Supersedes https://github.com/LazyAGI/LazyMind/pull/245
- Supersedes https://github.com/LazyAGI/LazyMind/pull/254

The combined branch keeps Cloud/Server mode as the default and keeps Local Runtime behavior behind the local runtime manager, local compose overlay, and local/frontend runtime flags.

## What changed

- Adds the frontend runtime facade and host frontend process support for local browser mode.
- Adds local document/office handling and local document parse profile wiring.
- Adds host-managed algorithm services, dynamic local port allocation, runtime state/config snapshots, and local compose env propagation.
- Resolves conflicts with the upstream Evo-disable change from #253 while preserving Cloud-visible behavior by default.

## Cloud compatibility impact

- Base `docker-compose.yml` is unchanged.
- Kong/RBAC/PostgreSQL/Redis/Milvus/OpenSearch Cloud paths are preserved.
- Local/Desktop behavior remains scoped to `local/docker-compose.local.yml`, local-runtime-manager commands, and explicit local runtime configuration.

## Local mode impact

- `make up-build-local` builds the local runtime manager and starts the Linux browser Local Runtime through process-compose.
- Frontend, auth-service, and algorithm services can run as host processes while remaining behind the Local Gateway/local proxy path.
- Local compose disables container services that are replaced by host processes in local mode.

## Validation

Passed:

- `git submodule sync -- algorithm/lazyllm && git submodule update --init algorithm/lazyllm`
- `go test ./...` in `local/local-runtime-manager`
- `go test ./...` in `local/local-proxy`
- `npm ci` in `tests/frontend`
- `npm test` in `tests/frontend`
- `docker compose -f docker-compose.yml -f local/docker-compose.local.yml config`

Not passed / blocked:

- `go test ./...` in `backend/core` fails on existing unrelated failures:
  - `lazymind/core/plugin`: `callDriverAgent` test calls have the old 4-argument shape while the function now requires `map[string][]string` as a fifth argument.
  - `lazymind/core/migrate`: missing `backend/core/migrations/20260423120000_create_word.up.sql`.
- `make lint` is blocked because `/usr/bin/python3` on this machine has no `pip`, so Makefile flake8 dependency installation fails before lint runs.
