### PR TITLE
fix local startup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 # Code style: Python (flake8) + Go (gofmt). Mirrors algorithm/lazyllm Makefile pattern.
-.PHONY: help lint install-flake8 install-golangci-lint lint-python lint-go lint-state-backend-boundary test test-hermetic test-hermetic-setup test-hermetic-check build up up-build up-build-local down clear reset-kb reset-all fresh-start compose-host-permissions file-watcher-dirs file-watcher-build file-watcher-run file-watcher-start file-watcher-stop desktop-stop-if-present
+.PHONY: help lint install-flake8 install-golangci-lint lint-python lint-go lint-state-backend-boundary test test-hermetic test-hermetic-setup test-hermetic-check build up up-build local-runtime-manager-build up-build-local down clear reset-kb reset-all fresh-start compose-host-permissions file-watcher-dirs file-watcher-build file-watcher-run file-watcher-start file-watcher-stop desktop-stop-if-present
 .DEFAULT_GOAL := help
 
 # Use legacy Docker builder by default to avoid pulling moby/buildkit:buildx-stable-1 from Docker Hub
@@ -13,8 +13,6 @@ LAZYMIND_LOCAL_BIN ?= local/local-runtime-manager/lazymind-local
 LAZYMIND_LOCAL_GOCACHE ?= $(CURDIR)/.codex-gocache/go-build
 LAZYMIND_LOCAL_DOWN_TIMEOUT ?= 150s
 export LAZYMIND_LOCAL_MILVUS_DB_PATH ?= $(CURDIR)/.lazymind-local/stores/milvus/lazymind.db
-PROCESS_COMPOSE_BIN ?= local/bin/process-compose
-PROCESS_COMPOSE_PKG ?= github.com/f1bonacc1/process-compose@v1.116.0
 comma := ,
 
 # ---------------------------------------------------------------------------
@@ -314,17 +312,21 @@ compose-host-permissions:
 	@echo "🔐 Ensuring compose bind mounts are readable by containers..."
 	@dir="$(CURDIR)"; \
 	while [ "$$dir" != "/" ] && [ "$$dir" != "$(HOME)" ]; do \
+		echo "  parent execute: $$dir"; \
 		chmod a+x "$$dir" 2>/dev/null || true; \
 		dir="$$(dirname "$$dir")"; \
 	done
+	@echo "  repo root read/execute: ."
 	@chmod a+rx .
 	@for path in $(_COMPOSE_BIND_CRITICAL_READ_PATHS); do \
 		if [ -e "$$path" ]; then \
+			echo "  critical read: $$path"; \
 			chmod -R a+rX "$$path"; \
 		fi; \
 	done
 	@for path in $(_COMPOSE_BIND_BEST_EFFORT_READ_PATHS); do \
 		if [ -e "$$path" ]; then \
+			echo "  best-effort read: $$path"; \
 			chmod -R a+rX "$$path" 2>/dev/null || true; \
 		fi; \
 	done
@@ -445,16 +447,11 @@ up-build:
 		echo "✅ file-watcher container enabled"; \
 	fi
 
-up-build-local:
-	@$(MAKE) --no-print-directory compose-host-permissions
-	@if [ ! -x "$(PROCESS_COMPOSE_BIN)" ]; then \
-		mkdir -p "$(dir $(PROCESS_COMPOSE_BIN))"; \
-		GOBIN="$(CURDIR)/local/bin" $(GO) install "$(PROCESS_COMPOSE_PKG)"; \
-	fi
-	@$(MAKE) --no-print-directory compose-host-permissions
+local-runtime-manager-build:
 	@mkdir -p "$(LAZYMIND_LOCAL_GOCACHE)"
 	@cd local/local-runtime-manager && GOCACHE="$(LAZYMIND_LOCAL_GOCACHE)" $(GO) build -buildvcs=false -o lazymind-local .
-	@$(MAKE) --no-print-directory compose-host-permissions
+
+up-build-local: local-runtime-manager-build
 	@"$(LAZYMIND_LOCAL_BIN)" up --profile "$(LAZYMIND_LOCAL_PROFILE)"
 
 clear:
@@ -484,28 +481,6 @@ clear:
 # After this, run: make up LAZYMIND_RESET_ALGO_ON_STARTUP=true
 # ---------------------------------------------------------------------------
 _KB_VOLUMES := milvus-etcd milvus-minio milvus-data opensearch-data rag-uploads
-_RESET_KB_LOCAL_PATHS := \
-	data/core/uploads \
-	data/scan/staging \
-	.lazymind-local/home/sqlite \
-	.lazymind-local/tmp/scan-control-plane \
-	.lazymind-local/stores/scan/file-watcher/staging \
-	.lazymind-local/stores/scan/file-watcher/snapshots
-_RESET_ALL_LOCAL_PATHS := \
-	data/core \
-	data/evo \
-	data/scan \
-	data/state/postgres \
-	data/state/redis \
-	data/subagent \
-	data/traces \
-	.lazymind-local/generated \
-	.lazymind-local/home \
-	.lazymind-local/logs \
-	.lazymind-local/run \
-	.lazymind-local/state \
-	.lazymind-local/stores \
-	.lazymind-local/tmp
 _ALL_VOLUMES := $(_KB_VOLUMES) pgdata redisdata sqlite-data
 
 # SQL run inside the running db container (or via docker run if db is stopped).
@@ -554,17 +529,10 @@ CASCADE;
 endef
 export _RESET_KB_SQL_APP
 
-reset-kb:
-	@if [ "$(LAZYMIND_FILE_WATCHER_MODE)" != "container" ]; then \
-		$(MAKE) --no-print-directory file-watcher-stop; \
-	fi
-	@if [ -x "$(LAZYMIND_LOCAL_BIN)" ]; then \
-		echo "⏹  Stopping Local Runtime before cleanup (profile=$(LAZYMIND_LOCAL_PROFILE), timeout=$(LAZYMIND_LOCAL_DOWN_TIMEOUT))..."; \
-		timeout "$(LAZYMIND_LOCAL_DOWN_TIMEOUT)" "$(LAZYMIND_LOCAL_BIN)" down --profile "$(LAZYMIND_LOCAL_PROFILE)" || \
-			echo "⚠️  Local Runtime manager down timed out or failed; continuing reset"; \
-	else \
-		echo "ℹ️  No Local Runtime manager found at $(LAZYMIND_LOCAL_BIN); skipping local runtime stop"; \
-	fi
+reset-kb: local-runtime-manager-build
+	@echo "🧹 Clearing Local Runtime KB state via local-runtime-manager..."
+	@timeout "$(LAZYMIND_LOCAL_DOWN_TIMEOUT)" "$(LAZYMIND_LOCAL_BIN)" reset --scope kb --profile "$(LAZYMIND_LOCAL_PROFILE)" || \
+		echo "⚠️  Local Runtime manager reset timed out or failed; continuing compose cleanup"
 	@echo "⏫ Starting PostgreSQL only for SQL cleanup..."
 	@$(_COMPOSE_LOCAL) $(_CLEANUP_COMPOSE_PROFILES) up -d db >/dev/null
 	@echo "⏳ Waiting for PostgreSQL readiness before SQL cleanup..."
@@ -603,22 +571,6 @@ reset-kb:
 			echo "  skip $$vol (not found)"; \
 		fi; \
 	done
-	@echo "🗑  Removing local KB caches and segment stores..."
-	@for path in $(_RESET_KB_LOCAL_PATHS); do \
-		if [ -e "$$path" ]; then \
-			echo "  removing $$path"; \
-			rm -rf "$$path" 2>/dev/null || true; \
-		else \
-			echo "  skip $$path (not found)"; \
-		fi; \
-	done
-	@echo "🗑  Removing local Milvus Lite data..."
-	@if [ -e "$(dir $(LAZYMIND_LOCAL_MILVUS_DB_PATH))" ]; then \
-		echo "  removing $(dir $(LAZYMIND_LOCAL_MILVUS_DB_PATH))"; \
-		rm -rf "$(dir $(LAZYMIND_LOCAL_MILVUS_DB_PATH))" 2>/dev/null || true; \
-	else \
-		echo "  skip $(dir $(LAZYMIND_LOCAL_MILVUS_DB_PATH)) (not found)"; \
-	fi
 	@echo "✅ KB data cleared."
 
 # ---------------------------------------------------------------------------
@@ -641,22 +593,9 @@ reset-all: reset-kb
 			done; \
 		fi; \
 	done
