### PR TITLE
fix(chat): remove active tool allowlist plumbing

### DIFF
--- a/algorithm/lazymind/chat/service/chat_service.py
+++ b/algorithm/lazymind/chat/service/chat_service.py
@@ -180,28 +180,6 @@ def _build_schedule_tools() -> list:
     return [build_schedule_tool_group()]
 
 
-def _collect_active_tool_names(configs: list) -> set[str]:
-    # Build a per-request callable allowlist from filtered tool configs.
-    # This is consumed by tool_runtime guard to prevent accidental execution
-    # when the model tries to call a tool that is not active in this session.
-    names: set[str] = set()
-    for cfg in configs:
-        inst = getattr(cfg, 'instance', None)
-        if inst is None:
-            continue
-        if callable(inst):
-            tool_name = str(getattr(inst, '__name__', '')).strip()
-            if tool_name:
-                names.add(tool_name)
-        public_apis = getattr(inst, '__public_apis__', None)
-        if isinstance(public_apis, (list, tuple)):
-            for method_name in public_apis:
-                method = str(method_name).strip()
-                if method:
-                    names.add(method)
-    return names
-
-
 def _build_user_attachment_context(history_files_per_turn: Dict[str, List[str]],
                                    current_turn_seq: Optional[int] = None) -> str:
     """Build the '## User Uploaded Files' context section from history_files_per_turn.
@@ -493,44 +471,19 @@ async def handle_chat(request: ChatRequest) -> Union[Dict[str, Any], StreamingRe
     active_configs = filter_tools(
         [cfg for cfg in DEFAULT_TOOLS if cfg.name not in disabled],
     )
-    # Persist the allowlist in session globals so ToolManager._safe_call can do a
-    # cheap active-tool guard check before executing any tool's business logic.
-    lazyllm.globals.config['active_tool_names'] = _collect_active_tool_names(active_configs)
-    # Plugin tools are dynamically injected and pre-validated by resolve_plugin_injection.
-    # Register ALL plugin_tools (advance_step, find_artifact, save_plugin_artifact, …)
-    # into the allowlist so the ToolGuard does not block any of them.
-    # plugin_stop_tools is only used by set_stop_tools below to control loop exit;
-    # it is not the source of the allowlist.
-    lazyllm.globals.config['active_tool_names'] |= {
-        getattr(fn, '__name__', '') for fn in plugin_tools if callable(fn)
-    }
     agent_tools = build_agent_tools(active_configs)
     # Respect enable_subagent flag: when false, suppress create_subagent and related tools.
     enable_subagent = agentic_config.get('enable_subagent', True)
     subagent_tools = _build_subagent_chat_tools(bool(agent.has_subagents)) if enable_subagent else []
-    # SubAgent chat tools (create_subagent, list_subagents, …) are always active;
-    # add their names to the allowlist so the ToolGuard does not block them.
-    lazyllm.globals.config['active_tool_names'] |= {
-        getattr(fn, '__name__', '') for fn in subagent_tools if callable(fn)
-    }
     mcp_tools = _build_mcp_tools(runtime.mcp_config) if runtime.mcp_config else []
     # User attachment tools are only meaningful when the user has uploaded files.
-    # Register them (and add to allowlist) whenever files_map is non-empty.
     attachment_tools = _build_user_attachment_tools(bool(files_map))
-    lazyllm.globals.config['active_tool_names'] |= {
-        getattr(fn, '__name__', '') for fn in attachment_tools if callable(fn)
-    }
     # Schedule tools are independent of plugin and subagent flags — always inject them
     # as a lazy group so the LLM only sees the gateway until the user mentions scheduling.
     schedule_tools = _build_schedule_tools()
-    lazyllm.globals.config['active_tool_names'] |= {
-        'create_schedule', 'list_schedules', 'cancel_schedule',
-        'update_schedule', 'trigger_schedule',
-    }
     # ask_user is a ChatAgent-only stop-tool. It is NOT in DEFAULT_TOOLS so SubAgents
     # (whose tool resolution falls back to DEFAULT_TOOLS) never see it.
     ask_user_tools = _build_ask_user_tool()
-    lazyllm.globals.config['active_tool_names'] |= {'ask_user'}
     all_tools = (agent_tools + subagent_tools + attachment_tools
                  + schedule_tools + ask_user_tools + plugin_tools + mcp_tools)
     set_trace_context({

--- a/tests/algorithm/chat/test_pipeline_agentic.py
+++ b/tests/algorithm/chat/test_pipeline_agentic.py
@@ -27,6 +27,9 @@ def test_handle_chat_constructs_react_agent_from_runtime_context(monkeypatch):
 
         __call__ = forward
 
+        def set_stop_tools(self, tools):
+            self.stop_tools = tools
+
     monkeypatch.setattr(chat_service, 'AutoModel', lambda model, config=False: f'{model}:{config}')
     monkeypatch.setattr(chat_service.lazyllm.tools.agent, 'ReactAgent', FakeAgent)
 

--- a/tests/algorithm/chat/test_pipeline_agentic.py
+++ b/tests/algorithm/chat/test_pipeline_agentic.py
@@ -27,9 +27,6 @@ def test_handle_chat_constructs_react_agent_from_runtime_context(monkeypatch):
 
         __call__ = forward
 
-        def set_stop_tools(self, tools):
-            self.stop_tools = tools
-
     monkeypatch.setattr(chat_service, 'AutoModel', lambda model, config=False: f'{model}:{config}')
     monkeypatch.setattr(chat_service.lazyllm.tools.agent, 'ReactAgent', FakeAgent)
 

--- a/tests/algorithm/chat/test_tool_registry.py
+++ b/tests/algorithm/chat/test_tool_registry.py
@@ -45,7 +45,6 @@ def test_web_search_requires_at_least_one_search_key():
 
 def test_registry_key_source_activates_function_tool():
     from lazymind.chat.engine.tools import kb_tmp_search
-    from lazymind.chat.service.chat_service import _collect_active_tool_names
     from lazyllm.tools.agent.toolsManager import ToolManager
 
     assert not hasattr(kb_tmp_search, '__key_source__')
@@ -60,7 +59,6 @@ def test_registry_key_source_activates_function_tool():
 
     configs = filter_tools(DEFAULT_TOOLS)
     assert 'temp_kb' in {cfg.name for cfg in configs}
-    assert 'kb_tmp_search' in _collect_active_tool_names(configs)
     manager = ToolManager(build_agent_tools([temp_kb_cfg]))
     assert [d['function']['name'] for d in manager.tools_description] == ['kb_tmp_search']
     group = _tool_group('temp_kb')


### PR DESCRIPTION
## Summary

- Remove main-repo plumbing for `lazyllm.globals.config['active_tool_names']`.
- Drop `_collect_active_tool_names` and the per-request allowlist updates from chat service.
- Update existing tool registry tests so they no longer depend on the removed helper.
- Update `algorithm/lazyllm` to the merged LazyLLM fix from LazyAGI/LazyLLM#1210.

## Problem

The main chat service was maintaining a second active-tool allowlist in session globals. That duplicated the tool availability already represented by LazyLLM `ToolManager._tool_call`, and could reject tools that were actually registered in the current tool manager.

## Solution

Keep tool construction and injection unchanged, but stop writing the redundant session-global allowlist. Unknown tool calls continue to be handled by LazyLLM's existing missing-tool path.

The submodule now points at the merged LazyLLM fix commit:

- `28205466 fix(tools): remove active tool allowlist guard (#1210)`

## Tests

- `PYTHONPATH=algorithm/lazyllm:algorithm pytest -q tests/algorithm/chat/test_tool_registry.py`
- `PYTHONPATH=algorithm/lazyllm:algorithm python -m py_compile algorithm/lazymind/chat/service/chat_service.py tests/algorithm/chat/test_tool_registry.py`

## Notes

- No base-class abstraction is needed here. This removes redundant state management rather than introducing a reusable workflow.
- Unrelated local files are not included in this PR.
