### PR TITLE
macOS app ad-hoc signing

### DIFF
--- a/desktop/README.md
+++ b/desktop/README.md
@@ -7,6 +7,7 @@ Planned first target:
 - macOS arm64 internal `.app` / `.zip`
 - bundled Go binaries, process-compose, Caddy, frontend dist, Python 3.11 runtime, and Python venvs
 - no bundled model weights
+- no Apple Developer ID signing or notarization
 
 Build entry:
 
@@ -19,7 +20,23 @@ Expected output:
 ```text
 desktop/dist/mac-arm64/LazyMind.app
 desktop/dist/LazyMind-darwin-arm64.zip
+desktop/dist/SHA256SUMS.txt
+desktop/dist/LazyMind-darwin-arm64.build.json
 ```
+
+The default build applies an ad-hoc code signature before zipping:
+
+```bash
+LAZYMIND_DESKTOP_SIGNING_MODE=adhoc make desktop-darwin-arm64
+```
+
+Use `LAZYMIND_DESKTOP_SIGNING_MODE=none` only when debugging signing issues.
+Ad-hoc signing is only for internal testing. It is not Developer ID signing and
+does not satisfy Apple notarization, so first-run Gatekeeper approval is still
+expected on another Mac.
+
+Tester instructions live in [RUN_ON_MAC.md](RUN_ON_MAC.md). Send testers the
+zip and `SHA256SUMS.txt`; the build manifest is for release/debug records.
 
 `desktop/build/` and `desktop/dist/` are per-worktree generated outputs.
 The build re-creates the bundled runtime for the current worktree on every run,