-	@echo "🗑  Removing local persistent data paths..."
-	@for path in $(_RESET_ALL_LOCAL_PATHS); do \
-		if [ -e "$$path" ]; then \
-			echo "  removing $$path"; \
-			rm -rf "$$path" 2>/dev/null || true; \
-		else \
-			echo "  skip $$path (not found)"; \
-		fi; \
-	done
-	@if [ -e data/core ] || [ -e data/evo ] || [ -e data/scan ] || [ -e data/state/postgres ] || [ -e data/state/redis ] || [ -e data/subagent ] || [ -e data/traces ]; then \
-		echo "🗑  Removing container-owned state paths via temporary postgres container..."; \
-		docker run --rm -v "$(CURDIR):/work" -w /work $${POSTGRES_IMAGE:-postgres:16} \
-			bash -lc 'rm -rf data/core data/evo data/scan data/state/postgres data/state/redis data/subagent data/traces' >/dev/null; \
-	else \
-		echo "ℹ️  No container-owned state paths remain"; \
-	fi
+	@echo "🧹 Clearing all Local Runtime persistent state via local-runtime-manager..."
+	@timeout "$(LAZYMIND_LOCAL_DOWN_TIMEOUT)" "$(LAZYMIND_LOCAL_BIN)" reset --scope all --profile "$(LAZYMIND_LOCAL_PROFILE)" || \
+		echo "⚠️  Local Runtime manager full reset timed out or failed; continuing Python cache cleanup"
 	@echo "🧹 Clearing Python cache..."
 	@find . -type d -name '__pycache__' ! -path '*/\.git/*' -exec rm -rf {} + 2>/dev/null || true
 	@find . -type f -name '*.pyc' ! -path '*/\.git/*' -delete 2>/dev/null || true

--- a/local/local-proxy/configs/cloud-replace-kong.yaml
+++ b/local/local-proxy/configs/cloud-replace-kong.yaml
@@ -14,6 +14,7 @@ cors:
     - "http://127.0.0.1:5173"
     - "http://localhost:${LAZYMIND_FRONTEND_PORT}"
     - "http://127.0.0.1:${LAZYMIND_FRONTEND_PORT}"
+    - "${LAZYMIND_FRONTEND_LAN_ORIGIN}"
 
 timeouts:
   connect: 10s

--- a/local/local-proxy/configs/local-no-evo.yaml
+++ b/local/local-proxy/configs/local-no-evo.yaml
@@ -12,6 +12,7 @@ cors:
   allowedOrigins:
     - "http://localhost:5173"
     - "http://127.0.0.1:5173"
+    - "${LAZYMIND_FRONTEND_LAN_ORIGIN}"
 
 timeouts:
   connect: 10s

--- a/local/local-proxy/configs/local.yaml
+++ b/local/local-proxy/configs/local.yaml
@@ -12,6 +12,7 @@ cors:
   allowedOrigins:
     - "http://localhost:5173"
     - "http://127.0.0.1:5173"
+    - "${LAZYMIND_FRONTEND_LAN_ORIGIN}"
 
 timeouts:
   connect: 10s

--- a/local/local-proxy/internal/config/config.go
+++ b/local/local-proxy/internal/config/config.go
@@ -76,6 +76,7 @@ func Load(configPath string) (Config, error) {
 	}
 
 	cfg.applyEnvOverrides()
+	cfg.normalize()
 
 	if err := cfg.Validate(); err != nil {
 		return Config{}, fmt.Errorf("invalid config: %w", err)
@@ -172,6 +173,26 @@ func (c *Config) applyEnvOverrides() {
 		}
 		c.Listen.Port = port
 	}
