### PR TITLE
fix(memory): update pending review drafts

### DIFF
--- a/algorithm/lazymind/chat/engine/tools/memory_editor.py
+++ b/algorithm/lazymind/chat/engine/tools/memory_editor.py
@@ -13,7 +13,11 @@ from lazymind.rewrite.base import (
 )
 from lazymind.rewrite.memory import _apply_memory_edit_operations
 from lazymind.rewrite.preference import _apply_user_preference_edit_operations
-from lazymind.review.memory_review.db import insert_memory_review_record
+from lazymind.review.memory_review.db import (
+    find_pending_memory_review_record,
+    insert_memory_review_record,
+    update_memory_review_record,
+)
 
 
 class EditOperation(TypedDict, total=False):
@@ -60,8 +64,7 @@ def memory_editor(
 
     Only claim to have saved, remembered, or recorded something when this tool
     or another durable-write tool was actually called in the same response. If
-    no write tool was called, do not say things like "已保存到记忆",
-    "我会记住你的偏好", "I've saved this", or "I'll remember that".
+    no write tool was called, do not say things like "I've saved this", or "I'll remember that".
 
     The tool applies the supplied JSON edit operations to the original text,
     validates the edited full text, and writes one pending row to the
@@ -108,7 +111,21 @@ def memory_editor(
     agentic_config = lazyllm.globals['agentic_config']
     user_id = str(agentic_config.get('user_id') or '').strip()
     session_id = str(agentic_config.get('session_id') or '').strip()
-    current_content = agentic_config.get(raw_target) or ''
+    pending_record = find_pending_memory_review_record(
+        target=raw_target,
+        user_id=user_id,
+    )
+    if session_id and pending_record is not None:
+        return tool_error(
+            'memory_editor',
+            'There is an unresolved pending change; tell user to handle it before submitting another edit.'
+        )
+
+    current_content = (
+        pending_record.get('content', '')
+        if pending_record is not None
+        else agentic_config.get(raw_target) or ''
+    )
     operation_payload = [dict(op) for op in operations]
     try:
         apply_operations = (
@@ -126,14 +143,23 @@ def memory_editor(
     except UnprocessableContentError as exc:
         return tool_error('memory_editor', str(exc))
 
-    insert_memory_review_record(
-        target=raw_target,
-        user_id=user_id,
-        session_id=session_id,
-        source_content=current_content,
-        content=edited_content,
-        operations=operation_payload,
-    )
+    if pending_record is not None:
+        update_memory_review_record(
+            record_id=str(pending_record.get('id') or ''),
+            session_id=session_id or str(pending_record.get('session_id') or ''),
+            source_content=current_content,
+            content=edited_content,
+            operations=list(pending_record.get('operations') or []) + operation_payload,
+        )
+    else:
+        insert_memory_review_record(
+            target=raw_target,
+            user_id=user_id,
+            session_id=session_id,
+            source_content=current_content,
+            content=edited_content,
+            operations=operation_payload,
+        )
     return tool_success('memory_editor', {
         'target': raw_target,
         'status': 'pending_review',

--- a/algorithm/lazymind/review/memory_review/db.py
+++ b/algorithm/lazymind/review/memory_review/db.py
@@ -58,6 +58,121 @@ def _get_memory_review_conn() -> Engine:
     return _get_engine(url=url, dsn=dsn)
 
 
+def _decode_operations(value: Any) -> List[Dict[str, Any]]:
+    if value is None:
+        return []
+    if isinstance(value, list):
+        return [dict(item) for item in value if isinstance(item, dict)]
+    if isinstance(value, str):
+        try:
+            decoded = json.loads(value)
+        except json.JSONDecodeError:
+            return []
+        if isinstance(decoded, list):
+            return [dict(item) for item in decoded if isinstance(item, dict)]
+    return []
+
+
+def find_pending_memory_review_record(
+    *,
+    target: str,
+    user_id: str,
+) -> Optional[Dict[str, Any]]:
+    if target not in {'memory', 'user_preference'}:
+        raise ValueError("target must be one of 'memory' or 'user_preference'.")
+    if not user_id.strip():
+        raise ValueError('user_id is required.')
+
+    engine = _get_memory_review_conn()
+    with engine.begin() as conn:
+        row = conn.execute(
+            text(
+                f"""
+                SELECT
+                    id,
+                    target,
+                    user_id,
+                    session_id,
+                    source_content,
+                    content,
+                    operations,
+                    state,
+                    review_status,
+                    time
+                FROM {MEMORY_REVIEW_TABLE}
+                WHERE user_id = :user_id
+                    AND target = :target
+                    AND state = 'success'
+                    AND review_status = 'pending'
+                ORDER BY time DESC, id DESC
+                LIMIT 1
+                """
+            ),
+            {
+                'user_id': user_id.strip(),
+                'target': target,
+            },
+        ).mappings().first()
+
+    if row is None:
+        return None
+    record = dict(row)
+    record['operations'] = _decode_operations(record.get('operations'))
+    return record
+
+
+def update_memory_review_record(
+    *,
+    record_id: str,
+    session_id: str = '',
+    content: str,
+    source_content: str = '',
+    operations: Optional[List[Dict[str, Any]]] = None,
+) -> Dict[str, Any]:
+    if not record_id.strip():
+        raise ValueError('record_id is required.')
+    if not isinstance(content, str) or not content.strip():
+        raise ValueError('content must be a non-empty string.')
+
+    operation_payload = json.dumps(operations or [], ensure_ascii=False)
+    updated_at = datetime.now(timezone.utc).isoformat()
+
+    engine = _get_memory_review_conn()
+    with engine.begin() as conn:
+        result = conn.execute(
+            text(
+                f"""
+                UPDATE {MEMORY_REVIEW_TABLE}
+                SET
+                    session_id = :session_id,
+                    source_content = :source_content,
+                    content = :content,
+                    operations = CAST(:operations AS JSONB),
+                    time = :time
+                WHERE id = :id
+                    AND review_status = 'pending'
+                """
+            ),
+            {
+                'id': record_id.strip(),
+                'session_id': session_id.strip(),
+                'source_content': source_content,
+                'content': content,
+                'operations': operation_payload,
+                'time': updated_at,
+            },
+        )
+        if result.rowcount == 0:
+            raise RuntimeError('pending memory review record not found.')
+
+    return {
+        'id': record_id.strip(),
+        'state': 'success',
+        'review_status': 'pending',
+        'time': updated_at,
+    }
+
+
 def insert_memory_review_record(
     *,
     target: str,

--- a/backend/core/resourceupdate/idle.go
+++ b/backend/core/resourceupdate/idle.go
@@ -410,8 +410,18 @@ func (p *IdleProcessor) ProcessEvent(ctx context.Context, eventID string) error 
 			return p.markEventFailed(tx, event.ID, now, "load_system_user_preference_failed", err.Error())
 		}
 
+		memoryContent, err := memoryReviewContentWithPendingDraft(ctx, tx, event.UserID, orm.ResourceUpdateResourceTypeMemory, memory.Content)
+		if err != nil {
+			cleanupSessionID = event.SessionID
+			return p.markEventFailed(tx, event.ID, now, "load_pending_memory_review_failed", err.Error())
+		}
 		userContent := evolution.FormatSystemUserPreferenceForChat(preference)
-		memoryTaskID, err := createIdleGenerateTask(ctx, tx, event, memory.ID, memory.Content, userContent, historyJSON, now)
+		userContent, err = memoryReviewContentWithPendingDraft(ctx, tx, event.UserID, orm.ResourceUpdateResourceTypeUserPreference, userContent)
+		if err != nil {
+			cleanupSessionID = event.SessionID
+			return p.markEventFailed(tx, event.ID, now, "load_pending_user_preference_review_failed", err.Error())
+		}
+		memoryTaskID, err := createIdleGenerateTask(ctx, tx, event, memory.ID, memoryContent, userContent, historyJSON, now)
 		if err != nil {
 			cleanupSessionID = event.SessionID
 			return p.markEventFailed(tx, event.ID, now, "create_memory_task_failed", err.Error())
@@ -510,6 +520,17 @@ func loadSystemUserPreferenceForIdle(ctx context.Context, db *gorm.DB, userID st
 		Order("created_at ASC").
 		Take(&row).Error
 	return row, err
+}
+
+func memoryReviewContentWithPendingDraft(ctx context.Context, db *gorm.DB, userID, target, currentContent string) (string, error) {
+	result, err := LatestPendingMemoryReviewResult(ctx, db, userID, target)
+	if err == nil {
+		return result.Content, nil
+	}
+	if errors.Is(err, errReviewNotFound) {
+		return currentContent, nil
+	}
+	return "", err
 }
 
 func createIdleGenerateTask(ctx context.Context, db *gorm.DB, event orm.ConversationIdleEvent, resourceID, memoryContent, userContent string, historyJSON json.RawMessage, now time.Time) (string, error) {

--- a/backend/core/resourceupdate/idle_test.go
+++ b/backend/core/resourceupdate/idle_test.go
@@ -308,6 +308,66 @@ func TestIdleFallbackCreatesCombinedMemoryReviewTaskWithoutSensitiveRequestField
 	}
 }
 
+func TestIdleFallbackUsesPendingMemoryReviewDraftContent(t *testing.T) {
+	db := newIdleTestDB(t)
+	store := newFakeIdleStore()
+	ctx := context.Background()
+	now := time.Date(2026, 6, 9, 10, 0, 0, 0, time.UTC)
+	insertIdleResources(t, db, "user-1", now)
+	insertMemoryReviewResult(t, db, MemoryReviewResult{
+		ID:           "pending-memory",
+		UserID:       "user-1",
+		Target:       orm.ResourceUpdateResourceTypeMemory,
+		Content:      "draft memory",
+		Operations:   json.RawMessage(`[]`),
+		State:        memoryReviewStateSuccess,
+		ReviewStatus: reviewStatusPending,
+		Time:         now.Add(-2 * time.Minute),
+	})
+	insertMemoryReviewResult(t, db, MemoryReviewResult{
+		ID:           "pending-preference",
+		UserID:       "user-1",
+		Target:       orm.ResourceUpdateResourceTypeUserPreference,
+		Content:      "draft preference",
+		Operations:   json.RawMessage(`[]`),
+		State:        memoryReviewStateSuccess,
+		ReviewStatus: reviewStatusPending,
+		Time:         now.Add(-time.Minute),
+	})
+	insertIdleEvent(t, db, "session-draft:h1", "session-draft", "user-1", "h1", now.Add(-time.Hour), now.Add(-time.Minute))
+	store.history[conversationIdleHistoryKey("session-draft")] = []idleHistoryMessage{
+		{Role: "user", Content: "please remember another thing"},
+	}
+
+	processor := newIdleProcessorWithStore(db, store, Config{
+		WorkerLockTTL:                     time.Minute,
+		ConversationIdleFallbackBatchSize: 10,
+	}, "idle-test")
+	processor.clock = func() time.Time { return now }
+	result, err := processor.RunFallbackOnce(ctx)
+	if err != nil {
+		t.Fatalf("fallback run: %v", err)
+	}
+	if result.Found != 1 || result.Triggered != 1 {
+		t.Fatalf("unexpected fallback result: %#v", result)
+	}
+
+	var task orm.ResourceUpdateTask
+	if err := db.Take(&task).Error; err != nil {
+		t.Fatalf("read task: %v", err)
+	}
+	var request memoryGenerateRequestJSON
+	if err := json.Unmarshal(task.RequestJSON, &request); err != nil {
+		t.Fatalf("unmarshal request: %v", err)
+	}
+	if request.Memory != "draft memory" {
+		t.Fatalf("expected pending memory draft in request, got %q", request.Memory)
+	}
+	if request.User != "draft preference" {
+		t.Fatalf("expected pending user_preference draft in request, got %q", request.User)
+	}
+}
+
 func TestIdleCleanupKeepsHistoryForNewerEvent(t *testing.T) {
 	store := newFakeIdleStore()
 	ctx := context.Background()
@@ -339,6 +399,7 @@ func newIdleTestDB(t *testing.T) *gorm.DB {
 		&orm.ConversationIdleEvent{},
 		&orm.SystemMemory{},
 		&orm.SystemUserPreference{},
+		&orm.MemoryReviewResult{},
 	); err != nil {
 		t.Fatalf("auto migrate idle models: %v", err)
 	}

--- a/tests/algorithm/test_skill_memory_tools.py
+++ b/tests/algorithm/test_skill_memory_tools.py
@@ -16,6 +16,9 @@ def test_memory_editor_operations_write_memory_review(monkeypatch):
         records.append(kwargs)
         return {'id': 'review-1', 'review_status': 'pending'}
 
+    def fake_update_memory_review_record(**kwargs):
+        raise AssertionError(f'unexpected update: {kwargs}')
+
     monkeypatch.setattr(memory_mod, 'UnprocessableContentError', FakeUnprocessableContentError)
     monkeypatch.setattr(
         memory_mod,
@@ -33,6 +36,8 @@ def test_memory_editor_operations_write_memory_review(monkeypatch):
         lambda current, payload: current.replace('old', payload['operations'][0]['new']),
     )
     monkeypatch.setattr(memory_mod, 'insert_memory_review_record', fake_insert_memory_review_record)
+    monkeypatch.setattr(memory_mod, 'update_memory_review_record', fake_update_memory_review_record)
+    monkeypatch.setattr(memory_mod, 'find_pending_memory_review_record', lambda **kwargs: None)
     monkeypatch.setattr(
         memory_mod.lazyllm,
         'globals',
@@ -75,6 +80,97 @@ def test_memory_editor_operations_write_memory_review(monkeypatch):
             'content': 'new',
             'operations': [{'op': 'replace_text', 'old': 'old', 'new': 'new'}],
         },
+    ]
+
+
+def test_memory_editor_blocks_chat_when_pending_review_exists(monkeypatch):
+    monkeypatch.setattr(
+        memory_mod.lazyllm,
+        'globals',
+        {
+            'agentic_config': {
+                'user_id': 'user-1',
+                'session_id': 'chat-session',
+                'memory': 'old',
+            }
+        },
+    )
+    monkeypatch.setattr(
+        memory_mod,
+        'find_pending_memory_review_record',
+        lambda **kwargs: {'id': 'pending-1', 'content': 'draft', 'operations': []},
+    )
+    monkeypatch.setattr(
+        memory_mod,
+        'insert_memory_review_record',
+        lambda **kwargs: (_ for _ in ()).throw(AssertionError('unexpected insert')),
+    )
+    monkeypatch.setattr(
+        memory_mod,
+        'update_memory_review_record',
+        lambda **kwargs: (_ for _ in ()).throw(AssertionError('unexpected update')),
+    )
+
+    result = memory_mod.memory_editor(
+        'memory',
+        [{'op': 'replace_text', 'old': 'old', 'new': 'new'}],
+    )
+
+    assert result['success'] is False
+    assert result['tool'] == 'memory_editor'
+    assert result['error']['reason'] == (
+        'There is an unresolved pending change; tell user to handle it before submitting another edit.'
+    )
+
+
+def test_memory_editor_review_updates_pending_draft(monkeypatch):
+    update_calls = []
+
+    monkeypatch.setattr(
+        memory_mod.lazyllm,
+        'globals',
+        {'agentic_config': {'user_id': 'user-1', 'memory': 'current memory'}},
+    )
+    monkeypatch.setattr(memory_mod, '_validate_generated_content', lambda memory_type, content: content)
+    monkeypatch.setattr(
+        memory_mod,
+        '_apply_memory_edit_operations',
+        lambda current, payload: current.replace('draft old', payload['operations'][0]['new']),
+    )
+    monkeypatch.setattr(
+        memory_mod,
+        'find_pending_memory_review_record',
+        lambda **kwargs: {
+            'id': 'pending-1',
+            'content': 'draft old',
+            'operations': [{'op': 'replace_text', 'old': 'base', 'new': 'draft old'}],
+        },
+    )
+    monkeypatch.setattr(
+        memory_mod,
+        'insert_memory_review_record',
+        lambda **kwargs: (_ for _ in ()).throw(AssertionError('unexpected insert')),
+    )
+    monkeypatch.setattr(memory_mod, 'update_memory_review_record', lambda **kwargs: update_calls.append(kwargs))
+
+    result = memory_mod.memory_editor(
+        'memory',
+        [{'op': 'replace_text', 'old': 'draft old', 'new': 'draft new'}],
+    )
+
+    assert result['success'] is True
+    assert result['result']['status'] == 'pending_review'
+    assert update_calls == [
+        {
+            'record_id': 'pending-1',
+            'session_id': '',
+            'source_content': 'draft old',
+            'content': 'draft new',
+            'operations': [
+                {'op': 'replace_text', 'old': 'base', 'new': 'draft old'},
+                {'op': 'replace_text', 'old': 'draft old', 'new': 'draft new'},
+            ],
+        }
     ]
 
 


### PR DESCRIPTION
## Summary
- Reuse the latest pending memory/user_preference review draft as the base for idle memory review generation.
- Let algorithm-side memory_editor update an unresolved pending review draft during review runs instead of creating parallel pending rows.
- Block direct chat memory edits when an unresolved pending draft already exists, so users handle the existing review first.

## Root Cause
Pending memory_review rows were not treated as the current editable draft in all paths. Idle-triggered review could send stale accepted content to the algorithm service, and memory_editor only inserted new pending rows instead of updating an existing pending draft.

## Validation
- `PYTHONPATH=algorithm:algorithm/lazyllm /opt/homebrew/Caskroom/miniconda/base/bin/python -m pytest -q tests/algorithm/test_skill_memory_tools.py`
- `go test ./resourceupdate` from `backend/core`

## Notes
- Local-only files and the `algorithm/lazyllm` gitlink change were intentionally left out of this PR.
- No base-class abstraction was added; the new helpers are narrowly scoped DB/update utilities for the existing memory review module.