### PR TITLE
local模式动态探测端口

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -559,17 +559,28 @@ reset-kb:
 		$(MAKE) --no-print-directory file-watcher-stop; \
 	fi
 	@if [ -x "$(LAZYMIND_LOCAL_BIN)" ]; then \
-		echo "⏹  Stopping Local Runtime before cleanup..."; \
+		echo "⏹  Stopping Local Runtime before cleanup (profile=$(LAZYMIND_LOCAL_PROFILE), timeout=$(LAZYMIND_LOCAL_DOWN_TIMEOUT))..."; \
 		timeout "$(LAZYMIND_LOCAL_DOWN_TIMEOUT)" "$(LAZYMIND_LOCAL_BIN)" down --profile "$(LAZYMIND_LOCAL_PROFILE)" || \
 			echo "⚠️  Local Runtime manager down timed out or failed; continuing reset"; \
+	else \
+		echo "ℹ️  No Local Runtime manager found at $(LAZYMIND_LOCAL_BIN); skipping local runtime stop"; \
 	fi
 	@echo "⏫ Starting PostgreSQL only for SQL cleanup..."
 	@$(_COMPOSE_LOCAL) $(_CLEANUP_COMPOSE_PROFILES) up -d db >/dev/null
-	@for i in $$(seq 1 30); do \
-		if $(_COMPOSE_LOCAL) exec -T db psql -U root -d postgres -c 'SELECT 1' >/dev/null 2>&1; then exit 0; fi; \
+	@echo "⏳ Waiting for PostgreSQL readiness before SQL cleanup..."
+	@ready=0; \
+	for i in $$(seq 1 30); do \
+		if $(_COMPOSE_LOCAL) exec -T db psql -U root -d postgres -c 'SELECT 1' >/dev/null 2>&1; then \
+			echo "✅ PostgreSQL ready for SQL cleanup"; \
+			ready=1; \
+			break; \
+		fi; \
+		echo "  waiting for PostgreSQL ($$i/30)..."; \
 		sleep 1; \
 	done; \
-	echo "⚠️  db did not become ready; SQL cleanup may be skipped"
+	if [ "$$ready" -ne 1 ]; then \
+		echo "⚠️  db did not become ready; SQL cleanup may be skipped"; \
+	fi
 	@echo "🗑  Clearing KB tables in PostgreSQL (core DB)..."
 	@$(_COMPOSE_LOCAL) exec -T db psql -U root -d core -c "$$_RESET_KB_SQL_CORE" 2>&1 || \
 		echo "⚠️  core DB not running or tables not found — skipping"
@@ -579,8 +590,9 @@ reset-kb:
 	@echo "🗑  Dropping lazyllm schema tables in PostgreSQL (app DB)..."
 	@$(_COMPOSE_LOCAL) exec -T db psql -U root -d app -c "$$_RESET_KB_SQL_APP" 2>&1 || \
 		echo "⚠️  app DB not running or tables not found — skipping"
-	@echo "⏹  Stopping remaining services..."
+	@echo "⏹  Stopping remaining local compose services..."
 	@$(_COMPOSE_LOCAL) $(_CLEANUP_COMPOSE_PROFILES) down 2>/dev/null || true
+	@echo "⏹  Stopping remaining default Cloud/Kong compose services..."
 	@$(_COMPOSE) $(_CLEANUP_COMPOSE_PROFILES) down 2>/dev/null || true
 	@echo "🗑  Removing KB volumes: $(_KB_VOLUMES)..."
 	@for vol in $(_KB_VOLUMES); do \
@@ -592,9 +604,21 @@ reset-kb:
 		fi; \
 	done
 	@echo "🗑  Removing local KB caches and segment stores..."
-	@rm -rf $(_RESET_KB_LOCAL_PATHS) 2>/dev/null || true
+	@for path in $(_RESET_KB_LOCAL_PATHS); do \
+		if [ -e "$$path" ]; then \
+			echo "  removing $$path"; \
+			rm -rf "$$path" 2>/dev/null || true; \
+		else \
+			echo "  skip $$path (not found)"; \
+		fi; \
+	done
 	@echo "🗑  Removing local Milvus Lite data..."
-	@rm -rf "$(dir $(LAZYMIND_LOCAL_MILVUS_DB_PATH))" 2>/dev/null || true
+	@if [ -e "$(dir $(LAZYMIND_LOCAL_MILVUS_DB_PATH))" ]; then \
+		echo "  removing $(dir $(LAZYMIND_LOCAL_MILVUS_DB_PATH))"; \
+		rm -rf "$(dir $(LAZYMIND_LOCAL_MILVUS_DB_PATH))" 2>/dev/null || true; \
+	else \
+		echo "  skip $(dir $(LAZYMIND_LOCAL_MILVUS_DB_PATH)) (not found)"; \
+	fi
 	@echo "✅ KB data cleared."
 
 # ---------------------------------------------------------------------------
@@ -603,23 +627,40 @@ reset-kb:
 # ---------------------------------------------------------------------------
 reset-all: reset-kb
 	@echo "🗑  Removing all remaining persistent volumes (pgdata, redisdata, caches)..."
+	@echo "⏹  Stopping local compose stack and removing local volumes..."
 	@$(_COMPOSE_LOCAL) $(_CLEANUP_COMPOSE_PROFILES) down -v 2>/dev/null || true
+	@echo "⏹  Stopping default Cloud/Kong compose stack and removing default volumes..."
 	@$(_COMPOSE) $(_CLEANUP_COMPOSE_PROFILES) down -v 2>/dev/null || true
 	@for vol in $(_ALL_VOLUMES); do \
-		for full in $$(docker volume ls -q | grep -E "(^|_)$${vol}$$"); do \
-			docker volume rm "$$full" >/dev/null 2>&1 && echo "  removed $$full" || true; \
-		done; \
+		matches="$$(docker volume ls -q | grep -E "(^|_)$${vol}$$" || true)"; \
+		if [ -z "$$matches" ]; then \
+			echo "  skip $$vol (not found)"; \
+		else \
+			for full in $$matches; do \
+				docker volume rm "$$full" >/dev/null 2>&1 && echo "  removed $$full" || echo "  skip $$full (in use?)"; \
+			done; \
+		fi; \
 	done
 	@echo "🗑  Removing local persistent data paths..."
-	@rm -rf $(_RESET_ALL_LOCAL_PATHS) 2>/dev/null || true
+	@for path in $(_RESET_ALL_LOCAL_PATHS); do \
+		if [ -e "$$path" ]; then \
+			echo "  removing $$path"; \
+			rm -rf "$$path" 2>/dev/null || true; \
+		else \
+			echo "  skip $$path (not found)"; \
+		fi; \
+	done
 	@if [ -e data/core ] || [ -e data/evo ] || [ -e data/scan ] || [ -e data/state/postgres ] || [ -e data/state/redis ] || [ -e data/subagent ] || [ -e data/traces ]; then \