+}
+
+func (c *Config) normalize() {
+	if len(c.CORS.AllowedOrigins) == 0 {
+		return
+	}
+	origins := make([]string, 0, len(c.CORS.AllowedOrigins))
+	seen := make(map[string]struct{}, len(c.CORS.AllowedOrigins))
+	for _, origin := range c.CORS.AllowedOrigins {
+		origin = strings.TrimSpace(origin)
+		if origin == "" {
+			continue
+		}
+		if _, ok := seen[origin]; ok {
+			continue
+		}
+		seen[origin] = struct{}{}
+		origins = append(origins, origin)
+	}
+	c.CORS.AllowedOrigins = origins
 }
 
 func (c Config) ListenAddr() string {

--- a/local/local-proxy/internal/config/config_test.go
+++ b/local/local-proxy/internal/config/config_test.go
@@ -245,6 +245,33 @@ func TestLoadCloudReplaceKongConfigFile(t *testing.T) {
 	wantRoute("evo-route", "/api/evo", "http://127.0.0.1:18047", "/healthz", true, true)
 }
 
+func TestLoadCloudReplaceKongConfigFileIncludesLANOriginWhenSet(t *testing.T) {
+	t.Setenv("LAZYMIND_LOCAL_PROXY_PORT", "5024")
+	t.Setenv("LAZYMIND_LOCAL_PROXY_AUTH_HOST_PORT", "18000")
+	t.Setenv("LAZYMIND_LOCAL_PROXY_CORE_HOST_PORT", "18001")
+	t.Setenv("LAZYMIND_LOCAL_PROXY_CHAT_HOST_PORT", "18046")
+	t.Setenv("LAZYMIND_LOCAL_PROXY_SCAN_HOST_PORT", "18080")
+	t.Setenv("LAZYMIND_LOCAL_PROXY_EVO_HOST_PORT", "18047")
+	t.Setenv("LAZYMIND_FRONTEND_PORT", "8090")
+	t.Setenv("LAZYMIND_FRONTEND_LAN_ORIGIN", "http://10.0.0.2:8090")
+
+	cfg, err := Load(filepath.Join("..", "..", "configs", "cloud-replace-kong.yaml"))
+	if err != nil {
+		t.Fatalf("Load cloud-replace-kong.yaml: %v", err)
+	}
+
+	wantOrigins := []string{
+		"http://localhost:5173",
+		"http://127.0.0.1:5173",
+		"http://localhost:8090",
+		"http://127.0.0.1:8090",
+		"http://10.0.0.2:8090",
+	}
+	if !reflect.DeepEqual(cfg.CORS.AllowedOrigins, wantOrigins) {
+		t.Fatalf("allowedOrigins = %#v, want %#v", cfg.CORS.AllowedOrigins, wantOrigins)
+	}
+}
+
 func TestLoadUsesCLIConfigPathOverEnv(t *testing.T) {
 	root := t.TempDir()
 	envPath := writeTestConfigToDir(t, root, "env-config.yaml", `

--- a/local/local-runtime-manager/config.go
+++ b/local/local-runtime-manager/config.go
@@ -41,6 +41,7 @@ const (
 	routerPortPoolEndEnvVar       = "LAZYMIND_ROUTER_PORT_POOL_END"
 	routerPortsPerInstanceEnvVar  = "LAZYMIND_ROUTER_PORTS_PER_INSTANCE"
 	frontendPortEnvVar            = "LAZYMIND_FRONTEND_PORT"
+	frontendLANOriginEnvVar       = "LAZYMIND_FRONTEND_LAN_ORIGIN"
 	authServicePortEnvVar         = "LAZYMIND_AUTH_SERVICE_PORT"
 	authServicePythonEnvVar       = "LAZYMIND_AUTH_SERVICE_PYTHON"
 	authServiceUVEnvVar           = "LAZYMIND_AUTH_SERVICE_UV"

--- a/local/local-runtime-manager/local_proxy.go
+++ b/local/local-runtime-manager/local_proxy.go
@@ -80,6 +80,7 @@ func localRuntimeEnv(cfg RuntimeConfig) []string {
 	return []string{
 		processComposePortEnvVar + "=" + strconv.Itoa(cfg.ProcessComposePort),
 		frontendPortEnvVar + "=" + strconv.Itoa(cfg.FrontendPort),
+		frontendLANOriginEnvVar + "=" + frontendLANOrigin(cfg),
 		localNetworkProfileEnvVar + "=" + cfg.NetworkProfile,
 		localProxyAddressEnvVar + "=" + cfg.LocalProxy.Address,
 		localProxyPortEnvVar + "=" + strconv.Itoa(cfg.LocalProxy.Port),
@@ -90,4 +91,18 @@ func localRuntimeEnv(cfg RuntimeConfig) []string {
 		localProxyScanHostPortEnvVar + "=" + strconv.Itoa(cfg.LocalProxy.ScanHostPort),
 		localProxyEvoHostPortEnvVar + "=" + strconv.Itoa(cfg.LocalProxy.EvoHostPort),
 	}
+}
+
+func frontendLANOrigin(cfg RuntimeConfig) string {
+	if explicit := strings.TrimSpace(os.Getenv(frontendLANOriginEnvVar)); explicit != "" {
+		return explicit
+	}
+	if cfg.NetworkProfile != "lan" {
+		return ""
+	}
+	ip := firstLANIPv4()
+	if ip == "" {
+		return ""
+	}
+	return "http://" + ip + ":" + strconv.Itoa(cfg.FrontendPort)
 }

--- a/local/local-runtime-manager/main.go
+++ b/local/local-runtime-manager/main.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"log"
 	"os"
+	"strings"
 )
 
 func main() {
@@ -81,6 +82,26 @@ func (c *CLI) Run(ctx context.Context, args []string) error {
 			_, _ = io.WriteString(c.out, "\n")
 		}
 		return nil
+	case "reset":
+		scope, profile, repoRoot, err := parseResetArgs(args[1:], c.errOut)
+		if err != nil {
+			return err
+		}
+		cfg, paths, err := NewRuntimeConfig(profile, repoRoot)
+		if err != nil {
+			return err
+		}
+		return manager.Reset(ctx, cfg, paths, scope)
+	case "service":
+		service, action, profile, repoRoot, err := parseServiceArgs(args[1:], c.errOut)
+		if err != nil {
+			return err
+		}
+		cfg, paths, err := NewRuntimeConfig(profile, repoRoot)
+		if err != nil {
+			return err
+		}
+		return manager.RunServiceAction(ctx, cfg, paths, service, action)
 	case "internal":
 		return c.runInternal(ctx, manager, args[1:])
 	default:
@@ -214,10 +235,53 @@ func parseStatusArgs(args []string, out io.Writer) (bool, string, string, error)
 	return *asJSON, *profile, *repoRoot, nil
 }
 
+func parseResetArgs(args []string, out io.Writer) (ResetScope, string, string, error) {
+	fs := flag.NewFlagSet("reset", flag.ContinueOnError)
+	fs.SetOutput(out)
+	scopeText := fs.String("scope", string(ResetScopeKB), "")
+	profile := fs.String("profile", defaultProfileValue(), "")
+	repoRoot := fs.String("repo-root", "", "")
+	if err := fs.Parse(args); err != nil {
+		return "", "", "", err
+	}
+	if len(fs.Args()) != 0 {
+		return "", "", "", fmt.Errorf("unexpected positional args: %v", fs.Args())
+	}
+	scope, err := parseResetScope(*scopeText)
+	if err != nil {
+		return "", "", "", err
+	}
+	return scope, *profile, *repoRoot, nil
+}
+
+func parseServiceArgs(args []string, out io.Writer) (string, string, string, string, error) {
+	fs := flag.NewFlagSet("service", flag.ContinueOnError)
+	fs.SetOutput(out)
+	service := fs.String("name", "", "")
+	action := fs.String("action", "", "")
+	profile := fs.String("profile", defaultProfileValue(), "")
+	repoRoot := fs.String("repo-root", "", "")
+	if err := fs.Parse(args); err != nil {
+		return "", "", "", "", err
+	}
+	if len(fs.Args()) != 0 {
+		return "", "", "", "", fmt.Errorf("unexpected positional args: %v", fs.Args())
+	}
+	if strings.TrimSpace(*service) == "" {
+		return "", "", "", "", fmt.Errorf("--name is required")
+	}
+	if strings.TrimSpace(*action) == "" {
+		return "", "", "", "", fmt.Errorf("--action is required")
+	}
+	return *service, *action, *profile, *repoRoot, nil
+}
+
 func (c *CLI) usage() {
 	_, _ = io.WriteString(c.out, "Usage:\n")
 	_, _ = io.WriteString(c.out, "  lazymind-local up --profile <profile>\n")
 	_, _ = io.WriteString(c.out, "  lazymind-local down --profile <profile>\n")
 	_, _ = io.WriteString(c.out, "  lazymind-local status --json\n")
+	_, _ = io.WriteString(c.out, "  lazymind-local reset --scope kb|all --profile <profile>\n")
+	_, _ = io.WriteString(c.out, "  lazymind-local service --name file-watcher --action build|start|stop --profile <profile>\n")
 	_, _ = io.WriteString(c.out, "  lazymind-local internal compose-up|compose-down|compose-services|local-proxy-run|local-proxy-down|auth-service-run|auth-service-down|core-run|core-down|scan-control-plane-run|scan-control-plane-down|file-watcher-run|file-watcher-down|frontend-run|frontend-down|milvus-lite-run|milvus-lite-down|algorithm-run|algorithm-down --profile <profile>\n")
 }

--- a/local/local-runtime-manager/manager.go
+++ b/local/local-runtime-manager/manager.go
@@ -17,61 +17,67 @@ import (
 )
 
 type RuntimeManager struct {
-	runner         CommandRunner
-	execPath       string
-	now            func() time.Time
-	out            io.Writer
-	errOut         io.Writer
-	probeAPI       func(port int, timeout time.Duration) bool
-	probeAuth      func(port int, timeout time.Duration) bool
-	probeCore      func(port int, timeout time.Duration) bool
-	probeScan      func(port int, timeout time.Duration) bool
-	probeFileWatch func(port int, timeout time.Duration) bool
-	waitHostReady  func(context.Context, RuntimeConfig) error
-	runtimeReady   func(context.Context, RuntimeConfig, RuntimePaths) bool
-	pollInterval   time.Duration
-	upTimeout      time.Duration
-	downTimeout    time.Duration
-	compose        *ComposeManager
-	processCompose *ProcessComposeManager
-	localProxy     *LocalProxyManager
-	authService    *AuthServiceManager
-	coreService    *CoreServiceManager
-	scanControl    *ScanControlPlaneManager
-	fileWatcher    *FileWatcherManager
-	frontend       *FrontendManager
-	algorithm      *AlgorithmServiceManager
-	milvusLite     *MilvusLiteManager
+	runner          CommandRunner
+	execPath        string
+	now             func() time.Time
+	out             io.Writer
+	errOut          io.Writer
+	probeAPI        func(port int, timeout time.Duration) bool
+	probeLocalProxy func(port int, timeout time.Duration) bool
+	probeFrontend   func(port int, timeout time.Duration) bool
+	probeAuth       func(port int, timeout time.Duration) bool
+	probeCore       func(port int, timeout time.Duration) bool
+	probeScan       func(port int, timeout time.Duration) bool
+	probeFileWatch  func(port int, timeout time.Duration) bool
+	waitHostReady   func(context.Context, RuntimeConfig) error
+	runtimeReady    func(context.Context, RuntimeConfig, RuntimePaths) bool
+	pollInterval    time.Duration
+	upTimeout       time.Duration
+	downTimeout     time.Duration
+	compose         *ComposeManager
+	processCompose  *ProcessComposeManager
+	localProxy      *LocalProxyManager
+	authService     *AuthServiceManager
+	coreService     *CoreServiceManager
+	scanControl     *ScanControlPlaneManager
+	fileWatcher     *FileWatcherManager
+	frontend        *FrontendManager
+	algorithm       *AlgorithmServiceManager
+	milvusLite      *MilvusLiteManager
 }
+
+const startupProgressInterval = 10 * time.Second
 
 func NewRuntimeManager(r CommandRunner, execPath string) *RuntimeManager {
 	processCompose := NewProcessComposeManager(r, execPath)
 	return &RuntimeManager{
-		runner:         r,
-		execPath:       execPath,
-		now:            time.Now,
-		out:            io.Discard,
-		errOut:         io.Discard,
-		probeAPI:       processCompose.ProbeAPI,
-		probeAuth:      authServiceHealthAlive,
-		probeCore:      coreServiceHealthAlive,
-		probeScan:      scanControlPlaneHealthAlive,
-		probeFileWatch: fileWatcherHealthAlive,
-		waitHostReady:  waitForHostAlgorithmReadiness,
-		runtimeReady:   nil,
-		pollInterval:   2 * time.Second,
-		upTimeout:      envDuration(localUpTimeoutEnvVar, time.Duration(defaultLocalUpTimeout)*time.Second),
-		downTimeout:    envDuration(localDownTimeoutEnvVar, time.Duration(defaultLocalDownTimeout)*time.Second),
-		compose:        NewComposeManager(r),
-		processCompose: processCompose,
-		localProxy:     NewLocalProxyManager(r),
-		authService:    NewAuthServiceManager(r),
-		coreService:    NewCoreServiceManager(r),
-		scanControl:    NewScanControlPlaneManager(r),
-		fileWatcher:    NewFileWatcherManager(r),
-		frontend:       NewFrontendManager(r),
-		algorithm:      NewAlgorithmServiceManager(r),
-		milvusLite:     NewMilvusLiteManager(r),
+		runner:          r,
+		execPath:        execPath,
+		now:             time.Now,
+		out:             io.Discard,
+		errOut:          io.Discard,
+		probeAPI:        processCompose.ProbeAPI,
+		probeLocalProxy: localProxyHealthAlive,
+		probeFrontend:   frontendHealthAlive,
+		probeAuth:       authServiceHealthAlive,
+		probeCore:       coreServiceHealthAlive,
+		probeScan:       scanControlPlaneHealthAlive,
+		probeFileWatch:  fileWatcherHealthAlive,
+		waitHostReady:   waitForHostAlgorithmReadiness,
+		runtimeReady:    nil,
+		pollInterval:    2 * time.Second,
+		upTimeout:       envDuration(localUpTimeoutEnvVar, time.Duration(defaultLocalUpTimeout)*time.Second),
+		downTimeout:     envDuration(localDownTimeoutEnvVar, time.Duration(defaultLocalDownTimeout)*time.Second),
+		compose:         NewComposeManager(r),
+		processCompose:  processCompose,
+		localProxy:      NewLocalProxyManager(r),
+		authService:     NewAuthServiceManager(r),
+		coreService:     NewCoreServiceManager(r),
+		scanControl:     NewScanControlPlaneManager(r),
+		fileWatcher:     NewFileWatcherManager(r),
+		frontend:        NewFrontendManager(r),
+		algorithm:       NewAlgorithmServiceManager(r),
+		milvusLite:      NewMilvusLiteManager(r),
 	}
 }
 
@@ -152,6 +158,7 @@ func (m *RuntimeManager) Up(ctx context.Context, cfg RuntimeConfig, paths Runtim
 		return err
 	}
 
+	m.progressf("preparing local runtime directories and process-compose config")
 	generatedFile, err := os.Create(paths.GeneratedConfig)
 	if err != nil {
 		return err
@@ -176,6 +183,7 @@ func (m *RuntimeManager) Up(ctx context.Context, cfg RuntimeConfig, paths Runtim
 		return err
 	}
 
+	m.progressf("starting process-compose supervisor on 127.0.0.1:%d", cfg.ProcessComposePort)
 	if err := m.processCompose.Up(ctx, cfg, paths); err != nil {
 		state = newStateWithServiceStatus(state, "failed")
 		state.OverallStatus = "failed"
@@ -183,12 +191,14 @@ func (m *RuntimeManager) Up(ctx context.Context, cfg RuntimeConfig, paths Runtim
 		return err
 	}
 
+	m.progressf("waiting for process-compose API on 127.0.0.1:%d", cfg.ProcessComposePort)
 	if !m.waitForProcessComposeAPI(ctx, cfg.ProcessComposePort, 15*time.Second) {
 		state = newStateWithServiceStatus(state, "failed")
 		state.OverallStatus = "failed"
 		_ = writeRuntimeState(paths.StateFile, state)
 		return fmt.Errorf("process-compose API did not become ready on port %d", cfg.ProcessComposePort)
 	}
+	m.progressf("process-compose API ready on 127.0.0.1:%d", cfg.ProcessComposePort)
 
 	logCtx, stopLogs := context.WithCancel(ctx)
 	logErrCh := make(chan error, 1)
@@ -217,6 +227,12 @@ func (m *RuntimeManager) Up(ctx context.Context, cfg RuntimeConfig, paths Runtim
 		}
 		return waitErr
 	}
+	if err := m.waitForLocalProxyHealthy(ctx, cfg.LocalProxy.Port, m.upTimeout); err != nil {
+		state = newStateWithServiceStatus(state, "failed")
+		state.OverallStatus = "failed"
+		_ = writeRuntimeState(paths.StateFile, state)
+		return err
+	}
 	if err := m.waitForAuthServiceHealthy(ctx, cfg.AuthService.Port, m.upTimeout, paths.AuthServicePIDFile); err != nil {
 		state = newStateWithServiceStatus(state, "failed")
 		state.OverallStatus = "failed"
@@ -241,11 +257,17 @@ func (m *RuntimeManager) Up(ctx context.Context, cfg RuntimeConfig, paths Runtim
 		_ = writeRuntimeState(paths.StateFile, state)
 		return err
 	}
-	if waitErr := m.waitHostReady(ctx, cfg); waitErr != nil {
+	if waitErr := m.waitHostAlgorithmsReady(ctx, cfg); waitErr != nil {
 		state = newStateWithServiceStatus(state, "failed")
 		state.OverallStatus = "failed"
 		_ = writeRuntimeState(paths.StateFile, state)
 		return waitErr
+	}
+	if err := m.waitForFrontendHealthy(ctx, cfg.FrontendPort, m.upTimeout); err != nil {
+		state = newStateWithServiceStatus(state, "failed")
+		state.OverallStatus = "failed"
+		_ = writeRuntimeState(paths.StateFile, state)
+		return err
 	}
 
 	state = newStateWithServiceStatus(state, "running")
@@ -264,8 +286,12 @@ func (m *RuntimeManager) waitForAuthServiceHealthy(ctx context.Context, port int
 	ticker := time.NewTicker(500 * time.Millisecond)
 	defer ticker.Stop()
 	sawPIDFile := false
+	url := fmt.Sprintf("http://127.0.0.1:%d/health", port)
+	nextReport := m.now().Add(startupProgressInterval)
+	m.progressf("waiting for auth-service health: %s", url)
 	for {
 		if m.probeAuth(port, time.Second) {
+			m.progressf("auth-service ready: %s", url)
 			return nil
 		}
 		alive, err := upLockProcessAlive(pidFile)
@@ -277,6 +303,10 @@ func (m *RuntimeManager) waitForAuthServiceHealthy(ctx context.Context, port int
 		} else if sawPIDFile && os.IsNotExist(err) {
 			return fmt.Errorf("auth-service process exited before becoming healthy")
 		}
+		if !m.now().Before(nextReport) {
+			m.progressf("still waiting for auth-service health: %s", url)
+			nextReport = m.now().Add(startupProgressInterval)
+		}
 		select {
 		case <-ctx.Done():
 			return ctx.Err()
@@ -287,41 +317,42 @@ func (m *RuntimeManager) waitForAuthServiceHealthy(ctx context.Context, port int
 	}
 }
 
+func (m *RuntimeManager) waitForLocalProxyHealthy(ctx context.Context, port int, timeout time.Duration) error {
+	return m.waitForServiceProbeReady(ctx, m.probeLocalProxy, port, localProxyProcessName, "/_local/healthz", timeout)
+}
+
+func (m *RuntimeManager) waitForFrontendHealthy(ctx context.Context, port int, timeout time.Duration) error {
+	return m.waitForServiceProbeReady(ctx, m.probeFrontend, port, frontendProcessName, "/", timeout)
+}
+
 func (m *RuntimeManager) waitForCoreHealthy(ctx context.Context, port int, timeout time.Duration) error {
-	deadline := time.NewTimer(timeout)
-	defer deadline.Stop()
-	ticker := time.NewTicker(500 * time.Millisecond)
-	defer ticker.Stop()
-	for {
-		if m.probeCore(port, time.Second) {
-			return nil
-		}
-		select {
-		case <-ctx.Done():
-			return ctx.Err()
-		case <-deadline.C:
-			return fmt.Errorf("core health check timed out on port %d", port)
-		case <-ticker.C:
-		}
-	}
+	return m.waitForServiceProbeReady(ctx, m.probeCore, port, "core", "/health", timeout)
 }
 
 func (m *RuntimeManager) waitForScanControlPlaneHealthy(ctx context.Context, port int, timeout time.Duration) error {
-	return waitForServiceProbeReady(ctx, m.probeScan, port, scanControlPlaneProcessName, timeout)
+	return m.waitForServiceProbeReady(ctx, m.probeScan, port, scanControlPlaneProcessName, "/health", timeout)
 }
 
 func (m *RuntimeManager) waitForFileWatcherHealthy(ctx context.Context, port int, timeout time.Duration) error {
-	return waitForServiceProbeReady(ctx, m.probeFileWatch, port, fileWatcherProcessName, timeout)
+	return m.waitForServiceProbeReady(ctx, m.probeFileWatch, port, fileWatcherProcessName, "/health", timeout)
 }
 
-func waitForServiceProbeReady(ctx context.Context, probe func(int, time.Duration) bool, port int, service string, timeout time.Duration) error {
+func (m *RuntimeManager) waitForServiceProbeReady(ctx context.Context, probe func(int, time.Duration) bool, port int, service string, path string, timeout time.Duration) error {
 	deadline := time.NewTimer(timeout)
 	defer deadline.Stop()
 	ticker := time.NewTicker(500 * time.Millisecond)
 	defer ticker.Stop()
+	url := fmt.Sprintf("http://127.0.0.1:%d%s", port, path)
+	nextReport := m.now().Add(startupProgressInterval)
+	m.progressf("waiting for %s health: %s", service, url)
 	for {
 		if probe(port, time.Second) {
+			m.progressf("%s ready: %s", service, url)
 			return nil
+		}
+		if !m.now().Before(nextReport) {
+			m.progressf("still waiting for %s health: %s", service, url)
+			nextReport = m.now().Add(startupProgressInterval)
 		}
 		select {
 		case <-ctx.Done():
@@ -331,6 +362,74 @@ func waitForServiceProbeReady(ctx context.Context, probe func(int, time.Duration
 		case <-ticker.C:
 		}
 	}
+}
+
+func (m *RuntimeManager) waitHostAlgorithmsReady(ctx context.Context, cfg RuntimeConfig) error {
+	m.progressf("waiting for host algorithm services")
+	monitorCtx, cancel := context.WithCancel(ctx)
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		m.reportHostAlgorithmReadiness(monitorCtx, cfg)
+	}()
+
+	waitErr := m.waitHostReady(ctx, cfg)
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(100 * time.Millisecond):
+	}
+	if waitErr != nil {
+		return waitErr
+	}
+	m.progressf("host algorithm services ready")
+	return nil
+}
+
+func (m *RuntimeManager) reportHostAlgorithmReadiness(ctx context.Context, cfg RuntimeConfig) {
+	m.progressf("host algorithm status: %s", hostAlgorithmReadinessSummary(ctx, cfg))
+	ticker := time.NewTicker(startupProgressInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			m.progressf("host algorithm status: %s", hostAlgorithmReadinessSummary(ctx, cfg))
+		}
+	}
+}
+
+func hostAlgorithmReadinessSummary(ctx context.Context, cfg RuntimeConfig) string {
+	statuses := make([]string, 0, len(algorithmProcessSpecs(cfg.Algorithm))+2)
+	if cfg.ModeProfile.VectorStore.ManagedProcess {
+		statuses = append(statuses, readinessLabel(milvusLiteProcessName, tcpOK(ctx, "127.0.0.1", cfg.ModeProfile.VectorStore.Port, 500*time.Millisecond)))
+	}
+	for _, spec := range algorithmProcessSpecs(cfg.Algorithm) {
+		url := fmt.Sprintf("http://127.0.0.1:%d%s", spec.Port, spec.HealthPath)
+		statuses = append(statuses, readinessLabel(spec.Name, httpOK(ctx, url, 500*time.Millisecond)))
+	}
+	registrationURL := fmt.Sprintf("http://127.0.0.1:%d/algo/list", cfg.Algorithm.ProcessorPort)
+	registrationCtx, cancel := context.WithTimeout(ctx, 500*time.Millisecond)
+	defer cancel()
+	statuses = append(statuses, readinessLabel("algorithm-registration", algorithmRegistered(registrationCtx, registrationURL)))
+	return strings.Join(statuses, ", ")
+}
+
+func readinessLabel(name string, ready bool) string {
+	status := "waiting"
+	if ready {
+		status = "ready"
+	}
+	return name + "=" + status
+}
+
+func localProxyHealthAlive(port int, timeout time.Duration) bool {
+	return httpOK(context.Background(), fmt.Sprintf("http://127.0.0.1:%d/_local/healthz", port), timeout)
+}
+
+func frontendHealthAlive(port int, timeout time.Duration) bool {
+	return httpOK(context.Background(), fmt.Sprintf("http://127.0.0.1:%d/", port), timeout)
 }
 
 func (m *RuntimeManager) Down(ctx context.Context, cfg RuntimeConfig, paths RuntimePaths) error {
@@ -484,10 +583,10 @@ func (m *RuntimeManager) checkRuntimeReady(ctx context.Context, cfg RuntimeConfi
 			return false
 		}
 	}
-	if !httpOK(ctx, fmt.Sprintf("http://127.0.0.1:%d/_local/healthz", cfg.LocalProxy.Port), 500*time.Millisecond) {
+	if !m.probeLocalProxy(cfg.LocalProxy.Port, 500*time.Millisecond) {
 		return false
 	}
-	if !httpOK(ctx, fmt.Sprintf("http://127.0.0.1:%d/", cfg.FrontendPort), 500*time.Millisecond) {
+	if !m.probeFrontend(cfg.FrontendPort, 500*time.Millisecond) {
 		return false
 	}
 	if !m.probeAuth(cfg.AuthService.Port, 500*time.Millisecond) {
@@ -930,7 +1029,7 @@ func (m *RuntimeManager) Status(ctx context.Context, cfg RuntimeConfig, paths Ru
 		hostHealthy := true
 		lp := resp.Services[localProxyProcessName]
 		lp.Kind = "host-process"
-		if httpOK(ctx, fmt.Sprintf("http://127.0.0.1:%d/_local/healthz", cfg.LocalProxy.Port), 500*time.Millisecond) {
+		if m.probeLocalProxy(cfg.LocalProxy.Port, 500*time.Millisecond) {
 			lp.Status = "running"
 		} else {
 			hostHealthy = false
@@ -946,7 +1045,7 @@ func (m *RuntimeManager) Status(ctx context.Context, cfg RuntimeConfig, paths Ru
 		resp.Services[authServiceProcessName] = auth
 		frontend := resp.Services[frontendProcessName]
 		frontend.Kind = "host-process"
-		if httpOK(ctx, fmt.Sprintf("http://127.0.0.1:%d/", cfg.FrontendPort), 500*time.Millisecond) {
+		if m.probeFrontend(cfg.FrontendPort, 500*time.Millisecond) {
 			frontend.Status = "running"
 		} else {
 			hostHealthy = false

--- a/local/local-runtime-manager/manager_test.go
+++ b/local/local-runtime-manager/manager_test.go
@@ -123,6 +123,46 @@ func TestRuntimeConfigAllowsFileWatcherBaseRootOverride(t *testing.T) {
 	}
 }
 
+func TestParseResetArgsDefaultsToKB(t *testing.T) {
+	scope, profile, repoRoot, err := parseResetArgs([]string{"--repo-root", "/tmp/repo"}, io.Discard)
+	if err != nil {
+		t.Fatalf("parse reset args: %v", err)
+	}
+	if scope != ResetScopeKB {
+		t.Fatalf("scope = %q, want %q", scope, ResetScopeKB)
+	}
+	if profile != defaultProfileValue() {
+		t.Fatalf("profile = %q, want default profile", profile)
+	}
+	if repoRoot != "/tmp/repo" {
+		t.Fatalf("repo root = %q", repoRoot)
+	}
+}
+
+func TestParseResetArgsRejectsUnknownScope(t *testing.T) {
+	if _, _, _, err := parseResetArgs([]string{"--scope", "everything"}, io.Discard); err == nil {
+		t.Fatalf("expected unknown reset scope to fail")
+	}
+}
+
+func TestParseServiceArgsRequiresNameAndAction(t *testing.T) {
+	if _, _, _, _, err := parseServiceArgs([]string{"--name", fileWatcherProcessName}, io.Discard); err == nil {
+		t.Fatalf("expected missing action to fail")
+	}
+	service, action, profile, repoRoot, err := parseServiceArgs([]string{
+		"--name", fileWatcherProcessName,
+		"--action", "build",
+		"--profile", "linux-browser",
+		"--repo-root", "/tmp/repo",
+	}, io.Discard)
+	if err != nil {
+		t.Fatalf("parse service args: %v", err)
+	}
+	if service != fileWatcherProcessName || action != "build" || profile != "linux-browser" || repoRoot != "/tmp/repo" {
+		t.Fatalf("unexpected parsed service args: %q %q %q %q", service, action, profile, repoRoot)
+	}
+}
+
 func TestRuntimeConfigAllocatesAvailableLocalPorts(t *testing.T) {
 	for _, envName := range []string{
 		processComposePortEnvVar,
@@ -300,6 +340,19 @@ func TestRuntimeConfigAllowsLANNetworkProfile(t *testing.T) {
 	if cfg.NetworkProfile != "lan" {
 		t.Fatalf("network profile = %q, want lan", cfg.NetworkProfile)
 	}
+}
+
+func TestLocalRuntimeEnvIncludesExplicitFrontendLANOrigin(t *testing.T) {
+	t.Setenv(localNetworkProfileEnvVar, "lan")
+	t.Setenv(frontendLANOriginEnvVar, "http://10.0.0.2:8090")
+	repo := t.TempDir()
+	writeComposeFixture(t, repo)
+	cfg, _, err := NewRuntimeConfig(defaultProfileValue(), repo)
+	if err != nil {
+		t.Fatalf("runtime config: %v", err)
+	}
+	env := localRuntimeEnv(cfg)
+	assertEnvContains(t, env, frontendLANOriginEnvVar+"=http://10.0.0.2:8090")
 }
 
 func TestRuntimeConfigLANFrontendPortAvoidsWildcardOccupiedDefault(t *testing.T) {
@@ -780,6 +833,162 @@ func TestBuildEnabledServicesUsesDockerComposeBuild(t *testing.T) {
 	runner.assertCommandCount(2)
 }
 
+func TestProcessComposeGOBINUsesAbsolutePath(t *testing.T) {
+	root := t.TempDir()
+	t.Chdir(root)
+
+	got, err := processComposeGOBIN(filepath.Join("relative", "repo"))
+	if err != nil {
+		t.Fatalf("process compose GOBIN: %v", err)
+	}
+	want := filepath.Join(root, "relative", "repo", "local", "bin")
+	if got != want {
+		t.Fatalf("GOBIN = %q, want %q", got, want)
+	}
+	if !filepath.IsAbs(got) {
+		t.Fatalf("GOBIN should be absolute: %q", got)
+	}
+}
+
+func TestResetKBLocalStateRemovesRuntimePathsAndRunsSQLiteCleanup(t *testing.T) {
+	repo := t.TempDir()
+	writeComposeFixture(t, repo)
+	_, paths, err := NewRuntimeConfig(defaultProfileValue(), repo)
+	if err != nil {
+		t.Fatalf("runtime config: %v", err)
+	}
+	for _, path := range localKBResetPaths(paths) {
+		if err := os.MkdirAll(path, 0o755); err != nil {
+			t.Fatalf("mkdir reset path %s: %v", path, err)
+		}
+		if err := os.WriteFile(filepath.Join(path, "marker"), []byte("x"), 0o644); err != nil {
+			t.Fatalf("write marker in %s: %v", path, err)
+		}
+	}
+
+	runner := &fakeRunner{t: t}
+	manager := NewRuntimeManager(runner, filepath.Join(repo, "lazymind-local"))
+	runner.handlers = append(runner.handlers, func(cmd Command) (CommandResult, error) {
+		if cmd.Name != "python3" {
+			t.Fatalf("expected sqlite cleanup to use python3 got %s", cmd.Name)
+		}
+		if len(cmd.Args) != 4 || cmd.Args[0] != "-c" || cmd.Args[2] != paths.CoreDBPath || cmd.Args[3] != paths.LazyLLMDBPath {
+			t.Fatalf("unexpected sqlite cleanup args: %v", cmd.Args)
+		}
+		if !strings.Contains(cmd.Args[1], "DROP TABLE IF EXISTS") {
+			t.Fatalf("sqlite cleanup script should drop lazyllm tables")
+		}
+		return CommandResult{}, nil
+	})
+
+	if err := manager.resetKBLocalState(context.Background(), paths); err != nil {
+		t.Fatalf("reset KB local state: %v", err)
+	}
+	runner.assertCommandCount(1)
+	for _, path := range localKBResetPaths(paths) {
+		if _, err := os.Stat(path); !os.IsNotExist(err) {
+			t.Fatalf("expected %s to be removed, err=%v", path, err)
+		}
+	}
+}
+
+func TestResetAllLocalStateRemovesRuntimePersistentPaths(t *testing.T) {
+	repo := t.TempDir()
+	writeComposeFixture(t, repo)
+	_, paths, err := NewRuntimeConfig(defaultProfileValue(), repo)
+	if err != nil {
+		t.Fatalf("runtime config: %v", err)
+	}
+	for _, path := range localAllResetPaths(paths) {
+		if err := os.MkdirAll(path, 0o755); err != nil {
+			t.Fatalf("mkdir reset path %s: %v", path, err)
+		}
+	}
+
+	manager := NewRuntimeManager(&fakeRunner{t: t}, filepath.Join(repo, "lazymind-local"))
+	if err := manager.resetAllLocalState(context.Background(), paths); err != nil {
+		t.Fatalf("reset all local state: %v", err)
+	}
+	for _, path := range localAllResetPaths(paths) {
+		if _, err := os.Stat(path); !os.IsNotExist(err) {
+			t.Fatalf("expected %s to be removed, err=%v", path, err)
+		}
+	}
+}
+
+func TestRunServiceActionBuildsFileWatcher(t *testing.T) {
+	repo := t.TempDir()
+	writeComposeFixture(t, repo)
+	cfg, paths, err := NewRuntimeConfig(defaultProfileValue(), repo)
+	if err != nil {
+		t.Fatalf("runtime config: %v", err)
+	}
+
+	runner := &fakeRunner{t: t}
+	manager := NewRuntimeManager(runner, filepath.Join(repo, "lazymind-local"))
+	runner.handlers = append(runner.handlers, func(cmd Command) (CommandResult, error) {
+		assertCommand(t, cmd, "go", "build", "-buildvcs=false", "-o", paths.FileWatcherBin, "./cmd/main.go")
+		if cmd.Dir != filepath.Join(repo, fileWatcherSourceDirName) {
+			t.Fatalf("file-watcher build dir = %q", cmd.Dir)
+		}
+		return CommandResult{}, nil
+	})
+
+	if err := manager.RunServiceAction(context.Background(), cfg, paths, fileWatcherProcessName, "build"); err != nil {
+		t.Fatalf("run service build: %v", err)
+	}
+	runner.assertCommandCount(1)
+}
+
+func TestRemoveLocalPathWithDockerUsesAbsoluteHostMount(t *testing.T) {
+	root := t.TempDir()
+	t.Chdir(root)
+	repo := "repo"
+	path := filepath.Join(repo, "data", "core")
+	if err := os.MkdirAll(path, 0o755); err != nil {
+		t.Fatalf("mkdir path: %v", err)
+	}
+	absRepo, err := filepath.Abs(repo)
+	if err != nil {
+		t.Fatalf("abs repo: %v", err)
+	}
+
+	runner := &fakeRunner{t: t}
+	manager := NewRuntimeManager(runner, filepath.Join(absRepo, "lazymind-local"))
+	runner.handlers = append(runner.handlers, func(cmd Command) (CommandResult, error) {
+		assertCommandContainsInOrder(t, cmd, "docker", []string{
+			"run", "--rm",
+			"-v", absRepo + ":/work",
+			"-w", "/work",
+		})
+		if cmd.Dir != absRepo {
+			t.Fatalf("docker cleanup dir = %q, want %q", cmd.Dir, absRepo)
+		}
+		if got := cmd.Args[len(cmd.Args)-1]; got != "rm -rf data/core" {
+			t.Fatalf("docker cleanup script = %q", got)
+		}
+		return CommandResult{}, nil
+	})
+
+	if err := manager.removeLocalPathWithDocker(context.Background(), repo, path); err != nil {
+		t.Fatalf("remove path with docker: %v", err)
+	}
+	runner.assertCommandCount(1)
+}
+
+func TestRunServiceActionRejectsUnsupportedService(t *testing.T) {
+	repo := t.TempDir()
+	writeComposeFixture(t, repo)
+	cfg, paths, err := NewRuntimeConfig(defaultProfileValue(), repo)
+	if err != nil {
+		t.Fatalf("runtime config: %v", err)
+	}
+	manager := NewRuntimeManager(&fakeRunner{t: t}, filepath.Join(repo, "lazymind-local"))
+	if err := manager.RunServiceAction(context.Background(), cfg, paths, "core", "build"); err == nil {
+		t.Fatalf("expected unsupported service to fail")
+	}
+}
+
 func TestClassifyComposeReadinessReportsFatalBeforePending(t *testing.T) {
 	state, reason := classifyComposeReadiness([]ComposeServiceStatus{
 		{Service: "chat", State: "created"},
@@ -1200,6 +1409,8 @@ func TestManagerUpWritesStateAndStartsProcessCompose(t *testing.T) {
 	runner := &fakeRunner{t: t}
 	manager := NewRuntimeManager(runner, filepath.Join(repo, "lazymind-local"))
 	manager.probeAPI = func(port int, timeout time.Duration) bool { return true }
+	manager.probeLocalProxy = func(port int, timeout time.Duration) bool { return true }
+	manager.probeFrontend = func(port int, timeout time.Duration) bool { return true }
 	manager.probeAuth = func(port int, timeout time.Duration) bool { return true }
 	manager.probeCore = func(port int, timeout time.Duration) bool { return true }
 	manager.probeScan = func(port int, timeout time.Duration) bool { return true }

--- a/local/local-runtime-manager/permissions.go
+++ b/local/local-runtime-manager/permissions.go
@@ -79,12 +79,13 @@ func ensureWritableDir(dir string) error {
 	if err := os.MkdirAll(dir, 0o755); err != nil {
 		return err
 	}
-	probe := filepath.Join(dir, ".lazymind-write-test")
-	f, err := os.OpenFile(probe, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o600)
+	f, err := os.CreateTemp(dir, ".lazymind-write-test-*")
 	if err != nil {
 		return err
 	}
+	probe := f.Name()
 	if err := f.Close(); err != nil {
+		_ = os.Remove(probe)
 		return err
 	}
 	return os.Remove(probe)

--- a/local/local-runtime-manager/processcompose.go
+++ b/local/local-runtime-manager/processcompose.go
@@ -19,6 +19,8 @@ type ProcessComposeManager struct {
 	execPath string
 }
 
+const processComposePackage = "github.com/f1bonacc1/process-compose@v1.116.0"
+
 func NewProcessComposeManager(r CommandRunner, execPath string) *ProcessComposeManager {
 	return &ProcessComposeManager{runner: r, execPath: execPath}
 }
@@ -202,6 +204,9 @@ func runtimeCommandEnv(cfg RuntimeConfig) []string {
 }
 
 func (m *ProcessComposeManager) Up(ctx context.Context, cfg RuntimeConfig, paths RuntimePaths) error {
+	if err := m.EnsureBinary(ctx, paths.RepoRoot); err != nil {
+		return err
+	}
 	args := []string{
 		"--config", filepath.ToSlash(paths.GeneratedConfig),
 		"-D",
@@ -222,6 +227,9 @@ func (m *ProcessComposeManager) FollowLogs(ctx context.Context, cfg RuntimeConfi
 	streamer, ok := m.runner.(CommandStreamer)
 	if !ok {
 		return nil
+	}
+	if err := m.EnsureBinary(ctx, paths.RepoRoot); err != nil {
+		return err
 	}
 	args := []string{
 		"-p", strconv.Itoa(cfg.ProcessComposePort),
@@ -244,6 +252,9 @@ func (m *ProcessComposeManager) FollowLogs(ctx context.Context, cfg RuntimeConfi
 }
 
 func (m *ProcessComposeManager) Down(ctx context.Context, cfg RuntimeConfig, paths RuntimePaths) error {
+	if err := m.EnsureBinary(ctx, paths.RepoRoot); err != nil {
+		return err
+	}
 	args := []string{
 		"-p", strconv.Itoa(cfg.ProcessComposePort),
 		"--token-file", paths.RunDirTokenFile,
@@ -273,16 +284,50 @@ func (m *ProcessComposeManager) ProbeAPI(port int, timeout time.Duration) bool {
 	return resp.StatusCode < 500
 }
 
+func (m *ProcessComposeManager) EnsureBinary(ctx context.Context, repoRoot string) error {
+	if _, ok := m.runner.(*ExecRunner); !ok {
+		return nil
+	}
+	candidate := filepath.Join(repoRoot, localProcessComposeBin)
+	if info, err := os.Stat(candidate); err == nil && !info.IsDir() {
+		return nil
+	}
+	if err := os.MkdirAll(filepath.Dir(candidate), 0o755); err != nil {
+		return err
+	}
+	gobin, err := processComposeGOBIN(repoRoot)
+	if err != nil {
+		return fmt.Errorf("resolve process-compose GOBIN: %w", err)
+	}
+	res, err := m.runner.Run(ctx, Command{
+		Name: "go",
+		Args: []string{"install", processComposePackage},
+		Dir:  repoRoot,
+		Env:  []string{"GOBIN=" + gobin},
+	})
+	if err != nil {
+		return fmt.Errorf("install process-compose failed: %w (%s)", err, strings.TrimSpace(res.Stderr))
+	}
+	return nil
+}
+
+func processComposeGOBIN(repoRoot string) (string, error) {
+	return filepath.Abs(filepath.Join(repoRoot, "local", "bin"))
+}
+
 func quoteShellArg(value string) string {
 	if value == "" {
 		return "''"
 	}
 	if strings.IndexFunc(value, func(r rune) bool {
-		return r == ' ' || r == '\t' || r == '\n'
+		return !(r >= 'A' && r <= 'Z') &&
+			!(r >= 'a' && r <= 'z') &&
+			!(r >= '0' && r <= '9') &&
+			r != '_' && r != '-' && r != '.' && r != '/'
 	}) == -1 {
 		return value
 	}
-	return strconv.Quote(value)
+	return "'" + strings.ReplaceAll(value, "'", "'\"'\"'") + "'"
 }
 
 func processComposeCommand(repoRoot string) string {

--- a/local/local-runtime-manager/reset.go
+++ b/local/local-runtime-manager/reset.go
@@ -1,0 +1,245 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+type ResetScope string
+
+const (
+	ResetScopeKB  ResetScope = "kb"
+	ResetScopeAll ResetScope = "all"
+)
+
+func parseResetScope(raw string) (ResetScope, error) {
+	switch strings.ToLower(strings.TrimSpace(raw)) {
+	case "", string(ResetScopeKB):
+		return ResetScopeKB, nil
+	case string(ResetScopeAll):
+		return ResetScopeAll, nil
+	default:
+		return "", fmt.Errorf("--scope must be kb or all")
+	}
+}
+
+func (m *RuntimeManager) Reset(ctx context.Context, cfg RuntimeConfig, paths RuntimePaths, scope ResetScope) error {
+	if scope != ResetScopeKB && scope != ResetScopeAll {
+		return fmt.Errorf("unsupported reset scope %q", scope)
+	}
+	m.progressf("stopping Local Runtime before %s reset", scope)
+	if err := m.Down(ctx, cfg, paths); err != nil {
+		m.progressf("Local Runtime down failed during reset; continuing cleanup: %v", err)
+	}
+	if err := m.resetKBLocalState(ctx, paths); err != nil {
+		return err
+	}
+	if scope == ResetScopeAll {
+		if err := m.resetAllLocalState(ctx, paths); err != nil {
+			return err
+		}
+		m.progressf("local persistent data cleared")
+		return nil
+	}
+	m.progressf("local KB data cleared")
+	return nil
+}
+
+func (m *RuntimeManager) RunServiceAction(ctx context.Context, cfg RuntimeConfig, paths RuntimePaths, service string, action string) error {
+	service = strings.ToLower(strings.TrimSpace(service))
+	action = strings.ToLower(strings.TrimSpace(action))
+	if service != fileWatcherProcessName {
+		return fmt.Errorf("unsupported service %q", service)
+	}
+	switch action {
+	case "build":
+		if err := paths.EnsureAllDirs(); err != nil {
+			return err
+		}
+		return m.fileWatcher.build(ctx, paths)
+	case "start":
+		return m.fileWatcher.Run(ctx, cfg, paths)
+	case "stop":
+		return m.fileWatcher.Down(ctx, paths)
+	default:
+		return fmt.Errorf("unsupported service action %q", action)
+	}
+}
+
+func (m *RuntimeManager) resetKBLocalState(ctx context.Context, paths RuntimePaths) error {
+	if err := m.resetLocalSQLiteKBState(ctx, paths); err != nil {
+		return err
+	}
+	for _, path := range localKBResetPaths(paths) {
+		if err := m.removeLocalPath(ctx, paths.RepoRoot, path); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (m *RuntimeManager) resetAllLocalState(ctx context.Context, paths RuntimePaths) error {
+	for _, path := range localAllResetPaths(paths) {
+		if err := m.removeLocalPath(ctx, paths.RepoRoot, path); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func localKBResetPaths(paths RuntimePaths) []string {
+	return []string{
+		filepath.Join(paths.RepoRoot, "data", "core", "uploads"),
+		filepath.Join(paths.RepoRoot, "data", "scan", "staging"),
+		filepath.Join(paths.AlgorithmHome, "sqlite"),
+		paths.ScanControlPlaneTempDir,
+		filepath.Join(paths.FileWatcherBaseRoot, "staging"),
+		filepath.Join(paths.FileWatcherBaseRoot, "snapshots"),
+		filepath.Dir(paths.MilvusLiteDBPath),
+	}
+}
+
+func localAllResetPaths(paths RuntimePaths) []string {
+	return []string{
+		filepath.Join(paths.RepoRoot, "data", "core"),
+		filepath.Join(paths.RepoRoot, "data", "evo"),
+		filepath.Join(paths.RepoRoot, "data", "scan"),
+		filepath.Join(paths.RepoRoot, "data", "state", "postgres"),
+		filepath.Join(paths.RepoRoot, "data", "state", "redis"),
+		filepath.Join(paths.RepoRoot, "data", "subagent"),
+		filepath.Join(paths.RepoRoot, "data", "traces"),
+		paths.GeneratedDir,
+		paths.AlgorithmHome,
+		paths.LogsDir,
+		paths.RunDir,
+		paths.StateDir,
+		filepath.Join(paths.RuntimeRoot, "stores"),
+		filepath.Join(paths.RuntimeRoot, "tmp"),
+	}
+}
+
+func (m *RuntimeManager) removeLocalPath(ctx context.Context, repoRoot string, path string) error {
+	if strings.TrimSpace(path) == "" {
+		return nil
+	}
+	if _, err := os.Stat(path); os.IsNotExist(err) {
+		m.progressf("  skip %s (not found)", displayPath(repoRoot, path))
+		return nil
+	}
+	m.progressf("  removing %s", displayPath(repoRoot, path))
+	if err := os.RemoveAll(path); err == nil {
+		return nil
+	}
+	if err := m.removeLocalPathWithDocker(ctx, repoRoot, path); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (m *RuntimeManager) removeLocalPathWithDocker(ctx context.Context, repoRoot string, path string) error {
+	absRepoRoot, err := filepath.Abs(repoRoot)
+	if err != nil {
+		return fmt.Errorf("resolve repo root for docker cleanup: %w", err)
+	}
+	absPath, err := filepath.Abs(path)
+	if err != nil {
+		return fmt.Errorf("resolve path for docker cleanup: %w", err)
+	}
+	rel, err := filepath.Rel(absRepoRoot, absPath)
+	if err != nil || strings.HasPrefix(rel, "..") || filepath.IsAbs(rel) {
+		return fmt.Errorf("refusing docker cleanup outside repo: %s", path)
+	}
+	image := envText("POSTGRES_IMAGE", "postgres:16")
+	res, runErr := m.runner.Run(ctx, Command{
+		Name: "docker",
+		Args: []string{
+			"run", "--rm",
+			"-v", absRepoRoot + ":/work",
+			"-w", "/work",
+			image,
+			"sh", "-lc", "rm -rf " + quoteShellArg(filepath.ToSlash(rel)),
+		},
+		Dir: absRepoRoot,
+	})
+	if runErr != nil {
+		return fmt.Errorf("remove %s with docker failed: %w (%s)", rel, runErr, strings.TrimSpace(res.Stderr))
+	}
+	return nil
+}
+
+func (m *RuntimeManager) resetLocalSQLiteKBState(ctx context.Context, paths RuntimePaths) error {
+	python := envText("PYTHON", "python3")
+	script := `
+import os
+import sqlite3
+import sys
+
+core_db, lazyllm_db = sys.argv[1], sys.argv[2]
+
+core_statements = [
+    "DELETE FROM tasks",
+    "DELETE FROM upload_sessions",
+    "DELETE FROM uploaded_files",
+    "DELETE FROM documents",
+    "DELETE FROM acl_kbs",
+    "DELETE FROM default_datasets",
+    "DELETE FROM datasets",
+    "UPDATE conversations SET search_config = '{}' WHERE search_config IS NOT NULL AND search_config <> '{}'",
+]
+
+lazyllm_tables = [
+    "lazyllm_doc_node_group_status",
+    "lazyllm_doc_parse_state",
+    "lazyllm_kb_algorithm",
+    "lazyllm_kb_documents",
+    "lazyllm_knowledge_bases",
+    "lazyllm_doc_path_locks",
+    "lazyllm_documents",
+    "lazyllm_doc_service_tasks",
+    "lazyllm_callback_records",
+    "lazyllm_idempotency_records",
+    "lazyllm_node_group",
+    "lazyllm_algorithm",
+    "lazyllm_waiting_task_queue",
+    "lazyllm_finished_task_queue",
+]
+
+def run(path, statements):
+    if not path or not os.path.exists(path):
+        return
+    conn = sqlite3.connect(path)
+    try:
+        for sql in statements:
+            try:
+                conn.execute(sql)
+            except sqlite3.OperationalError as exc:
+                message = str(exc).lower()
+                if "no such table" not in message and "no such column" not in message:
+                    raise
+        conn.commit()
+    finally:
+        conn.close()
+
+run(core_db, core_statements)
+run(lazyllm_db, ["DROP TABLE IF EXISTS " + table for table in lazyllm_tables])
+`
+	res, err := m.runner.Run(ctx, Command{
+		Name: python,
+		Args: []string{"-c", script, paths.CoreDBPath, paths.LazyLLMDBPath},
+		Dir:  paths.RepoRoot,
+	})
+	if err != nil {
+		return fmt.Errorf("reset local SQLite KB state failed: %w (%s)", err, strings.TrimSpace(res.Stderr))
+	}
+	return nil
+}
+
+func displayPath(repoRoot string, path string) string {
+	if rel, err := filepath.Rel(repoRoot, path); err == nil && !strings.HasPrefix(rel, "..") {
+		return filepath.ToSlash(rel)
+	}
+	return path
+}

--- a/local/local-runtime-manager/scan_services.go
+++ b/local/local-runtime-manager/scan_services.go
@@ -100,6 +100,16 @@ func (m *ScanControlPlaneManager) build(ctx context.Context, paths RuntimePaths)
 }
 
 func (m *ScanControlPlaneManager) waitForDatabase(ctx context.Context, cfg RuntimeConfig, paths RuntimePaths) error {
+	if err := os.MkdirAll(filepath.Dir(paths.ScanDBPath), 0o755); err != nil {
+		return err
+	}
+	if err := os.MkdirAll(paths.ScanControlPlaneStateDir, 0o755); err != nil {
+		return err
+	}
+	if strings.EqualFold(envText("LAZYMIND_SCAN_CONTROL_PLANE_DB_DRIVER", "sqlite"), "sqlite") {
+		return nil
+	}
+
 	deadline := time.NewTimer(scanControlPlaneDBWaitTimeout)
 	defer deadline.Stop()
 	ticker := time.NewTicker(500 * time.Millisecond)
@@ -250,7 +260,8 @@ func scanControlPlaneEnv(cfg RuntimeConfig, paths RuntimePaths) []string {
 		"LAZYMIND_RUNTIME_MODE=local",
 		"LAZYMIND_SCAN_CONTROL_PLANE_ADDRESS=127.0.0.1",
 		"LAZYMIND_SCAN_CONTROL_PLANE_PORT=" + strconv.Itoa(cfg.LocalProxy.ScanHostPort),
-		"LAZYMIND_SCAN_CONTROL_PLANE_DB_DSN=" + coreDatabaseDSN(cfg.Algorithm.PostgresPort, "scan_control_plane", "root", "123456"),
+		"LAZYMIND_SCAN_CONTROL_PLANE_DB_DRIVER=sqlite",
+		"LAZYMIND_SCAN_CONTROL_PLANE_DB_DSN=" + paths.ScanDBPath,
 		"LAZYMIND_SCAN_CONTROL_PLANE_DB_MIGRATION_FILE=" + filepath.Join(paths.RepoRoot, scanControlPlaneSourceDirName, "migrations", "20260519101723_init.up.sql"),
 		"LAZYMIND_SCAN_CONTROL_PLANE_CORE_BASE_URL=http://127.0.0.1:" + strconv.Itoa(cfg.LocalProxy.CoreHostPort),
 		"LAZYMIND_SCAN_CONTROL_PLANE_AGENT_BASE_URL=http://127.0.0.1:" + strconv.Itoa(cfg.FileWatcher.Port),

--- a/local/local-runtime-manager/scan_services_test.go
+++ b/local/local-runtime-manager/scan_services_test.go
@@ -3,11 +3,14 @@ package main
 import (
 	"context"
 	"net"
+	"os"
+	"path/filepath"
 	"strconv"
 	"testing"
 )
 
 func TestScanControlPlaneWaitForDatabaseUsesPsql(t *testing.T) {
+	t.Setenv("LAZYMIND_SCAN_CONTROL_PLANE_DB_DRIVER", "postgres")
 	repo := t.TempDir()
 	writeComposeFixture(t, repo)
 	cfg, paths, err := NewRuntimeConfig(defaultProfileValue(), repo)
@@ -53,4 +56,40 @@ func TestScanControlPlaneWaitForDatabaseUsesPsql(t *testing.T) {
 		t.Fatalf("wait database: %v", err)
 	}
 	runner.assertCommandCount(1)
+}
+
+func TestScanControlPlaneWaitForDatabasePreparesSQLiteDirs(t *testing.T) {
+	repo := t.TempDir()
+	writeComposeFixture(t, repo)
+	cfg, paths, err := NewRuntimeConfig(defaultProfileValue(), repo)
+	if err != nil {
+		t.Fatalf("runtime config: %v", err)
+	}
+	runner := &fakeRunner{t: t}
+	manager := NewScanControlPlaneManager(runner)
+
+	if err := manager.waitForDatabase(context.Background(), cfg, paths); err != nil {
+		t.Fatalf("wait database: %v", err)
+	}
+	runner.assertCommandCount(0)
+	for _, dir := range []string{filepath.Dir(paths.ScanDBPath), paths.ScanControlPlaneStateDir} {
+		if _, err := os.Stat(dir); err != nil {
+			t.Fatalf("expected sqlite dir %s: %v", dir, err)
+		}
+	}
+}
+
+func TestScanControlPlaneEnvUsesSQLite(t *testing.T) {
+	repo := t.TempDir()
+	writeComposeFixture(t, repo)
+	cfg, paths, err := NewRuntimeConfig(defaultProfileValue(), repo)
+	if err != nil {
+		t.Fatalf("runtime config: %v", err)
+	}
+	env := scanControlPlaneEnv(cfg, paths)
+
+	assertEnvContains(t, env, "LAZYMIND_SCAN_CONTROL_PLANE_DB_DRIVER=sqlite")
+	assertEnvContains(t, env, "LAZYMIND_SCAN_CONTROL_PLANE_DB_DSN="+paths.ScanDBPath)
+	assertEnvContains(t, env, "LAZYMIND_STATE_BACKEND=sqlite")
+	assertEnvContains(t, env, "LAZYMIND_STATE_SQLITE_PATH="+filepath.Join(paths.ScanControlPlaneStateDir, "scan_state.db"))
 }


### PR DESCRIPTION
修复local模式启动过程中的问题，并将local模式的启动过程尽量由local-runtime-manager负责，减少对Makefile的改动。

## What changed

- Moved local-mode startup and reset responsibilities out of `Makefile` and into `local-runtime-manager`.
- Added `lazymind-local reset --scope kb|all` and `lazymind-local service --name file-watcher --action build|start|stop`.
- Let the manager bootstrap `process-compose`, emit startup progress, and wait for local proxy/frontend readiness before reporting ready.
- Fixed local LAN login by propagating the frontend LAN origin into local proxy CORS config and filtering empty duplicate origins.
- Defaulted host scan-control-plane local mode to SQLite and avoided Docker PostgreSQL readiness waits for that host profile.
- Made local permission probing use unique temp files to avoid concurrent startup races.

## Why

`make up-build-local` was carrying too much local runtime orchestration and produced repeated/noisy permission logs while startup appeared stuck. Local runtime cleanup was also split between Makefile shell loops and manager state. Centralizing the local-specific work in `local-runtime-manager` keeps Makefile focused on Cloud/Compose compatibility while making browser local mode easier to start, reset, and debug.

## Impact

Cloud/server defaults are preserved. Base `docker-compose.yml`, Kong/RBAC, PostgreSQL, Redis, Milvus, OpenSearch, and Cloud-visible Evo behavior are not removed. Compose SQL cleanup and Docker volume cleanup remain in Makefile for Cloud and legacy local compatibility.

Local browser mode now has clearer startup progress, manager-owned local state reset, LAN-origin-aware login, and SQLite-backed host scan-control-plane defaults.

## Validation

- `(cd local/local-runtime-manager && go test ./...)`
- `(cd local/local-proxy && go test ./...)`
- `git diff --check origin/main...HEAD`
- `make -n up-build-local`
- `make -n reset-kb`
- `make -n reset-all`
- `make local-runtime-manager-build`

Full destructive `make reset-all` and smoke were not rerun during publish because the worktree was already clean and those steps clear local persistent data.