### PR TITLE
feat: skill organize

### DIFF
--- a/algorithm/lazymind/chat/app.py
+++ b/algorithm/lazymind/chat/app.py
@@ -13,7 +13,7 @@ from lazymind.chat.api import (
 )
 from lazymind.chat.service.utils.trace_archive import start_local_trace_maintenance
 from lazymind.rewrite.api import rewrite_routes
-from lazymind.review.api import memory_review_routes, skill_review_routes
+from lazymind.review.api import memory_review_routes, skill_organize_routes, skill_review_routes
 
 
 def register_chat_routers(app: FastAPI) -> FastAPI:
@@ -30,6 +30,7 @@ def register_chat_routers(app: FastAPI) -> FastAPI:
     if not config['router_child_proxied_only']:
         app.include_router(rewrite_routes.router)
         app.include_router(memory_review_routes.router)
+        app.include_router(skill_organize_routes.router)
         app.include_router(skill_review_routes.router)
         app.include_router(model_features_routes.router)
         app.include_router(model_check_routes.router)

--- a/algorithm/lazymind/review/api/__init__.py
+++ b/algorithm/lazymind/review/api/__init__.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
-from . import memory_review_routes, skill_review_routes
+from . import memory_review_routes, skill_organize_routes, skill_review_routes
 
 __all__ = [
     'memory_review_routes',
+    'skill_organize_routes',
     'skill_review_routes',
 ]

--- a/algorithm/lazymind/review/api/skill_organize_routes.py
+++ b/algorithm/lazymind/review/api/skill_organize_routes.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+import asyncio
+from functools import partial
+
+from fastapi import APIRouter
+from fastapi.responses import JSONResponse
+from lazyllm import LOG
+from lazyllm import ThreadPoolExecutor
+
+from lazymind.review.skill_organize.config import DEFAULT_BACKGROUND_WORKERS
+from lazymind.review.skill_organize.schemas import SkillOrganizeRequest
+from lazymind.review.service.skill_organize import build_skill_organize_taskid, run_skill_organize
+
+router = APIRouter()
+background_executor = ThreadPoolExecutor(max_workers=DEFAULT_BACKGROUND_WORKERS)
+
+
+@router.on_event('shutdown')
+def shutdown_background_executor() -> None:
+    background_executor.shutdown(wait=False, cancel_futures=True)
+
+
+@router.post('/api/chat/skill_organize', summary='Organize existing skills and write an organize review record')
+async def skill_organize(payload: SkillOrganizeRequest):
+    loop = asyncio.get_running_loop()
+    taskid = build_skill_organize_taskid(payload.requestid)
+    try:
+        future = loop.run_in_executor(
+            background_executor,
+            partial(run_skill_organize, payload, taskid),
+        )
+    except Exception as exc:
+        LOG.exception(f'[SkillOrganize] failed to submit skill organize task: {exc}')
+        return JSONResponse(
+            status_code=500,
+            content={
+                'code': 500,
+                'msg': f'skill organize submit failed: {exc}',
+                'data': {'requestid': payload.requestid, 'taskid': taskid},
+            },
+        )
+
+    LOG.info(f'[SkillOrganize] skill organize accepted: {payload.requestid} task={taskid} for user {payload.user_id}')
+    future.add_done_callback(lambda item: _log_skill_organize_result(payload, taskid, item))
+    return JSONResponse(
+        status_code=200,
+        content={
+            'code': 0,
+            'msg': 'skill organize accepted',
+            'data': {'status': 'running', 'requestid': payload.requestid, 'taskid': taskid},
+        },
+    )
+
+
+def _log_skill_organize_result(payload: SkillOrganizeRequest, taskid: str, future: asyncio.Future) -> None:
+    try:
+        result = future.result()
+        LOG.info(f'[SkillOrganize] skill organize completed: {payload.requestid} task={taskid} for user {payload.user_id}')
+        LOG.info(f'[SkillOrganize] skill organize result: {result.model_dump()}')
+    except Exception as exc:
+        LOG.exception(f'[SkillOrganize] skill organize failed in background task={taskid}: {exc}')

--- a/algorithm/lazymind/review/api/skill_organize_routes.py
+++ b/algorithm/lazymind/review/api/skill_organize_routes.py
@@ -56,7 +56,8 @@ async def skill_organize(payload: SkillOrganizeRequest):
 def _log_skill_organize_result(payload: SkillOrganizeRequest, taskid: str, future: asyncio.Future) -> None:
     try:
         result = future.result()
-        LOG.info(f'[SkillOrganize] skill organize completed: {payload.requestid} task={taskid} for user {payload.user_id}')
+        LOG.info(f'[SkillOrganize] skill organize completed: {payload.requestid} \
+            task={taskid} for user {payload.user_id}')
         LOG.info(f'[SkillOrganize] skill organize result: {result.model_dump()}')
     except Exception as exc:
         LOG.exception(f'[SkillOrganize] skill organize failed in background task={taskid}: {exc}')