-		echo "🗑  Removing container-owned state paths..."; \
+		echo "🗑  Removing container-owned state paths via temporary postgres container..."; \
 		docker run --rm -v "$(CURDIR):/work" -w /work $${POSTGRES_IMAGE:-postgres:16} \
 			bash -lc 'rm -rf data/core data/evo data/scan data/state/postgres data/state/redis data/subagent data/traces' >/dev/null; \
+	else \
+		echo "ℹ️  No container-owned state paths remain"; \
 	fi
 	@echo "🧹 Clearing Python cache..."
 	@find . -type d -name '__pycache__' ! -path '*/\.git/*' -exec rm -rf {} + 2>/dev/null || true
 	@find . -type f -name '*.pyc' ! -path '*/\.git/*' -delete 2>/dev/null || true
+	@echo "✅ Python cache cleared."
 	@echo "✅ Full reset done. All persistent data removed."
 
 # ---------------------------------------------------------------------------

--- a/local/local-runtime-manager/compose.go
+++ b/local/local-runtime-manager/compose.go
@@ -22,6 +22,10 @@ type ComposeServiceStatus struct {
 	ExitCode int
 }
 
+type ComposeStartupPlan struct {
+	Services []string
+}
+
 type composeReadinessState int
 
 const (
@@ -151,30 +155,38 @@ func (m *ComposeManager) ComposeHasContainers(ctx context.Context, repoRoot stri
 	return len(statuses) > 0, nil
 }
 
-func (m *ComposeManager) ComposeUp(ctx context.Context, cfg RuntimeConfig, paths RuntimePaths) error {
-	repoRoot := paths.RepoRoot
+func (m *ComposeManager) ComposeStartupPlan(ctx context.Context, repoRoot string) (ComposeStartupPlan, error) {
 	services, err := m.ComposeServices(ctx, repoRoot)
 	if err != nil {
-		return err
+		return ComposeStartupPlan{}, err
 	}
 	disabled, err := parseRuntimeOverlay(filepath.Join(repoRoot, localComposeOverrideName))
 	if err != nil && !os.IsNotExist(err) {
-		return err
+		return ComposeStartupPlan{}, err
 	}
 
 	remaining, err := filterRemainingServices(services, disabled.DisabledContainerTypes)
 	if err != nil {
+		return ComposeStartupPlan{}, err
+	}
+	return ComposeStartupPlan{Services: remaining}, nil
+}
+
+func (m *ComposeManager) ComposeUp(ctx context.Context, cfg RuntimeConfig, paths RuntimePaths) error {
+	repoRoot := paths.RepoRoot
+	plan, err := m.ComposeStartupPlan(ctx, repoRoot)
+	if err != nil {
 		return err
 	}
-	if len(remaining) == 0 {
-		_ = cfg.Profile
+	if len(plan.Services) == 0 {
+		return nil
 	}
-	if err := m.BuildEnabledServices(ctx, repoRoot, remaining); err != nil {
+	if err := m.BuildEnabledServices(ctx, repoRoot, plan.Services); err != nil {
 		return err
 	}
 
 	args := append(m.composeArgs(repoRoot), "up", "--no-build", "--detach", "--no-deps")
-	args = append(args, remaining...)
+	args = append(args, plan.Services...)
 	env := localComposeEnv(cfg)
 	if streamer, ok := m.runner.(CommandStreamer); ok {
 		err := streamer.Stream(ctx, Command{Name: "docker", Args: args, Dir: repoRoot, Env: env}, os.Stdout, os.Stderr)
@@ -260,7 +272,9 @@ func localComposeEnv(cfg RuntimeConfig) []string {
 		"LAZYMIND_FRONTEND_PORT=" + strconv.Itoa(cfg.FrontendPort),
 		"LAZYMIND_LOCAL_NETWORK_PROFILE=" + cfg.NetworkProfile,
 		"LAZYMIND_LOCAL_PROXY_PORT=" + strconv.Itoa(cfg.LocalProxy.Port),
+		"LAZYMIND_LOCAL_AUTH_PORT=" + strconv.Itoa(cfg.LocalProxy.AuthHostPort),
 		"LAZYMIND_LOCAL_PROXY_AUTH_HOST_PORT=" + strconv.Itoa(cfg.LocalProxy.AuthHostPort),
+		"LAZYMIND_AUTH_SERVICE_PORT=" + strconv.Itoa(cfg.LocalProxy.AuthHostPort),
 		"LAZYMIND_LOCAL_PROXY_CORE_HOST_PORT=" + strconv.Itoa(cfg.LocalProxy.CoreHostPort),
 		"LAZYMIND_LOCAL_CORE_PORT=" + strconv.Itoa(cfg.LocalProxy.CoreHostPort),
 		"LAZYMIND_LOCAL_PROXY_CHAT_HOST_PORT=" + strconv.Itoa(cfg.LocalProxy.ChatHostPort),
@@ -401,4 +415,25 @@ func classifyComposeReadiness(statuses []ComposeServiceStatus) (composeReadiness
 		}
 	}
 	return composeReadinessReady, "all services ready"
+}
+
+func filterComposeStatuses(statuses []ComposeServiceStatus, services []string) []ComposeServiceStatus {
+	if len(services) == 0 {
+		return nil
+	}
+	wanted := make(map[string]struct{}, len(services))
+	for _, service := range services {
+		wanted[service] = struct{}{}
+	}
+	filtered := make([]ComposeServiceStatus, 0, len(statuses))
+	for _, st := range statuses {
+		service := st.Service
+		if service == "" {
+			service = st.Name
+		}
+		if _, ok := wanted[service]; ok {
+			filtered = append(filtered, st)
+		}
+	}
+	return filtered
 }

--- a/local/local-runtime-manager/compose.go
+++ b/local/local-runtime-manager/compose.go
@@ -161,11 +161,14 @@ func (m *ComposeManager) ComposeStartupPlan(ctx context.Context, repoRoot string
 		return ComposeStartupPlan{}, err
 	}
 	disabled, err := parseRuntimeOverlay(filepath.Join(repoRoot, localComposeOverrideName))
-	if err != nil && !os.IsNotExist(err) {
+	disabledContainerTypes := []string{}
+	if err == nil {
+		disabledContainerTypes = disabled.DisabledContainerTypes
+	} else if !os.IsNotExist(err) {
 		return ComposeStartupPlan{}, err
 	}
 
-	remaining, err := filterRemainingServices(services, disabled.DisabledContainerTypes)
+	remaining, err := filterRemainingServices(services, disabledContainerTypes)
 	if err != nil {
 		return ComposeStartupPlan{}, err
 	}

--- a/local/local-runtime-manager/config.go
+++ b/local/local-runtime-manager/config.go
@@ -18,6 +18,7 @@ const (
 	localNetworkProfileEnvVar     = "LAZYMIND_LOCAL_NETWORK_PROFILE"
 	localProxyAddressEnvVar       = "LAZYMIND_LOCAL_PROXY_ADDRESS"
 	localProxyPortEnvVar          = "LAZYMIND_LOCAL_PROXY_PORT"
+	localAuthPortEnvVar           = "LAZYMIND_LOCAL_AUTH_PORT"
 	localProxyAuthHostPortEnvVar  = "LAZYMIND_LOCAL_PROXY_AUTH_HOST_PORT"
 	localProxyCoreHostPortEnvVar  = "LAZYMIND_LOCAL_PROXY_CORE_HOST_PORT"
 	localProxyChatHostPortEnvVar  = "LAZYMIND_LOCAL_PROXY_CHAT_HOST_PORT"
@@ -179,6 +180,7 @@ type RuntimeConfig struct {
 	CaddyVersion       string
 	Algorithm          AlgorithmConfig
 	FileWatcher        FileWatcherConfig
+	PortResolutions    []PortResolution `json:"-"`
 }
 
 type LocalProxyConfig struct {
@@ -231,6 +233,14 @@ type AlgorithmConfig struct {
 	EnableEvo      bool
 }
 
+type PortResolution struct {
+	Name          string
+	EnvName       string
+	RequestedPort int
+	ResolvedPort  int
+	Reason        string
+}
+
 type ServiceEndpoints struct {
 	Host      ServiceEndpointURLs `json:"host"`
 	Container ServiceEndpointURLs `json:"container"`
@@ -278,7 +288,8 @@ func firstAvailableLocalPort(start int, attempts int) int {
 }
 
 type localPortAllocator struct {
-	used map[int]struct{}
+	used        map[int]struct{}
+	resolutions []PortResolution
 }
 
 func newLocalPortAllocator() *localPortAllocator {
@@ -293,38 +304,50 @@ func (a *localPortAllocator) reserve(port int) int {
 }
 
 func (a *localPortAllocator) envOrAvailable(envName string, fallback int) int {
-	if strings.TrimSpace(os.Getenv(envName)) != "" {
-		return a.reserve(envPort(envName, fallback))
-	}
-	return a.availableFrom(fallback, 500)
+	return a.firstEnvOrAvailable([]string{envName}, fallback)
 }
 
 func (a *localPortAllocator) envOrAvailableDefaultCanMove(envName string, fallback int) int {
-	return a.envOrAvailableDefaultCanMoveOn(envName, fallback, "127.0.0.1")
+	return a.firstEnvOrAvailableOn([]string{envName}, fallback, "127.0.0.1")
 }
 
 func (a *localPortAllocator) envOrAvailableDefaultCanMoveOn(envName string, fallback int, address string) int {
-	raw := strings.TrimSpace(os.Getenv(envName))
-	if raw == "" {
-		return a.availableFromOn(fallback, 500, address)
-	}
-	port := envPort(envName, fallback)
-	if envBool(localPortsPinnedEnvVar, false) {
-		return a.reserve(port)
-	}
-	if port != fallback || localPortAvailableOn(address, port) {
-		return a.reserve(port)
-	}
-	return a.availableFromOn(fallback, 500, address)
+	return a.firstEnvOrAvailableOn([]string{envName}, fallback, address)
 }
 
 func (a *localPortAllocator) firstEnvOrAvailable(envNames []string, fallback int) int {
+	return a.firstEnvOrAvailableOn(envNames, fallback, "127.0.0.1")
+}
+
+func (a *localPortAllocator) firstEnvOrAvailableOn(envNames []string, fallback int, address string) int {
 	for _, envName := range envNames {
 		if strings.TrimSpace(os.Getenv(envName)) != "" {
-			return a.reserve(envPort(envName, fallback))
+			requested := envPort(envName, fallback)
+			if envBool(localPortsPinnedEnvVar, false) {
+				return a.reserve(requested)
+			}
+			if a.portAvailableOn(address, requested) {
+				return a.reserve(requested)
+			}
+			resolved := a.availableFromOn(requested, 500, address)
+			a.resolutions = append(a.resolutions, PortResolution{
+				EnvName:       envName,
+				RequestedPort: requested,
+				ResolvedPort:  resolved,
+				Reason:        "preferred port unavailable",
+			})
+			return resolved
 		}
 	}
-	return a.availableFrom(fallback, 500)
+	resolved := a.availableFromOn(fallback, 500, address)
+	if resolved != fallback {
+		a.resolutions = append(a.resolutions, PortResolution{
+			RequestedPort: fallback,
+			ResolvedPort:  resolved,
+			Reason:        "default port unavailable",
+		})
+	}
+	return resolved
 }
 
 func (a *localPortAllocator) availableFrom(start int, attempts int) int {
@@ -333,15 +356,47 @@ func (a *localPortAllocator) availableFrom(start int, attempts int) int {
 
 func (a *localPortAllocator) availableFromOn(start int, attempts int, address string) int {
 	for port := start; port < start+attempts && port < 65536; port++ {
-		if _, ok := a.used[port]; ok {
-			continue
+		if a.portAvailableOn(address, port) {
+			return a.reserve(port)
 		}
-		if !localPortAvailableOn(address, port) {
-			continue
-		}
-		return a.reserve(port)
 	}
 	return a.reserve(start)
+}
+
+func (a *localPortAllocator) portAvailable(port int) bool {
+	if _, ok := a.used[port]; ok {
+		return false
+	}
+	return localPortAvailable(port)
+}
+
+func (a *localPortAllocator) portAvailableOn(address string, port int) bool {
+	if _, ok := a.used[port]; ok {
+		return false
+	}
+	return localPortAvailableOn(address, port)
+}
+
+func (a *localPortAllocator) setLastResolutionName(name string) {
+	if len(a.resolutions) == 0 {
+		return
+	}
+	last := &a.resolutions[len(a.resolutions)-1]
+	if last.Name == "" {
+		last.Name = name
+	}
+}
+
+func (a *localPortAllocator) resolvedPort(name string, envNames []string, fallback int) int {
+	port := a.firstEnvOrAvailable(envNames, fallback)
+	a.setLastResolutionName(name)
+	return port
+}
+
+func (a *localPortAllocator) resolvedPortOn(name string, envNames []string, fallback int, address string) int {
+	port := a.firstEnvOrAvailableOn(envNames, fallback, address)
+	a.setLastResolutionName(name)
+	return port
 }
 
 func localPortAvailable(port int) bool {
@@ -617,22 +672,22 @@ func NewRuntimeConfig(profile, repoRootHint string) (RuntimeConfig, RuntimePaths
 	if networkProfile == "lan" {
 		frontendBindCheckAddress = "0.0.0.0"
 	}
-	processComposePort := ports.envOrAvailable(processComposePortEnvVar, defaultProcessComposePort)
-	frontendPort := ports.envOrAvailableDefaultCanMoveOn(frontendPortEnvVar, defaultFrontendPort, frontendBindCheckAddress)
-	localProxyPort := ports.envOrAvailable(localProxyPortEnvVar, defaultLocalProxyPort)
-	authHostPort := ports.envOrAvailable(localProxyAuthHostPortEnvVar, defaultLocalProxyAuthHostPort)
-	coreHostPort := ports.firstEnvOrAvailable([]string{localCorePortEnvVar, localProxyCoreHostPortEnvVar}, defaultLocalProxyCoreHostPort)
-	scanHostPort := ports.envOrAvailable(localProxyScanHostPortEnvVar, defaultLocalProxyScanHostPort)
-	fileWatcherPort := ports.envOrAvailable(localFileWatcherPortEnvVar, defaultLocalFileWatcherPort)
-	postgresPort := ports.envOrAvailable(localPostgresPortEnvVar, defaultLocalPostgresPort)
-	docPort := ports.envOrAvailable(localDocPortEnvVar, defaultLocalDocPort)
-	processorPort := ports.envOrAvailable(localProcessorPortEnvVar, defaultLocalProcessorPort)
-	algoPort := ports.envOrAvailable(localAlgoPortEnvVar, defaultLocalAlgoPort)
-	workerPort := ports.envOrAvailable(localWorkerPortEnvVar, defaultLocalWorkerPort)
-	milvusPort := ports.envOrAvailable(localMilvusPortEnvVar, defaultLocalMilvusPort)
-	openSearchPort := ports.envOrAvailable(localOpenSearchPortEnvVar, defaultLocalOpenSearchPort)
-	chatPort := ports.firstEnvOrAvailable([]string{localChatPortEnvVar, localProxyChatHostPortEnvVar}, defaultLocalProxyChatHostPort)
-	evoPort := ports.firstEnvOrAvailable([]string{localEvoPortEnvVar, localProxyEvoHostPortEnvVar}, defaultLocalProxyEvoHostPort)
+	processComposePort := ports.resolvedPort("process-compose", []string{processComposePortEnvVar}, defaultProcessComposePort)
+	frontendPort := ports.resolvedPortOn("frontend", []string{frontendPortEnvVar}, defaultFrontendPort, frontendBindCheckAddress)
+	localProxyPort := ports.resolvedPort("local-proxy", []string{localProxyPortEnvVar}, defaultLocalProxyPort)
+	authHostPort := ports.resolvedPort("auth-service", []string{localAuthPortEnvVar, localProxyAuthHostPortEnvVar, authServicePortEnvVar}, defaultLocalProxyAuthHostPort)
+	coreHostPort := ports.resolvedPort("core", []string{localCorePortEnvVar, localProxyCoreHostPortEnvVar}, defaultLocalProxyCoreHostPort)
+	scanHostPort := ports.resolvedPort("scan-control-plane", []string{localProxyScanHostPortEnvVar}, defaultLocalProxyScanHostPort)
+	fileWatcherPort := ports.resolvedPort("file-watcher", []string{localFileWatcherPortEnvVar}, defaultLocalFileWatcherPort)
+	postgresPort := ports.resolvedPort("postgres", []string{localPostgresPortEnvVar}, defaultLocalPostgresPort)
+	docPort := ports.resolvedPort("document-service", []string{localDocPortEnvVar}, defaultLocalDocPort)
+	processorPort := ports.resolvedPort("processor-server", []string{localProcessorPortEnvVar}, defaultLocalProcessorPort)
+	algoPort := ports.resolvedPort("lazyllm-algo", []string{localAlgoPortEnvVar}, defaultLocalAlgoPort)
+	workerPort := ports.resolvedPort("processor-worker", []string{localWorkerPortEnvVar}, defaultLocalWorkerPort)
+	milvusPort := ports.resolvedPort("milvus-lite", []string{localMilvusPortEnvVar}, defaultLocalMilvusPort)
+	openSearchPort := ports.resolvedPort("opensearch", []string{localOpenSearchPortEnvVar}, defaultLocalOpenSearchPort)
+	chatPort := ports.resolvedPort("chat", []string{localChatPortEnvVar, localProxyChatHostPortEnvVar}, defaultLocalProxyChatHostPort)
+	evoPort := ports.resolvedPort("evo-api", []string{localEvoPortEnvVar, localProxyEvoHostPortEnvVar}, defaultLocalProxyEvoHostPort)
 	milvusLiteDBPath := filepath.Clean(envText(localMilvusLiteDBPathEnvVar, p.MilvusLiteDBPath))
 	return RuntimeConfig{
 		Profile:            profile,
@@ -676,6 +731,7 @@ func NewRuntimeConfig(profile, repoRootHint string) (RuntimeConfig, RuntimePaths
 			WatchHostDir:  defaultFileWatcherWatchHostDir(root),
 			HostPathStyle: envText("LAZYMIND_FILE_WATCHER_HOST_PATH_STYLE", "posix"),
 		},
+		PortResolutions: ports.resolutions,
 	}, p, nil
 }
 

--- a/local/local-runtime-manager/config.go
+++ b/local/local-runtime-manager/config.go
@@ -304,22 +304,22 @@ func (a *localPortAllocator) reserve(port int) int {
 }
 
 func (a *localPortAllocator) envOrAvailable(envName string, fallback int) int {
-	return a.firstEnvOrAvailable([]string{envName}, fallback)
+	return a.firstEnvOrAvailable("", []string{envName}, fallback)
 }
 
 func (a *localPortAllocator) envOrAvailableDefaultCanMove(envName string, fallback int) int {
-	return a.firstEnvOrAvailableOn([]string{envName}, fallback, "127.0.0.1")
+	return a.firstEnvOrAvailableOn("", []string{envName}, fallback, "127.0.0.1")
 }
 
 func (a *localPortAllocator) envOrAvailableDefaultCanMoveOn(envName string, fallback int, address string) int {
-	return a.firstEnvOrAvailableOn([]string{envName}, fallback, address)
+	return a.firstEnvOrAvailableOn("", []string{envName}, fallback, address)
 }
 
-func (a *localPortAllocator) firstEnvOrAvailable(envNames []string, fallback int) int {
-	return a.firstEnvOrAvailableOn(envNames, fallback, "127.0.0.1")
+func (a *localPortAllocator) firstEnvOrAvailable(name string, envNames []string, fallback int) int {
+	return a.firstEnvOrAvailableOn(name, envNames, fallback, "127.0.0.1")
 }
 
-func (a *localPortAllocator) firstEnvOrAvailableOn(envNames []string, fallback int, address string) int {
+func (a *localPortAllocator) firstEnvOrAvailableOn(name string, envNames []string, fallback int, address string) int {
 	for _, envName := range envNames {
 		if strings.TrimSpace(os.Getenv(envName)) != "" {
 			requested := envPort(envName, fallback)
@@ -331,6 +331,7 @@ func (a *localPortAllocator) firstEnvOrAvailableOn(envNames []string, fallback i
 			}
 			resolved := a.availableFromOn(requested, 500, address)
 			a.resolutions = append(a.resolutions, PortResolution{
+				Name:          name,
 				EnvName:       envName,
 				RequestedPort: requested,
 				ResolvedPort:  resolved,
@@ -342,6 +343,7 @@ func (a *localPortAllocator) firstEnvOrAvailableOn(envNames []string, fallback i
 	resolved := a.availableFromOn(fallback, 500, address)
 	if resolved != fallback {
 		a.resolutions = append(a.resolutions, PortResolution{
+			Name:          name,
 			RequestedPort: fallback,
 			ResolvedPort:  resolved,
 			Reason:        "default port unavailable",
@@ -377,26 +379,12 @@ func (a *localPortAllocator) portAvailableOn(address string, port int) bool {
 	return localPortAvailableOn(address, port)
 }
 
-func (a *localPortAllocator) setLastResolutionName(name string) {
-	if len(a.resolutions) == 0 {
-		return
-	}
-	last := &a.resolutions[len(a.resolutions)-1]
-	if last.Name == "" {
-		last.Name = name
-	}
-}
-
 func (a *localPortAllocator) resolvedPort(name string, envNames []string, fallback int) int {
-	port := a.firstEnvOrAvailable(envNames, fallback)
-	a.setLastResolutionName(name)
-	return port
+	return a.firstEnvOrAvailable(name, envNames, fallback)
 }
 
 func (a *localPortAllocator) resolvedPortOn(name string, envNames []string, fallback int, address string) int {
-	port := a.firstEnvOrAvailableOn(envNames, fallback, address)
-	a.setLastResolutionName(name)
-	return port
+	return a.firstEnvOrAvailableOn(name, envNames, fallback, address)
 }
 
 func localPortAvailable(port int) bool {

--- a/local/local-runtime-manager/local_proxy.go
+++ b/local/local-runtime-manager/local_proxy.go
@@ -83,6 +83,7 @@ func localRuntimeEnv(cfg RuntimeConfig) []string {
 		localNetworkProfileEnvVar + "=" + cfg.NetworkProfile,
 		localProxyAddressEnvVar + "=" + cfg.LocalProxy.Address,
 		localProxyPortEnvVar + "=" + strconv.Itoa(cfg.LocalProxy.Port),
+		localAuthPortEnvVar + "=" + strconv.Itoa(cfg.LocalProxy.AuthHostPort),
 		localProxyAuthHostPortEnvVar + "=" + strconv.Itoa(cfg.LocalProxy.AuthHostPort),
 		localProxyCoreHostPortEnvVar + "=" + strconv.Itoa(cfg.LocalProxy.CoreHostPort),
 		localProxyChatHostPortEnvVar + "=" + strconv.Itoa(cfg.LocalProxy.ChatHostPort),

--- a/local/local-runtime-manager/manager.go
+++ b/local/local-runtime-manager/manager.go
@@ -86,6 +86,10 @@ func (m *RuntimeManager) SetOutput(out, errOut io.Writer) {
 	m.errOut = errOut
 }
 
+func (m *RuntimeManager) progressf(format string, args ...any) {
+	_, _ = fmt.Fprintf(m.out, format+"\n", args...)
+}
+
 func randomHexToken() (string, error) {
 	raw := make([]byte, 16)
 	if _, err := rand.Read(raw); err != nil {
@@ -344,19 +348,26 @@ func (m *RuntimeManager) Down(ctx context.Context, cfg RuntimeConfig, paths Runt
 	var downErr error
 	apiAlive := m.probeAPI(cfg.ProcessComposePort, 500*time.Millisecond)
 	if apiAlive {
+		m.progressf("stopping process-compose on 127.0.0.1:%d (timeout %s)", cfg.ProcessComposePort, m.downTimeout)
 		downCtx, cancel := context.WithTimeout(ctx, m.downTimeout)
 		defer cancel()
 		downErr = m.processCompose.Down(downCtx, cfg, paths)
+	} else {
+		m.progressf("process-compose API not reachable on 127.0.0.1:%d; skipping process-compose down", cfg.ProcessComposePort)
 	}
 	if downErr != nil {
+		m.progressf("process-compose down failed; killing stale local runtime processes")
 		_ = m.killStaleRuntimeProcesses(context.Background(), paths.RepoRoot)
 	}
+	m.progressf("stopping frontend Caddy on 127.0.0.1:%d", cfg.FrontendPort)
 	if err := m.frontend.Down(ctx, cfg, paths); err != nil && downErr == nil {
 		downErr = err
 	}
+	m.progressf("stopping Local Gateway proxy on 127.0.0.1:%d", cfg.LocalProxy.Port)
 	if err := m.localProxy.Down(ctx, cfg, paths); err != nil && downErr == nil {
 		downErr = err
 	}
+	m.progressf("stopping Docker Compose fallback services")
 	if fallbackErr := m.compose.ComposeDown(ctx, paths.RepoRoot, cfg.Profile); fallbackErr != nil {
 		state = newStateWithServiceStatus(state, "failed")
 		state.OverallStatus = "failed"
@@ -368,19 +379,24 @@ func (m *RuntimeManager) Down(ctx context.Context, cfg RuntimeConfig, paths Runt
 	}
 	downErr = nil
 	for _, spec := range algorithmProcessSpecs(cfg.Algorithm) {
+		m.progressf("stopping algorithm process %s", spec.Name)
 		if err := m.algorithm.Down(ctx, paths, spec.Name); err != nil && downErr == nil {
 			downErr = err
 		}
 	}
+	m.progressf("stopping Milvus Lite process")
 	if err := m.milvusLite.Down(ctx, paths); err != nil && downErr == nil {
 		downErr = err
 	}
+	m.progressf("stopping core service on 127.0.0.1:%d", cfg.LocalProxy.CoreHostPort)
 	if err := m.coreService.Down(ctx, cfg, paths); err != nil && downErr == nil {
 		downErr = err
 	}
+	m.progressf("stopping scan-control-plane on 127.0.0.1:%d", cfg.LocalProxy.ScanHostPort)
 	if err := m.scanControl.Down(ctx, paths); err != nil && downErr == nil {
 		downErr = err
 	}
+	m.progressf("stopping file-watcher on 127.0.0.1:%d", cfg.FileWatcher.Port)
 	if err := m.fileWatcher.Down(ctx, paths); err != nil && downErr == nil {
 		downErr = err
 	}
@@ -390,6 +406,7 @@ func (m *RuntimeManager) Down(ctx context.Context, cfg RuntimeConfig, paths Runt
 		_ = writeRuntimeState(paths.StateFile, state)
 		return downErr
 	}
+	m.progressf("stopping auth-service on 127.0.0.1:%d", cfg.AuthService.Port)
 	if err := m.authService.Down(ctx, cfg, paths); err != nil {
 		return err
 	}
@@ -595,6 +612,8 @@ func (m *RuntimeManager) waitForRuntimeStopped(ctx context.Context, cfg RuntimeC
 	defer deadline.Stop()
 	ticker := time.NewTicker(m.pollInterval)
 	defer ticker.Stop()
+	nextReport := m.now()
+	m.progressf("waiting up to %s for local runtime processes and containers to stop", timeout)
 
 	for {
 		apiAlive := cfg.ProcessComposePort > 0 && m.probeAPI(cfg.ProcessComposePort, 500*time.Millisecond)
@@ -609,6 +628,28 @@ func (m *RuntimeManager) waitForRuntimeStopped(ctx context.Context, cfg RuntimeC
 		}
 		if err == nil && !apiAlive && !hasContainers && !authAlive && !milvusAlive {
 			return nil
+		}
+		if !m.now().Before(nextReport) {
+			blockers := make([]string, 0, 5)
+			if apiAlive {
+				blockers = append(blockers, "process-compose API")
+			}
+			if err != nil {
+				blockers = append(blockers, "compose status check")
+			} else if hasContainers {
+				blockers = append(blockers, "compose containers")
+			}
+			if authAlive {
+				blockers = append(blockers, "auth-service")
+			}
+			if milvusAlive {
+				blockers = append(blockers, "Milvus Lite")
+			}
+			if len(blockers) == 0 {
+				blockers = append(blockers, "runtime probes")
+			}
+			m.progressf("still waiting for local runtime to stop: %s", strings.Join(blockers, ", "))
+			nextReport = m.now().Add(5 * time.Second)
 		}
 		select {
 		case <-ctx.Done():

--- a/local/local-runtime-manager/manager.go
+++ b/local/local-runtime-manager/manager.go
@@ -135,6 +135,10 @@ func (m *RuntimeManager) Up(ctx context.Context, cfg RuntimeConfig, paths Runtim
 		return err
 	}
 	cfg = freshCfg
+	if err := validatePinnedLocalPorts(cfg); err != nil {
+		return err
+	}
+	m.printPortResolutionSummary(cfg)
 
 	token, err := randomHexToken()
 	if err != nil {
@@ -449,13 +453,19 @@ func (m *RuntimeManager) checkRuntimeReady(ctx context.Context, cfg RuntimeConfi
 	if m.runtimeReady != nil {
 		return m.runtimeReady(ctx, cfg, paths)
 	}
-	statuses, err := m.compose.ComposeStatus(ctx, paths.RepoRoot)
+	plan, err := m.compose.ComposeStartupPlan(ctx, paths.RepoRoot)
 	if err != nil {
 		return false
 	}
-	state, _ := classifyComposeReadiness(statuses)
-	if state != composeReadinessReady {
-		return false
+	if len(plan.Services) > 0 {
+		statuses, err := m.compose.ComposeStatus(ctx, paths.RepoRoot)
+		if err != nil {
+			return false
+		}
+		state, _ := classifyComposeReadiness(filterComposeStatuses(statuses, plan.Services))
+		if state != composeReadinessReady {
+			return false
+		}
 	}
 	if !httpOK(ctx, fmt.Sprintf("http://127.0.0.1:%d/_local/healthz", cfg.LocalProxy.Port), 500*time.Millisecond) {
 		return false
@@ -527,6 +537,13 @@ func (m *RuntimeManager) waitForProcessComposeAPI(ctx context.Context, port int,
 }
 
 func (m *RuntimeManager) waitForComposeTerminalState(ctx context.Context, cfg RuntimeConfig, paths RuntimePaths) error {
+	plan, err := m.compose.ComposeStartupPlan(ctx, paths.RepoRoot)
+	if err != nil {
+		return err
+	}
+	if len(plan.Services) == 0 {
+		return nil
+	}
 	timeout := m.upTimeout
 	if timeout <= 0 {
 		timeout = time.Duration(defaultLocalUpTimeout) * time.Second
@@ -543,7 +560,7 @@ func (m *RuntimeManager) waitForComposeTerminalState(ctx context.Context, cfg Ru
 		if err != nil {
 			lastReason = err.Error()
 		} else {
-			state, reason := classifyComposeReadiness(statuses)
+			state, reason := classifyComposeReadiness(filterComposeStatuses(statuses, plan.Services))
 			lastReason = reason
 			switch state {
 			case composeReadinessReady:
@@ -616,6 +633,79 @@ func (m *RuntimeManager) printReadySummary(cfg RuntimeConfig) {
 		}
 	}
 	_, _ = fmt.Fprintf(m.out, "status: local/local-runtime-manager/lazymind-local status --json --profile %s\n", cfg.Profile)
+}
+
+func (m *RuntimeManager) printPortResolutionSummary(cfg RuntimeConfig) {
+	for _, resolution := range cfg.PortResolutions {
+		name := resolution.Name
+		if name == "" {
+			name = "local service"
+		}
+		envName := resolution.EnvName
+		if envName == "" {
+			envName = "default"
+		}
+		_, _ = fmt.Fprintf(
+			m.errOut,
+			"local port moved: %s %s preferred %d, using %d (%s)\n",
+			name,
+			envName,
+			resolution.RequestedPort,
+			resolution.ResolvedPort,
+			resolution.Reason,
+		)
+	}
+}
+
+func validatePinnedLocalPorts(cfg RuntimeConfig) error {
+	if !envBool(localPortsPinnedEnvVar, false) {
+		return nil
+	}
+	seen := map[int]string{}
+	for _, item := range resolvedLocalPorts(cfg) {
+		if previous, ok := seen[item.port]; ok {
+			return fmt.Errorf("local ports are pinned but %s and %s both resolve to port %d", previous, item.name, item.port)
+		}
+		seen[item.port] = item.name
+		if !localPortAvailableOn(item.address, item.port) {
+			return fmt.Errorf("local ports are pinned and %s port %d is already in use; unset %s or choose a free port", item.name, item.port, localPortsPinnedEnvVar)
+		}
+	}
+	return nil
+}
+
+type localPortItem struct {
+	name    string
+	port    int
+	address string
+}
+
+func resolvedLocalPorts(cfg RuntimeConfig) []localPortItem {
+	frontendAddress := "127.0.0.1"
+	if cfg.NetworkProfile == "lan" {
+		frontendAddress = "0.0.0.0"
+	}
+	items := []localPortItem{
+		{name: "process-compose", port: cfg.ProcessComposePort, address: "127.0.0.1"},
+		{name: "frontend", port: cfg.FrontendPort, address: frontendAddress},
+		{name: "local-proxy", port: cfg.LocalProxy.Port, address: "127.0.0.1"},
+		{name: "auth-service", port: cfg.AuthService.Port, address: "127.0.0.1"},
+		{name: "core", port: cfg.LocalProxy.CoreHostPort, address: "127.0.0.1"},
+		{name: "scan-control-plane", port: cfg.LocalProxy.ScanHostPort, address: "127.0.0.1"},
+		{name: "file-watcher", port: cfg.FileWatcher.Port, address: "127.0.0.1"},
+		{name: "postgres", port: cfg.Algorithm.PostgresPort, address: "127.0.0.1"},
+		{name: "document-service", port: cfg.Algorithm.DocPort, address: "127.0.0.1"},
+		{name: "processor-server", port: cfg.Algorithm.ProcessorPort, address: "127.0.0.1"},
+		{name: "lazyllm-algo", port: cfg.Algorithm.AlgoPort, address: "127.0.0.1"},
+		{name: "processor-worker", port: cfg.Algorithm.WorkerPort, address: "127.0.0.1"},
+		{name: "chat", port: cfg.Algorithm.ChatPort, address: "127.0.0.1"},
+		{name: "milvus-lite", port: cfg.ModeProfile.VectorStore.Port, address: "127.0.0.1"},
+		{name: "opensearch", port: cfg.Algorithm.OpenSearchPort, address: "127.0.0.1"},
+	}
+	if cfg.Algorithm.EnableEvo {
+		items = append(items, localPortItem{name: "evo-api", port: cfg.Algorithm.EvoPort, address: "127.0.0.1"})
+	}
+	return items
 }
 
 func firstLANIPv4() string {

--- a/local/local-runtime-manager/manager_test.go
+++ b/local/local-runtime-manager/manager_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -1484,6 +1485,8 @@ func TestRuntimeManagerDownFallsBackToComposeDownOnProcessComposeFailure(t *test
 	writeComposeFixture(t, repo)
 	runner := &fakeRunner{t: t}
 	manager := NewRuntimeManager(runner, filepath.Join(repo, "lazymind-local"))
+	var output bytes.Buffer
+	manager.SetOutput(&output, io.Discard)
 	probeCalls := 0
 	manager.probeAPI = func(port int, timeout time.Duration) bool {
 		probeCalls++
@@ -1565,6 +1568,17 @@ func TestRuntimeManagerDownFallsBackToComposeDownOnProcessComposeFailure(t *test
 	}
 	if got := state.Services[processComposeServiceName].Status; got != "stopped" {
 		t.Fatalf("unexpected service status %s", got)
+	}
+	for _, want := range []string{
+		"stopping process-compose",
+		"process-compose down failed; killing stale local runtime processes",
+		"stopping Docker Compose fallback services",
+		"stopping auth-service",
+		"waiting up to",
+	} {
+		if !strings.Contains(output.String(), want) {
+			t.Fatalf("expected down progress output to contain %q, got:\n%s", want, output.String())
+		}
 	}
 	if len(runner.calls) != 6 {
 		t.Fatalf("expected 6 commands got %d", len(runner.calls))

--- a/local/local-runtime-manager/manager_test.go
+++ b/local/local-runtime-manager/manager_test.go
@@ -239,6 +239,16 @@ func TestRuntimeConfigMovesExplicitUnpinnedAuthPortWhenOccupied(t *testing.T) {
 	if len(cfg.PortResolutions) == 0 {
 		t.Fatalf("expected a port resolution note")
 	}
+	found := false
+	for _, resolution := range cfg.PortResolutions {
+		if resolution.Name == "auth-service" && resolution.EnvName == localAuthPortEnvVar {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("expected auth-service resolution note, got %#v", cfg.PortResolutions)
+	}
 }
 
 func TestRuntimeConfigKeepsPinnedFrontendPortWhenOccupied(t *testing.T) {

--- a/local/local-runtime-manager/manager_test.go
+++ b/local/local-runtime-manager/manager_test.go
@@ -207,6 +207,39 @@ func TestRuntimeConfigMovesDefaultFrontendPortWhenOccupied(t *testing.T) {
 	}
 }
 
+func TestRuntimeConfigMovesExplicitUnpinnedAuthPortWhenOccupied(t *testing.T) {
+	t.Setenv(localAuthPortEnvVar, strconv.Itoa(defaultLocalProxyAuthHostPort))
+	ln := occupyLocalPorts(t, defaultLocalProxyAuthHostPort)
+	defer func() {
+		for _, existing := range ln {
+			_ = existing.Close()
+		}
+	}()
+
+	repo := t.TempDir()
+	writeComposeFixture(t, repo)
+	cfg, _, err := NewRuntimeConfig(defaultProfileValue(), repo)
+	if err != nil {
+		t.Fatalf("runtime config: %v", err)
+	}
+	if cfg.AuthService.Port == defaultLocalProxyAuthHostPort {
+		t.Fatalf("expected auth port to move when explicit unpinned port is occupied")
+	}
+	env := strings.Join(localComposeEnv(cfg), "\n")
+	for _, want := range []string{
+		"LAZYMIND_LOCAL_AUTH_PORT=" + strconv.Itoa(cfg.AuthService.Port),
+		"LAZYMIND_LOCAL_PROXY_AUTH_HOST_PORT=" + strconv.Itoa(cfg.AuthService.Port),
+		"LAZYMIND_AUTH_SERVICE_PORT=" + strconv.Itoa(cfg.AuthService.Port),
+	} {
+		if !strings.Contains(env, want) {
+			t.Fatalf("compose env missing %q in %s", want, env)
+		}
+	}
+	if len(cfg.PortResolutions) == 0 {
+		t.Fatalf("expected a port resolution note")
+	}
+}
+
 func TestRuntimeConfigKeepsPinnedFrontendPortWhenOccupied(t *testing.T) {
 	t.Setenv(frontendPortEnvVar, strconv.Itoa(defaultFrontendPort))
 	t.Setenv(localPortsPinnedEnvVar, "1")
@@ -285,6 +318,37 @@ func TestRuntimeConfigRejectsUnknownNetworkProfile(t *testing.T) {
 	writeComposeFixture(t, repo)
 	if _, _, err := NewRuntimeConfig(defaultProfileValue(), repo); err == nil {
 		t.Fatal("expected invalid network profile error")
+	}
+}
+
+func TestRuntimeManagerUpFailsFastWhenPinnedPortIsOccupied(t *testing.T) {
+	t.Setenv(frontendPortEnvVar, strconv.Itoa(defaultFrontendPort))
+	t.Setenv(localPortsPinnedEnvVar, "1")
+	ln := occupyLocalPorts(t, defaultFrontendPort)
+	defer func() {
+		for _, existing := range ln {
+			_ = existing.Close()
+		}
+	}()
+
+	repo := t.TempDir()
+	writeComposeFixture(t, repo)
+	runner := &fakeRunner{t: t}
+	manager := NewRuntimeManager(runner, filepath.Join(repo, "lazymind-local"))
+	manager.runtimeReady = func(context.Context, RuntimeConfig, RuntimePaths) bool { return false }
+	cfg, paths, err := NewRuntimeConfig(defaultProfileValue(), repo)
+	if err != nil {
+		t.Fatalf("runtime config: %v", err)
+	}
+	err = manager.Up(context.Background(), cfg, paths)
+	if err == nil {
+		t.Fatal("expected pinned port conflict")
+	}
+	if !strings.Contains(err.Error(), "frontend port") || !strings.Contains(err.Error(), localPortsPinnedEnvVar) {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(runner.calls) != 0 {
+		t.Fatalf("expected no process-compose or docker calls before pinned port failure, got %d", len(runner.calls))
 	}
 }
 
@@ -718,6 +782,18 @@ func TestClassifyComposeReadinessReportsFatalBeforePending(t *testing.T) {
 	}
 }
 
+func TestFilterComposeStatusesIgnoresDisabledStaleContainers(t *testing.T) {
+	statuses := []ComposeServiceStatus{
+		{Service: "auth-service", State: "exited", ExitCode: 1},
+		{Service: "core", State: "running", Health: "healthy"},
+	}
+	filtered := filterComposeStatuses(statuses, []string{"core"})
+	state, reason := classifyComposeReadiness(filtered)
+	if state != composeReadinessReady {
+		t.Fatalf("expected ready state for enabled core only, got %v: %s", state, reason)
+	}
+}
+
 func TestComposeUpCommandIsCanonical(t *testing.T) {
 	repo := t.TempDir()
 	writeComposeFixture(t, repo)
@@ -822,6 +898,38 @@ func TestComposeUpOmitsDisabledServices(t *testing.T) {
 	}
 	if err := manager.compose.ComposeUp(context.Background(), cfg, paths); err != nil {
 		t.Fatalf("compose up: %v", err)
+	}
+}
+
+func TestComposeUpSkipsDockerComposeWhenAllServicesDisabled(t *testing.T) {
+	repo := t.TempDir()
+	writeComposeFixture(t, repo)
+	overlay := filepath.Join(repo, localComposeOverrideName)
+	if err := os.WriteFile(overlay, []byte("x-lazymind-local:\n  mode: local\n  disabled_container_services:\n    - auth-service\n    - core\n"), 0o644); err != nil {
+		t.Fatalf("write overlay: %v", err)
+	}
+
+	runner := &fakeRunner{t: t}
+	manager := NewRuntimeManager(runner, filepath.Join(repo, "lazymind-local"))
+	runner.handlers = append(runner.handlers, func(cmd Command) (CommandResult, error) {
+		assertCommandContainsInOrder(t, cmd, "docker", []string{
+			"compose",
+			"-f", filepath.Join(repo, repoComposeFileName),
+			"-f", filepath.Join(repo, localComposeOverrideName),
+			"config", "--services",
+		})
+		return CommandResult{Stdout: "auth-service\ncore\n"}, nil
+	})
+
+	cfg, paths, err := NewRuntimeConfig(defaultProfileValue(), repo)
+	if err != nil {
+		t.Fatalf("runtime config: %v", err)
+	}
+	if err := manager.compose.ComposeUp(context.Background(), cfg, paths); err != nil {
+		t.Fatalf("compose up: %v", err)
+	}
+	if len(runner.calls) != 1 {
+		t.Fatalf("expected only compose config call, got %d calls: %#v", len(runner.calls), runner.calls)
 	}
 }
 
@@ -1106,6 +1214,14 @@ func TestManagerUpWritesStateAndStartsProcessCompose(t *testing.T) {
 			"compose",
 			"-f", filepath.Join(repo, repoComposeFileName),
 			"-f", filepath.Join(repo, localComposeOverrideName),
+			"config", "--services",
+		})
+		return CommandResult{Stdout: "auth-service\ncore\ndb-bootstrap\n"}, nil
+	}, func(cmd Command) (CommandResult, error) {
+		assertCommandContainsInOrder(t, cmd, "docker", []string{
+			"compose",
+			"-f", filepath.Join(repo, repoComposeFileName),
+			"-f", filepath.Join(repo, localComposeOverrideName),
 			"ps",
 			"-a",
 			"--format",
@@ -1202,6 +1318,14 @@ func TestRuntimeManagerUpFailsWhenHostAlgorithmsDoNotBecomeReady(t *testing.T) {
 	runner.handlers = append(runner.handlers, func(cmd Command) (CommandResult, error) {
 		return CommandResult{}, nil
 	}, func(cmd Command) (CommandResult, error) {
+		assertCommandContainsInOrder(t, cmd, "docker", []string{
+			"compose",
+			"-f", filepath.Join(repo, repoComposeFileName),
+			"-f", filepath.Join(repo, localComposeOverrideName),
+			"config", "--services",
+		})
+		return CommandResult{Stdout: "auth-service\ncore\ndb-bootstrap\n"}, nil
+	}, func(cmd Command) (CommandResult, error) {
 		return CommandResult{Stdout: readyComposeStatusJSON()}, nil
 	})
 	cfg, paths, err := NewRuntimeConfig(defaultProfileValue(), repo)
@@ -1280,6 +1404,15 @@ func TestRuntimeManagerUpFailsOnExitedService(t *testing.T) {
 		func(cmd Command) (CommandResult, error) {
 			assertCommandContainsInOrder(t, cmd, "process-compose", []string{"--config", filepath.ToSlash(paths.GeneratedConfig)})
 			return CommandResult{}, nil
+		},
+		func(cmd Command) (CommandResult, error) {
+			assertCommandContainsInOrder(t, cmd, "docker", []string{
+				"compose",
+				"-f", filepath.Join(repo, repoComposeFileName),
+				"-f", filepath.Join(repo, localComposeOverrideName),
+				"config", "--services",
+			})
+			return CommandResult{Stdout: "lazyllm-parse-server\n"}, nil
 		},
 		func(cmd Command) (CommandResult, error) {
 			assertCommandContainsInOrder(t, cmd, "docker", []string{

--- a/local/local-runtime-manager/processcompose.go
+++ b/local/local-runtime-manager/processcompose.go
@@ -193,6 +193,7 @@ func runtimeCommandEnv(cfg RuntimeConfig) []string {
 	env = append(env,
 		localPortsPinnedEnvVar+"=1",
 		processComposePortEnvVar+"="+strconv.Itoa(cfg.ProcessComposePort),
+		localAuthPortEnvVar+"="+strconv.Itoa(cfg.AuthService.Port),
 		authServicePortEnvVar+"="+strconv.Itoa(cfg.AuthService.Port),
 		localFileWatcherPortEnvVar+"="+strconv.Itoa(cfg.FileWatcher.Port),
 		localMilvusLiteDBPathEnvVar+"="+cfg.ModeProfile.VectorStore.DBPath,


### PR DESCRIPTION
使用容器编排时不用担心端口占用的问题，但local模式下都用的宿主机地址上的端口，被其他应用占用端口是有可能发生的事情。所以local模式下每个组件使用什么端口需要在启动前进行动态探测和选择，并配置相关组件后再启动。

## What changed

- Hardened Local Runtime port resolution so local ports are centrally resolved before process-compose starts services.
- Treat unpinned explicit local port env values as preferences and move to the next free loopback port when occupied.
- Added pinned-port fail-fast behavior through `LAZYMIND_LOCAL_PORTS_PINNED=1`.
- Normalized auth port aliases across local compose, process-compose, and local proxy env propagation.
- Fixed local compose startup so a fully disabled container plan skips `docker compose up` instead of accidentally starting the full compose project.
- Scoped compose readiness checks to services enabled for the current local startup plan.
- Improved local reset/shutdown logging so reset flows report progress more clearly.

## Why

`make up-build-local` can fail when a historical local port is already occupied, for example by another worktree or a stale local process. In the fully local path, an empty Docker Compose service list could also revive disabled containers such as `auth-service`, producing host port bind failures like `address already in use`.

## Impact

- Local browser mode becomes more resilient on shared developer machines and multi-worktree setups.
- Pinned-port users still get deterministic strict behavior.
- Cloud/Server mode remains unchanged: base compose, Kong routing, RBAC/auth-service behavior, and middleware profiles are preserved.

## Validation

- `cd local/local-runtime-manager && go test -count=1 ./...`
- `git diff --check origin/main..HEAD`
