### PR TITLE
fix(chat): snapshot citation image maps

### DIFF
--- a/algorithm/lazymind/chat/service/utils/markdown_images.py
+++ b/algorithm/lazymind/chat/service/utils/markdown_images.py
@@ -25,7 +25,7 @@ def build_image_url_map_from_config(config: Dict[str, Any] | None) -> Dict[str, 
     url_map: Dict[str, str] = {}
     registry = config.get('_image_url_registry')
     if isinstance(registry, dict):
-        for key, value in registry.items():
+        for key, value in list(registry.items()):
             signed = static_file_url_from_any(str(value))
             if signed:
                 url_map[str(key)] = signed
@@ -33,7 +33,7 @@ def build_image_url_map_from_config(config: Dict[str, Any] | None) -> Dict[str, 
 
     refs = config.get('_citation_sources')
     if isinstance(refs, dict):
-        for source in refs.values():
+        for source in list(refs.values()):
             if not isinstance(source, dict):
                 continue
             for field in ('text', 'content'):

--- a/tests/algorithm/chat/test_markdown_images_concurrency.py
+++ b/tests/algorithm/chat/test_markdown_images_concurrency.py
@@ -1,0 +1,47 @@
+import threading
+
+from lazymind.chat.service.utils.citations import (
+    annotate_citations,
+    reset_citation_state,
+)
+from lazymind.chat.service.utils.markdown_images import build_image_url_map_from_config
+
+
+def test_build_image_url_map_tolerates_concurrent_citation_updates():
+    state = {}
+    reset_citation_state(state)
+
+    registry = state['_image_url_registry']
+    for index in range(5000):
+        registry[f'initial-{index}'] = f'/static-files/initial-{index}.png'
+
+    errors = []
+    stop = threading.Event()
+
+    def reader():
+        try:
+            for _ in range(100):
+                build_image_url_map_from_config(state)
+        except Exception as exc:  # pragma: no cover - assertion below reports the type.
+            errors.append(exc)
+        finally:
+            stop.set()
+
+    def writer():
+        index = 0
+        while not stop.is_set() and index < 10000:
+            annotate_citations({
+                'uid': f'node-{index}',
+                'docid': f'doc-{index}',
+                'text': f'/static-files/generated-{index}.png',
+                'metadata': {},
+            }, state)
+            index += 1
+
+    threads = [threading.Thread(target=reader), threading.Thread(target=writer)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+
+    assert errors == []


### PR DESCRIPTION
## Summary

- Snapshot citation image registries before iterating so concurrent citation updates cannot raise `dictionary changed size during iteration`.
- Add a regression test that reads the image URL map while citation annotation mutates the same request-local state.

## Root Cause

`StreamCallHelper` runs the agent in a worker thread while the SSE path formats streamed/final frames. KB tools can mutate `citation_state` via `annotate_citations` at the same time `rewrite_markdown_image_urls` iterates `_image_url_registry` or `_citation_sources`.

## Validation

- `python -m pytest tests/algorithm/chat/test_markdown_images.py tests/algorithm/chat/test_markdown_images_blocked.py tests/algorithm/chat/test_markdown_images_concurrency.py tests/algorithm/chat/test_agentic_event_translator.py`