--- a/desktop/RUN_ON_MAC.md
+++ b/desktop/RUN_ON_MAC.md
@@ -1,0 +1,80 @@
+# 在 Apple Silicon Mac 上运行 LazyMind 内测版
+
+## 适用范围
+
+这个包只用于内部测试，当前只支持 Apple Silicon Mac。Intel Mac 暂不支持。
+
+这个版本没有 Apple Developer ID 签名，也没有 Apple notarization。macOS 第一次启动时可能会拦截；只有在确认包来源可信时才继续打开。Apple 官方的放行说明见 [Open a Mac app from an unidentified developer](https://support.apple.com/en-us/102445)。
+
+## 你会收到
+
+- `LazyMind-darwin-arm64.zip`
+- `SHA256SUMS.txt`
+
+## 安装
+
+1. 把两个文件放到同一个目录，例如 `~/Downloads`。
+2. 可选但推荐：打开 Terminal 校验 zip 完整性。
+
+   ```bash
+   cd ~/Downloads
+   shasum -a 256 -c SHA256SUMS.txt
+   ```
+
+   看到 `LazyMind-darwin-arm64.zip: OK` 后继续。
+
+3. 双击解压 `LazyMind-darwin-arm64.zip`。
+4. 把 `LazyMind.app` 拖到 `/Applications`。
+
+## 首次启动
+
+1. 双击 `/Applications/LazyMind.app`。
+2. 如果 macOS 提示无法验证开发者或无法检查恶意软件，先点 `Done` 或关闭提示。
+3. 打开 `System Settings` -> `Privacy & Security`，滚动到底部，点击 `Open Anyway`。
+4. 再次确认 `Open`。之后通常可以直接双击启动。
+
+## 终端兜底
+
+仅在你确认包来源可信、并且 UI 放行仍失败时使用：
+
+```bash
+xattr -dr com.apple.quarantine /Applications/LazyMind.app
+codesign --verify --deep --strict --verbose=2 /Applications/LazyMind.app
+open /Applications/LazyMind.app
+```
+
+如果 `codesign --verify` 失败，请不要继续运行，把完整输出发给开发者。
+
+## 启动和排障
+
+首次启动可能需要几分钟，因为 LazyMind 会启动本地 runtime。启动页可以点：
+
+- `Show startup log` 查看启动进度
+- `Copy logs` 复制日志
+- `Open logs` 打开日志目录
+
+反馈问题时请提供这个文件：
+
+```text
+~/Library/Application Support/LazyMind/runtime/logs/desktop-startup.log
+```
+
+也可以提供整个日志目录：
+
+```text
+~/Library/Application Support/LazyMind/runtime/logs
+```
+
+## 卸载
+
+退出 LazyMind 后删除：
+
+```text
+/Applications/LazyMind.app
+```
+
+如需清除本地测试数据，再删除：
+
+```text
+~/Library/Application Support/LazyMind
+```

--- a/desktop/scripts/build-darwin-arm64.sh
+++ b/desktop/scripts/build-darwin-arm64.sh
@@ -112,6 +112,30 @@ sign_app() {
   esac
 }
 
+verify_zipped_app() {
+  local app_path="$1"
+  local zip_path="$2"
+  local temp_dir
+  local extracted_app
+
+  if [[ "${SIGNING_MODE}" == "none" ]]; then
+    echo "==> Skipping archived app signature verification (LAZYMIND_DESKTOP_SIGNING_MODE=none)"
+    return 0
+  fi
+  echo "==> Verifying archived app signature"
+  temp_dir="$(mktemp -d "${TMPDIR:-/tmp}/lazymind-archive-verify.XXXXXX")"
+  if ! ditto -x -k "${zip_path}" "${temp_dir}"; then
+    remove_generated_path "${temp_dir}"
+    return 1
+  fi
+  extracted_app="${temp_dir}/$(basename "${app_path}")"
+  if ! codesign --verify --deep --strict --verbose=2 "${extracted_app}"; then
+    remove_generated_path "${temp_dir}"
+    return 1
+  fi
+  remove_generated_path "${temp_dir}"
+}
+
 write_release_metadata() {
   local app_path="$1"
   local zip_path="$2"
@@ -316,7 +340,8 @@ fi
 if [[ -d "${APP_PATH}" ]]; then
   sign_app "${APP_PATH}"
   remove_generated_path "${ZIP_PATH}"
-  ditto -c -k --norsrc --keepParent "${APP_PATH}" "${ZIP_PATH}"
+  ditto -c -k --keepParent "${APP_PATH}" "${ZIP_PATH}"
+  verify_zipped_app "${APP_PATH}" "${ZIP_PATH}"
   write_release_metadata "${APP_PATH}" "${ZIP_PATH}"
   echo "LazyMind.app: ${APP_PATH}"
   echo "Zip: ${ZIP_PATH}"

--- a/desktop/scripts/build-darwin-arm64.sh
+++ b/desktop/scripts/build-darwin-arm64.sh
@@ -7,18 +7,29 @@ RUNTIME_ROOT="${BUILD_ROOT}/runtime"
 DIST_ROOT="${ROOT}/desktop/dist"
 APP_RUNTIME_ROOT="${DIST_ROOT}/runtime"
 APP_ICON="${ROOT}/desktop/electron/assets/LazyMind.icns"
+SHA256SUMS_PATH="${DIST_ROOT}/SHA256SUMS.txt"
+BUILD_MANIFEST_PATH="${DIST_ROOT}/LazyMind-darwin-arm64.build.json"
 
 GO_BIN="${GO:-go}"
 PNPM_BIN="${PNPM:-pnpm}"
 UV_BIN="${UV:-uv}"
 GO_BUILD_FLAGS=(-trimpath -buildvcs=false -ldflags="-s -w")
 GO_INSTALL_FLAGS=(-trimpath -ldflags="-s -w")
+SIGNING_MODE="${LAZYMIND_DESKTOP_SIGNING_MODE:-adhoc}"
 
 : "${ELECTRON_CACHE:=${HOME}/Library/Caches/electron}"
 : "${ELECTRON_BUILDER_CACHE:=${HOME}/Library/Caches/electron-builder}"
 export ELECTRON_CACHE
 export ELECTRON_BUILDER_CACHE
 export PYTHONDONTWRITEBYTECODE=1
+
+case "${SIGNING_MODE}" in
+  adhoc|none) ;;
+  *)
+    echo "LAZYMIND_DESKTOP_SIGNING_MODE must be adhoc or none, got: ${SIGNING_MODE}" >&2
+    exit 2
+    ;;
+esac
 
 remove_generated_path() {
   local target="$1"
@@ -80,6 +91,122 @@ prune_runtime_app() {
   fi
   remove_generated_path "${app_root}/algorithm/lazyllm/docs"
   remove_generated_path "${app_root}/backend/core/core"
+}
+
+sha256_file() {
+  shasum -a 256 "$1" | awk '{print $1}'
+}
+
+sign_app() {
+  local app_path="$1"
+  case "${SIGNING_MODE}" in
+    adhoc)
+      echo "==> Applying ad-hoc code signature"
+      xattr -cr "${app_path}" 2>/dev/null || true
+      codesign --force --deep --sign - "${app_path}"
+      codesign --verify --deep --strict --verbose=2 "${app_path}"
+      ;;
+    none)
+      echo "==> Skipping code signing (LAZYMIND_DESKTOP_SIGNING_MODE=none)"
+      ;;
+  esac
+}
+
+write_release_metadata() {
+  local app_path="$1"
+  local zip_path="$2"
+  local zip_hash
+  local git_commit
+  local git_dirty
+
+  zip_hash="$(sha256_file "${zip_path}")"
+  git_commit="$(git -C "${ROOT}" rev-parse HEAD 2>/dev/null || printf 'unknown')"
+  if [[ -n "$(git -C "${ROOT}" status --short 2>/dev/null)" ]]; then
+    git_dirty="true"
+  else
+    git_dirty="false"
+  fi
+
+  {
+    printf '%s  %s\n' "${zip_hash}" "$(basename "${zip_path}")"
+  } > "${SHA256SUMS_PATH}"
+
+  BUILD_MANIFEST_PATH="${BUILD_MANIFEST_PATH}" \
+  ROOT="${ROOT}" \
+  APP_PATH="${app_path}" \
+  ZIP_PATH="${zip_path}" \
+  ZIP_HASH="${zip_hash}" \
+  GIT_COMMIT="${git_commit}" \
+  GIT_DIRTY="${git_dirty}" \
+  SIGNING_MODE="${SIGNING_MODE}" \
+  node -e '
+const crypto = require("node:crypto");
+const fs = require("node:fs");
+const path = require("node:path");
+
+function hashFileTree(root) {
+  const digest = crypto.createHash("sha256");
+
+  function walk(dir) {
+    const entries = fs.readdirSync(dir).sort((a, b) => a.localeCompare(b));
+    for (const entry of entries) {
+      const full = path.join(dir, entry);
+      const rel = path.relative(root, full);
+      const stat = fs.lstatSync(full);
+      digest.update(rel);
+      digest.update("\0");
+      if (stat.isDirectory()) {
+        digest.update("dir\0");
+        walk(full);
+      } else if (stat.isSymbolicLink()) {
+        digest.update("symlink\0");
+        digest.update(fs.readlinkSync(full));
+        digest.update("\0");
+      } else if (stat.isFile()) {
+        digest.update("file\0");
+        digest.update(fs.readFileSync(full));
+        digest.update("\0");
+      }
+    }
+  }
+
+  walk(root);
+  return digest.digest("hex");
+}
+
+const manifest = {
+  version: 1,
+  product: "LazyMind",
+  platform: "darwin",
+  arch: "arm64",
+  builtAt: new Date().toISOString(),
+  git: {
+    commit: process.env.GIT_COMMIT,
+    dirty: process.env.GIT_DIRTY === "true"
+  },
+  signing: {
+    mode: process.env.SIGNING_MODE,
+    note: process.env.SIGNING_MODE === "adhoc"
+      ? "Ad-hoc signed for internal testing. This is not Developer ID signing or notarization."
+      : "Unsigned internal testing build."
+  },
+  artifacts: {
+    app: {
+      path: path.relative(process.env.ROOT, process.env.APP_PATH),
+      treeSha256: hashFileTree(process.env.APP_PATH)
+    },
+    zip: {
+      path: path.relative(process.env.ROOT, process.env.ZIP_PATH),
+      sha256: process.env.ZIP_HASH
+    },
+    checksums: {
+      path: path.relative(process.env.ROOT, path.join(path.dirname(process.env.ZIP_PATH), "SHA256SUMS.txt"))
+    }
+  }
+};
+
+fs.writeFileSync(process.env.BUILD_MANIFEST_PATH, `${JSON.stringify(manifest, null, 2)}\n`);
+'
 }
 
 mkdir -p \
