### PR TITLE
fix: add English period and exclamation mark to CHUNKING_REGEX for sentence splitting

### DIFF
--- a/algorithm/lazymind/parsing/engine/transform/para_parser.py
+++ b/algorithm/lazymind/parsing/engine/transform/para_parser.py
@@ -57,7 +57,7 @@ def split_by_char() -> Callable[[str], List[str]]:
 
 
 SENTENCE_CHUNK_OVERLAP = 200
-CHUNKING_REGEX = r'[^。？\?！!\.\n]+[。？\?！!\.\n]?'
+CHUNKING_REGEX = r'[^。？?！!.\n]+[。？?！!.\n]*|[。？?！!.\n]+'
 DEFAULT_PARAGRAPH_SEP = '\n\n\n'
 
 DEFAULT_CHUNK_SIZE = 1024

--- a/algorithm/lazymind/parsing/engine/transform/para_parser.py
+++ b/algorithm/lazymind/parsing/engine/transform/para_parser.py
@@ -57,7 +57,7 @@ def split_by_char() -> Callable[[str], List[str]]:
 
 
 SENTENCE_CHUNK_OVERLAP = 200
-CHUNKING_REGEX = r'[^。？\?！\n]+[。？\?！\n]?'
+CHUNKING_REGEX = r'[^。？\?！!\.\n]+[。？\?！!\.\n]?'
 DEFAULT_PARAGRAPH_SEP = '\n\n\n'
 
 DEFAULT_CHUNK_SIZE = 1024


### PR DESCRIPTION
#  PR Description

`CHUNKING_REGEX` was missing `.` and `!`, so English sentences were not
split into `line` nodes correctly.

**Before:** `"Hello world. This is a test! OK?"` → single chunk
**After:**  → three separate `line` nodes

# Changes
- `para_parser.py`: add `\.` and `!` to `CHUNKING_REGEX` character classes

#  Related Issue
Fixes #267

# Demo 

**Before**:
<img width="746" height="461" alt="企业微信截图_17828846701165" src="https://github.com/user-attachments/assets/e6191254-b5da-4488-8713-0c0b0890d341" />

**After**:
<img width="771" height="457" alt="企业微信截图_17828847105790" src="https://github.com/user-attachments/assets/5328cc95-9e09-4f3f-9d46-957289003fa1" />

