### PR TITLE
local-runtime: use Milvus Lite in local mode

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,7 @@ LAZYMIND_LOCAL_PROFILE ?= linux-browser
 LAZYMIND_LOCAL_BIN ?= local/local-runtime-manager/lazymind-local
 LAZYMIND_LOCAL_GOCACHE ?= $(CURDIR)/.codex-gocache/go-build
 LAZYMIND_LOCAL_DOWN_TIMEOUT ?= 150s
+export LAZYMIND_LOCAL_MILVUS_DB_PATH ?= $(CURDIR)/.lazymind-local/stores/milvus/lazymind.db
 PROCESS_COMPOSE_BIN ?= local/bin/process-compose
 PROCESS_COMPOSE_PKG ?= github.com/f1bonacc1/process-compose@v1.116.0
 comma := ,
@@ -592,6 +593,8 @@ reset-kb:
 	done
 	@echo "🗑  Removing local KB caches and segment stores..."
 	@rm -rf $(_RESET_KB_LOCAL_PATHS) 2>/dev/null || true
+	@echo "🗑  Removing local Milvus Lite data..."
+	@rm -rf "$(dir $(LAZYMIND_LOCAL_MILVUS_DB_PATH))" 2>/dev/null || true
 	@echo "✅ KB data cleared."
 
 # ---------------------------------------------------------------------------

--- a/algorithm/lazymind/config.py
+++ b/algorithm/lazymind/config.py
@@ -33,6 +33,8 @@ def _model_config_path_post_action(resolved_path):
 # All LAZYMIND_* environment variables are registered here.
 config = Config(prefix='LAZYMIND', home='~/.lazyllm_rag')
 _LAZYMIND_ROOT = os.path.dirname(__file__)
+config.add('runtime_mode', str, 'cloud', 'RUNTIME_MODE',
+           description='LazyMind runtime mode profile: cloud or local.')
 
 # ---------------------------------------------------------------------------
 # Chat