--- a/algorithm/lazymind/review/service/skill_organize.py
+++ b/algorithm/lazymind/review/service/skill_organize.py
@@ -37,12 +37,20 @@ def run_skill_organize(
     with lazyllm.new_session(resolved_taskid):
         inject_model_config(request.model_configs)
         llm = AutoModel(model='llm')
-        return _run_skill_organize(
-            request,
-            llm,
-            taskid=resolved_taskid,
-            remote_fs=remote_fs or build_skill_remote_fs(request.fs_base_url),
-        )
+        owns_remote_fs = remote_fs is None
+        client = remote_fs or build_skill_remote_fs()
+        try:
+            return _run_skill_organize(
+                request,
+                llm,
+                taskid=resolved_taskid,
+                remote_fs=client,
+            )
+        finally:
+            if owns_remote_fs:
+                close = getattr(client, 'close', None)
+                if callable(close):
+                    close()
 
 
 def _run_skill_organize(
@@ -69,7 +77,7 @@ def _run_skill_organize(
 
         draft = materialize_fs_draft(plan, source_skills, llm)
         write_stage_file(work_dir, taskid, STAGE_DRAFT, draft)
-        fs_apply = remote_fs.apply_draft(request.user_id, draft, task_id=taskid)
+        fs_apply = remote_fs.apply_draft(request.user_id, draft, task_id=request.requestid)
         write_stage_file(work_dir, taskid, STAGE_VALIDATION, {'status': 'completed', 'fs_apply': fs_apply})
 
         organize_result = _build_organize_result(

--- a/algorithm/lazymind/review/service/skill_organize.py
+++ b/algorithm/lazymind/review/service/skill_organize.py
@@ -1,0 +1,180 @@
+from __future__ import annotations
+
+from datetime import datetime
+from pathlib import Path
+from time import perf_counter
+from typing import Any
+
+import lazyllm
+from lazyllm import AutoModel, LOG
+
+from lazymind.model_config import inject_model_config
+from lazymind.review.skill_organize.config import (
+    STAGE_DRAFT,
+    STAGE_PLAN,
+    STAGE_RESULT,
+    STAGE_SOURCE,
+    STAGE_SUMMARY,
+    STAGE_VALIDATION,
+)
+from lazymind.review.skill_organize.db import insert_skill_organize_result
+from lazymind.review.skill_organize.materializer import materialize_fs_draft
+from lazymind.review.skill_organize.parser import parse_skill_summaries
+from lazymind.review.skill_organize.planner import build_organize_plan
+from lazymind.review.skill_organize.reports import write_stage_file
+from lazymind.review.skill_organize.schemas import SkillOrganizeRequest, SkillOrganizeResult
+from lazymind.review.skill_organize.skillremotefs import SkillRemoteFSClient, build_skill_remote_fs
+from lazymind.review.skill_organize.validator import validate_source_skills
+
+
+def run_skill_organize(
+    request: SkillOrganizeRequest,
+    taskid: str | None = None,
+    *,
+    remote_fs: SkillRemoteFSClient | None = None,
+) -> SkillOrganizeResult:
+    resolved_taskid = taskid or build_skill_organize_taskid(request.requestid)
+    with lazyllm.new_session(resolved_taskid):
+        inject_model_config(request.model_configs)
+        llm = AutoModel(model='llm')
+        return _run_skill_organize(
+            request,
+            llm,
+            taskid=resolved_taskid,
+            remote_fs=remote_fs or build_skill_remote_fs(request.fs_base_url),
+        )
+
+
+def _run_skill_organize(
+    request: SkillOrganizeRequest,
+    llm: AutoModel,
+    *,
+    taskid: str,
+    remote_fs: SkillRemoteFSClient,
+) -> SkillOrganizeResult:
+    work_dir = _resolve_artifact_dir(request.artifact_dir)
+    artifact_dir = str(work_dir / taskid) if work_dir is not None else ''
+    started_at = datetime.now()
+    started_perf = perf_counter()
+    try:
+        source_skills = remote_fs.load_skills(request.user_id, request.skills, task_id=request.requestid)
+        validate_source_skills(source_skills)
+        write_stage_file(work_dir, taskid, STAGE_SOURCE, source_skills)
+
+        summaries = parse_skill_summaries(source_skills)
+        write_stage_file(work_dir, taskid, STAGE_SUMMARY, summaries)
+
+        plan = build_organize_plan(summaries, source_skills, llm)
+        write_stage_file(work_dir, taskid, STAGE_PLAN, plan)
+
+        draft = materialize_fs_draft(plan, source_skills, llm)
+        write_stage_file(work_dir, taskid, STAGE_DRAFT, draft)
+        fs_apply = remote_fs.apply_draft(request.user_id, draft, task_id=taskid)
+        write_stage_file(work_dir, taskid, STAGE_VALIDATION, {'status': 'completed', 'fs_apply': fs_apply})
+
+        organize_result = _build_organize_result(
+            request=request,
+            plan=plan.model_dump(),
+            draft=draft.model_dump(),
+            fs_apply=fs_apply,
+            artifact_dir=artifact_dir,
+            taskid=taskid,
+            started_at=started_at,
+            duration_ms=_duration_ms(started_perf),
+        )
+        write_stage_file(work_dir, taskid, STAGE_RESULT, organize_result)
+        inserted_count = insert_skill_organize_result(
+            record_id=taskid,
+            requestid=request.requestid,
+            user_id=request.user_id,
+            organize_result=organize_result,
+        )
+        LOG.info(f'[SkillOrganize] completed request={request.requestid} task={taskid} inserted_count={inserted_count}')
+        return SkillOrganizeResult(
+            success=True,
+            requestid=request.requestid,
+            taskid=taskid,
+            inserted_count=inserted_count,
+            artifact_dir=artifact_dir,
+        )
+    except Exception as exc:
+        LOG.exception(f'[SkillOrganize] failed request={request.requestid} task={taskid}: {exc}')
+        error_result = {
+            'kind': 'skill_organize',
+            'requestid': request.requestid,
+            'taskid': taskid,
+            'userid': request.user_id,
+            'status': 'failed',
+            'error': str(exc),
+            'artifact_dir': artifact_dir,
+            'started_at': started_at.isoformat(),
+            'duration_ms': _duration_ms(started_perf),
+            'created_at': datetime.now().isoformat(),
+        }
+        write_stage_file(work_dir, taskid, STAGE_RESULT, error_result)
+        inserted_count = 0
+        try:
+            inserted_count = insert_skill_organize_result(
+                record_id=taskid,
+                requestid=request.requestid,
+                user_id=request.user_id,
+                organize_result=error_result,
+            )
+        except Exception as insert_exc:
+            LOG.exception(f'[SkillOrganize] failed to insert failed run stats: {insert_exc}')
+        return SkillOrganizeResult(
+            success=False,
+            requestid=request.requestid,
+            taskid=taskid,
+            inserted_count=inserted_count,
+            artifact_dir=artifact_dir,
+            error=str(exc),
+        )
+
+
+def _build_organize_result(
+    *,
+    request: SkillOrganizeRequest,
+    plan: dict[str, Any],
+    draft: dict[str, Any],
+    fs_apply: dict[str, Any],
+    artifact_dir: str,
+    taskid: str,
+    started_at: datetime,
+    duration_ms: int,
+) -> dict[str, Any]:
+    return {
+        'kind': 'skill_organize',
+        'requestid': request.requestid,
+        'taskid': taskid,
+        'userid': request.user_id,
+        'status': 'completed',
+        'plans': plan.get('plans', []),
+        'fs_draft': {
+            'delete_paths': draft.get('delete_paths', []),
+            'upsert_paths': [
+                item.get('path')
+                for item in draft.get('upsert_skills', [])
+                if isinstance(item, dict)
+            ],
+        },
+        'fs_apply': fs_apply,
+        'artifact_dir': artifact_dir,
+        'started_at': started_at.isoformat(),
+        'duration_ms': duration_ms,
+        'created_at': datetime.now().isoformat(),
+    }
+
+
+def build_skill_organize_taskid(requestid: str) -> str:
+    return f'{requestid}_{datetime.now().strftime("%Y%m%d%H%M%S%f")}'
+
+
+def _duration_ms(started_perf: float) -> int:
+    return max(0, int((perf_counter() - started_perf) * 1000))
+
+
+def _resolve_artifact_dir(artifact_dir: str | Path | None) -> Path | None:
+    if artifact_dir is None or (isinstance(artifact_dir, str) and not artifact_dir.strip()):
+        return None
+    return Path(artifact_dir)

--- a/algorithm/lazymind/review/skill_organize/__init__.py
+++ b/algorithm/lazymind/review/skill_organize/__init__.py
@@ -1,0 +1,2 @@
+"""Skill organize pipeline."""
+

--- a/algorithm/lazymind/review/skill_organize/__init__.py
+++ b/algorithm/lazymind/review/skill_organize/__init__.py
@@ -1,2 +1,1 @@
 """Skill organize pipeline."""
-

--- a/algorithm/lazymind/review/skill_organize/config.py
+++ b/algorithm/lazymind/review/skill_organize/config.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+
+DEFAULT_SKILL_ORGANIZE_LIMIT = 20
+MAX_SKILL_ORGANIZE_LIMIT = 20
+DEFAULT_BACKGROUND_WORKERS = 2
+DEFAULT_MATERIALIZE_WORKERS = 4
+DEFAULT_REPORT_DIR_NAME = 'lazyrag_skill_organize_reports'
+
+STAGE_SOURCE = 'source'
+STAGE_SUMMARY = 'summary'
+STAGE_PLAN = 'plan'
+STAGE_DRAFT = 'draft'
+STAGE_VALIDATION = 'validation'
+STAGE_RESULT = 'result'
+STAGE_REPORT = 'report'
+
+STAGE_FILES = {
+    STAGE_SOURCE: '01_source_skills.json',
+    STAGE_SUMMARY: '02_skill_summaries.json',
+    STAGE_PLAN: '03_organize_plan.json',
+    STAGE_DRAFT: '04_fs_draft.json',
+    STAGE_VALIDATION: '05_validation.json',
+    STAGE_RESULT: 'result.json',
+    STAGE_REPORT: 'failure_report.json',
+}

--- a/algorithm/lazymind/review/skill_organize/db.py
+++ b/algorithm/lazymind/review/skill_organize/db.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+import json
+from datetime import date, datetime
+from decimal import Decimal
+from typing import Any, Optional
+from uuid import UUID
+
+from sqlalchemy import create_engine, text
+from sqlalchemy.engine import Engine
+
+from lazymind.common.postgres import normalize_postgres_sqlalchemy_url
+from lazymind.config import config as _cfg
+from lazymind.review.skill_review.db import SKILL_REVIEW_RUN_STATS_TABLE
+
+_DB_URL_ENV = 'LAZYMIND_DATABASE_URL'
+_CORE_DB_URL_ENV = 'LAZYMIND_CORE_DATABASE_URL'
+_DB_ENV_HINT = f'{_CORE_DB_URL_ENV} or {_DB_URL_ENV}'
+_engine_cache: dict[str, Engine] = {}
+
+
+def insert_skill_organize_result(
+    *,
+    record_id: str,
+    requestid: str,
+    user_id: str,
+    organize_result: dict[str, Any],
+) -> int:
+    summary = json.dumps(_jsonable_value(organize_result), ensure_ascii=False)
+    status = str(organize_result.get('status') or 'completed').strip()
+    if status not in {'running', 'completed', 'skipped', 'failed'}:
+        status = 'completed'
+    with _get_app_conn().begin() as conn:
+        conn.execute(
+            text(
+                f"""INSERT INTO {SKILL_REVIEW_RUN_STATS_TABLE}
+                       (id, requestid, userid, status, started_at, duration_ms,
+                        summary)
+                    VALUES
+                       (:id, :requestid, :userid, :status, :started_at,
+                        :duration_ms, CAST(:summary AS JSONB))
+                    ON CONFLICT (id) DO UPDATE SET
+                       requestid = EXCLUDED.requestid,
+                       userid = EXCLUDED.userid,
+                       status = EXCLUDED.status,
+                       started_at = EXCLUDED.started_at,
+                       duration_ms = EXCLUDED.duration_ms,
+                       summary = EXCLUDED.summary"""
+            ),
+            {
+                'id': record_id,
+                'userid': user_id,
+                'requestid': requestid,
+                'status': status,
+                'started_at': str(organize_result.get('started_at') or organize_result.get('created_at') or ''),
+                'duration_ms': int(organize_result.get('duration_ms') or 0),
+                'summary': summary,
+            },
+        )
+    return 1
+
+
+def _get_app_conn() -> Engine:
+    core_db_url = _get_core_db_url()
+    if core_db_url:
+        return _get_engine(core_db_url)
+    db_url = _get_db_url()
+    if db_url:
+        return _get_engine(db_url)
+    raise RuntimeError(f'[SkillOrganize] {_DB_ENV_HINT} is not set; cannot connect to app database.')
+
+
+def _get_db_url() -> Optional[str]:
+    value = _cfg['database_url']
+    return value if value and value.strip() else None
+
+
+def _get_core_db_url() -> Optional[str]:
+    value = _cfg['core_database_url']
+    return value if value and value.strip() else None
+
+
+def _get_engine(url: str) -> Engine:
+    engine_url = normalize_postgres_sqlalchemy_url(url)
+    engine = _engine_cache.get(engine_url)
+    if engine is None:
+        engine = create_engine(engine_url, future=True, pool_pre_ping=True)
+        _engine_cache[engine_url] = engine
+    return engine
+
+
+def _jsonable_value(value: Any) -> Any:
+    if isinstance(value, dict):
+        return {key: _jsonable_value(item) for key, item in value.items()}
+    if isinstance(value, list):
+        return [_jsonable_value(item) for item in value]
+    if isinstance(value, (datetime, date)):
+        return value.isoformat()
+    if isinstance(value, Decimal):
+        return float(value)
+    if isinstance(value, UUID):
+        return str(value)
+    return value

--- a/algorithm/lazymind/review/skill_organize/db.py
+++ b/algorithm/lazymind/review/skill_organize/db.py
@@ -52,7 +52,7 @@ def insert_skill_organize_result(
                 'userid': user_id,
                 'requestid': requestid,
                 'status': status,
-                'started_at': str(organize_result.get('started_at') or organize_result.get('created_at') or ''),
+                'started_at': organize_result.get('started_at') or organize_result.get('created_at') or None,
                 'duration_ms': int(organize_result.get('duration_ms') or 0),
                 'summary': summary,
             },

--- a/algorithm/lazymind/review/skill_organize/materializer.py
+++ b/algorithm/lazymind/review/skill_organize/materializer.py
@@ -1,0 +1,128 @@
+from __future__ import annotations
+
+from concurrent.futures import as_completed
+
+from lazyllm import LOG, ThreadPoolExecutor
+
+from lazymind.review.skill_organize.config import DEFAULT_MATERIALIZE_WORKERS
+from lazymind.review.skill_organize.prompts import materialize_draft_prompt
+from lazymind.review.skill_organize.schemas import (
+    MaterializedSkillContent,
+    SkillFsDraft,
+    SkillFsDraftItem,
+    SkillOrganizePlan,
+    SkillPlan,
+    SourceSkill,
+)
+from lazymind.review.skill_organize.validator import validate_fs_draft
+from lazymind.review.skill_review.json_call import call_json
+
+
+def materialize_fs_draft(
+    plan: SkillOrganizePlan,
+    source_skills: list[SourceSkill],
+    llm,
+    *,
+    max_retries: int = 3,
+    max_workers: int = DEFAULT_MATERIALIZE_WORKERS,
+) -> SkillFsDraft:
+    all_delete_paths: list[str] = []
+    all_upserts = []
+    by_path = {item.path: item for item in source_skills}
+    partials: list[SkillFsDraft | None] = [None] * len(plan.plans)
+    errors: list[str] = []
+
+    with ThreadPoolExecutor(max_workers=max(1, max_workers)) as executor:
+        futures = {
+            executor.submit(_materialize_plan_item, item, by_path, llm, max_retries=max_retries): (index, item)
+            for index, item in enumerate(plan.plans)
+        }
+        for fut in as_completed(futures):
+            index, item = futures[fut]
+            try:
+                partials[index] = fut.result()
+            except Exception as exc:
+                LOG.warning(f'[SkillOrganize] failed to materialize plan item {index} {item.source_paths}: {exc}')
+                errors.append(f'plans[{index}] {item.source_paths}: {exc}')
+
+    if errors:
+        raise ValueError('failed to materialize fs draft: ' + '; '.join(errors))
+
+    for partial in partials:
+        if partial is None:
+            continue
+        all_delete_paths.extend(partial.delete_paths)
+        all_upserts.extend(partial.upsert_skills)
+    draft = SkillFsDraft(delete_paths=all_delete_paths, upsert_skills=all_upserts)
+    validate_fs_draft(draft, source_skills)
+    return draft
+
+
+def _materialize_plan_item(
+    plan: SkillPlan,
+    by_path: dict[str, SourceSkill],
+    llm,
+    *,
+    max_retries: int,
+) -> SkillFsDraft:
+    if plan.type == 'keep':
+        return SkillFsDraft()
+    if plan.type == 'delete_duplicate':
+        return SkillFsDraft(delete_paths=list(plan.source_paths))
+
+    sources = [by_path[path] for path in plan.source_paths]
+    upsert = _materialize_upsert_skill(plan, sources, llm, max_retries=max_retries)
+    delete_paths = _merge_delete_paths(plan) if plan.type == 'merge' else []
+    return SkillFsDraft(delete_paths=delete_paths, upsert_skills=[upsert])
+
+
+def _materialize_upsert_skill(
+    plan: SkillPlan,
+    sources: list[SourceSkill],
+    llm,
+    *,
+    max_retries: int,
+) -> SkillFsDraftItem:
+    prompt = materialize_draft_prompt(
+        _prompt_plan(plan),
+        [_prompt_source_skill(item) for item in sources],
+    )
+    last_error: Exception | None = None
+    for attempt in range(max_retries):
+        try:
+            payload = call_json(llm, prompt, MaterializedSkillContent, max_retries=1)
+            materialized = MaterializedSkillContent.model_validate(payload)
+            item = SkillFsDraftItem(path=plan.target_path, content=materialized.content)
+            validate_fs_draft(SkillFsDraft(upsert_skills=[item]), sources)
+            return item
+        except Exception as exc:
+            last_error = exc
+            LOG.warning(
+                f'[SkillOrganize] materialize {plan.type} '
+                f'{plan.source_paths} attempt {attempt + 1} failed: {exc}'
+            )
+    raise ValueError(f'failed to materialize valid upsert skill for {plan.source_paths}: {last_error}') from last_error
+
+
+def _merge_delete_paths(plan: SkillPlan) -> list[str]:
+    return [path for path in plan.source_paths if path != plan.target_path]
+
+
+def _prompt_plan(plan: SkillPlan) -> dict:
+    return {
+        'type': plan.type,
+        'source_names': plan.source_names,
+        'target_name': plan.target_name,
+        'target_category': plan.target_category,
+        'target_description': plan.target_description,
+        'target_applicable_scenario': plan.target_applicable_scenario,
+        'step_handling_policy': plan.step_handling_policy,
+        'reason': plan.reason,
+    }
+
+
+def _prompt_source_skill(skill: SourceSkill) -> dict:
+    return {
+        'name': skill.name,
+        'content': skill.content,
+    }

--- a/algorithm/lazymind/review/skill_organize/parser.py
+++ b/algorithm/lazymind/review/skill_organize/parser.py
@@ -33,6 +33,7 @@ def parse_skill_summaries(skills: Iterable[SourceSkill]) -> list[SkillSummary]:
 
 def parse_skill_summary(skill: SourceSkill) -> SkillSummary:
     frontmatter, body = parse_skill_frontmatter(skill.content)
+    frontmatter = frontmatter or {}
     name = str(frontmatter.get('name') or skill.name).strip()
     category = str(frontmatter.get('category') or skill.category).strip()
     description = str(frontmatter.get('description') or '').strip()
@@ -48,9 +49,9 @@ def parse_skill_summary(skill: SourceSkill) -> SkillSummary:
     )
 
 
-def _extract_core_steps(body: str) -> list[str]:
+def _extract_core_steps(body: str | None) -> list[str]:
     section = _extract_section_text(body, _STEP_HEADING_HINTS, compact=False)
-    source = section or body
+    source = section or body or ''
     steps: list[str] = []
     for match in _LIST_ITEM_RE.finditer(source):
         item = _first_sentence(match.group(1))

--- a/algorithm/lazymind/review/skill_organize/parser.py
+++ b/algorithm/lazymind/review/skill_organize/parser.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+import re
+from typing import Iterable
+
+from lazymind.chat.engine.tools.infra.skill_validation import parse_skill_frontmatter
+from lazymind.review.skill_organize.schemas import SkillSummary, SourceSkill
+
+_HEADING_RE = re.compile(r'^(#{1,6})\s+(.+?)\s*$', re.M)
+_LIST_ITEM_RE = re.compile(r'^\s*(?:[-*+]|\d+[.)])\s+(.+?)\s*$', re.M)
+_STEP_HEADING_HINTS = {
+    'sop',
+    'workflow',
+    'steps',
+    'procedure',
+    'process',
+    '操作流程',
+    '步骤',
+    '流程',
+}
+_SCENARIO_HEADING_HINTS = {
+    'applicable scenario',
+    'applicable scenarios',
+    'scenario',
+    'when to use',
+    '适用场景',
+}
+
+
+def parse_skill_summaries(skills: Iterable[SourceSkill]) -> list[SkillSummary]:
+    return [parse_skill_summary(skill) for skill in skills]
+
+
+def parse_skill_summary(skill: SourceSkill) -> SkillSummary:
+    frontmatter, body = parse_skill_frontmatter(skill.content)
+    name = str(frontmatter.get('name') or skill.name).strip()
+    category = str(frontmatter.get('category') or skill.category).strip()
+    description = str(frontmatter.get('description') or '').strip()
+    applicable_scenario = _extract_section_text(body, _SCENARIO_HEADING_HINTS)
+    core_steps = _extract_core_steps(body)
+    return SkillSummary(
+        name=name,
+        path=skill.path,
+        category=category,
+        description=description,
+        applicable_scenario=applicable_scenario,
+        core_steps=core_steps,
+    )
+
+
+def _extract_core_steps(body: str) -> list[str]:
+    section = _extract_section_text(body, _STEP_HEADING_HINTS, compact=False)
+    source = section or body
+    steps: list[str] = []
+    for match in _LIST_ITEM_RE.finditer(source):
+        item = _first_sentence(match.group(1))
+        if item:
+            steps.append(item)
+        if len(steps) >= 8:
+            break
+    return steps
+
+
+def _extract_section_text(body: str, headings: set[str], *, compact: bool = True) -> str:
+    matches = list(_HEADING_RE.finditer(body or ''))
+    for index, match in enumerate(matches):
+        heading_level = len(match.group(1))
+        title = _normalize_heading(match.group(2))
+        if title not in headings:
+            continue
+        start = match.end()
+        end = len(body)
+        for next_match in matches[index + 1:]:
+            if len(next_match.group(1)) <= heading_level:
+                end = next_match.start()
+                break
+        value = body[start:end]
+        return _compact_text(value) if compact else value.strip()
+    return ''
+
+
+def _normalize_heading(value: str) -> str:
+    return re.sub(r'\s+', ' ', value.strip().strip(':：')).lower()
+
+
+def _compact_text(value: str) -> str:
+    lines = [line.strip() for line in value.splitlines()]
+    text = ' '.join(line for line in lines if line)
+    return re.sub(r'\s+', ' ', text).strip()
+
+
+def _first_sentence(value: str) -> str:
+    cleaned = _compact_text(value)
+    if not cleaned:
+        return ''
+    parts = re.split(r'(?<=[。.!?])\s+', cleaned, maxsplit=1)
+    return parts[0].strip()

--- a/algorithm/lazymind/review/skill_organize/planner.py
+++ b/algorithm/lazymind/review/skill_organize/planner.py
@@ -27,4 +27,3 @@ def build_organize_plan(
             last_error = exc
             LOG.warning(f'[SkillOrganize] plan attempt {attempt + 1} failed: {exc}')
     raise ValueError(f'failed to build valid organize plan: {last_error}') from last_error
-

--- a/algorithm/lazymind/review/skill_organize/planner.py
+++ b/algorithm/lazymind/review/skill_organize/planner.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from lazyllm import LOG
+
+from lazymind.review.skill_organize.prompts import organize_plan_prompt
+from lazymind.review.skill_organize.schemas import SkillOrganizePlan, SkillSummary, SourceSkill
+from lazymind.review.skill_organize.validator import validate_plan
+from lazymind.review.skill_review.json_call import call_json
+
+
+def build_organize_plan(
+    summaries: list[SkillSummary],
+    source_skills: list[SourceSkill],
+    llm,
+    *,
+    max_retries: int = 3,
+) -> SkillOrganizePlan:
+    prompt = organize_plan_prompt([item.model_dump() for item in summaries])
+    last_error: Exception | None = None
+    for attempt in range(max_retries):
+        try:
+            payload = call_json(llm, prompt, SkillOrganizePlan, max_retries=1)
+            plan = SkillOrganizePlan.model_validate(payload)
+            validate_plan(plan, source_skills)
+            return plan
+        except Exception as exc:
+            last_error = exc
+            LOG.warning(f'[SkillOrganize] plan attempt {attempt + 1} failed: {exc}')
+    raise ValueError(f'failed to build valid organize plan: {last_error}') from last_error
+

--- a/algorithm/lazymind/review/skill_organize/prompts.py
+++ b/algorithm/lazymind/review/skill_organize/prompts.py
@@ -1,0 +1,156 @@
+# flake8: noqa: E501
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+
+def organize_plan_prompt(skill_summaries: list[dict[str, Any]]) -> str:
+    return f"""
+You are a Skill Organize Planner.
+
+Skill Organize is a lightweight boundary-cleanup module for an existing Skill Library.
+The library grows over time, so it may contain duplicated skills, overlapping applicable scenarios, vague descriptions, or several skills that actually describe the same reusable capability.
+
+Your task is NOT to rewrite skills. Your task is to decide how this small batch of existing skills should be organized so future skill retrieval and injection become clearer.
+
+You will receive compact Skill Summaries, not full SKILL.md files. Each summary contains the skill name, path, category, frontmatter description, applicable scenario text, and the first sentence of important workflow steps. Use these summaries to produce an organize plan only. Do not generate final SKILL.md content in this stage.
+
+# What You Are Optimizing
+
+The main optimization target is the skill boundary:
+
+1. description: the routing sentence that tells the system when to invoke the skill.
+2. applicable_scenario: the human-readable applicability boundary inside the skill body.
+3. high-level workflow fit: whether the existing steps still match the proposed boundary.
+
+Most of the value should come from clearer descriptions/scenarios and from merging truly duplicated capabilities. Avoid unnecessary workflow redesign.
+
+# Common Library Problems To Detect
+
+- Multiple skills cover the same user intent and same completion condition.
+- A skill description is too broad, too narrow, or unclear compared with its steps.
+- A skill's applicable scenario overlaps heavily with another skill.
+- A single reusable capability has been split across several near-duplicate skills.
+- A skill is an exact or near-exact duplicate of another skill and should be deprecated.
+
+# Principles
+
+- Source preservation: every output plan item must point back to source_names and source_paths from the input. Do not invent source skills.
+- Exclusive assignment: each input skill must be assigned to exactly one plan item. Do not put the same source path in both a merge/refactor/keep item and a delete_duplicate item.
+- No new capabilities: do not introduce a capability, scenario, workflow, tool, or domain that is not supported by the summaries.
+- Description first: prefer improving description and applicable_scenario over changing steps.
+- Experience preservation: assume the existing SOP/steps contain useful experience. Preserve them unless there is a clear reason not to.
+- Minimal step change: refactor may modify steps only when a step conflicts with the new boundary, is clearly duplicated, or contains one-off trajectory residue.
+- Merge conservatively: merge only when skills have substantially the same capability boundary, target object/action space, and completion condition. Similar style is not enough.
+- Delete conservatively: delete_duplicate only for duplicate or superseded skills whose useful capability is covered elsewhere in this plan.
+- No split/replace/global rebuild: this module does not split a skill into many skills, replace a skill with a newly invented one, run embedding clustering, or redesign the whole library.
+- Identity: each skill has both name and path. Both can identify a skill, but path is the primary source reference.
+
+# Action Selection Guide
+
+- keep: choose this when a skill has a clear boundary and does not significantly overlap with others. It should produce no filesystem changes later.
+- refactor: choose this when one skill should remain one skill, but its description/applicable_scenario needs clearer boundaries. Use keep_steps unless the steps visibly conflict with the new boundary.
+- merge: choose this when two or more skills represent the same reusable capability and should become one target skill. The target boundary must be supported by all source skills, not broader than them.
+- delete_duplicate: choose this when a source skill should be removed because its capability is duplicated or superseded by another skill that is kept or refactored elsewhere. Do not use delete_duplicate for a skill that is already included in a merge plan; merge already determines which source paths are removed.
+
+# Boundary Judgement Hints
+
+Treat skills as the same capability when they share:
+- the same reusable user intent;
+- the same primary target object or artifact;
+- the same action space;
+- the same success/completion condition;
+- compatible core steps.
+
+Treat skills as different capabilities when they differ in:
+- read-only analysis vs state-changing execution;
+- different target object classes;
+- different completion criteria;
+- materially different workflow stages;
+- different user decision points or risk controls.
+
+# Step Handling Policy
+
+- keep_steps: preserve the source workflow. Use for keep/refactor when steps still match the new boundary.
+- minimally_adjust_steps: use only for refactor when the workflow has obvious duplicated, conflicting, or one-off trajectory steps.
+- merge_and_deduplicate_existing_steps: use for merge to combine source experience and remove repeated steps.
+- none: use for delete_duplicate, or keep when no materialization is needed.
+
+# Output Rules
+
+Return ONLY valid JSON:
+{{
+  "plans": [
+    {{
+      "type": "keep | refactor | merge | delete_duplicate",
+      "source_names": ["..."],
+      "source_paths": ["..."],
+      "target_name": "kebab-case-name",
+      "target_path": "skills/category/kebab-case-name",
+      "target_category": "category",
+      "target_description": "...",
+      "target_applicable_scenario": "...",
+      "step_handling_policy": "keep_steps | minimally_adjust_steps | merge_and_deduplicate_existing_steps | none",
+      "reason": "..."
+    }}
+  ]
+}}
+
+# Field Requirements
+
+- Every input skill path must appear in exactly one plan.source_paths across the whole output.
+- A source path must never appear in more than one plan item.
+- source_paths must only use paths from the input.
+- keep: one source skill, target fields may equal the source identity, step_handling_policy should be keep_steps or none.
+- refactor: one source skill, target_name and target_path are required, step_handling_policy must be keep_steps or minimally_adjust_steps.
+- merge: two or more source skills, target_name and target_path are required, step_handling_policy must be merge_and_deduplicate_existing_steps. Do not also emit delete_duplicate items for any source_paths used by this merge.
+- delete_duplicate: one source skill, target fields may be empty, step_handling_policy should be none, reason must explain which separately kept/refactored skill covers it.
+- target_name must be kebab-case English.
+- source_paths and target_path must be skill package roots in the form skills/<category>/<skill_name>, not SKILL.md file paths.
+- Output should use the same natural language as the source skills for descriptions and scenarios.
+- target_description should be concise and suitable for routing.
+- target_applicable_scenario should clearly state positive applicability and nearby boundaries.
+- reason should explain the boundary decision, not just restate the action.
+
+# Skill Summaries
+{json.dumps(skill_summaries, ensure_ascii=False, indent=2)}
+"""
+
+
+def materialize_draft_prompt(plan: dict[str, Any], source_skills: list[dict[str, Any]]) -> str:
+    return f"""
+You are a Skill Materializer.
+
+You receive one organize plan item plus its source SKILL.md files.
+Generate only the new or updated target SKILL.md for human review.
+
+Deletion and keep decisions are handled by deterministic code from the organize plan. Do not output delete paths.
+The target path is determined by code from the plan's target name/category. Do not output a path.
+
+# Principles
+
+- The plan is authoritative: keep its action, source names, target name/category, description, scenario, and step policy.
+- Do not create unsupported capabilities, scenarios, tools, workflows, or risk controls.
+- Preserve existing SOP/steps by default. Change steps only when the plan explicitly requires minimal adjustment or merge deduplication.
+- The content must be a complete valid SKILL.md with YAML frontmatter name/category/description and Markdown body.
+
+# Action Rules
+
+- refactor: output the complete updated SKILL.md content. Update frontmatter description and applicable scenario; preserve SOP unless step_handling_policy is minimally_adjust_steps.
+- merge: output the complete merged SKILL.md content. Combine source-supported guidance and deduplicate repeated steps without broadening beyond the plan.
+
+# Output Rules
+
+Return ONLY valid JSON:
+{{
+  "content": "complete SKILL.md content"
+}}
+
+# Plan
+{json.dumps(plan, ensure_ascii=False, indent=2)}
+
+# Source SKILL.md Files
+{json.dumps(source_skills, ensure_ascii=False, indent=2)}
+"""

--- a/algorithm/lazymind/review/skill_organize/reports.py
+++ b/algorithm/lazymind/review/skill_organize/reports.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from lazymind.review.skill_organize.config import STAGE_FILES
+from lazymind.review.skill_review.reports import (
+    finish_stage_report,
+    stable_hash,
+    stage_error,
+    start_stage,
+    write_json_file,
+)
+
+
+def write_stage_file(base_dir: Path | None, taskid: str, stage: str, value: Any) -> Path | None:
+    if base_dir is None:
+        return None
+    filename = STAGE_FILES[stage]
+    return write_json_file(Path(base_dir) / taskid / filename, value)
+
+
+__all__ = [
+    'finish_stage_report',
+    'stable_hash',
+    'stage_error',
+    'start_stage',
+    'write_json_file',
+    'write_stage_file',
+]

--- a/algorithm/lazymind/review/skill_organize/schemas.py
+++ b/algorithm/lazymind/review/skill_organize/schemas.py
@@ -13,7 +13,6 @@ class SkillOrganizeRequest(BaseModel):
     requestid: str = Field(..., min_length=1)
     user_id: str = Field(..., min_length=1)
     skills: List[str] = Field(default_factory=list, max_length=MAX_SKILL_ORGANIZE_LIMIT)
-    fs_base_url: str = ''
     artifact_dir: Optional[str] = None
     model_configs: Dict[str, Any] = Field(default_factory=dict)
 
@@ -21,7 +20,6 @@ class SkillOrganizeRequest(BaseModel):
     def validate_payload(self) -> 'SkillOrganizeRequest':
         self.requestid = self.requestid.strip()
         self.user_id = self.user_id.strip()
-        self.fs_base_url = self.fs_base_url.strip()
         self.skills = [str(item).strip() for item in self.skills if str(item).strip()]
         if not self.skills:
             raise ValueError("'skills' must contain at least one skill name or path.")

--- a/algorithm/lazymind/review/skill_organize/schemas.py
+++ b/algorithm/lazymind/review/skill_organize/schemas.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+from typing import Any, Dict, List, Literal, Optional
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+from lazymind.review.skill_organize.config import MAX_SKILL_ORGANIZE_LIMIT
+
+
+class SkillOrganizeRequest(BaseModel):
+    model_config = ConfigDict(extra='forbid')
+
+    requestid: str = Field(..., min_length=1)
+    user_id: str = Field(..., min_length=1)
+    skills: List[str] = Field(default_factory=list, max_length=MAX_SKILL_ORGANIZE_LIMIT)
+    fs_base_url: str = ''
+    artifact_dir: Optional[str] = None
+    model_configs: Dict[str, Any] = Field(default_factory=dict)
+
+    @model_validator(mode='after')
+    def validate_payload(self) -> 'SkillOrganizeRequest':
+        self.requestid = self.requestid.strip()
+        self.user_id = self.user_id.strip()
+        self.fs_base_url = self.fs_base_url.strip()
+        self.skills = [str(item).strip() for item in self.skills if str(item).strip()]
+        if not self.skills:
+            raise ValueError("'skills' must contain at least one skill name or path.")
+        if len(set(self.skills)) != len(self.skills):
+            raise ValueError("'skills' must not contain duplicate entries.")
+        return self
+
+
+class SourceSkill(BaseModel):
+    name: str
+    path: str
+    category: str = ''
+    content: str
+
+
+class SkillSummary(BaseModel):
+    name: str
+    path: str
+    category: str = ''
+    description: str = ''
+    applicable_scenario: str = ''
+    core_steps: List[str] = Field(default_factory=list)
+
+
+class SkillPlan(BaseModel):
+    type: Literal['keep', 'refactor', 'merge', 'delete_duplicate']
+    source_names: List[str] = Field(default_factory=list)
+    source_paths: List[str] = Field(default_factory=list)
+    target_name: str = ''
+    target_path: str = ''
+    target_category: str = ''
+    target_description: str = ''
+    target_applicable_scenario: str = ''
+    step_handling_policy: Literal[
+        'keep_steps',
+        'minimally_adjust_steps',
+        'merge_and_deduplicate_existing_steps',
+        'none',
+    ] = 'none'
+    reason: str = ''
+
+
+class SkillOrganizePlan(BaseModel):
+    plans: List[SkillPlan] = Field(default_factory=list)
+
+
+class SkillFsDraftItem(BaseModel):
+    path: str
+    content: str
+
+
+class MaterializedSkillContent(BaseModel):
+    content: str
+
+
+class SkillFsDraft(BaseModel):
+    delete_paths: List[str] = Field(default_factory=list)
+    upsert_skills: List[SkillFsDraftItem] = Field(default_factory=list)
+
+
+class SkillOrganizeResult(BaseModel):
+    success: bool
+    requestid: str
+    taskid: str = ''
+    inserted_count: int = 0
+    artifact_dir: str = ''
+    error: Optional[str] = None

--- a/algorithm/lazymind/review/skill_organize/skillremotefs.py
+++ b/algorithm/lazymind/review/skill_organize/skillremotefs.py
@@ -23,10 +23,11 @@ class SkillRemoteFS:
     """Remote skill filesystem client for the Skill Organize pipeline."""
 
     def __init__(self, base_url: str = '', timeout: float | None = None):
-        self.base_url = (base_url or str(_cfg['core_api_url'] or '').strip()).rstrip('/')
+        self.base_url = (base_url or str(_cfg['skill_fs_url'] or '').strip()).rstrip('/')
         self.timeout = timeout or float(_cfg['core_api_timeout'] or 10)
+        self.session = requests.Session()
         if not self.base_url:
-            raise RuntimeError("'core_api_url' is required for skill remote fs access.")
+            raise RuntimeError("'skill_fs_url' is required for skill remote fs access.")
 
     def load_skills(self, user_id: str, skills: list[str], *, task_id: str = '') -> list[SourceSkill]:
         loaded = [_load_local_skill_if_possible(item) for item in skills]
@@ -110,7 +111,7 @@ class SkillRemoteFS:
         )
 
     def _request(self, method: str, endpoint: str, **kwargs) -> requests.Response:
-        response = requests.request(
+        response = self.session.request(
             method,
             f'{self.base_url}/remote-fs/{endpoint}',
             timeout=self.timeout,
@@ -122,6 +123,9 @@ class SkillRemoteFS:
                 f'with HTTP {response.status_code}: {response.text[:500]}'
             )
         return response
+
+    def close(self) -> None:
+        self.session.close()
 
     def _request_json(self, method: str, endpoint: str, **kwargs) -> dict:
         response = self._request(method, endpoint, **kwargs)

--- a/algorithm/lazymind/review/skill_organize/skillremotefs.py
+++ b/algorithm/lazymind/review/skill_organize/skillremotefs.py
@@ -1,0 +1,212 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Protocol
+from urllib.parse import urlparse
+
+import requests
+
+from lazymind.chat.engine.tools.infra.skill_validation import parse_skill_frontmatter
+from lazymind.config import config as _cfg
+from lazymind.review.skill_organize.schemas import SkillFsDraft, SourceSkill
+
+
+class SkillRemoteFSClient(Protocol):
+    def load_skills(self, user_id: str, skills: list[str], *, task_id: str = '') -> list[SourceSkill]:
+        ...
+
+    def apply_draft(self, user_id: str, draft: SkillFsDraft, *, task_id: str) -> dict:
+        ...
+
+
+class SkillRemoteFS:
+    """Remote skill filesystem client for the Skill Organize pipeline."""
+
+    def __init__(self, base_url: str = '', timeout: float | None = None):
+        self.base_url = (base_url or str(_cfg['core_api_url'] or '').strip()).rstrip('/')
+        self.timeout = timeout or float(_cfg['core_api_timeout'] or 10)
+        if not self.base_url:
+            raise RuntimeError("'core_api_url' is required for skill remote fs access.")
+
+    def load_skills(self, user_id: str, skills: list[str], *, task_id: str = '') -> list[SourceSkill]:
+        loaded = [_load_local_skill_if_possible(item) for item in skills]
+        if all(item is not None for item in loaded):
+            return [item for item in loaded if item is not None]
+
+        organize_task_id = _organize_task_id(task_id)
+        result: list[SourceSkill] = []
+        for item in skills:
+            path = _skill_package_root(item)
+            content = self.read_skill(path, user_id=user_id, task_id=organize_task_id)
+            frontmatter, _ = parse_skill_frontmatter(content)
+            category, name = _category_name_from_path(path)
+            result.append(SourceSkill(
+                name=str(frontmatter.get('name') or name).strip(),
+                path=path,
+                category=str(frontmatter.get('category') or category).strip(),
+                content=content,
+            ))
+        return result
+
+    def apply_draft(self, user_id: str, draft: SkillFsDraft, *, task_id: str) -> dict:
+        organize_task_id = _organize_task_id(task_id)
+        deleted_paths: list[str] = []
+        upserted_paths: list[str] = []
+        for path in draft.delete_paths:
+            package_root = _skill_package_root(path)
+            self.trash_skill(package_root, user_id=user_id)
+            deleted_paths.append(package_root)
+        for item in draft.upsert_skills:
+            path = _skill_package_root(item.path)
+            package_root = path
+            if not self.exists(package_root, user_id=user_id, task_id=organize_task_id):
+                self.mkdir(package_root, user_id=user_id, task_id=organize_task_id)
+            self.write_skill(path, item.content, user_id=user_id, task_id=organize_task_id)
+            upserted_paths.append(path)
+        return {
+            'deleted_paths': deleted_paths,
+            'upserted_paths': upserted_paths,
+        }
+
+    def read_skill(self, path: str, *, user_id: str, task_id: str = '') -> str:
+        response = self._request(
+            'GET',
+            'content',
+            params=_params(user_id=user_id, task_id=task_id, path=_skill_file_path(path)),
+        )
+        return response.text
+
+    def exists(self, path: str, *, user_id: str, task_id: str = '') -> bool:
+        payload = self._request_json(
+            'GET',
+            'exists',
+            params=_params(user_id=user_id, task_id=task_id, path=_normalize_remote_path(path)),
+        )
+        return bool(payload.get('exists'))
+
+    def mkdir(self, path: str, *, user_id: str, task_id: str) -> None:
+        self._request_json(
+            'POST',
+            'dir',
+            params=_params(user_id=user_id, task_id=task_id),
+            json={'path': _normalize_remote_path(path), 'recursive': True},
+        )
+
+    def write_skill(self, path: str, content: str, *, user_id: str, task_id: str) -> None:
+        self._request_json(
+            'PUT',
+            'content',
+            params=_params(user_id=user_id, task_id=task_id, path=_skill_file_path(path)),
+            data=content.encode('utf-8'),
+            headers={'Content-Type': 'text/markdown; charset=utf-8'},
+        )
+
+    def trash_skill(self, path: str, *, user_id: str) -> None:
+        self._request_json(
+            'POST',
+            'trash',
+            params=_params(user_id=user_id, path=_normalize_remote_path(path)),
+            json={'path': _normalize_remote_path(path)},
+        )
+
+    def _request(self, method: str, endpoint: str, **kwargs) -> requests.Response:
+        response = requests.request(
+            method,
+            f'{self.base_url}/remote-fs/{endpoint}',
+            timeout=self.timeout,
+            **kwargs,
+        )
+        if not response.ok:
+            raise RuntimeError(
+                f'SkillRemoteFS {method} /remote-fs/{endpoint} failed '
+                f'with HTTP {response.status_code}: {response.text[:500]}'
+            )
+        return response
+
+    def _request_json(self, method: str, endpoint: str, **kwargs) -> dict:
+        response = self._request(method, endpoint, **kwargs)
+        try:
+            payload: Any = response.json()
+        except ValueError as exc:
+            raise RuntimeError(f'SkillRemoteFS {method} /remote-fs/{endpoint} returned non-JSON response') from exc
+        if isinstance(payload, dict) and payload.get('code') not in (None, 0):
+            raise RuntimeError(payload.get('message') or payload.get('msg') or f'remote-fs {endpoint} failed')
+        if isinstance(payload, dict) and isinstance(payload.get('data'), dict):
+            return payload['data']
+        return payload if isinstance(payload, dict) else {}
+
+
+def build_skill_remote_fs(base_url: str = '') -> SkillRemoteFSClient:
+    return SkillRemoteFS(base_url=base_url)
+
+
+def _load_local_skill_if_possible(value: str) -> SourceSkill | None:
+    path = Path(value)
+    if not path.exists() or not path.is_file():
+        return None
+    content = path.read_text(encoding='utf-8')
+    frontmatter, _ = parse_skill_frontmatter(content)
+    name = str(frontmatter.get('name') or path.parent.name).strip()
+    category = str(frontmatter.get('category') or path.parent.parent.name).strip()
+    return SourceSkill(
+        name=name,
+        path=_normalize_local_skill_path(path),
+        category=category,
+        content=content,
+    )
+
+
+def _params(**kwargs: str) -> dict[str, str]:
+    return {key: value for key, value in kwargs.items() if value}
+
+
+def _organize_task_id(task_id: str) -> str:
+    normalized = str(task_id or '').strip()
+    if not normalized:
+        raise ValueError('task_id is required for skill organize remote fs operations')
+    return normalized if normalized.startswith('org_') else f'org_{normalized}'
+
+
+def _normalize_remote_path(path: str) -> str:
+    raw = str(path or '').strip()
+    if '://' in raw:
+        parsed = urlparse(raw)
+        raw = f'{parsed.netloc}{parsed.path}'
+    return raw.strip('/')
+
+
+def _skill_file_path(path: str) -> str:
+    normalized = _normalize_remote_path(path)
+    if not normalized:
+        raise ValueError('skill path must be non-empty')
+    if normalized.endswith('/SKILL.md'):
+        return normalized
+    if normalized.endswith('.md'):
+        return normalized
+    return f'{normalized}/SKILL.md'
+
+
+def _skill_package_root(path: str) -> str:
+    normalized = _normalize_remote_path(path)
+    if normalized.endswith('/SKILL.md'):
+        return normalized[:-len('/SKILL.md')]
+    if normalized.endswith('.md'):
+        parts = normalized.split('/')
+        if len(parts) < 4:
+            raise ValueError(f'cannot infer skill package root from path {path!r}')
+        return '/'.join(parts[:3])
+    return normalized
+
+
+def _category_name_from_path(path: str) -> tuple[str, str]:
+    root = _skill_package_root(path)
+    parts = root.split('/')
+    if len(parts) < 3 or parts[0] != 'skills':
+        raise ValueError(f'skill path must be skills/<category>/<name>, got {path!r}')
+    return parts[1], parts[2]
+
+
+def _normalize_local_skill_path(path: Path) -> str:
+    if path.name == 'SKILL.md':
+        return str(path.parent)
+    return str(path)

--- a/algorithm/lazymind/review/skill_organize/validator.py
+++ b/algorithm/lazymind/review/skill_organize/validator.py
@@ -1,0 +1,110 @@
+from __future__ import annotations
+
+import re
+from collections import Counter
+
+from lazymind.chat.engine.tools.infra.skill_validation import validate_skill_content
+from lazymind.review.skill_organize.config import MAX_SKILL_ORGANIZE_LIMIT
+from lazymind.review.skill_organize.schemas import (
+    SkillFsDraft,
+    SkillOrganizePlan,
+    SourceSkill,
+)
+
+_KEBAB_CASE_RE = re.compile(r'^[a-z0-9]+(?:-[a-z0-9]+)*$')
+
+
+def validate_source_skills(skills: list[SourceSkill]) -> None:
+    if not skills:
+        raise ValueError('at least one source skill is required')
+    if len(skills) > MAX_SKILL_ORGANIZE_LIMIT:
+        raise ValueError(f'at most {MAX_SKILL_ORGANIZE_LIMIT} skills can be organized at once')
+    _ensure_unique([item.path for item in skills], 'source skill path')
+    _ensure_unique([item.name for item in skills], 'source skill name')
+    for skill in skills:
+        if not skill.name.strip():
+            raise ValueError(f'source skill at {skill.path!r} has empty name')
+        if not skill.path.strip():
+            raise ValueError(f'source skill {skill.name!r} has empty path')
+        if skill.path.endswith('/SKILL.md'):
+            raise ValueError(f'source skill path must be package root, got {skill.path!r}')
+        if not skill.content.strip():
+            raise ValueError(f'source skill {skill.path!r} has empty content')
+
+
+def validate_plan(plan: SkillOrganizePlan, source_skills: list[SourceSkill]) -> None:
+    if not plan.plans:
+        raise ValueError('organize plan must contain at least one plan item')
+    source_paths = {item.path for item in source_skills}
+    source_names = {item.name for item in source_skills}
+    covered_paths: set[str] = set()
+    path_plan_index: dict[str, int] = {}
+    for index, item in enumerate(plan.plans):
+        label = f'plans[{index}]'
+        if not item.reason.strip():
+            raise ValueError(f'{label}.reason is required')
+        if not item.source_paths:
+            raise ValueError(f'{label}.source_paths is required')
+        _ensure_unique(item.source_paths, f'{label}.source_paths')
+        unknown_paths = sorted(set(item.source_paths) - source_paths)
+        if unknown_paths:
+            raise ValueError(f'{label}.source_paths contains unknown paths: {unknown_paths}')
+        unknown_names = sorted(set(item.source_names) - source_names)
+        if unknown_names:
+            raise ValueError(f'{label}.source_names contains unknown names: {unknown_names}')
+        for path in item.source_paths:
+            if path in path_plan_index:
+                raise ValueError(
+                    f'source path {path!r} appears in both plans[{path_plan_index[path]}] and {label}; '
+                    'each source skill must be handled by exactly one plan item'
+                )
+            path_plan_index[path] = index
+        covered_paths.update(item.source_paths)
+
+        if item.type in {'refactor', 'merge'}:
+            if not item.target_name:
+                raise ValueError(f'{label}.target_name is required for {item.type}')
+            if not _KEBAB_CASE_RE.match(item.target_name):
+                raise ValueError(f'{label}.target_name must be kebab-case English')
+            if not item.target_path:
+                raise ValueError(f'{label}.target_path is required for {item.type}')
+            if item.target_path.endswith('/SKILL.md'):
+                raise ValueError(f'{label}.target_path must be package root, got {item.target_path!r}')
+        if item.type == 'merge' and len(item.source_paths) < 2:
+            raise ValueError(f'{label}.source_paths must contain at least two paths for merge')
+        if item.type == 'refactor' and item.step_handling_policy not in {'keep_steps', 'minimally_adjust_steps'}:
+            raise ValueError(f'{label}.step_handling_policy is invalid for refactor')
+        if item.type == 'merge' and item.step_handling_policy != 'merge_and_deduplicate_existing_steps':
+            raise ValueError(f'{label}.step_handling_policy must be merge_and_deduplicate_existing_steps for merge')
+        if item.type == 'keep' and item.step_handling_policy not in {'keep_steps', 'none'}:
+            raise ValueError(f'{label}.step_handling_policy is invalid for keep')
+        if item.type == 'delete_duplicate' and len(item.source_paths) != 1:
+            raise ValueError(f'{label}.source_paths must contain exactly one path for delete_duplicate')
+
+    missing = sorted(source_paths - covered_paths)
+    if missing:
+        raise ValueError(f'every input skill path must be covered by plan; missing={missing}')
+
+
+def validate_fs_draft(draft: SkillFsDraft, source_skills: list[SourceSkill]) -> None:
+    source_paths = {item.path for item in source_skills}
+    _ensure_unique(draft.delete_paths, 'delete path')
+    _ensure_unique([item.path for item in draft.upsert_skills], 'upsert path')
+    unknown_delete_paths = sorted(set(draft.delete_paths) - source_paths)
+    if unknown_delete_paths:
+        raise ValueError(f'delete_paths contains paths outside source skills: {unknown_delete_paths}')
+    for item in draft.upsert_skills:
+        if not item.path.strip():
+            raise ValueError('upsert skill path is required')
+        if item.path.endswith('/SKILL.md'):
+            raise ValueError(f'upsert skill path must be package root, got {item.path!r}')
+        content_error = validate_skill_content(item.content)
+        if content_error:
+            raise ValueError(f'upsert skill {item.path!r} is invalid: {content_error}')
+
+
+def _ensure_unique(values: list[str], label: str) -> None:
+    counts = Counter(values)
+    duplicates = sorted(value for value, count in counts.items() if count > 1)
+    if duplicates:
+        raise ValueError(f'duplicate {label}: {duplicates}')


### PR DESCRIPTION
新增 Skill Organize 核心流程。

随着 skill 数量增长，库里会逐渐出现能力重复、职责边界模糊、适用场景重叠、描述不适合检索等问题。本模块提供一套自动化的 skill 整理流程，用来分析一批已有 skill 的能力边界、适用场景和重复关系，并生成可审阅、可追踪的整理结果。整体目标是让 skill 库更清晰、更少重复、更容易被准确检索和使用。

主要改动：
* 新增 skill_organize 模块，包含 schema、prompt、planner、materializer、validator、RemoteFS client 和中间结果输出，最终* 整理得到的skill直接写入 Draft fs，任务状态写入表格 skill_review_run_stats。
* 新增 /api/chat/skill_organize 异步接口，提交后立即返回 taskid，后台执行组织任务。
* 使用 requestid + 时间戳 生成 taskid，作为本次任务唯一 ID 和 skill_review_run_stats.id。