### PR TITLE
local模式可以监听在127.0.0.1或0.0.0.0

### DIFF
--- a/local/local-runtime-manager/algorithm_service.go
+++ b/local/local-runtime-manager/algorithm_service.go
@@ -442,6 +442,9 @@ func localSegmentStoreURIOrPath(cfg RuntimeConfig, paths RuntimePaths) string {
 }
 
 func ensureAlgorithmDataDirs(paths RuntimePaths) error {
+	if err := ensureLocalDataRootWritable(paths.RepoRoot); err != nil {
+		return err
+	}
 	dirs := []string{
 		filepath.Join(paths.RepoRoot, "data", "core", "uploads"),
 		filepath.Join(paths.RepoRoot, "data", "traces"),

--- a/local/local-runtime-manager/compose.go
+++ b/local/local-runtime-manager/compose.go
@@ -258,6 +258,7 @@ func (m *ComposeManager) ComposeConfigJSON(ctx context.Context, repoRoot string)
 func localComposeEnv(cfg RuntimeConfig) []string {
 	return []string{
 		"LAZYMIND_FRONTEND_PORT=" + strconv.Itoa(cfg.FrontendPort),
+		"LAZYMIND_LOCAL_NETWORK_PROFILE=" + cfg.NetworkProfile,
 		"LAZYMIND_LOCAL_PROXY_PORT=" + strconv.Itoa(cfg.LocalProxy.Port),
 		"LAZYMIND_LOCAL_PROXY_AUTH_HOST_PORT=" + strconv.Itoa(cfg.LocalProxy.AuthHostPort),
 		"LAZYMIND_LOCAL_PROXY_CORE_HOST_PORT=" + strconv.Itoa(cfg.LocalProxy.CoreHostPort),

--- a/local/local-runtime-manager/config.go
+++ b/local/local-runtime-manager/config.go
@@ -300,18 +300,22 @@ func (a *localPortAllocator) envOrAvailable(envName string, fallback int) int {
 }
 
 func (a *localPortAllocator) envOrAvailableDefaultCanMove(envName string, fallback int) int {
+	return a.envOrAvailableDefaultCanMoveOn(envName, fallback, "127.0.0.1")
+}
+
+func (a *localPortAllocator) envOrAvailableDefaultCanMoveOn(envName string, fallback int, address string) int {
 	raw := strings.TrimSpace(os.Getenv(envName))
 	if raw == "" {
-		return a.availableFrom(fallback, 500)
+		return a.availableFromOn(fallback, 500, address)
 	}
 	port := envPort(envName, fallback)
 	if envBool(localPortsPinnedEnvVar, false) {
 		return a.reserve(port)
 	}
-	if port != fallback || localPortAvailable(port) {
+	if port != fallback || localPortAvailableOn(address, port) {
 		return a.reserve(port)
 	}
-	return a.availableFrom(fallback, 500)
+	return a.availableFromOn(fallback, 500, address)
 }
 
 func (a *localPortAllocator) firstEnvOrAvailable(envNames []string, fallback int) int {
@@ -324,11 +328,15 @@ func (a *localPortAllocator) firstEnvOrAvailable(envNames []string, fallback int
 }
 
 func (a *localPortAllocator) availableFrom(start int, attempts int) int {
+	return a.availableFromOn(start, attempts, "127.0.0.1")
+}
+
+func (a *localPortAllocator) availableFromOn(start int, attempts int, address string) int {
 	for port := start; port < start+attempts && port < 65536; port++ {
 		if _, ok := a.used[port]; ok {
 			continue
 		}
-		if !localPortAvailable(port) {
+		if !localPortAvailableOn(address, port) {
 			continue
 		}
 		return a.reserve(port)
@@ -337,7 +345,11 @@ func (a *localPortAllocator) availableFrom(start int, attempts int) int {
 }
 
 func localPortAvailable(port int) bool {
-	ln, err := net.Listen("tcp", net.JoinHostPort("127.0.0.1", strconv.Itoa(port)))
+	return localPortAvailableOn("127.0.0.1", port)
+}
+
+func localPortAvailableOn(address string, port int) bool {
+	ln, err := net.Listen("tcp", net.JoinHostPort(address, strconv.Itoa(port)))
 	if err != nil {
 		return false
 	}
@@ -597,8 +609,16 @@ func NewRuntimeConfig(profile, repoRootHint string) (RuntimeConfig, RuntimePaths
 		AlgorithmPIDDir:          filepath.Join(runtimeRoot, "run", "algorithm"),
 	}
 	ports := newLocalPortAllocator()
+	networkProfile, err := localNetworkProfile()
+	if err != nil {
+		return RuntimeConfig{}, RuntimePaths{}, err
+	}
+	frontendBindCheckAddress := "127.0.0.1"
+	if networkProfile == "lan" {
+		frontendBindCheckAddress = "0.0.0.0"
+	}
 	processComposePort := ports.envOrAvailable(processComposePortEnvVar, defaultProcessComposePort)
-	frontendPort := ports.envOrAvailableDefaultCanMove(frontendPortEnvVar, defaultFrontendPort)
+	frontendPort := ports.envOrAvailableDefaultCanMoveOn(frontendPortEnvVar, defaultFrontendPort, frontendBindCheckAddress)
 	localProxyPort := ports.envOrAvailable(localProxyPortEnvVar, defaultLocalProxyPort)
 	authHostPort := ports.envOrAvailable(localProxyAuthHostPortEnvVar, defaultLocalProxyAuthHostPort)
 	coreHostPort := ports.firstEnvOrAvailable([]string{localCorePortEnvVar, localProxyCoreHostPortEnvVar}, defaultLocalProxyCoreHostPort)
@@ -614,10 +634,6 @@ func NewRuntimeConfig(profile, repoRootHint string) (RuntimeConfig, RuntimePaths
 	chatPort := ports.firstEnvOrAvailable([]string{localChatPortEnvVar, localProxyChatHostPortEnvVar}, defaultLocalProxyChatHostPort)
 	evoPort := ports.firstEnvOrAvailable([]string{localEvoPortEnvVar, localProxyEvoHostPortEnvVar}, defaultLocalProxyEvoHostPort)
 	milvusLiteDBPath := filepath.Clean(envText(localMilvusLiteDBPathEnvVar, p.MilvusLiteDBPath))
-	networkProfile, err := localNetworkProfile()
-	if err != nil {
-		return RuntimeConfig{}, RuntimePaths{}, err
-	}
 	return RuntimeConfig{
 		Profile:            profile,
 		RepoRoot:           p.RepoRoot,

--- a/local/local-runtime-manager/config.go
+++ b/local/local-runtime-manager/config.go
@@ -15,6 +15,7 @@ const (
 	processComposePortEnvVar      = "LAZYMIND_PROCESS_COMPOSE_PORT"
 	localUpTimeoutEnvVar          = "LAZYMIND_LOCAL_UP_TIMEOUT"
 	localDownTimeoutEnvVar        = "LAZYMIND_LOCAL_DOWN_TIMEOUT"
+	localNetworkProfileEnvVar     = "LAZYMIND_LOCAL_NETWORK_PROFILE"
 	localProxyAddressEnvVar       = "LAZYMIND_LOCAL_PROXY_ADDRESS"
 	localProxyPortEnvVar          = "LAZYMIND_LOCAL_PROXY_PORT"
 	localProxyAuthHostPortEnvVar  = "LAZYMIND_LOCAL_PROXY_AUTH_HOST_PORT"
@@ -54,7 +55,8 @@ const (
 	defaultLocalUpTimeout         = 30 * 60
 	defaultLocalDownTimeout       = 2 * 60
 	defaultFrontendPort           = 8090
-	defaultLocalProxyAddress      = "0.0.0.0"
+	defaultLocalNetworkProfile    = "localhost"
+	defaultLocalProxyAddress      = "127.0.0.1"
 	defaultLocalProxyPort         = 5024
 	defaultLocalProxyAuthHostPort = 18000
 	defaultLocalProxyCoreHostPort = 18001
@@ -171,6 +173,7 @@ type RuntimeConfig struct {
 	ModeProfile        RuntimeModeProfileConfig
 	ProcessComposePort int
 	FrontendPort       int
+	NetworkProfile     string
 	LocalProxy         LocalProxyConfig
 	AuthService        AuthServiceConfig
 	CaddyVersion       string
@@ -381,6 +384,19 @@ func envBool(name string, fallback bool) bool {
 		return false
 	default:
 		return fallback
+	}
+}
+
+func localNetworkProfile() (string, error) {
+	profile := strings.ToLower(strings.TrimSpace(os.Getenv(localNetworkProfileEnvVar)))
+	if profile == "" {
+		return defaultLocalNetworkProfile, nil
+	}
+	switch profile {
+	case "localhost", "lan":
+		return profile, nil
+	default:
+		return "", fmt.Errorf("%s must be localhost or lan", localNetworkProfileEnvVar)
 	}
 }
 
@@ -598,6 +614,10 @@ func NewRuntimeConfig(profile, repoRootHint string) (RuntimeConfig, RuntimePaths
 	chatPort := ports.firstEnvOrAvailable([]string{localChatPortEnvVar, localProxyChatHostPortEnvVar}, defaultLocalProxyChatHostPort)
 	evoPort := ports.firstEnvOrAvailable([]string{localEvoPortEnvVar, localProxyEvoHostPortEnvVar}, defaultLocalProxyEvoHostPort)
 	milvusLiteDBPath := filepath.Clean(envText(localMilvusLiteDBPathEnvVar, p.MilvusLiteDBPath))
+	networkProfile, err := localNetworkProfile()
+	if err != nil {
+		return RuntimeConfig{}, RuntimePaths{}, err
+	}
 	return RuntimeConfig{
 		Profile:            profile,
 		RepoRoot:           p.RepoRoot,
@@ -605,6 +625,7 @@ func NewRuntimeConfig(profile, repoRootHint string) (RuntimeConfig, RuntimePaths
 		ModeProfile:        localRuntimeModeProfile(milvusPort, milvusLiteDBPath),
 		ProcessComposePort: processComposePort,
 		FrontendPort:       frontendPort,
+		NetworkProfile:     networkProfile,
 		CaddyVersion:       envText(caddyVersionEnvVar, defaultCaddyVersion),
 		LocalProxy: LocalProxyConfig{
 			Address:      envText(localProxyAddressEnvVar, defaultLocalProxyAddress),

--- a/local/local-runtime-manager/core_service.go
+++ b/local/local-runtime-manager/core_service.go
@@ -32,6 +32,9 @@ func (m *CoreServiceManager) Run(ctx context.Context, cfg RuntimeConfig, paths R
 	if err := paths.EnsureAllDirs(); err != nil {
 		return err
 	}
+	if err := ensureLocalDataRootWritable(paths.RepoRoot); err != nil {
+		return err
+	}
 	for _, dir := range []string{
 		filepath.Join(paths.RepoRoot, "data", "core", "uploads"),
 		filepath.Join(paths.RepoRoot, "data", "subagent"),

--- a/local/local-runtime-manager/frontend.go
+++ b/local/local-runtime-manager/frontend.go
@@ -113,13 +113,19 @@ func frontendBuildEnv() []string {
 func writeCaddyfile(paths RuntimePaths, cfg RuntimeConfig) error {
 	distRoot := filepath.ToSlash(filepath.Join(paths.RepoRoot, "frontend", "dist"))
 	proxy := "http://127.0.0.1:" + strconv.Itoa(cfg.LocalProxy.Port)
+	siteAddress := fmt.Sprintf("http://localhost:%d, http://127.0.0.1:%d", cfg.FrontendPort, cfg.FrontendPort)
+	bindAddress := "127.0.0.1"
+	if cfg.NetworkProfile == "lan" {
+		siteAddress = fmt.Sprintf("http://:%d", cfg.FrontendPort)
+		bindAddress = "0.0.0.0"
+	}
 	content := fmt.Sprintf(`{
 	admin off
 	auto_https off
 }
 
-http://localhost:%d, http://127.0.0.1:%d {
-	bind 127.0.0.1
+%s {
+	bind %s
 	root * %s
 	encode gzip
 
@@ -140,7 +146,7 @@ http://localhost:%d, http://127.0.0.1:%d {
 		file_server
 	}
 }
-`, cfg.FrontendPort, cfg.FrontendPort, strconv.Quote(distRoot), proxy, proxy)
+`, siteAddress, bindAddress, strconv.Quote(distRoot), proxy, proxy)
 	return os.WriteFile(paths.CaddyConfig, []byte(content), 0o644)
 }
 

--- a/local/local-runtime-manager/local_proxy.go
+++ b/local/local-runtime-manager/local_proxy.go
@@ -80,6 +80,7 @@ func localRuntimeEnv(cfg RuntimeConfig) []string {
 	return []string{
 		processComposePortEnvVar + "=" + strconv.Itoa(cfg.ProcessComposePort),
 		frontendPortEnvVar + "=" + strconv.Itoa(cfg.FrontendPort),
+		localNetworkProfileEnvVar + "=" + cfg.NetworkProfile,
 		localProxyAddressEnvVar + "=" + cfg.LocalProxy.Address,
 		localProxyPortEnvVar + "=" + strconv.Itoa(cfg.LocalProxy.Port),
 		localProxyAuthHostPortEnvVar + "=" + strconv.Itoa(cfg.LocalProxy.AuthHostPort),

--- a/local/local-runtime-manager/manager.go
+++ b/local/local-runtime-manager/manager.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"net"
 	"os"
 	"regexp"
 	"strconv"
@@ -609,7 +610,34 @@ func (m *RuntimeManager) printReadySummary(cfg RuntimeConfig) {
 	_, _ = fmt.Fprintf(m.out, "local runtime ready\n")
 	_, _ = fmt.Fprintf(m.out, "process-compose: http://127.0.0.1:%d\n", cfg.ProcessComposePort)
 	_, _ = fmt.Fprintf(m.out, "frontend: http://localhost:%d\n", cfg.FrontendPort)
+	if cfg.NetworkProfile == "lan" {
+		if ip := firstLANIPv4(); ip != "" {
+			_, _ = fmt.Fprintf(m.out, "frontend LAN: http://%s:%d\n", ip, cfg.FrontendPort)
+		}
+	}
 	_, _ = fmt.Fprintf(m.out, "status: local/local-runtime-manager/lazymind-local status --json --profile %s\n", cfg.Profile)
+}
+
+func firstLANIPv4() string {
+	addrs, err := net.InterfaceAddrs()
+	if err != nil {
+		return ""
+	}
+	for _, addr := range addrs {
+		var ip net.IP
+		switch v := addr.(type) {
+		case *net.IPNet:
+			ip = v.IP
+		case *net.IPAddr:
+			ip = v.IP
+		}
+		ip = ip.To4()
+		if ip == nil || ip.IsLoopback() {
+			continue
+		}
+		return ip.String()
+	}
+	return ""
 }
 
 func acquireUpLock(paths RuntimePaths) (func(), error) {

--- a/local/local-runtime-manager/manager_test.go
+++ b/local/local-runtime-manager/manager_test.go
@@ -228,6 +228,45 @@ func TestRuntimeConfigKeepsPinnedFrontendPortWhenOccupied(t *testing.T) {
 	}
 }
 
+func TestRuntimeConfigDefaultsToLocalhostNetworkProfile(t *testing.T) {
+	t.Setenv(localNetworkProfileEnvVar, "")
+	t.Setenv(localProxyAddressEnvVar, "")
+	repo := t.TempDir()
+	writeComposeFixture(t, repo)
+	cfg, _, err := NewRuntimeConfig(defaultProfileValue(), repo)
+	if err != nil {
+		t.Fatalf("runtime config: %v", err)
+	}
+	if cfg.NetworkProfile != "localhost" {
+		t.Fatalf("network profile = %q, want localhost", cfg.NetworkProfile)
+	}
+	if cfg.LocalProxy.Address != "127.0.0.1" {
+		t.Fatalf("local proxy address = %q, want 127.0.0.1", cfg.LocalProxy.Address)
+	}
+}
+
+func TestRuntimeConfigAllowsLANNetworkProfile(t *testing.T) {
+	t.Setenv(localNetworkProfileEnvVar, "lan")
+	repo := t.TempDir()
+	writeComposeFixture(t, repo)
+	cfg, _, err := NewRuntimeConfig(defaultProfileValue(), repo)
+	if err != nil {
+		t.Fatalf("runtime config: %v", err)
+	}
+	if cfg.NetworkProfile != "lan" {
+		t.Fatalf("network profile = %q, want lan", cfg.NetworkProfile)
+	}
+}
+
+func TestRuntimeConfigRejectsUnknownNetworkProfile(t *testing.T) {
+	t.Setenv(localNetworkProfileEnvVar, "public")
+	repo := t.TempDir()
+	writeComposeFixture(t, repo)
+	if _, _, err := NewRuntimeConfig(defaultProfileValue(), repo); err == nil {
+		t.Fatal("expected invalid network profile error")
+	}
+}
+
 func TestFrontendBuildEnvIncludesLocalViteOverrides(t *testing.T) {
 	t.Setenv("VITE_LAZYMIND_MODE", "")
 	t.Setenv("VITE_HIDE_EVO", "true")
@@ -242,6 +281,72 @@ func TestFrontendBuildEnvIncludesLocalViteOverrides(t *testing.T) {
 		"VITE_APP_LOGO=/logo.svg",
 		"VITE_APP_CHAT_TITLE=Local Chat",
 	})
+}
+
+func TestWriteCaddyfileBindsLocalhostByDefault(t *testing.T) {
+	repo := t.TempDir()
+	writeComposeFixture(t, repo)
+	cfg, paths, err := NewRuntimeConfig(defaultProfileValue(), repo)
+	if err != nil {
+		t.Fatalf("runtime config: %v", err)
+	}
+	if err := paths.EnsureAllDirs(); err != nil {
+		t.Fatalf("ensure dirs: %v", err)
+	}
+	if err := writeCaddyfile(paths, cfg); err != nil {
+		t.Fatalf("write caddyfile: %v", err)
+	}
+	raw, err := os.ReadFile(paths.CaddyConfig)
+	if err != nil {
+		t.Fatalf("read caddyfile: %v", err)
+	}
+	content := string(raw)
+	for _, want := range []string{
+		"http://localhost:" + strconv.Itoa(cfg.FrontendPort),
+		"http://127.0.0.1:" + strconv.Itoa(cfg.FrontendPort),
+		"bind 127.0.0.1",
+		"reverse_proxy http://127.0.0.1:" + strconv.Itoa(cfg.LocalProxy.Port),
+	} {
+		if !strings.Contains(content, want) {
+			t.Fatalf("caddyfile missing %q:\n%s", want, content)
+		}
+	}
+	if strings.Contains(content, "bind 0.0.0.0") {
+		t.Fatalf("default caddyfile should not bind all interfaces:\n%s", content)
+	}
+}
+
+func TestWriteCaddyfileBindsLANFrontendOnly(t *testing.T) {
+	t.Setenv(localNetworkProfileEnvVar, "lan")
+	repo := t.TempDir()
+	writeComposeFixture(t, repo)
+	cfg, paths, err := NewRuntimeConfig(defaultProfileValue(), repo)
+	if err != nil {
+		t.Fatalf("runtime config: %v", err)
+	}
+	if err := paths.EnsureAllDirs(); err != nil {
+		t.Fatalf("ensure dirs: %v", err)
+	}
+	if err := writeCaddyfile(paths, cfg); err != nil {
+		t.Fatalf("write caddyfile: %v", err)
+	}
+	raw, err := os.ReadFile(paths.CaddyConfig)
+	if err != nil {
+		t.Fatalf("read caddyfile: %v", err)
+	}
+	content := string(raw)
+	for _, want := range []string{
+		"http://:" + strconv.Itoa(cfg.FrontendPort),
+		"bind 0.0.0.0",
+		"reverse_proxy http://127.0.0.1:" + strconv.Itoa(cfg.LocalProxy.Port),
+	} {
+		if !strings.Contains(content, want) {
+			t.Fatalf("caddyfile missing %q:\n%s", want, content)
+		}
+	}
+	if strings.Contains(content, "http://localhost:") || strings.Contains(content, "http://127.0.0.1:"+strconv.Itoa(cfg.FrontendPort)+" {") {
+		t.Fatalf("lan caddyfile should use wildcard host matching:\n%s", content)
+	}
 }
 
 func TestAlgorithmServiceEnvIncludesCloudParityDefaults(t *testing.T) {

--- a/local/local-runtime-manager/manager_test.go
+++ b/local/local-runtime-manager/manager_test.go
@@ -258,6 +258,27 @@ func TestRuntimeConfigAllowsLANNetworkProfile(t *testing.T) {
 	}
 }
 
+func TestRuntimeConfigLANFrontendPortAvoidsWildcardOccupiedDefault(t *testing.T) {
+	t.Setenv(localNetworkProfileEnvVar, "lan")
+	t.Setenv(frontendPortEnvVar, "")
+	ln := occupyPortsOn(t, "0.0.0.0", defaultFrontendPort)
+	defer func() {
+		for _, existing := range ln {
+			_ = existing.Close()
+		}
+	}()
+
+	repo := t.TempDir()
+	writeComposeFixture(t, repo)
+	cfg, _, err := NewRuntimeConfig(defaultProfileValue(), repo)
+	if err != nil {
+		t.Fatalf("runtime config: %v", err)
+	}
+	if cfg.FrontendPort == defaultFrontendPort {
+		t.Fatalf("expected LAN frontend port to avoid wildcard-occupied default")
+	}
+}
+
 func TestRuntimeConfigRejectsUnknownNetworkProfile(t *testing.T) {
 	t.Setenv(localNetworkProfileEnvVar, "public")
 	repo := t.TempDir()
@@ -1549,15 +1570,19 @@ func writeComposeFixture(t *testing.T, repo string) {
 }
 
 func occupyLocalPorts(t *testing.T, ports ...int) []net.Listener {
+	return occupyPortsOn(t, "127.0.0.1", ports...)
+}
+
+func occupyPortsOn(t *testing.T, address string, ports ...int) []net.Listener {
 	t.Helper()
 	listeners := make([]net.Listener, 0, len(ports))
 	for _, port := range ports {
-		ln, err := net.Listen("tcp", net.JoinHostPort("127.0.0.1", strconv.Itoa(port)))
+		ln, err := net.Listen("tcp", net.JoinHostPort(address, strconv.Itoa(port)))
 		if err != nil {
 			for _, existing := range listeners {
 				_ = existing.Close()
 			}
-			t.Skipf("port %d is already in use on this test host: %v", port, err)
+			t.Skipf("port %d is already in use on %s on this test host: %v", port, address, err)
 		}
 		listeners = append(listeners, ln)
 	}

--- a/local/local-runtime-manager/permissions.go
+++ b/local/local-runtime-manager/permissions.go
@@ -4,8 +4,10 @@ import (
 	"fmt"
 	"io/fs"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"runtime"
+	"strconv"
 )
 
 var composeBindCriticalReadPaths = []string{
@@ -49,6 +51,62 @@ func ensureComposeBindPermissions(repoRoot string) error {
 			continue
 		}
 		_ = makeTreeContainerReadable(path)
+	}
+	return nil
+}
+
+func ensureLocalDataRootWritable(repoRoot string) error {
+	if runtime.GOOS == "windows" {
+		return nil
+	}
+	dataRoot := filepath.Join(repoRoot, "data")
+	if err := ensureWritableDir(dataRoot); err == nil {
+		return nil
+	} else if os.IsPermission(err) {
+		if repairErr := repairLocalDataRootWithDocker(repoRoot); repairErr != nil {
+			return fmt.Errorf("local data root %s is not writable and docker repair failed: %w", dataRoot, repairErr)
+		}
+		if retryErr := ensureWritableDir(dataRoot); retryErr != nil {
+			return fmt.Errorf("local data root %s is still not writable after docker repair: %w", dataRoot, retryErr)
+		}
+		return nil
+	} else {
+		return err
+	}
+}
+
+func ensureWritableDir(dir string) error {
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return err
+	}
+	probe := filepath.Join(dir, ".lazymind-write-test")
+	f, err := os.OpenFile(probe, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o600)
+	if err != nil {
+		return err
+	}
+	if err := f.Close(); err != nil {
+		return err
+	}
+	return os.Remove(probe)
+}
+
+func repairLocalDataRootWithDocker(repoRoot string) error {
+	image := envText("POSTGRES_IMAGE", "postgres:16")
+	uid := strconv.Itoa(os.Getuid())
+	gid := strconv.Itoa(os.Getgid())
+	cmd := exec.Command(
+		"docker",
+		"run",
+		"--rm",
+		"-v", repoRoot+":/work",
+		"-w", "/work",
+		image,
+		"sh",
+		"-lc",
+		"mkdir -p data && chown -R "+uid+":"+gid+" data",
+	)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("%w (%s)", err, string(out))
 	}
 	return nil
 }

--- a/local/local-runtime-manager/permissions_test.go
+++ b/local/local-runtime-manager/permissions_test.go
@@ -56,3 +56,19 @@ func TestEnsureComposeBindPermissionsMakesCriticalPathsReadable(t *testing.T) {
 		}
 	}
 }
+
+func TestEnsureLocalDataRootWritableCreatesWritableDataDir(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("chmod permission bits are Unix-specific")
+	}
+	repo := t.TempDir()
+
+	if err := ensureLocalDataRootWritable(repo); err != nil {
+		t.Fatalf("ensure local data root writable: %v", err)
+	}
+
+	probe := filepath.Join(repo, "data", "probe")
+	if err := os.WriteFile(probe, []byte("ok"), 0o600); err != nil {
+		t.Fatalf("expected data root to be writable: %v", err)
+	}
+}

--- a/local/local-runtime-manager/state.go
+++ b/local/local-runtime-manager/state.go
@@ -31,6 +31,7 @@ type ProcessComposeState struct {
 type RuntimeConfigSnapshot struct {
 	FrontendPort       int                       `json:"frontendPort,omitempty"`
 	ModeProfile        RuntimeModeProfileConfig  `json:"modeProfile,omitempty"`
+	NetworkProfile     string                    `json:"networkProfile,omitempty"`
 	LocalProxy         LocalProxyConfig          `json:"localProxy,omitempty"`
 	AuthService        AuthServiceConfig         `json:"authService,omitempty"`
 	Algorithm          AlgorithmConfig           `json:"algorithm,omitempty"`
@@ -155,11 +156,12 @@ func defaultRuntimeState(cfg RuntimeConfig, apiPort int, tokenPath string) Runti
 
 func snapshotRuntimeConfig(cfg RuntimeConfig) RuntimeConfigSnapshot {
 	return RuntimeConfigSnapshot{
-		FrontendPort: cfg.FrontendPort,
-		ModeProfile:  cfg.ModeProfile,
-		LocalProxy:   cfg.LocalProxy,
-		AuthService:  cfg.AuthService,
-		Algorithm:    cfg.Algorithm,
+		FrontendPort:   cfg.FrontendPort,
+		ModeProfile:    cfg.ModeProfile,
+		NetworkProfile: cfg.NetworkProfile,
+		LocalProxy:     cfg.LocalProxy,
+		AuthService:    cfg.AuthService,
+		Algorithm:      cfg.Algorithm,
 		FileWatcher: FileWatcherConfigSnapshot{
 			Port:          cfg.FileWatcher.Port,
 			AgentID:       cfg.FileWatcher.AgentID,


### PR DESCRIPTION
## Summary

- add `LAZYMIND_LOCAL_NETWORK_PROFILE=localhost|lan` for Linux/browser local runtime frontend binding
- keep local-proxy and backend service communication on loopback while allowing `lan` mode to expose only the frontend Caddy listener
- repair root-owned local `data/` directories before host core/algorithm services create writable upload paths

## Why

`make up-build-local` previously kept the frontend Caddy listener bound to `127.0.0.1`, so another machine on the same trusted LAN could not open the local browser runtime. A simple all-service `0.0.0.0` bind would expose more local backend surface than needed. This keeps the public surface to the frontend port and routes API traffic back through the local gateway on `127.0.0.1`.

During smoke, local startup also hit a root-owned `data/` directory left by container cleanup, causing core to fail creating `data/core`. The runtime manager now repairs that local-only writable data root before host services start.

## Cloud compatibility

- base `docker-compose.yml` is unchanged
- Cloud/Kong/RBAC behavior is unchanged
- PostgreSQL, Redis, Milvus, OpenSearch profiles are preserved
- Evo visibility in Cloud mode is unchanged

## Validation

- `go test ./...` in `local/local-runtime-manager`
- `go test ./...` in `local/local-proxy`
- `git diff --check HEAD~1..HEAD`
- `/home/panyang/lazymind-toolkit/skills/lazymind-local-smoke/scripts/run_local_smoke.sh --repo /home/panyang/.codex/worktrees/1e39/LazyMind --skip-reset --skip-build`
  - smoke used `http://localhost:8092`
  - chat smoke passed
  - KB upload/parse/index/chat smoke passed

## Notes

The normal local default remains localhost-only. LAN access is opt-in with:

```bash
LAZYMIND_LOCAL_NETWORK_PROFILE=lan make up-build-local
```