@@ -178,9 +305,16 @@ if [[ ! -d "${APP_PATH}" ]]; then
   fi
 fi
 if [[ -d "${APP_PATH}" ]]; then
-  ditto -c -k --keepParent "${APP_PATH}" "${ZIP_PATH}"
+  sign_app "${APP_PATH}"
+  xattr -cr "${APP_PATH}" 2>/dev/null || true
+  remove_generated_path "${ZIP_PATH}"
+  ditto -c -k --norsrc --keepParent "${APP_PATH}" "${ZIP_PATH}"
+  write_release_metadata "${APP_PATH}" "${ZIP_PATH}"
   echo "LazyMind.app: ${APP_PATH}"
   echo "Zip: ${ZIP_PATH}"
+  echo "Checksums: ${SHA256SUMS_PATH}"
+  echo "Build manifest: ${BUILD_MANIFEST_PATH}"
+  echo "Tester guide: ${ROOT}/desktop/RUN_ON_MAC.md"
 else
   echo "Expected app not found: ${APP_PATH}" >&2
   exit 1

--- a/desktop/scripts/build-darwin-arm64.sh
+++ b/desktop/scripts/build-darwin-arm64.sh
@@ -148,7 +148,7 @@ function hashFileTree(root) {
   const digest = crypto.createHash("sha256");
 
   function walk(dir) {
-    const entries = fs.readdirSync(dir).sort((a, b) => a.localeCompare(b));
+    const entries = fs.readdirSync(dir).sort();
     for (const entry of entries) {
       const full = path.join(dir, entry);
       const rel = path.relative(root, full);
@@ -164,7 +164,16 @@ function hashFileTree(root) {
         digest.update("\0");
       } else if (stat.isFile()) {
         digest.update("file\0");
-        digest.update(fs.readFileSync(full));
+        const fd = fs.openSync(full, "r");
+        const buffer = Buffer.alloc(65536);
+        try {
+          let bytesRead;
+          while ((bytesRead = fs.readSync(fd, buffer, 0, buffer.length, null)) > 0) {
+            digest.update(buffer.subarray(0, bytesRead));
+          }
+        } finally {
+          fs.closeSync(fd);
+        }
         digest.update("\0");
       }
     }
@@ -306,7 +315,6 @@ if [[ ! -d "${APP_PATH}" ]]; then
 fi
 if [[ -d "${APP_PATH}" ]]; then
   sign_app "${APP_PATH}"
-  xattr -cr "${APP_PATH}" 2>/dev/null || true
   remove_generated_path "${ZIP_PATH}"
   ditto -c -k --norsrc --keepParent "${APP_PATH}" "${ZIP_PATH}"
   write_release_metadata "${APP_PATH}" "${ZIP_PATH}"


### PR DESCRIPTION
在使用Apple Developer Program账号进行签名和公证之前，先使用开发期的临时签名方案进行测试。

## Summary

- add an ad-hoc signing step to the Darwin arm64 desktop packaging flow
- generate SHA256 checksums and a build manifest for internal release records
- document how testers can run the unsigned/not-notarized Apple Silicon build on another Mac

## Why

We do not currently have an Apple Developer Program account, but still need a practical internal testing flow where a `.app` can be copied to another Mac. This keeps the build explicit about its trust boundary: ad-hoc signing is for internal consistency checks only and does not replace Developer ID signing or notarization.

## Impact

- `make desktop-darwin-arm64` now defaults to `LAZYMIND_DESKTOP_SIGNING_MODE=adhoc` and verifies the generated `.app` before zipping.
- The build emits `desktop/dist/SHA256SUMS.txt` and `desktop/dist/LazyMind-darwin-arm64.build.json` alongside the existing zip.
- Testers get a dedicated Apple Silicon run guide with Gatekeeper UI steps, terminal fallback, logs, and uninstall instructions.

## Validation

- `bash -n desktop/scripts/build-darwin-arm64.sh`
- `git diff --check upstream/main...HEAD`
- `LAZYMIND_DESKTOP_SIGNING_MODE=bad bash desktop/scripts/build-darwin-arm64.sh` exits with code `2`

The full `make desktop-darwin-arm64` build was not run in this thread because it is heavy and may download/build Go, pnpm, Electron, and uv-managed Python dependencies.