@@ -129,8 +131,6 @@ config.add('review_debug', bool, False, 'REVIEW_DEBUG', description='Enable revi
 # Parsing
 # ---------------------------------------------------------------------------
 config.add('milvus_uri', str, None, 'MILVUS_URI', description='Milvus vector store URI (required).')
-config.add('local_milvus_mode', str, 'container', 'LOCAL_MILVUS_MODE',
-           description='Local Milvus mode: lite, container, or external. Lite uses the default database.')
 config.add('mineru_backend', str, 'pipeline', 'MINERU_BACKEND', description='MinerU processing backend.')
 config.add('mineru_server_port', int, 8000, 'MINERU_SERVER_PORT', description='MinerU server port.')
 config.add('ocr_cache_dir', str, os.path.join(config['shared_upload_dir'], '.image_cache'), 'OCR_CACHE_DIR',

--- a/algorithm/lazymind/config.py
+++ b/algorithm/lazymind/config.py
@@ -129,6 +129,8 @@ config.add('review_debug', bool, False, 'REVIEW_DEBUG', description='Enable revi
 # Parsing
 # ---------------------------------------------------------------------------
 config.add('milvus_uri', str, None, 'MILVUS_URI', description='Milvus vector store URI (required).')
+config.add('local_milvus_mode', str, 'container', 'LOCAL_MILVUS_MODE',
+           description='Local Milvus mode: lite, container, or external. Lite uses the default database.')
 config.add('mineru_backend', str, 'pipeline', 'MINERU_BACKEND', description='MinerU processing backend.')
 config.add('mineru_server_port', int, 8000, 'MINERU_SERVER_PORT', description='MinerU server port.')
 config.add('ocr_cache_dir', str, os.path.join(config['shared_upload_dir'], '.image_cache'), 'OCR_CACHE_DIR',

--- a/algorithm/lazymind/local_milvus_lite.py
+++ b/algorithm/lazymind/local_milvus_lite.py
@@ -8,28 +8,28 @@ from pathlib import Path
 from milvus_lite.server import Server
 
 
-LOG = logging.getLogger("lazymind.local_milvus_lite")
+LOG = logging.getLogger('lazymind.local_milvus_lite')
 
 
 def _parse_args():
-    parser = argparse.ArgumentParser(description="Run Milvus Lite as a LazyMind local host process.")
-    parser.add_argument("--db-file", required=True, help="Milvus Lite database file path.")
-    parser.add_argument("--address", required=True, help="Loopback host:port for the Milvus gRPC endpoint.")
+    parser = argparse.ArgumentParser(description='Run Milvus Lite as a LazyMind local host process.')
+    parser.add_argument('--db-file', required=True, help='Milvus Lite database file path.')
+    parser.add_argument('--address', required=True, help='Loopback host:port for the Milvus gRPC endpoint.')
     return parser.parse_args()
 
 
 def main() -> int:
-    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(name)s: %(message)s")
+    logging.basicConfig(level=logging.INFO, format='%(asctime)s %(levelname)s %(name)s: %(message)s')
     args = _parse_args()
     db_file = Path(args.db_file).expanduser().resolve()
     db_file.parent.mkdir(parents=True, exist_ok=True)
 
     server = Server(str(db_file), args.address)
     if not server.init():
-        LOG.error("failed to initialize Milvus Lite at %s", db_file)
+        LOG.error('failed to initialize Milvus Lite at %s', db_file)
         return 1
     if not server.start():
-        LOG.error("failed to start Milvus Lite at %s on %s", db_file, args.address)
+        LOG.error('failed to start Milvus Lite at %s on %s', db_file, args.address)
         return 1
 
     stopping = False
@@ -39,18 +39,18 @@ def main() -> int:
         if stopping:
             return
         stopping = True
-        LOG.info("stopping Milvus Lite after signal %s", signum)
+        LOG.info('stopping Milvus Lite after signal %s', signum)
         server.stop()
 
     signal.signal(signal.SIGINT, _stop)
     signal.signal(signal.SIGTERM, _stop)
-    LOG.info("Milvus Lite started at %s using %s", args.address, db_file)
+    LOG.info('Milvus Lite started at %s using %s', args.address, db_file)
 
     try:
         while not stopping:
-            proc = getattr(server, "_p", None)
+            proc = getattr(server, '_p', None)
             if proc is not None and proc.poll() is not None:
-                LOG.error("Milvus Lite child exited with code %s", proc.returncode)
+                LOG.error('Milvus Lite child exited with code %s', proc.returncode)
                 return proc.returncode or 1
             time.sleep(0.5)
     finally:
@@ -58,5 +58,5 @@ def main() -> int:
     return 0
 
 
-if __name__ == "__main__":
+if __name__ == '__main__':
     sys.exit(main())

--- a/algorithm/lazymind/local_milvus_lite.py
+++ b/algorithm/lazymind/local_milvus_lite.py
@@ -1,0 +1,62 @@
+import argparse
+import logging
+import signal
+import sys
+import time
+from pathlib import Path
+
+from milvus_lite.server import Server
+
+
+LOG = logging.getLogger("lazymind.local_milvus_lite")
+
+
+def _parse_args():
+    parser = argparse.ArgumentParser(description="Run Milvus Lite as a LazyMind local host process.")
+    parser.add_argument("--db-file", required=True, help="Milvus Lite database file path.")
+    parser.add_argument("--address", required=True, help="Loopback host:port for the Milvus gRPC endpoint.")
+    return parser.parse_args()
+
+
+def main() -> int:
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(name)s: %(message)s")
+    args = _parse_args()
+    db_file = Path(args.db_file).expanduser().resolve()
+    db_file.parent.mkdir(parents=True, exist_ok=True)
+
+    server = Server(str(db_file), args.address)
+    if not server.init():
+        LOG.error("failed to initialize Milvus Lite at %s", db_file)
+        return 1
+    if not server.start():
+        LOG.error("failed to start Milvus Lite at %s on %s", db_file, args.address)
+        return 1
+
+    stopping = False
+
+    def _stop(signum, _frame):
+        nonlocal stopping
+        if stopping:
+            return
+        stopping = True
+        LOG.info("stopping Milvus Lite after signal %s", signum)
+        server.stop()
+
+    signal.signal(signal.SIGINT, _stop)
+    signal.signal(signal.SIGTERM, _stop)
+    LOG.info("Milvus Lite started at %s using %s", args.address, db_file)
+
+    try:
+        while not stopping:
+            proc = getattr(server, "_p", None)
+            if proc is not None and proc.poll() is not None:
+                LOG.error("Milvus Lite child exited with code %s", proc.returncode)
+                return proc.returncode or 1
+            time.sleep(0.5)
+    finally:
+        server.stop()
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/algorithm/lazymind/parsing/service/build_document.py
+++ b/algorithm/lazymind/parsing/service/build_document.py
@@ -1,5 +1,6 @@
 import lazyllm
 from copy import deepcopy
+from typing import NamedTuple, Optional
 from lazyllm.tracing import set_trace_context
 from lazyllm import AutoModel
 from lazyllm.tools.rag import AdaptiveTransform, CodeSplitter, Document, LLMParser, TransformArgs
@@ -43,6 +44,11 @@ def _quiet_trace(kbs):
     return call
 
 
+class _VectorStoreProfile(NamedTuple):
+    db_name_override: Optional[str]
+    index_type_override: Optional[str]
+
+
 def get_algo_server_port() -> int:
     port = _cfg['algo_server_port']
     if port:
@@ -50,33 +56,46 @@ def get_algo_server_port() -> int:
     return _cfg['document_server_port']
 
 
-def _milvus_lite_index_kwargs(index_kwargs):
-    lite_kwargs = deepcopy(index_kwargs)
-    for item in lite_kwargs:
-        item['index_type'] = 'FLAT'
-        item.setdefault('metric_type', 'COSINE')
-        item['params'] = {}
-    return lite_kwargs
+# Static mode profiles. None means the profile keeps LazyLLM's default behavior.
+_VECTOR_STORE_PROFILE_BY_MODE = {
+    'cloud': _VectorStoreProfile(db_name_override=None, index_type_override=None),
+    'local': _VectorStoreProfile(db_name_override='', index_type_override='FLAT'),
+}
 
 
 def _runtime_mode() -> str:
-    return (_cfg['runtime_mode'] or 'cloud').strip().lower()
+    mode = (_cfg['runtime_mode'] or 'cloud').strip().lower()
+    if mode not in _VECTOR_STORE_PROFILE_BY_MODE:
+        return 'cloud'
+    return mode
+
+
+def _runtime_index_kwargs(index_kwargs, mode: str):
+    index_type_override = _VECTOR_STORE_PROFILE_BY_MODE[mode].index_type_override
+    if not index_type_override:
+        return index_kwargs
+    runtime_kwargs = deepcopy(index_kwargs)
+    for item in runtime_kwargs:
+        item['index_type'] = index_type_override
+        item.setdefault('metric_type', 'COSINE')
+        item['params'] = {}
+    return runtime_kwargs
 
 
 def _build_store_config(index_kwargs):
     milvus_uri = _cfg['milvus_uri']
     if not milvus_uri:
         raise ValueError('LAZYMIND_MILVUS_URI is required')
-    if _runtime_mode() == 'local':
-        index_kwargs = _milvus_lite_index_kwargs(index_kwargs)
+    mode = _runtime_mode()
+    profile = _VECTOR_STORE_PROFILE_BY_MODE[mode]
     milvus_kwargs = {
         'uri': milvus_uri,
-        'index_kwargs': index_kwargs,
+        'index_kwargs': _runtime_index_kwargs(index_kwargs, mode),
     }
-    if _runtime_mode() == 'local':
-        # Milvus Lite 2.4 does not implement the database-management API.
-        # Empty db_name keeps LazyLLM on the default database and skips create_database().
-        milvus_kwargs['db_name'] = ''
+    if profile.db_name_override is not None:
+        # Profiles without overrides keep LazyLLM's default vector-store behavior.
+        # Passing an empty name opts into the default database and skips creation.
+        milvus_kwargs['db_name'] = profile.db_name_override
 
     store_type = _cfg['segment_store_type']
     uri_or_path = _cfg['segment_store_uri_or_path']

--- a/algorithm/lazymind/parsing/service/build_document.py
+++ b/algorithm/lazymind/parsing/service/build_document.py
@@ -59,17 +59,21 @@ def _milvus_lite_index_kwargs(index_kwargs):
     return lite_kwargs
 
 
+def _runtime_mode() -> str:
+    return (_cfg['runtime_mode'] or 'cloud').strip().lower()
+
+
 def _build_store_config(index_kwargs):
     milvus_uri = _cfg['milvus_uri']
     if not milvus_uri:
         raise ValueError('LAZYMIND_MILVUS_URI is required')
-    if (_cfg['local_milvus_mode'] or '').lower() == 'lite':
+    if _runtime_mode() == 'local':
         index_kwargs = _milvus_lite_index_kwargs(index_kwargs)
     milvus_kwargs = {
         'uri': milvus_uri,
         'index_kwargs': index_kwargs,
     }
-    if (_cfg['local_milvus_mode'] or '').lower() == 'lite':
+    if _runtime_mode() == 'local':
         # Milvus Lite 2.4 does not implement the database-management API.
         # Empty db_name keeps LazyLLM on the default database and skips create_database().
         milvus_kwargs['db_name'] = ''

--- a/algorithm/lazymind/parsing/service/build_document.py
+++ b/algorithm/lazymind/parsing/service/build_document.py
@@ -1,4 +1,5 @@
 import lazyllm
+from copy import deepcopy
 from lazyllm.tracing import set_trace_context
 from lazyllm import AutoModel
 from lazyllm.tools.rag import AdaptiveTransform, CodeSplitter, Document, LLMParser, TransformArgs
@@ -49,10 +50,29 @@ def get_algo_server_port() -> int:
     return _cfg['document_server_port']
 
 
+def _milvus_lite_index_kwargs(index_kwargs):
+    lite_kwargs = deepcopy(index_kwargs)
+    for item in lite_kwargs:
+        item['index_type'] = 'FLAT'
+        item.setdefault('metric_type', 'COSINE')
+        item['params'] = {}
+    return lite_kwargs
+
+
 def _build_store_config(index_kwargs):
     milvus_uri = _cfg['milvus_uri']
     if not milvus_uri:
         raise ValueError('LAZYMIND_MILVUS_URI is required')
+    if (_cfg['local_milvus_mode'] or '').lower() == 'lite':
+        index_kwargs = _milvus_lite_index_kwargs(index_kwargs)
+    milvus_kwargs = {
+        'uri': milvus_uri,
+        'index_kwargs': index_kwargs,
+    }
+    if (_cfg['local_milvus_mode'] or '').lower() == 'lite':
+        # Milvus Lite 2.4 does not implement the database-management API.
+        # Empty db_name keeps LazyLLM on the default database and skips create_database().
+        milvus_kwargs['db_name'] = ''
 
     store_type = _cfg['segment_store_type']
     uri_or_path = _cfg['segment_store_uri_or_path']
@@ -82,10 +102,7 @@ def _build_store_config(index_kwargs):
     return {
         'vector_store': {
             'type': 'milvus',
-            'kwargs': {
-                'uri': milvus_uri,
-                'index_kwargs': index_kwargs,
-            },
+            'kwargs': milvus_kwargs,
         },
         'segment_store': segment_store,
     }

--- a/algorithm/requirements.txt
+++ b/algorithm/requirements.txt
@@ -4,6 +4,7 @@ python-multipart
 opensearch-py
 pymilvus==2.4.14
 milvus-lite==2.4.10
+setuptools<81
 # openai-whisper
 # pydub
 

--- a/local/local-runtime-manager/algorithm_service.go
+++ b/local/local-runtime-manager/algorithm_service.go
@@ -360,8 +360,8 @@ func (m *AlgorithmServiceManager) waitForDependencies(ctx context.Context, cfg R
 		if err := waitForHTTPOnly(ctx, cfg.Algorithm.ProcessorPort, "/health", "processor-server", 3*time.Minute); err != nil {
 			return err
 		}
-		if cfg.Algorithm.MilvusMode != "external" {
-			if err := waitForTCP(ctx, "127.0.0.1", cfg.Algorithm.MilvusPort, "Milvus", 5*time.Minute); err != nil {
+		if cfg.ModeProfile.VectorStore.ManagedProcess {
+			if err := waitForTCP(ctx, "127.0.0.1", cfg.ModeProfile.VectorStore.Port, "Milvus", 5*time.Minute); err != nil {
 				return err
 			}
 		}
@@ -501,7 +501,7 @@ func algorithmServiceEnv(cfg RuntimeConfig, paths RuntimePaths, service string) 
 		"LAZYMIND_USE_INNER_MODEL=true",
 		"LAZYMIND_RESET_ALGO_ON_STARTUP=" + envText("LAZYMIND_RESET_ALGO_ON_STARTUP", "false"),
 		"LAZYMIND_RESET_ALL_ON_STARTUP=" + envText("LAZYMIND_RESET_ALL_ON_STARTUP", "false"),
-		"LAZYMIND_MILVUS_URI=" + localMilvusURI(cfg),
+		"LAZYMIND_MILVUS_URI=" + cfg.ModeProfile.VectorStore.Endpoint,
 		"LAZYMIND_OPENSEARCH_URI=" + envText("LAZYMIND_OPENSEARCH_URI", fmt.Sprintf("https://127.0.0.1:%d", cfg.Algorithm.OpenSearchPort)),
 		"LAZYMIND_OPENSEARCH_USER=" + envText("LAZYMIND_OPENSEARCH_USER", "admin"),
 		"LAZYMIND_OPENSEARCH_PASSWORD=" + envText("LAZYMIND_OPENSEARCH_PASSWORD", "LazyRAG_OpenSearch123!"),
@@ -562,13 +562,6 @@ func localRouterPortPool(cfg RuntimeConfig) (int, int) {
 		end = envPort(routerPortPoolEndEnvVar, end)
 	}
 	return start, end
-}
-
-func localMilvusURI(cfg RuntimeConfig) string {
-	if cfg.Algorithm.MilvusMode == "external" {
-		return envText("LAZYMIND_MILVUS_URI", "")
-	}
-	return fmt.Sprintf("http://127.0.0.1:%d", cfg.Algorithm.MilvusPort)
 }
 
 func algorithmPIDFile(paths RuntimePaths, service string) string {

--- a/local/local-runtime-manager/algorithm_service.go
+++ b/local/local-runtime-manager/algorithm_service.go
@@ -221,7 +221,9 @@ func (m *AlgorithmServiceManager) preparePython(ctx context.Context, paths Runti
 		stamp = filepath.Join(filepath.Dir(paths.AlgorithmVenv), "algorithm-evo.ready")
 	}
 	if _, err := os.Stat(stamp); err == nil {
-		return nil
+		if m.pythonModuleAvailable(ctx, paths, "pkg_resources") {
+			return nil
+		}
 	}
 	if _, err := os.Stat(paths.AlgorithmPython); os.IsNotExist(err) {
 		if err := m.createVenv(ctx, paths, false); err != nil {
@@ -250,6 +252,14 @@ func (m *AlgorithmServiceManager) preparePython(ctx context.Context, paths Runti
 		}
 	}
 	return os.WriteFile(stamp, []byte(time.Now().UTC().Format(time.RFC3339)+"\n"), 0o644)
+}
+
+func (m *AlgorithmServiceManager) pythonModuleAvailable(ctx context.Context, paths RuntimePaths, module string) bool {
+	if _, err := os.Stat(paths.AlgorithmPython); err != nil {
+		return false
+	}
+	res, err := m.runner.Run(ctx, Command{Name: paths.AlgorithmPython, Args: []string{"-c", "import " + module}, Dir: paths.RepoRoot})
+	return err == nil && strings.TrimSpace(res.Stderr) == ""
 }
 
 func (m *AlgorithmServiceManager) createVenv(ctx context.Context, paths RuntimePaths, clear bool) error {
@@ -350,7 +360,7 @@ func (m *AlgorithmServiceManager) waitForDependencies(ctx context.Context, cfg R
 		if err := waitForHTTPOnly(ctx, cfg.Algorithm.ProcessorPort, "/health", "processor-server", 3*time.Minute); err != nil {
 			return err
 		}
-		if isBuiltInServiceURI("LAZYMIND_MILVUS_URI", "http://milvus:19530") {
+		if cfg.Algorithm.MilvusMode != "external" {
 			if err := waitForTCP(ctx, "127.0.0.1", cfg.Algorithm.MilvusPort, "Milvus", 5*time.Minute); err != nil {
 				return err
 			}
@@ -423,6 +433,7 @@ func algorithmServiceEnv(cfg RuntimeConfig, paths RuntimePaths, service string) 
 	dbURL := fmt.Sprintf("postgresql+psycopg://app:app@127.0.0.1:%d/app", cfg.Algorithm.PostgresPort)
 	noProxy := envText("no_proxy", "127.0.0.1,localhost,::1,core,chat,evo-api,doc-server,lazyllm-algo,parsing,milvus,opensearch,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16")
 	noProxyUpper := envText("NO_PROXY", noProxy)
+	routerPoolStart, routerPoolEnd := localRouterPortPool(cfg)
 	env := []string{
 		"LAZYMIND_RUNTIME_MODE=local",
 		"PYTHONPATH=" + pythonPath,
@@ -490,7 +501,7 @@ func algorithmServiceEnv(cfg RuntimeConfig, paths RuntimePaths, service string) 
 		"LAZYMIND_USE_INNER_MODEL=true",
 		"LAZYMIND_RESET_ALGO_ON_STARTUP=" + envText("LAZYMIND_RESET_ALGO_ON_STARTUP", "false"),
 		"LAZYMIND_RESET_ALL_ON_STARTUP=" + envText("LAZYMIND_RESET_ALL_ON_STARTUP", "false"),
-		"LAZYMIND_MILVUS_URI=" + fmt.Sprintf("http://127.0.0.1:%d", cfg.Algorithm.MilvusPort),
+		"LAZYMIND_MILVUS_URI=" + localMilvusURI(cfg),
 		"LAZYMIND_OPENSEARCH_URI=" + envText("LAZYMIND_OPENSEARCH_URI", fmt.Sprintf("https://127.0.0.1:%d", cfg.Algorithm.OpenSearchPort)),
 		"LAZYMIND_OPENSEARCH_USER=" + envText("LAZYMIND_OPENSEARCH_USER", "admin"),
 		"LAZYMIND_OPENSEARCH_PASSWORD=" + envText("LAZYMIND_OPENSEARCH_PASSWORD", "LazyRAG_OpenSearch123!"),
@@ -511,9 +522,9 @@ func algorithmServiceEnv(cfg RuntimeConfig, paths RuntimePaths, service string) 
 		"LAZYMIND_MAX_CONCURRENCY=" + envText("LAZYMIND_MAX_CONCURRENCY", "10"),
 		"LAZYMIND_LLM_PRIORITY=" + envText("LAZYMIND_LLM_PRIORITY", "0"),
 		"LAZYMIND_ENABLE_ROUTER=" + envText("LAZYMIND_ENABLE_ROUTER", "true"),
-		"LAZYMIND_ROUTER_PORT_POOL_START=18100",
-		"LAZYMIND_ROUTER_PORT_POOL_END=18999",
-		"LAZYMIND_ROUTER_PORTS_PER_INSTANCE=100",
+		routerPortPoolStartEnvVar + "=" + strconv.Itoa(routerPoolStart),
+		routerPortPoolEndEnvVar + "=" + strconv.Itoa(routerPoolEnd),
+		routerPortsPerInstanceEnvVar + "=" + strconv.Itoa(defaultRouterPortsPerInstance),
 		"LAZYMIND_ROUTER_DEFAULT_ALGO_PATH=" + filepath.Join(paths.RepoRoot, "algorithm", "lazymind", "chat"),
 		"LAZYMIND_ROUTER_DEFAULT_INSTANCE_COUNT=1",
 		"LAZYMIND_PLUGINS_DIR=" + filepath.Join(paths.RepoRoot, "plugins"),
@@ -533,6 +544,31 @@ func algorithmServiceEnv(cfg RuntimeConfig, paths RuntimePaths, service string) 
 		env = append(env, "LAZYMIND_DOCUMENT_SERVICE_CALLBACK_URL=http://127.0.0.1:"+strconv.Itoa(cfg.Algorithm.DocPort)+"/v1/internal/callbacks/tasks")
 	}
 	return env
+}
+
+func localRouterPortPool(cfg RuntimeConfig) (int, int) {
+	if strings.TrimSpace(os.Getenv(routerPortPoolStartEnvVar)) != "" {
+		start := envPort(routerPortPoolStartEnvVar, defaultRouterPortPoolStart)
+		end := envPort(routerPortPoolEndEnvVar, start+defaultRouterPortsPerInstance-1)
+		return start, end
+	}
+	offset := cfg.ProcessComposePort - defaultProcessComposePort
+	start := defaultRouterPortPoolStart + offset*defaultRouterPortsPerInstance
+	if start < 1024 || start+defaultRouterPortsPerInstance-1 >= 65536 {
+		start = defaultRouterPortPoolStart
+	}
+	end := start + defaultRouterPortsPerInstance - 1
+	if strings.TrimSpace(os.Getenv(routerPortPoolEndEnvVar)) != "" {
+		end = envPort(routerPortPoolEndEnvVar, end)
+	}
+	return start, end
+}
+
+func localMilvusURI(cfg RuntimeConfig) string {
+	if cfg.Algorithm.MilvusMode == "external" {
+		return envText("LAZYMIND_MILVUS_URI", "")
+	}
+	return fmt.Sprintf("http://127.0.0.1:%d", cfg.Algorithm.MilvusPort)
 }
 
 func algorithmPIDFile(paths RuntimePaths, service string) string {
@@ -665,6 +701,17 @@ func waitForTCP(ctx context.Context, host string, port int, label string, timeou
 		case <-ticker.C:
 		}
 	}
+}
+
+func tcpOK(ctx context.Context, host string, port int, timeout time.Duration) bool {
+	address := net.JoinHostPort(host, strconv.Itoa(port))
+	dialer := net.Dialer{Timeout: timeout}
+	conn, err := dialer.DialContext(ctx, "tcp", address)
+	if err != nil {
+		return false
+	}
+	_ = conn.Close()
+	return true
 }
 
 func processAlive(pid int) bool {

--- a/local/local-runtime-manager/algorithm_service.go
+++ b/local/local-runtime-manager/algorithm_service.go
@@ -259,7 +259,7 @@ func (m *AlgorithmServiceManager) pythonModuleAvailable(ctx context.Context, pat
 		return false
 	}
 	res, err := m.runner.Run(ctx, Command{Name: paths.AlgorithmPython, Args: []string{"-c", "import " + module}, Dir: paths.RepoRoot})
-	return err == nil && strings.TrimSpace(res.Stderr) == ""
+	return err == nil
 }
 
 func (m *AlgorithmServiceManager) createVenv(ctx context.Context, paths RuntimePaths, clear bool) error {

--- a/local/local-runtime-manager/algorithm_service.go
+++ b/local/local-runtime-manager/algorithm_service.go
@@ -258,7 +258,7 @@ func (m *AlgorithmServiceManager) pythonModuleAvailable(ctx context.Context, pat
 	if _, err := os.Stat(paths.AlgorithmPython); err != nil {
 		return false
 	}
-	res, err := m.runner.Run(ctx, Command{Name: paths.AlgorithmPython, Args: []string{"-c", "import " + module}, Dir: paths.RepoRoot})
+	_, err := m.runner.Run(ctx, Command{Name: paths.AlgorithmPython, Args: []string{"-c", "import " + module}, Dir: paths.RepoRoot})
 	return err == nil
 }
 

--- a/local/local-runtime-manager/compose.go
+++ b/local/local-runtime-manager/compose.go
@@ -53,7 +53,8 @@ func derivedComposeProfileArgs() []string {
 	if enabledFromEnv("LAZYMIND_DEPLOY_MINERU") {
 		profiles = append(profiles, "mineru")
 	}
-	if isBuiltInServiceURI("LAZYMIND_MILVUS_URI", "http://milvus:19530") {
+	if normalizeMilvusMode(envText(localMilvusModeEnvVar, defaultLocalMilvusMode)) == "container" &&
+		isBuiltInServiceURI("LAZYMIND_MILVUS_URI", "http://milvus:19530") {
 		profiles = append(profiles, "milvus")
 	}
 	if localSegmentStoreUsesBuiltInOpenSearch() {

--- a/local/local-runtime-manager/compose.go
+++ b/local/local-runtime-manager/compose.go
@@ -53,10 +53,6 @@ func derivedComposeProfileArgs() []string {
 	if enabledFromEnv("LAZYMIND_DEPLOY_MINERU") {
 		profiles = append(profiles, "mineru")
 	}
-	if normalizeMilvusMode(envText(localMilvusModeEnvVar, defaultLocalMilvusMode)) == "container" &&
-		isBuiltInServiceURI("LAZYMIND_MILVUS_URI", "http://milvus:19530") {
-		profiles = append(profiles, "milvus")
-	}
 	if localSegmentStoreUsesBuiltInOpenSearch() {
 		profiles = append(profiles, "opensearch")
 	}
@@ -277,7 +273,7 @@ func localComposeEnv(cfg RuntimeConfig) []string {
 		"LAZYMIND_LOCAL_WORKER_PORT=" + strconv.Itoa(cfg.Algorithm.WorkerPort),
 		"LAZYMIND_LOCAL_CHAT_PORT=" + strconv.Itoa(cfg.Algorithm.ChatPort),
 		"LAZYMIND_LOCAL_EVO_PORT=" + strconv.Itoa(cfg.Algorithm.EvoPort),
-		"LAZYMIND_LOCAL_MILVUS_PORT=" + strconv.Itoa(cfg.Algorithm.MilvusPort),
+		"LAZYMIND_LOCAL_MILVUS_PORT=" + strconv.Itoa(cfg.ModeProfile.VectorStore.Port),
 		"LAZYMIND_LOCAL_OPENSEARCH_PORT=" + strconv.Itoa(cfg.Algorithm.OpenSearchPort),
 	}
 }

--- a/local/local-runtime-manager/config.go
+++ b/local/local-runtime-manager/config.go
@@ -32,8 +32,7 @@ const (
 	localChatPortEnvVar           = "LAZYMIND_LOCAL_CHAT_PORT"
 	localEvoPortEnvVar            = "LAZYMIND_LOCAL_EVO_PORT"
 	localMilvusPortEnvVar         = "LAZYMIND_LOCAL_MILVUS_PORT"
-	localMilvusModeEnvVar         = "LAZYMIND_LOCAL_MILVUS_MODE"
-	localMilvusDBPathEnvVar       = "LAZYMIND_LOCAL_MILVUS_DB_PATH"
+	localMilvusLiteDBPathEnvVar   = "LAZYMIND_LOCAL_MILVUS_DB_PATH"
 	localOpenSearchPortEnvVar     = "LAZYMIND_LOCAL_OPENSEARCH_PORT"
 	localEnableEvoEnvVar          = "LAZYMIND_LOCAL_ENABLE_EVO"
 	routerPortPoolStartEnvVar     = "LAZYMIND_ROUTER_PORT_POOL_START"
@@ -68,7 +67,6 @@ const (
 	defaultLocalAlgoPort          = 18004
 	defaultLocalWorkerPort        = 18005
 	defaultLocalMilvusPort        = 19530
-	defaultLocalMilvusMode        = "lite"
 	defaultLocalOpenSearchPort    = 19200
 	defaultRouterPortPoolStart    = 18100
 	defaultRouterPortsPerInstance = 100
@@ -165,6 +163,7 @@ type RuntimeConfig struct {
 	Profile            string
 	RepoRoot           string
 	RuntimeRoot        string
+	ModeProfile        RuntimeModeProfileConfig
 	ProcessComposePort int
 	FrontendPort       int
 	LocalProxy         LocalProxyConfig
@@ -199,6 +198,19 @@ type FileWatcherConfig struct {
 	HostPathStyle string
 }
 
+type RuntimeModeProfileConfig struct {
+	Name        string
+	VectorStore VectorStoreConfig
+}
+
+type VectorStoreConfig struct {
+	Engine         string
+	Endpoint       string
+	Port           int
+	ManagedProcess bool
+	DBPath         string
+}
+
 type AlgorithmConfig struct {
 	PostgresPort   int
 	DocPort        int
@@ -207,10 +219,7 @@ type AlgorithmConfig struct {
 	WorkerPort     int
 	ChatPort       int
 	EvoPort        int
-	MilvusPort     int
-	MilvusMode     string
 	OpenSearchPort int
-	MilvusDBPath   string
 	EnableEvo      bool
 }
 
@@ -398,12 +407,16 @@ func defaultFileWatcherBaseRoot(repoRoot string) string {
 	return filepath.Clean(filepath.Join(repoRoot, raw))
 }
 
-func normalizeMilvusMode(mode string) string {
-	switch strings.ToLower(strings.TrimSpace(mode)) {
-	case "container", "external":
-		return strings.ToLower(strings.TrimSpace(mode))
-	default:
-		return defaultLocalMilvusMode
+func localRuntimeModeProfile(milvusPort int, milvusLiteDBPath string) RuntimeModeProfileConfig {
+	return RuntimeModeProfileConfig{
+		Name: "local",
+		VectorStore: VectorStoreConfig{
+			Engine:         "milvus-lite",
+			Endpoint:       "http://127.0.0.1:" + strconv.Itoa(milvusPort),
+			Port:           milvusPort,
+			ManagedProcess: true,
+			DBPath:         milvusLiteDBPath,
+		},
 	}
 }
 
@@ -569,12 +582,12 @@ func NewRuntimeConfig(profile, repoRootHint string) (RuntimeConfig, RuntimePaths
 	openSearchPort := ports.envOrAvailable(localOpenSearchPortEnvVar, defaultLocalOpenSearchPort)
 	chatPort := ports.firstEnvOrAvailable([]string{localChatPortEnvVar, localProxyChatHostPortEnvVar}, defaultLocalProxyChatHostPort)
 	evoPort := ports.firstEnvOrAvailable([]string{localEvoPortEnvVar, localProxyEvoHostPortEnvVar}, defaultLocalProxyEvoHostPort)
-	milvusMode := normalizeMilvusMode(envText(localMilvusModeEnvVar, defaultLocalMilvusMode))
-	milvusDBPath := filepath.Clean(envText(localMilvusDBPathEnvVar, p.MilvusLiteDBPath))
+	milvusLiteDBPath := filepath.Clean(envText(localMilvusLiteDBPathEnvVar, p.MilvusLiteDBPath))
 	return RuntimeConfig{
 		Profile:            profile,
 		RepoRoot:           p.RepoRoot,
 		RuntimeRoot:        runtimeRoot,
+		ModeProfile:        localRuntimeModeProfile(milvusPort, milvusLiteDBPath),
 		ProcessComposePort: processComposePort,
 		FrontendPort:       frontendPort,
 		CaddyVersion:       envText(caddyVersionEnvVar, defaultCaddyVersion),
@@ -595,10 +608,7 @@ func NewRuntimeConfig(profile, repoRootHint string) (RuntimeConfig, RuntimePaths
 			WorkerPort:     workerPort,
 			ChatPort:       chatPort,
 			EvoPort:        evoPort,
-			MilvusPort:     milvusPort,
-			MilvusMode:     milvusMode,
 			OpenSearchPort: openSearchPort,
-			MilvusDBPath:   milvusDBPath,
 			EnableEvo:      envBool(localEnableEvoEnvVar, false),
 		},
 		AuthService: AuthServiceConfig{

--- a/local/local-runtime-manager/config.go
+++ b/local/local-runtime-manager/config.go
@@ -32,8 +32,13 @@ const (
 	localChatPortEnvVar           = "LAZYMIND_LOCAL_CHAT_PORT"
 	localEvoPortEnvVar            = "LAZYMIND_LOCAL_EVO_PORT"
 	localMilvusPortEnvVar         = "LAZYMIND_LOCAL_MILVUS_PORT"
+	localMilvusModeEnvVar         = "LAZYMIND_LOCAL_MILVUS_MODE"
+	localMilvusDBPathEnvVar       = "LAZYMIND_LOCAL_MILVUS_DB_PATH"
 	localOpenSearchPortEnvVar     = "LAZYMIND_LOCAL_OPENSEARCH_PORT"
 	localEnableEvoEnvVar          = "LAZYMIND_LOCAL_ENABLE_EVO"
+	routerPortPoolStartEnvVar     = "LAZYMIND_ROUTER_PORT_POOL_START"
+	routerPortPoolEndEnvVar       = "LAZYMIND_ROUTER_PORT_POOL_END"
+	routerPortsPerInstanceEnvVar  = "LAZYMIND_ROUTER_PORTS_PER_INSTANCE"
 	frontendPortEnvVar            = "LAZYMIND_FRONTEND_PORT"
 	authServicePortEnvVar         = "LAZYMIND_AUTH_SERVICE_PORT"
 	authServicePythonEnvVar       = "LAZYMIND_AUTH_SERVICE_PYTHON"
@@ -63,7 +68,10 @@ const (
 	defaultLocalAlgoPort          = 18004
 	defaultLocalWorkerPort        = 18005
 	defaultLocalMilvusPort        = 19530
+	defaultLocalMilvusMode        = "lite"
 	defaultLocalOpenSearchPort    = 19200
+	defaultRouterPortPoolStart    = 18100
+	defaultRouterPortsPerInstance = 100
 	stateFileName                 = "runtime-state.json"
 	composeGeneratedFileName      = "process-compose.generated.yaml"
 	serviceEndpointsJSONName      = "service-endpoints.json"
@@ -96,6 +104,7 @@ const (
 	algoProcessName               = "lazyllm-algo"
 	chatProcessName               = "chat"
 	evoProcessName                = "evo-api"
+	milvusLiteProcessName         = "milvus-lite"
 )
 
 type RuntimePaths struct {
@@ -135,6 +144,9 @@ type RuntimePaths struct {
 	AlgoLog                  string
 	ChatLog                  string
 	EvoLog                   string
+	MilvusLiteLog            string
+	MilvusLitePIDFile        string
+	MilvusLiteDBPath         string
 	LocalProxyBin            string
 	CaddyBin                 string
 	LocalProxyConfig         string
@@ -196,7 +208,9 @@ type AlgorithmConfig struct {
 	ChatPort       int
 	EvoPort        int
 	MilvusPort     int
+	MilvusMode     string
 	OpenSearchPort int
+	MilvusDBPath   string
 	EnableEvo      bool
 }
 
@@ -384,6 +398,15 @@ func defaultFileWatcherBaseRoot(repoRoot string) string {
 	return filepath.Clean(filepath.Join(repoRoot, raw))
 }
 
+func normalizeMilvusMode(mode string) string {
+	switch strings.ToLower(strings.TrimSpace(mode)) {
+	case "container", "external":
+		return strings.ToLower(strings.TrimSpace(mode))
+	default:
+		return defaultLocalMilvusMode
+	}
+}
+
 func defaultAuthServicePortValue() int {
 	if v := os.Getenv(localProxyAuthHostPortEnvVar); v != "" {
 		return envPort(localProxyAuthHostPortEnvVar, defaultLocalProxyAuthHostPort)
@@ -513,6 +536,9 @@ func NewRuntimeConfig(profile, repoRootHint string) (RuntimeConfig, RuntimePaths
 		AlgoLog:                  filepath.Join(runtimeRoot, "logs", algoProcessName+".log"),
 		ChatLog:                  filepath.Join(runtimeRoot, "logs", chatProcessName+".log"),
 		EvoLog:                   filepath.Join(runtimeRoot, "logs", evoProcessName+".log"),
+		MilvusLiteLog:            filepath.Join(runtimeRoot, "logs", milvusLiteProcessName+".log"),
+		MilvusLitePIDFile:        filepath.Join(runtimeRoot, "run", milvusLiteProcessName+".pid"),
+		MilvusLiteDBPath:         filepath.Join(runtimeRoot, "stores", "milvus", "lazymind.db"),
 		LocalProxyBin:            filepath.Join(runtimeRoot, "bin", "local-proxy"),
 		CaddyBin:                 filepath.Join(runtimeRoot, "bin", "caddy"),
 		LocalProxyConfig:         filepath.Join(root, localProxyConfigName),
@@ -543,6 +569,8 @@ func NewRuntimeConfig(profile, repoRootHint string) (RuntimeConfig, RuntimePaths
 	openSearchPort := ports.envOrAvailable(localOpenSearchPortEnvVar, defaultLocalOpenSearchPort)
 	chatPort := ports.firstEnvOrAvailable([]string{localChatPortEnvVar, localProxyChatHostPortEnvVar}, defaultLocalProxyChatHostPort)
 	evoPort := ports.firstEnvOrAvailable([]string{localEvoPortEnvVar, localProxyEvoHostPortEnvVar}, defaultLocalProxyEvoHostPort)
+	milvusMode := normalizeMilvusMode(envText(localMilvusModeEnvVar, defaultLocalMilvusMode))
+	milvusDBPath := filepath.Clean(envText(localMilvusDBPathEnvVar, p.MilvusLiteDBPath))
 	return RuntimeConfig{
 		Profile:            profile,
 		RepoRoot:           p.RepoRoot,
@@ -568,7 +596,9 @@ func NewRuntimeConfig(profile, repoRootHint string) (RuntimeConfig, RuntimePaths
 			ChatPort:       chatPort,
 			EvoPort:        evoPort,
 			MilvusPort:     milvusPort,
+			MilvusMode:     milvusMode,
 			OpenSearchPort: openSearchPort,
+			MilvusDBPath:   milvusDBPath,
 			EnableEvo:      envBool(localEnableEvoEnvVar, false),
 		},
 		AuthService: AuthServiceConfig{
@@ -604,6 +634,7 @@ func (p RuntimePaths) EnsureAllDirs() error {
 		filepath.Dir(p.AlgorithmVenv),
 		p.AlgorithmHome,
 		p.AlgorithmPIDDir,
+		filepath.Dir(p.MilvusLiteDBPath),
 	}
 	for _, d := range dirs {
 		if err := os.MkdirAll(d, 0o755); err != nil {

--- a/local/local-runtime-manager/main.go
+++ b/local/local-runtime-manager/main.go
@@ -158,6 +158,10 @@ func (c *CLI) runInternal(ctx context.Context, manager *RuntimeManager, args []s
 		return manager.frontend.Run(ctx, cfg, paths)
 	case "frontend-down":
 		return manager.frontend.Down(ctx, cfg, paths)
+	case "milvus-lite-run":
+		return manager.milvusLite.Run(ctx, cfg, paths)
+	case "milvus-lite-down":
+		return manager.milvusLite.Down(ctx, paths)
 	default:
 		return fmt.Errorf("unknown internal command: %s", sub)
 	}
@@ -215,5 +219,5 @@ func (c *CLI) usage() {
 	_, _ = io.WriteString(c.out, "  lazymind-local up --profile <profile>\n")
 	_, _ = io.WriteString(c.out, "  lazymind-local down --profile <profile>\n")
 	_, _ = io.WriteString(c.out, "  lazymind-local status --json\n")
-	_, _ = io.WriteString(c.out, "  lazymind-local internal compose-up|compose-down|compose-services|local-proxy-run|local-proxy-down|auth-service-run|auth-service-down|core-run|core-down|scan-control-plane-run|scan-control-plane-down|file-watcher-run|file-watcher-down|frontend-run|frontend-down|algorithm-run|algorithm-down --profile <profile>\n")
+	_, _ = io.WriteString(c.out, "  lazymind-local internal compose-up|compose-down|compose-services|local-proxy-run|local-proxy-down|auth-service-run|auth-service-down|core-run|core-down|scan-control-plane-run|scan-control-plane-down|file-watcher-run|file-watcher-down|frontend-run|frontend-down|milvus-lite-run|milvus-lite-down|algorithm-run|algorithm-down --profile <profile>\n")
 }

--- a/local/local-runtime-manager/manager.go
+++ b/local/local-runtime-manager/manager.go
@@ -40,6 +40,7 @@ type RuntimeManager struct {
 	fileWatcher    *FileWatcherManager
 	frontend       *FrontendManager
 	algorithm      *AlgorithmServiceManager
+	milvusLite     *MilvusLiteManager
 }
 
 func NewRuntimeManager(r CommandRunner, execPath string) *RuntimeManager {
@@ -69,6 +70,7 @@ func NewRuntimeManager(r CommandRunner, execPath string) *RuntimeManager {
 		fileWatcher:    NewFileWatcherManager(r),
 		frontend:       NewFrontendManager(r),
 		algorithm:      NewAlgorithmServiceManager(r),
+		milvusLite:     NewMilvusLiteManager(r),
 	}
 }
 
@@ -341,31 +343,32 @@ func (m *RuntimeManager) Down(ctx context.Context, cfg RuntimeConfig, paths Runt
 		defer cancel()
 		downErr = m.processCompose.Down(downCtx, cfg, paths)
 	}
-	if downErr != nil || !apiAlive {
-		if downErr != nil {
-			_ = m.killStaleRuntimeProcesses(context.Background(), paths.RepoRoot)
-		}
-		if err := m.frontend.Down(ctx, cfg, paths); err != nil && downErr == nil {
-			downErr = err
-		}
-		if err := m.localProxy.Down(ctx, cfg, paths); err != nil && downErr == nil {
-			downErr = err
-		}
-		if fallbackErr := m.compose.ComposeDown(ctx, paths.RepoRoot, cfg.Profile); fallbackErr != nil {
-			state = newStateWithServiceStatus(state, "failed")
-			state.OverallStatus = "failed"
-			_ = writeRuntimeState(paths.StateFile, state)
-			if downErr != nil {
-				return fmt.Errorf("process-compose down failed: %w; docker compose down fallback failed: %v", downErr, fallbackErr)
-			}
-			return fallbackErr
-		}
-		downErr = nil
+	if downErr != nil {
+		_ = m.killStaleRuntimeProcesses(context.Background(), paths.RepoRoot)
 	}
+	if err := m.frontend.Down(ctx, cfg, paths); err != nil && downErr == nil {
+		downErr = err
+	}
+	if err := m.localProxy.Down(ctx, cfg, paths); err != nil && downErr == nil {
+		downErr = err
+	}
+	if fallbackErr := m.compose.ComposeDown(ctx, paths.RepoRoot, cfg.Profile); fallbackErr != nil {
+		state = newStateWithServiceStatus(state, "failed")
+		state.OverallStatus = "failed"
+		_ = writeRuntimeState(paths.StateFile, state)
+		if downErr != nil {
+			return fmt.Errorf("process-compose down failed: %w; docker compose down fallback failed: %v", downErr, fallbackErr)
+		}
+		return fallbackErr
+	}
+	downErr = nil
 	for _, spec := range algorithmProcessSpecs(cfg.Algorithm) {
 		if err := m.algorithm.Down(ctx, paths, spec.Name); err != nil && downErr == nil {
 			downErr = err
 		}
+	}
+	if err := m.milvusLite.Down(ctx, paths); err != nil && downErr == nil {
+		downErr = err
 	}
 	if err := m.coreService.Down(ctx, cfg, paths); err != nil && downErr == nil {
 		downErr = err
@@ -476,6 +479,9 @@ func (m *RuntimeManager) checkRuntimeReady(ctx context.Context, cfg RuntimeConfi
 			return false
 		}
 	}
+	if cfg.Algorithm.MilvusMode == "lite" && !tcpOK(ctx, "127.0.0.1", cfg.Algorithm.MilvusPort, 500*time.Millisecond) {
+		return false
+	}
 	return true
 }
 
@@ -579,7 +585,11 @@ func (m *RuntimeManager) waitForRuntimeStopped(ctx context.Context, cfg RuntimeC
 		if _, statErr := os.Stat(paths.AuthServicePIDFile); statErr == nil && cfg.AuthService.Port > 0 {
 			authAlive = m.probeAuth(cfg.AuthService.Port, 500*time.Millisecond)
 		}
-		if err == nil && !apiAlive && !hasContainers && !authAlive {
+		milvusAlive := false
+		if _, statErr := os.Stat(paths.MilvusLitePIDFile); statErr == nil && cfg.Algorithm.MilvusMode == "lite" && cfg.Algorithm.MilvusPort > 0 {
+			milvusAlive = tcpOK(ctx, "127.0.0.1", cfg.Algorithm.MilvusPort, 500*time.Millisecond)
+		}
+		if err == nil && !apiAlive && !hasContainers && !authAlive && !milvusAlive {
 			return nil
 		}
 		select {
@@ -736,6 +746,14 @@ func (m *RuntimeManager) Status(ctx context.Context, cfg RuntimeConfig, paths Ru
 			Status: "unknown",
 		}
 	}
+	if cfg.Algorithm.MilvusMode == "lite" {
+		if _, ok := resp.Services[milvusLiteProcessName]; !ok {
+			resp.Services[milvusLiteProcessName] = RuntimeServiceState{
+				Kind:   "host-process",
+				Status: "unknown",
+			}
+		}
+	}
 	for _, spec := range algorithmProcessSpecs(cfg.Algorithm) {
 		if _, ok := resp.Services[spec.Name]; !ok {
 			resp.Services[spec.Name] = RuntimeServiceState{
@@ -783,6 +801,20 @@ func (m *RuntimeManager) Status(ctx context.Context, cfg RuntimeConfig, paths Ru
 			hostHealthy = false
 		}
 		resp.Services[coreProcessName] = core
+		if cfg.Algorithm.MilvusMode == "lite" {
+			milvus := resp.Services[milvusLiteProcessName]
+			milvus.Kind = "host-process"
+			if tcpOK(ctx, "127.0.0.1", cfg.Algorithm.MilvusPort, 500*time.Millisecond) {
+				milvus.Status = "running"
+			} else if milvus.Status == "running" || milvus.Status == "starting" {
+				milvus.Status = "stale"
+				hostHealthy = false
+			} else if milvus.Status == "" || milvus.Status == "unknown" {
+				milvus.Status = "stopped"
+				hostHealthy = false
+			}
+			resp.Services[milvusLiteProcessName] = milvus
+		}
 		for _, spec := range algorithmProcessSpecs(cfg.Algorithm) {
 			svc := resp.Services[spec.Name]
 			svc.Kind = "host-process"

--- a/local/local-runtime-manager/manager.go
+++ b/local/local-runtime-manager/manager.go
@@ -479,7 +479,7 @@ func (m *RuntimeManager) checkRuntimeReady(ctx context.Context, cfg RuntimeConfi
 			return false
 		}
 	}
-	if cfg.Algorithm.MilvusMode == "lite" && !tcpOK(ctx, "127.0.0.1", cfg.Algorithm.MilvusPort, 500*time.Millisecond) {
+	if cfg.ModeProfile.VectorStore.ManagedProcess && !tcpOK(ctx, "127.0.0.1", cfg.ModeProfile.VectorStore.Port, 500*time.Millisecond) {
 		return false
 	}
 	return true
@@ -586,8 +586,8 @@ func (m *RuntimeManager) waitForRuntimeStopped(ctx context.Context, cfg RuntimeC
 			authAlive = m.probeAuth(cfg.AuthService.Port, 500*time.Millisecond)
 		}
 		milvusAlive := false
-		if _, statErr := os.Stat(paths.MilvusLitePIDFile); statErr == nil && cfg.Algorithm.MilvusMode == "lite" && cfg.Algorithm.MilvusPort > 0 {
-			milvusAlive = tcpOK(ctx, "127.0.0.1", cfg.Algorithm.MilvusPort, 500*time.Millisecond)
+		if _, statErr := os.Stat(paths.MilvusLitePIDFile); statErr == nil && cfg.ModeProfile.VectorStore.ManagedProcess && cfg.ModeProfile.VectorStore.Port > 0 {
+			milvusAlive = tcpOK(ctx, "127.0.0.1", cfg.ModeProfile.VectorStore.Port, 500*time.Millisecond)
 		}
 		if err == nil && !apiAlive && !hasContainers && !authAlive && !milvusAlive {
 			return nil
@@ -746,7 +746,7 @@ func (m *RuntimeManager) Status(ctx context.Context, cfg RuntimeConfig, paths Ru
 			Status: "unknown",
 		}
 	}
-	if cfg.Algorithm.MilvusMode == "lite" {
+	if cfg.ModeProfile.VectorStore.ManagedProcess {
 		if _, ok := resp.Services[milvusLiteProcessName]; !ok {
 			resp.Services[milvusLiteProcessName] = RuntimeServiceState{
 				Kind:   "host-process",
@@ -801,10 +801,10 @@ func (m *RuntimeManager) Status(ctx context.Context, cfg RuntimeConfig, paths Ru
 			hostHealthy = false
 		}
 		resp.Services[coreProcessName] = core
-		if cfg.Algorithm.MilvusMode == "lite" {
+		if cfg.ModeProfile.VectorStore.ManagedProcess {
 			milvus := resp.Services[milvusLiteProcessName]
 			milvus.Kind = "host-process"
-			if tcpOK(ctx, "127.0.0.1", cfg.Algorithm.MilvusPort, 500*time.Millisecond) {
+			if tcpOK(ctx, "127.0.0.1", cfg.ModeProfile.VectorStore.Port, 500*time.Millisecond) {
 				milvus.Status = "running"
 			} else {
 				hostHealthy = false

--- a/local/local-runtime-manager/manager.go
+++ b/local/local-runtime-manager/manager.go
@@ -806,12 +806,13 @@ func (m *RuntimeManager) Status(ctx context.Context, cfg RuntimeConfig, paths Ru
 			milvus.Kind = "host-process"
 			if tcpOK(ctx, "127.0.0.1", cfg.Algorithm.MilvusPort, 500*time.Millisecond) {
 				milvus.Status = "running"
-			} else if milvus.Status == "running" || milvus.Status == "starting" {
-				milvus.Status = "stale"
+			} else {
 				hostHealthy = false
-			} else if milvus.Status == "" || milvus.Status == "unknown" {
-				milvus.Status = "stopped"
-				hostHealthy = false
+				if milvus.Status == "running" || milvus.Status == "starting" {
+					milvus.Status = "stale"
+				} else if milvus.Status == "" || milvus.Status == "unknown" {
+					milvus.Status = "stopped"
+				}
 			}
 			resp.Services[milvusLiteProcessName] = milvus
 		}

--- a/local/local-runtime-manager/manager_test.go
+++ b/local/local-runtime-manager/manager_test.go
@@ -348,7 +348,7 @@ func TestAlgorithmServiceEnvIncludesCloudParityDefaults(t *testing.T) {
 		"LAZYLLM_PADDLE_API_KEY=",
 		"LAZYMIND_RESET_ALGO_ON_STARTUP=false",
 		"LAZYMIND_RESET_ALL_ON_STARTUP=false",
-		"LAZYMIND_MILVUS_URI=http://127.0.0.1:" + strconv.Itoa(cfg.Algorithm.MilvusPort),
+		"LAZYMIND_MILVUS_URI=" + cfg.ModeProfile.VectorStore.Endpoint,
 		"LAZYMIND_MAX_RETRIES=20",
 		"LAZYMIND_REVIEW_MAX_RETRIES=5",
 		"LAZYMIND_SKILL_REVIEW_DEBUG=false",
@@ -544,7 +544,6 @@ func TestFilterRemainingServices(t *testing.T) {
 }
 
 func TestBuildEnabledServicesUsesDockerComposeBuild(t *testing.T) {
-	t.Setenv(localMilvusModeEnvVar, "container")
 	repo := t.TempDir()
 	writeComposeFixture(t, repo)
 	runner := &fakeRunner{t: t}
@@ -554,7 +553,6 @@ func TestBuildEnabledServicesUsesDockerComposeBuild(t *testing.T) {
 			"compose",
 			"-f", filepath.Join(repo, repoComposeFileName),
 			"-f", filepath.Join(repo, localComposeOverrideName),
-			"--profile", "milvus",
 			"config", "--format", "json",
 		)
 		return CommandResult{Stdout: `{
@@ -569,7 +567,6 @@ func TestBuildEnabledServicesUsesDockerComposeBuild(t *testing.T) {
 			"compose",
 			"-f", filepath.Join(repo, repoComposeFileName),
 			"-f", filepath.Join(repo, localComposeOverrideName),
-			"--profile", "milvus",
 			"build",
 			"auth-service",
 			"web",
@@ -596,7 +593,6 @@ func TestClassifyComposeReadinessReportsFatalBeforePending(t *testing.T) {
 }
 
 func TestComposeUpCommandIsCanonical(t *testing.T) {
-	t.Setenv(localMilvusModeEnvVar, "container")
 	repo := t.TempDir()
 	writeComposeFixture(t, repo)
 	runner := &fakeRunner{t: t}
@@ -607,7 +603,6 @@ func TestComposeUpCommandIsCanonical(t *testing.T) {
 		expected := []string{"compose",
 			"-f", filepath.Join(repo, repoComposeFileName),
 			"-f", filepath.Join(repo, localComposeOverrideName),
-			"--profile", "milvus",
 			"config", "--services",
 		}
 		assertCommand(t, cmd, "docker", expected...)
@@ -618,7 +613,6 @@ func TestComposeUpCommandIsCanonical(t *testing.T) {
 			"compose",
 			"-f", filepath.Join(repo, repoComposeFileName),
 			"-f", filepath.Join(repo, localComposeOverrideName),
-			"--profile", "milvus",
 			"config", "--format", "json",
 		)
 		return CommandResult{Stdout: composeConfigJSONNoBuildFixture()}, nil
@@ -628,7 +622,6 @@ func TestComposeUpCommandIsCanonical(t *testing.T) {
 			"compose",
 			"-f", filepath.Join(repo, repoComposeFileName),
 			"-f", filepath.Join(repo, localComposeOverrideName),
-			"--profile", "milvus",
 			"up",
 			"--no-build",
 			"--detach",
@@ -651,7 +644,6 @@ func TestComposeUpCommandIsCanonical(t *testing.T) {
 }
 
 func TestComposeUpOmitsDisabledServices(t *testing.T) {
-	t.Setenv(localMilvusModeEnvVar, "container")
 	repo := t.TempDir()
 	writeComposeFixture(t, repo)
 	overlay := filepath.Join(repo, localComposeOverrideName)
@@ -668,7 +660,6 @@ func TestComposeUpOmitsDisabledServices(t *testing.T) {
 			"compose",
 			"-f", filepath.Join(repo, repoComposeFileName),
 			"-f", filepath.Join(repo, localComposeOverrideName),
-			"--profile", "milvus",
 			"config", "--format", "json",
 		})
 		return CommandResult{Stdout: composeConfigJSONNoBuildFixture()}, nil
@@ -677,7 +668,6 @@ func TestComposeUpOmitsDisabledServices(t *testing.T) {
 			"compose",
 			"-f", filepath.Join(repo, repoComposeFileName),
 			"-f", filepath.Join(repo, localComposeOverrideName),
-			"--profile", "milvus",
 			"up",
 			"--no-build",
 			"--detach",
@@ -844,8 +834,8 @@ func TestWriteGeneratedComposeConfig(t *testing.T) {
 	if !strings.Contains(milvusLite.Command, "internal milvus-lite-run --profile "+profile) {
 		t.Fatalf("missing milvus-lite-run command: %q", milvusLite.Command)
 	}
-	if !strings.Contains(milvusLite.Command, localMilvusModeEnvVar+"=lite") {
-		t.Fatalf("milvus-lite command missing mode env: %q", milvusLite.Command)
+	if !strings.Contains(milvusLite.Command, localMilvusLiteDBPathEnvVar+"="+cfg.ModeProfile.VectorStore.DBPath) {
+		t.Fatalf("milvus-lite command missing db path env: %q", milvusLite.Command)
 	}
 	if !strings.Contains(milvusLite.Shutdown.Command, "internal milvus-lite-down --profile "+profile) {
 		t.Fatalf("missing milvus-lite-down command: %q", milvusLite.Shutdown.Command)
@@ -878,27 +868,12 @@ func TestWriteGeneratedComposeConfig(t *testing.T) {
 
 func TestDerivedComposeProfilesUseBuiltInStoresByDefault(t *testing.T) {
 	t.Setenv("LAZYMIND_DEPLOY_MINERU", "")
-	t.Setenv(localMilvusModeEnvVar, "")
 	t.Setenv("LAZYMIND_MILVUS_URI", "")
 	t.Setenv("LAZYMIND_OPENSEARCH_URI", "")
 	t.Setenv("LAZYMIND_ENABLE_MILVUS_DASHBOARD", "")
 	t.Setenv("LAZYMIND_ENABLE_OPENSEARCH_DASHBOARD", "")
 
 	assertStringSlicesEqual(t, derivedComposeProfileArgs(), nil)
-}
-
-func TestDerivedComposeProfilesUseMilvusContainerMode(t *testing.T) {
-	t.Setenv("LAZYMIND_DEPLOY_MINERU", "")
-	t.Setenv(localMilvusModeEnvVar, "container")
-	t.Setenv("LAZYMIND_MILVUS_URI", "")
-	t.Setenv("LAZYMIND_SEGMENT_STORE_TYPE", "")
-	t.Setenv("LAZYMIND_SEGMENT_STORE_URI_OR_PATH", "")
-	t.Setenv("LAZYMIND_ENABLE_MILVUS_DASHBOARD", "")
-	t.Setenv("LAZYMIND_ENABLE_OPENSEARCH_DASHBOARD", "")
-
-	assertStringSlicesEqual(t, derivedComposeProfileArgs(), []string{
-		"--profile", "milvus",
-	})
 }
 
 func TestDerivedComposeProfilesUseOpenSearchWhenSegmentStoreRequiresBuiltInOpenSearch(t *testing.T) {
@@ -926,7 +901,6 @@ func TestDerivedComposeProfilesSkipExternalStores(t *testing.T) {
 }
 
 func TestComposeUpStreamsDockerComposeLogsWhenSupported(t *testing.T) {
-	t.Setenv(localMilvusModeEnvVar, "container")
 	repo := t.TempDir()
 	writeComposeFixture(t, repo)
 	runner := &fakeStreamRunner{fakeRunner: fakeRunner{t: t}}
@@ -936,7 +910,6 @@ func TestComposeUpStreamsDockerComposeLogsWhenSupported(t *testing.T) {
 			"compose",
 			"-f", filepath.Join(repo, repoComposeFileName),
 			"-f", filepath.Join(repo, localComposeOverrideName),
-			"--profile", "milvus",
 			"config", "--services",
 		)
 		return CommandResult{Stdout: "auth-service\ncore\n"}, nil
@@ -945,7 +918,6 @@ func TestComposeUpStreamsDockerComposeLogsWhenSupported(t *testing.T) {
 			"compose",
 			"-f", filepath.Join(repo, repoComposeFileName),
 			"-f", filepath.Join(repo, localComposeOverrideName),
-			"--profile", "milvus",
 			"config", "--format", "json",
 		)
 		return CommandResult{Stdout: composeConfigJSONNoBuildFixture()}, nil
@@ -955,7 +927,6 @@ func TestComposeUpStreamsDockerComposeLogsWhenSupported(t *testing.T) {
 			"compose",
 			"-f", filepath.Join(repo, repoComposeFileName),
 			"-f", filepath.Join(repo, localComposeOverrideName),
-			"--profile", "milvus",
 			"up",
 			"--no-build",
 			"--detach",
@@ -979,7 +950,6 @@ func TestComposeUpStreamsDockerComposeLogsWhenSupported(t *testing.T) {
 }
 
 func TestManagerUpWritesStateAndStartsProcessCompose(t *testing.T) {
-	t.Setenv(localMilvusModeEnvVar, "container")
 	repo := t.TempDir()
 	writeComposeFixture(t, repo)
 	runner := &fakeRunner{t: t}
@@ -1010,7 +980,6 @@ func TestManagerUpWritesStateAndStartsProcessCompose(t *testing.T) {
 			"compose",
 			"-f", filepath.Join(repo, repoComposeFileName),
 			"-f", filepath.Join(repo, localComposeOverrideName),
-			"--profile", "milvus",
 			"ps",
 			"-a",
 			"--format",
@@ -1126,7 +1095,6 @@ func TestRuntimeManagerUpFailsWhenHostAlgorithmsDoNotBecomeReady(t *testing.T) {
 }
 
 func TestRuntimeManagerUpReusesRunningProcessCompose(t *testing.T) {
-	t.Setenv(localMilvusModeEnvVar, "container")
 	repo := t.TempDir()
 	writeComposeFixture(t, repo)
 	runner := &fakeRunner{t: t}
@@ -1155,7 +1123,6 @@ func TestRuntimeManagerUpReusesRunningProcessCompose(t *testing.T) {
 			"compose",
 			"-f", filepath.Join(repo, repoComposeFileName),
 			"-f", filepath.Join(repo, localComposeOverrideName),
-			"--profile", "milvus",
 			"ps",
 			"-a",
 		})
@@ -1171,7 +1138,6 @@ func TestRuntimeManagerUpReusesRunningProcessCompose(t *testing.T) {
 }
 
 func TestRuntimeManagerUpFailsOnExitedService(t *testing.T) {
-	t.Setenv(localMilvusModeEnvVar, "container")
 	repo := t.TempDir()
 	writeComposeFixture(t, repo)
 	runner := &fakeRunner{t: t}
@@ -1194,7 +1160,6 @@ func TestRuntimeManagerUpFailsOnExitedService(t *testing.T) {
 				"compose",
 				"-f", filepath.Join(repo, repoComposeFileName),
 				"-f", filepath.Join(repo, localComposeOverrideName),
-				"--profile", "milvus",
 				"ps",
 				"-a",
 				"--format",
@@ -1207,7 +1172,6 @@ func TestRuntimeManagerUpFailsOnExitedService(t *testing.T) {
 				"compose",
 				"-f", filepath.Join(repo, repoComposeFileName),
 				"-f", filepath.Join(repo, localComposeOverrideName),
-				"--profile", "milvus",
 				"ps",
 				"-a",
 			})
@@ -1257,7 +1221,6 @@ func TestProcessComposeManagerDownCommandIncludesPortAndTokenFile(t *testing.T) 
 }
 
 func TestRuntimeManagerDownFallsBackToComposeDownOnProcessComposeFailure(t *testing.T) {
-	t.Setenv(localMilvusModeEnvVar, "container")
 	repo := t.TempDir()
 	writeComposeFixture(t, repo)
 	runner := &fakeRunner{t: t}
@@ -1312,7 +1275,6 @@ func TestRuntimeManagerDownFallsBackToComposeDownOnProcessComposeFailure(t *test
 				"compose",
 				"-f", filepath.Join(repo, repoComposeFileName),
 				"-f", filepath.Join(repo, localComposeOverrideName),
-				"--profile", "milvus",
 				"down",
 				"--remove-orphans",
 			})
@@ -1323,7 +1285,6 @@ func TestRuntimeManagerDownFallsBackToComposeDownOnProcessComposeFailure(t *test
 				"compose",
 				"-f", filepath.Join(repo, repoComposeFileName),
 				"-f", filepath.Join(repo, localComposeOverrideName),
-				"--profile", "milvus",
 				"ps",
 				"-a",
 				"--format",

--- a/local/local-runtime-manager/manager_test.go
+++ b/local/local-runtime-manager/manager_test.go
@@ -294,6 +294,8 @@ func TestAlgorithmServiceEnvIncludesCloudParityDefaults(t *testing.T) {
 		"LAZYMIND_SEGMENT_STORE_PASSWORD",
 		"LAZYMIND_EVO_CODE_TIMEOUT_S",
 		"LAZYMIND_EVO_LLM_ROLE",
+		routerPortPoolStartEnvVar,
+		routerPortPoolEndEnvVar,
 	} {
 		t.Setenv(name, "")
 	}
@@ -307,6 +309,7 @@ func TestAlgorithmServiceEnvIncludesCloudParityDefaults(t *testing.T) {
 	env := algorithmServiceEnv(cfg, paths, algoProcessName)
 	uploads := filepath.Join(paths.RepoRoot, "data", "core", "uploads")
 	noProxy := "127.0.0.1,localhost,::1,core,chat,evo-api,doc-server,lazyllm-algo,parsing,milvus,opensearch,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16"
+	routerPoolStart, routerPoolEnd := localRouterPortPool(cfg)
 	for _, want := range []string{
 		"LAZYLLM_INIT_DOC=True",
 		"LAZYMIND_MOUNT_BASE_DIR=" + uploads,
@@ -345,6 +348,7 @@ func TestAlgorithmServiceEnvIncludesCloudParityDefaults(t *testing.T) {
 		"LAZYLLM_PADDLE_API_KEY=",
 		"LAZYMIND_RESET_ALGO_ON_STARTUP=false",
 		"LAZYMIND_RESET_ALL_ON_STARTUP=false",
+		"LAZYMIND_MILVUS_URI=http://127.0.0.1:" + strconv.Itoa(cfg.Algorithm.MilvusPort),
 		"LAZYMIND_MAX_RETRIES=20",
 		"LAZYMIND_REVIEW_MAX_RETRIES=5",
 		"LAZYMIND_SKILL_REVIEW_DEBUG=false",
@@ -359,11 +363,36 @@ func TestAlgorithmServiceEnvIncludesCloudParityDefaults(t *testing.T) {
 		"LAZYMIND_EVO_CODE_TIMEOUT_S=900",
 		"LAZYMIND_EVO_LLM_ROLE=evo_llm",
 		"LAZYMIND_WORD_GROUP_APPLY_URL=",
+		routerPortPoolStartEnvVar + "=" + strconv.Itoa(routerPoolStart),
+		routerPortPoolEndEnvVar + "=" + strconv.Itoa(routerPoolEnd),
+		routerPortsPerInstanceEnvVar + "=" + strconv.Itoa(defaultRouterPortsPerInstance),
 	} {
 		if !containsString(env, want) {
 			t.Fatalf("algorithm env missing %q in %v", want, env)
 		}
 	}
+	for _, item := range env {
+		if strings.HasPrefix(item, "LAZYMIND_MILVUS_URI=") && strings.Contains(item, ".lazymind-local/stores/milvus") {
+			t.Fatalf("algorithm env must use Milvus endpoint, not Lite DB file: %q", item)
+		}
+	}
+}
+
+func TestAlgorithmServiceEnvOffsetsRouterPoolWithProcessComposePort(t *testing.T) {
+	t.Setenv(routerPortPoolStartEnvVar, "")
+	t.Setenv(routerPortPoolEndEnvVar, "")
+	repo := t.TempDir()
+	writeComposeFixture(t, repo)
+	cfg, paths, err := NewRuntimeConfig(defaultProfileValue(), repo)
+	if err != nil {
+		t.Fatalf("runtime config: %v", err)
+	}
+	cfg.ProcessComposePort = defaultProcessComposePort + 2
+
+	env := algorithmServiceEnv(cfg, paths, chatProcessName)
+	start := defaultRouterPortPoolStart + 2*defaultRouterPortsPerInstance
+	assertEnvContains(t, env, routerPortPoolStartEnvVar+"="+strconv.Itoa(start))
+	assertEnvContains(t, env, routerPortPoolEndEnvVar+"="+strconv.Itoa(start+defaultRouterPortsPerInstance-1))
 }
 
 func TestAlgorithmServiceEnvUsesOpenSearchSegmentStoreWhenRequested(t *testing.T) {
@@ -515,6 +544,7 @@ func TestFilterRemainingServices(t *testing.T) {
 }
 
 func TestBuildEnabledServicesUsesDockerComposeBuild(t *testing.T) {
+	t.Setenv(localMilvusModeEnvVar, "container")
 	repo := t.TempDir()
 	writeComposeFixture(t, repo)
 	runner := &fakeRunner{t: t}
@@ -566,6 +596,7 @@ func TestClassifyComposeReadinessReportsFatalBeforePending(t *testing.T) {
 }
 
 func TestComposeUpCommandIsCanonical(t *testing.T) {
+	t.Setenv(localMilvusModeEnvVar, "container")
 	repo := t.TempDir()
 	writeComposeFixture(t, repo)
 	runner := &fakeRunner{t: t}
@@ -620,6 +651,7 @@ func TestComposeUpCommandIsCanonical(t *testing.T) {
 }
 
 func TestComposeUpOmitsDisabledServices(t *testing.T) {
+	t.Setenv(localMilvusModeEnvVar, "container")
 	repo := t.TempDir()
 	writeComposeFixture(t, repo)
 	overlay := filepath.Join(repo, localComposeOverrideName)
@@ -805,6 +837,25 @@ func TestWriteGeneratedComposeConfig(t *testing.T) {
 	if fileWatcher.Namespace != "host" {
 		t.Fatalf("unexpected file-watcher namespace %q", fileWatcher.Namespace)
 	}
+	milvusLite, ok := parsed.Processes[milvusLiteProcessName]
+	if !ok {
+		t.Fatal("missing milvus-lite process")
+	}
+	if !strings.Contains(milvusLite.Command, "internal milvus-lite-run --profile "+profile) {
+		t.Fatalf("missing milvus-lite-run command: %q", milvusLite.Command)
+	}
+	if !strings.Contains(milvusLite.Command, localMilvusModeEnvVar+"=lite") {
+		t.Fatalf("milvus-lite command missing mode env: %q", milvusLite.Command)
+	}
+	if !strings.Contains(milvusLite.Shutdown.Command, "internal milvus-lite-down --profile "+profile) {
+		t.Fatalf("missing milvus-lite-down command: %q", milvusLite.Shutdown.Command)
+	}
+	if milvusLite.LogLocation != paths.MilvusLiteLog {
+		t.Fatalf("unexpected milvus-lite log location %q", milvusLite.LogLocation)
+	}
+	if milvusLite.Namespace != "host" {
+		t.Fatalf("unexpected milvus-lite namespace %q", milvusLite.Namespace)
+	}
 	for _, service := range []string{docServerProcessName, processorServerProcessName, processorWorkerProcessName, algoProcessName, chatProcessName} {
 		proc, ok := parsed.Processes[service]
 		if !ok {
@@ -827,6 +878,18 @@ func TestWriteGeneratedComposeConfig(t *testing.T) {
 
 func TestDerivedComposeProfilesUseBuiltInStoresByDefault(t *testing.T) {
 	t.Setenv("LAZYMIND_DEPLOY_MINERU", "")
+	t.Setenv(localMilvusModeEnvVar, "")
+	t.Setenv("LAZYMIND_MILVUS_URI", "")
+	t.Setenv("LAZYMIND_OPENSEARCH_URI", "")
+	t.Setenv("LAZYMIND_ENABLE_MILVUS_DASHBOARD", "")
+	t.Setenv("LAZYMIND_ENABLE_OPENSEARCH_DASHBOARD", "")
+
+	assertStringSlicesEqual(t, derivedComposeProfileArgs(), nil)
+}
+
+func TestDerivedComposeProfilesUseMilvusContainerMode(t *testing.T) {
+	t.Setenv("LAZYMIND_DEPLOY_MINERU", "")
+	t.Setenv(localMilvusModeEnvVar, "container")
 	t.Setenv("LAZYMIND_MILVUS_URI", "")
 	t.Setenv("LAZYMIND_SEGMENT_STORE_TYPE", "")
 	t.Setenv("LAZYMIND_SEGMENT_STORE_URI_OR_PATH", "")
@@ -847,7 +910,6 @@ func TestDerivedComposeProfilesUseOpenSearchWhenSegmentStoreRequiresBuiltInOpenS
 	t.Setenv("LAZYMIND_ENABLE_OPENSEARCH_DASHBOARD", "")
 
 	assertStringSlicesEqual(t, derivedComposeProfileArgs(), []string{
-		"--profile", "milvus",
 		"--profile", "opensearch",
 	})
 }
@@ -864,6 +926,7 @@ func TestDerivedComposeProfilesSkipExternalStores(t *testing.T) {
 }
 
 func TestComposeUpStreamsDockerComposeLogsWhenSupported(t *testing.T) {
+	t.Setenv(localMilvusModeEnvVar, "container")
 	repo := t.TempDir()
 	writeComposeFixture(t, repo)
 	runner := &fakeStreamRunner{fakeRunner: fakeRunner{t: t}}
@@ -916,6 +979,7 @@ func TestComposeUpStreamsDockerComposeLogsWhenSupported(t *testing.T) {
 }
 
 func TestManagerUpWritesStateAndStartsProcessCompose(t *testing.T) {
+	t.Setenv(localMilvusModeEnvVar, "container")
 	repo := t.TempDir()
 	writeComposeFixture(t, repo)
 	runner := &fakeRunner{t: t}
@@ -1062,6 +1126,7 @@ func TestRuntimeManagerUpFailsWhenHostAlgorithmsDoNotBecomeReady(t *testing.T) {
 }
 
 func TestRuntimeManagerUpReusesRunningProcessCompose(t *testing.T) {
+	t.Setenv(localMilvusModeEnvVar, "container")
 	repo := t.TempDir()
 	writeComposeFixture(t, repo)
 	runner := &fakeRunner{t: t}
@@ -1106,6 +1171,7 @@ func TestRuntimeManagerUpReusesRunningProcessCompose(t *testing.T) {
 }
 
 func TestRuntimeManagerUpFailsOnExitedService(t *testing.T) {
+	t.Setenv(localMilvusModeEnvVar, "container")
 	repo := t.TempDir()
 	writeComposeFixture(t, repo)
 	runner := &fakeRunner{t: t}
@@ -1191,6 +1257,7 @@ func TestProcessComposeManagerDownCommandIncludesPortAndTokenFile(t *testing.T) 
 }
 
 func TestRuntimeManagerDownFallsBackToComposeDownOnProcessComposeFailure(t *testing.T) {
+	t.Setenv(localMilvusModeEnvVar, "container")
 	repo := t.TempDir()
 	writeComposeFixture(t, repo)
 	runner := &fakeRunner{t: t}

--- a/local/local-runtime-manager/milvus_lite.go
+++ b/local/local-runtime-manager/milvus_lite.go
@@ -1,0 +1,156 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"syscall"
+	"time"
+)
+
+type MilvusLiteManager struct {
+	runner CommandRunner
+}
+
+func NewMilvusLiteManager(r CommandRunner) *MilvusLiteManager {
+	return &MilvusLiteManager{runner: r}
+}
+
+func (m *MilvusLiteManager) Run(ctx context.Context, cfg RuntimeConfig, paths RuntimePaths) error {
+	if cfg.Algorithm.MilvusMode != "lite" {
+		return nil
+	}
+	if err := paths.EnsureAllDirs(); err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(cfg.Algorithm.MilvusDBPath), 0o755); err != nil {
+		return err
+	}
+	algorithm := NewAlgorithmServiceManager(m.runner)
+	if err := algorithm.preparePython(ctx, paths, false); err != nil {
+		return err
+	}
+
+	address := "127.0.0.1:" + strconv.Itoa(cfg.Algorithm.MilvusPort)
+	cmd := exec.CommandContext(ctx, paths.AlgorithmPython,
+		"-m", "lazymind.local_milvus_lite",
+		"--db-file", cfg.Algorithm.MilvusDBPath,
+		"--address", address,
+	)
+	cmd.Dir = paths.RepoRoot
+	cmd.Env = append(os.Environ(), algorithmServiceEnv(cfg, paths, milvusLiteProcessName)...)
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Start(); err != nil {
+		return fmt.Errorf("start %s failed: %w", milvusLiteProcessName, err)
+	}
+	if err := os.WriteFile(paths.MilvusLitePIDFile, []byte(strconv.Itoa(cmd.Process.Pid)+"\n"), 0o600); err != nil {
+		_ = killAlgorithmProcess(cmd.Process)
+		return err
+	}
+
+	waitErr := make(chan error, 1)
+	go func() {
+		waitErr <- cmd.Wait()
+	}()
+	if err := waitForMilvusLiteReady(ctx, cfg.Algorithm.MilvusPort, waitErr); err != nil {
+		_ = killAlgorithmProcess(cmd.Process)
+		_ = os.Remove(paths.MilvusLitePIDFile)
+		return err
+	}
+
+	err := <-waitErr
+	_ = os.Remove(paths.MilvusLitePIDFile)
+	if ctx.Err() != nil {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("%s exited: %w", milvusLiteProcessName, err)
+	}
+	return nil
+}
+
+func (m *MilvusLiteManager) Down(ctx context.Context, paths RuntimePaths) error {
+	pid, err := readPIDFile(paths.MilvusLitePIDFile)
+	if err != nil {
+		return err
+	}
+	if pid <= 0 {
+		return nil
+	}
+	proc, err := os.FindProcess(pid)
+	if err != nil {
+		_ = os.Remove(paths.MilvusLitePIDFile)
+		return nil
+	}
+	if err := signalProcessGroup(pid, syscall.SIGINT); err != nil {
+		_ = proc.Signal(os.Interrupt)
+	}
+	deadline := time.NewTimer(10 * time.Second)
+	defer deadline.Stop()
+	ticker := time.NewTicker(250 * time.Millisecond)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			_ = signalProcessGroup(pid, syscall.SIGKILL)
+			_ = proc.Kill()
+			return ctx.Err()
+		case <-deadline.C:
+			_ = signalProcessGroup(pid, syscall.SIGKILL)
+			_ = proc.Kill()
+			_ = os.Remove(paths.MilvusLitePIDFile)
+			return nil
+		case <-ticker.C:
+			if !processAlive(pid) {
+				_ = os.Remove(paths.MilvusLitePIDFile)
+				return nil
+			}
+		}
+	}
+}
+
+func readPIDFile(path string) (int, error) {
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return 0, nil
+		}
+		return 0, err
+	}
+	pid, err := strconv.Atoi(strings.TrimSpace(string(raw)))
+	if err != nil || pid <= 0 {
+		_ = os.Remove(path)
+		return 0, nil
+	}
+	return pid, nil
+}
+
+func waitForMilvusLiteReady(ctx context.Context, port int, waitErr <-chan error) error {
+	deadline := time.NewTimer(5 * time.Minute)
+	defer deadline.Stop()
+	ticker := time.NewTicker(500 * time.Millisecond)
+	defer ticker.Stop()
+	for {
+		if tcpOK(ctx, "127.0.0.1", port, time.Second) {
+			return nil
+		}
+		select {
+		case err := <-waitErr:
+			if err == nil {
+				return fmt.Errorf("%s exited before becoming ready", milvusLiteProcessName)
+			}
+			return fmt.Errorf("%s exited before becoming ready: %w", milvusLiteProcessName, err)
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-deadline.C:
+			return fmt.Errorf("timed out waiting for %s at 127.0.0.1:%d", milvusLiteProcessName, port)
+		case <-ticker.C:
+		}
+	}
+}

--- a/local/local-runtime-manager/milvus_lite.go
+++ b/local/local-runtime-manager/milvus_lite.go
@@ -21,13 +21,13 @@ func NewMilvusLiteManager(r CommandRunner) *MilvusLiteManager {
 }
 
 func (m *MilvusLiteManager) Run(ctx context.Context, cfg RuntimeConfig, paths RuntimePaths) error {
-	if cfg.Algorithm.MilvusMode != "lite" {
+	if !cfg.ModeProfile.VectorStore.ManagedProcess {
 		return nil
 	}
 	if err := paths.EnsureAllDirs(); err != nil {
 		return err
 	}
-	if err := os.MkdirAll(filepath.Dir(cfg.Algorithm.MilvusDBPath), 0o755); err != nil {
+	if err := os.MkdirAll(filepath.Dir(cfg.ModeProfile.VectorStore.DBPath), 0o755); err != nil {
 		return err
 	}
 	algorithm := NewAlgorithmServiceManager(m.runner)
@@ -35,10 +35,10 @@ func (m *MilvusLiteManager) Run(ctx context.Context, cfg RuntimeConfig, paths Ru
 		return err
 	}
 
-	address := "127.0.0.1:" + strconv.Itoa(cfg.Algorithm.MilvusPort)
+	address := "127.0.0.1:" + strconv.Itoa(cfg.ModeProfile.VectorStore.Port)
 	cmd := exec.CommandContext(ctx, paths.AlgorithmPython,
 		"-m", "lazymind.local_milvus_lite",
-		"--db-file", cfg.Algorithm.MilvusDBPath,
+		"--db-file", cfg.ModeProfile.VectorStore.DBPath,
 		"--address", address,
 	)
 	cmd.Dir = paths.RepoRoot
@@ -58,7 +58,7 @@ func (m *MilvusLiteManager) Run(ctx context.Context, cfg RuntimeConfig, paths Ru
 	go func() {
 		waitErr <- cmd.Wait()
 	}()
-	if err := waitForMilvusLiteReady(ctx, cfg.Algorithm.MilvusPort, waitErr); err != nil {
+	if err := waitForMilvusLiteReady(ctx, cfg.ModeProfile.VectorStore.Port, waitErr); err != nil {
 		_ = killAlgorithmProcess(cmd.Process)
 		_ = os.Remove(paths.MilvusLitePIDFile)
 		return err

--- a/local/local-runtime-manager/processcompose.go
+++ b/local/local-runtime-manager/processcompose.go
@@ -139,7 +139,7 @@ func (m *ProcessComposeManager) WriteGeneratedConfig(w io.Writer, repoRoot strin
 			},
 		},
 	}
-	if cfg.Algorithm.MilvusMode == "lite" {
+	if cfg.ModeProfile.VectorStore.ManagedProcess {
 		pcCfg.Processes[milvusLiteProcessName] = processComposeProcess{
 			WorkingDir: repoRoot,
 			Command:    commandForMilvusLiteRun,
@@ -195,8 +195,7 @@ func runtimeCommandEnv(cfg RuntimeConfig) []string {
 		processComposePortEnvVar+"="+strconv.Itoa(cfg.ProcessComposePort),
 		authServicePortEnvVar+"="+strconv.Itoa(cfg.AuthService.Port),
 		localFileWatcherPortEnvVar+"="+strconv.Itoa(cfg.FileWatcher.Port),
-		localMilvusModeEnvVar+"="+cfg.Algorithm.MilvusMode,
-		localMilvusDBPathEnvVar+"="+cfg.Algorithm.MilvusDBPath,
+		localMilvusLiteDBPathEnvVar+"="+cfg.ModeProfile.VectorStore.DBPath,
 	)
 	return env
 }

--- a/local/local-runtime-manager/processcompose.go
+++ b/local/local-runtime-manager/processcompose.go
@@ -59,6 +59,8 @@ func (m *ProcessComposeManager) WriteGeneratedConfig(w io.Writer, repoRoot strin
 	commandForFileWatcherDown := commandWithEnv(commandEnv, quoteShellArg(m.execPath)+" internal file-watcher-down --profile "+profile)
 	commandForFrontendRun := commandWithEnv(commandEnv, quoteShellArg(m.execPath)+" internal frontend-run --profile "+profile)
 	commandForFrontendDown := commandWithEnv(commandEnv, quoteShellArg(m.execPath)+" internal frontend-down --profile "+profile)
+	commandForMilvusLiteRun := commandWithEnv(commandEnv, quoteShellArg(m.execPath)+" internal milvus-lite-run --profile "+profile)
+	commandForMilvusLiteDown := commandWithEnv(commandEnv, quoteShellArg(m.execPath)+" internal milvus-lite-down --profile "+profile)
 
 	pcCfg := processComposeConfig{
 		Version:         "0.5",
@@ -137,6 +139,18 @@ func (m *ProcessComposeManager) WriteGeneratedConfig(w io.Writer, repoRoot strin
 			},
 		},
 	}
+	if cfg.Algorithm.MilvusMode == "lite" {
+		pcCfg.Processes[milvusLiteProcessName] = processComposeProcess{
+			WorkingDir: repoRoot,
+			Command:    commandForMilvusLiteRun,
+			Shutdown: processComposeShutdown{
+				Command:        commandForMilvusLiteDown,
+				TimeoutSeconds: 20,
+			},
+			LogLocation: paths.MilvusLiteLog,
+			Namespace:   "host",
+		}
+	}
 	for _, svc := range algorithmProcessSpecs(cfg.Algorithm) {
 		run := commandWithEnv(commandEnv, quoteShellArg(m.execPath)+" internal algorithm-run --service "+svc.Name+" --profile "+profile)
 		down := commandWithEnv(commandEnv, quoteShellArg(m.execPath)+" internal algorithm-down --service "+svc.Name+" --profile "+profile)
@@ -181,6 +195,8 @@ func runtimeCommandEnv(cfg RuntimeConfig) []string {
 		processComposePortEnvVar+"="+strconv.Itoa(cfg.ProcessComposePort),
 		authServicePortEnvVar+"="+strconv.Itoa(cfg.AuthService.Port),
 		localFileWatcherPortEnvVar+"="+strconv.Itoa(cfg.FileWatcher.Port),
+		localMilvusModeEnvVar+"="+cfg.Algorithm.MilvusMode,
+		localMilvusDBPathEnvVar+"="+cfg.Algorithm.MilvusDBPath,
 	)
 	return env
 }

--- a/local/local-runtime-manager/state.go
+++ b/local/local-runtime-manager/state.go
@@ -122,6 +122,10 @@ func defaultRuntimeState(cfg RuntimeConfig, apiPort int, tokenPath string) Runti
 				Kind:   "host-process",
 				Status: "stopped",
 			},
+			milvusLiteProcessName: {
+				Kind:   "host-process",
+				Status: "stopped",
+			},
 			docServerProcessName: {
 				Kind:   "host-process",
 				Status: "stopped",
@@ -229,6 +233,10 @@ func newStateWithServiceStatus(state RuntimeState, serviceStatus string) Runtime
 	fileWatcher.Kind = "host-process"
 	fileWatcher.Status = serviceStatus
 	state.Services[fileWatcherProcessName] = fileWatcher
+	milvus := state.Services[milvusLiteProcessName]
+	milvus.Kind = "host-process"
+	milvus.Status = serviceStatus
+	state.Services[milvusLiteProcessName] = milvus
 	for _, name := range []string{
 		docServerProcessName,
 		processorServerProcessName,
@@ -315,7 +323,7 @@ func normalizeRuntimeServices(services map[string]RuntimeServiceState) map[strin
 		svc.Kind = "host-process"
 		normalized[coreProcessName] = svc
 	}
-	for _, name := range []string{scanControlPlaneProcessName, fileWatcherProcessName} {
+	for _, name := range []string{scanControlPlaneProcessName, fileWatcherProcessName, milvusLiteProcessName} {
 		if _, ok := services[name]; !ok {
 			normalized[name] = RuntimeServiceState{
 				Kind:   "host-process",

--- a/local/local-runtime-manager/state.go
+++ b/local/local-runtime-manager/state.go
@@ -30,6 +30,7 @@ type ProcessComposeState struct {
 
 type RuntimeConfigSnapshot struct {
 	FrontendPort       int                       `json:"frontendPort,omitempty"`
+	ModeProfile        RuntimeModeProfileConfig  `json:"modeProfile,omitempty"`
 	LocalProxy         LocalProxyConfig          `json:"localProxy,omitempty"`
 	AuthService        AuthServiceConfig         `json:"authService,omitempty"`
 	Algorithm          AlgorithmConfig           `json:"algorithm,omitempty"`
@@ -155,6 +156,7 @@ func defaultRuntimeState(cfg RuntimeConfig, apiPort int, tokenPath string) Runti
 func snapshotRuntimeConfig(cfg RuntimeConfig) RuntimeConfigSnapshot {
 	return RuntimeConfigSnapshot{
 		FrontendPort: cfg.FrontendPort,
+		ModeProfile:  cfg.ModeProfile,
 		LocalProxy:   cfg.LocalProxy,
 		AuthService:  cfg.AuthService,
 		Algorithm:    cfg.Algorithm,
@@ -174,6 +176,9 @@ func applyStateConfig(cfg RuntimeConfig, state RuntimeState) RuntimeConfig {
 	}
 	if state.Config.FrontendPort > 0 {
 		cfg.FrontendPort = state.Config.FrontendPort
+	}
+	if state.Config.ModeProfile.Name != "" {
+		cfg.ModeProfile = state.Config.ModeProfile
 	}
 	if state.Config.LocalProxy.Port > 0 {
 		cfg.LocalProxy = state.Config.LocalProxy


### PR DESCRIPTION
Local 模式改用 Milvus Lite host 进程，保留容器/外部 Milvus 可选。

Validation:
- go test -count=1 ./... in local/local-runtime-manager
- lazymind-local-smoke passed against http://localhost:8091
