### PR TITLE
Fix local auth session initialization and identity propagation

### DIFF
--- a/frontend/src/components/request.ts
+++ b/frontend/src/components/request.ts
@@ -5,6 +5,7 @@ import { AgentAppsAuth } from "@/components/auth";
 import i18n from "@/i18n";
 import { getApiBaseUrl } from "@/runtime/apiBase";
 import {
+  ensureLocalSession,
   isLocalSessionEnabled,
   restoreLocalSessionAndGetToken,
 } from "@/runtime/localSession";
@@ -335,7 +336,12 @@ export const handleError = async (error: AxiosError) => {
 };
 
 axiosInstance.interceptors.request.use(
-  (config) => applyOptionalAuthHeader(config),
+  async (config) => {
+    if (isLocalSessionEnabled()) {
+      await ensureLocalSession();
+    }
+    return applyOptionalAuthHeader(config);
+  },
   handleError,
 );
 axiosInstance.interceptors.response.use((response) => response, handleError);

--- a/frontend/src/components/request.ts
+++ b/frontend/src/components/request.ts
@@ -7,6 +7,7 @@ import { getApiBaseUrl } from "@/runtime/apiBase";
 import {
   ensureLocalSession,
   isLocalSessionEnabled,
+  localSessionInitialized,
   restoreLocalSessionAndGetToken,
 } from "@/runtime/localSession";
 
@@ -336,9 +337,12 @@ export const handleError = async (error: AxiosError) => {
 };
 
 axiosInstance.interceptors.request.use(
-  async (config) => {
-    if (isLocalSessionEnabled()) {
-      await ensureLocalSession();
+  (config) => {
+    if (
+      isLocalSessionEnabled() &&
+      (!AgentAppsAuth.getUserInfo()?.token || !localSessionInitialized)
+    ) {
+      return ensureLocalSession().then(() => applyOptionalAuthHeader(config));
     }
     return applyOptionalAuthHeader(config);
   },

--- a/frontend/src/layouts/MainLayout.tsx
+++ b/frontend/src/layouts/MainLayout.tsx
@@ -203,10 +203,12 @@ export default function MainLayout() {
       setUserInfo(AgentAppsAuth.getUserInfo());
     }
   }, []);
-  const localSessionGate = useLocalSessionGate(isLoggedIn, refreshLayoutUser);
+  const localSessionGate = useLocalSessionGate(refreshLayoutUser);
 
   useEffect(() => {
-    refreshLayoutUser();
+    if (!localSessionGate.enabled) {
+      refreshLayoutUser();
+    }
 
     const handleVisibilityChange = () => {
       if (document.visibilityState === "visible") {
@@ -236,7 +238,7 @@ export default function MainLayout() {
       window.removeEventListener("storage", handleStorage);
       window.removeEventListener(AUTH_USER_CHANGE_EVENT, handleUserChange);
     };
-  }, [refreshLayoutUser]);
+  }, [localSessionGate.enabled, refreshLayoutUser]);
 
   useEffect(() => {
     if (!isAdminUser && developerActive) {
@@ -629,29 +631,30 @@ export default function MainLayout() {
     }
   };
 
-  if (!isLoggedIn) {
-    if (localSessionGate.enabled) {
-      return (
-        <div className="local-session-gate">
-          <div className="local-session-panel">
-            {localSessionGate.loading ? <Spin /> : null}
-            <div className="local-session-title">LazyMind</div>
-            <div className="local-session-message">
-              {localSessionGate.error || t("layout.preparingLocalSession", "Preparing local session...")}
-            </div>
-            {localSessionGate.error ? (
-              <Button
-                type="primary"
-                loading={localSessionGate.loading}
-                onClick={localSessionGate.retry}
-              >
-                {t("common.retry", "Retry")}
-              </Button>
-            ) : null}
+  if (localSessionGate.enabled && (localSessionGate.loading || localSessionGate.error)) {
+    return (
+      <div className="local-session-gate">
+        <div className="local-session-panel">
+          {localSessionGate.loading ? <Spin /> : null}
+          <div className="local-session-title">LazyMind</div>
+          <div className="local-session-message">
+            {localSessionGate.error || t("layout.preparingLocalSession", "Preparing local session...")}
           </div>
+          {localSessionGate.error ? (
+            <Button
+              type="primary"
+              loading={localSessionGate.loading}
+              onClick={localSessionGate.retry}
+            >
+              {t("common.retry", "Retry")}
+            </Button>
+          ) : null}
         </div>
-      );
-    }
+      </div>
+    );
+  }
+
+  if (!isLoggedIn) {
     return <Navigate to="/login" replace />;
   }
 

--- a/frontend/src/runtime/localSession.ts
+++ b/frontend/src/runtime/localSession.ts
@@ -3,7 +3,7 @@ import { apiUrl } from "./apiBase";
 import { runtimeFeatures } from "./features";
 
 let localSessionPromise: Promise<UserInfo | null> | null = null;
-let localSessionInitialized = false;
+export let localSessionInitialized = false;
 
 export interface LocalSessionOptions {
   force?: boolean;

--- a/frontend/src/runtime/localSession.ts
+++ b/frontend/src/runtime/localSession.ts
@@ -3,6 +3,7 @@ import { apiUrl } from "./apiBase";
 import { runtimeFeatures } from "./features";
 
 let localSessionPromise: Promise<UserInfo | null> | null = null;
+let localSessionInitialized = false;
 
 export interface LocalSessionOptions {
   force?: boolean;
@@ -24,17 +25,18 @@ export async function ensureLocalSession(
   }
 
   const current = AgentAppsAuth.getUserInfo();
-  if (current?.token && !options?.force) {
+  if (current?.token && localSessionInitialized && !options?.force) {
     return current;
   }
 
-  if (!localSessionPromise || options?.force) {
+  if (!localSessionPromise) {
     localSessionPromise = (async () => {
       const session = await requestLocalAdminSession(Boolean(options?.force));
       if (!session?.token) {
         throw new Error("Local admin session did not return an access token");
       }
       AgentAppsAuth.setUserInfo(session);
+      localSessionInitialized = true;
       return AgentAppsAuth.getUserInfo();
     })().finally(() => {
       localSessionPromise = null;

--- a/frontend/src/runtime/useLocalSessionGate.ts
+++ b/frontend/src/runtime/useLocalSessionGate.ts
@@ -1,5 +1,4 @@
 import { useCallback, useEffect, useState } from "react";
-import { AgentAppsAuth } from "@/components/auth";
 import { ensureLocalSession, isLocalSessionEnabled } from "./localSession";
 
 export interface LocalSessionGateState {
@@ -10,11 +9,10 @@ export interface LocalSessionGateState {
 }
 
 export function useLocalSessionGate(
-  isLoggedIn: boolean,
   refreshLayoutUser: () => Promise<void>,
 ): LocalSessionGateState {
   const enabled = isLocalSessionEnabled();
-  const [loading, setLoading] = useState(() => enabled && !AgentAppsAuth.isLoggedIn());
+  const [loading, setLoading] = useState(enabled);
   const [error, setError] = useState("");
 
   const restore = useCallback(
@@ -35,7 +33,7 @@ export function useLocalSessionGate(
   );
 
   useEffect(() => {
-    if (!enabled || isLoggedIn) {
+    if (!enabled) {
       setLoading(false);
       return;
     }
@@ -65,7 +63,7 @@ export function useLocalSessionGate(
     return () => {
       cancelled = true;
     };
-  }, [enabled, isLoggedIn, refreshLayoutUser]);
+  }, [enabled, refreshLayoutUser]);
 
   const retry = useCallback(() => restore(true), [restore]);
 

--- a/local/local-runtime-manager/auth_service.go
+++ b/local/local-runtime-manager/auth_service.go
@@ -21,6 +21,7 @@ import (
 
 const (
 	authServiceOpenAPIExportEnvVar = "LAZYMIND_AUTH_OPENAPI_EXPORT_ENABLED"
+	authServicePermissionsEnvVar   = "LAZYMIND_AUTH_API_PERMISSIONS_FILE"
 	authServiceHealthPath          = "/api/authservice/auth/health"
 	authServiceHealthTimeout       = 180 * time.Second
 	authServiceDBWaitTimeout       = 180 * time.Second
@@ -39,6 +40,9 @@ func (m *AuthServiceManager) Run(ctx context.Context, cfg RuntimeConfig, paths R
 		return err
 	}
 	if err := m.preparePythonEnv(ctx, cfg, paths); err != nil {
+		return err
+	}
+	if err := m.generateAPIPermissions(ctx, paths); err != nil {
 		return err
 	}
 	if err := waitForAuthDatabase(ctx, cfg.AuthService.DatabaseURL); err != nil {
@@ -215,6 +219,39 @@ func (m *AuthServiceManager) installRequirements(ctx context.Context, paths Runt
 	return fmt.Errorf("install auth-service requirements failed: %w (%s)", runErr, strings.TrimSpace(res.Stderr))
 }
 
+func (m *AuthServiceManager) generateAPIPermissions(ctx context.Context, paths RuntimePaths) error {
+	output := authServicePermissionsPath(paths)
+	script := filepath.Join(paths.RepoRoot, "backend", "scripts", "extract_api_permissions.py")
+	sources := []string{
+		filepath.Join(paths.RepoRoot, "backend", "core"),
+		filepath.Join(paths.RepoRoot, "backend", "auth-service"),
+		filepath.Join(paths.RepoRoot, "backend", "scan-control-plane"),
+	}
+	args := []string{
+		script,
+		"--output", output,
+		"--exclude", "scripts,core,vendor",
+	}
+	args = append(args, sources...)
+	res, runErr := m.runner.Run(ctx, Command{
+		Name: authServicePythonPath(paths),
+		Args: args,
+		Dir:  paths.RepoRoot,
+		Env:  pythonRuntimeEnv(paths),
+	})
+	if runErr != nil {
+		return fmt.Errorf("generate auth-service API permissions failed: %w (%s)", runErr, strings.TrimSpace(res.Stderr))
+	}
+	if info, err := os.Stat(output); err != nil || info.IsDir() {
+		return fmt.Errorf("generate auth-service API permissions did not create %s", output)
+	}
+	return nil
+}
+
+func authServicePermissionsPath(paths RuntimePaths) string {
+	return filepath.Join(paths.GeneratedDir, "auth-api-permissions.json")
+}
+
 func authServicePythonPath(paths RuntimePaths) string {
 	if runtime.GOOS == "windows" {
 		return filepath.Join(paths.AuthServiceVenvDir, "Scripts", "python.exe")
@@ -246,6 +283,7 @@ func authServiceEnv(cfg RuntimeConfig, paths RuntimePaths) []string {
 		"LAZYMIND_BOOTSTRAP_ADMIN_PASSWORD=" + envText("LAZYMIND_BOOTSTRAP_ADMIN_PASSWORD", "admin"),
 		"LAZYMIND_MODEL_CONFIG_PATH=" + envText("LAZYMIND_MODEL_CONFIG_PATH", "dynamic"),
 		"LAZYMIND_CHAT_UNLIKE_SWITCH=" + envText("LAZYMIND_CHAT_UNLIKE_SWITCH", "true"),
+		authServicePermissionsEnvVar + "=" + authServicePermissionsPath(paths),
 		authServiceOpenAPIExportEnvVar + "=0",
 	}
 }

--- a/local/local-runtime-manager/auth_service.go
+++ b/local/local-runtime-manager/auth_service.go
@@ -242,8 +242,12 @@ func (m *AuthServiceManager) generateAPIPermissions(ctx context.Context, paths R
 	if runErr != nil {
 		return fmt.Errorf("generate auth-service API permissions failed: %w (%s)", runErr, strings.TrimSpace(res.Stderr))
 	}
-	if info, err := os.Stat(output); err != nil || info.IsDir() {
-		return fmt.Errorf("generate auth-service API permissions did not create %s", output)
+	info, err := os.Stat(output)
+	if err != nil {
+		return fmt.Errorf("generate auth-service API permissions output file error: %w", err)
+	}
+	if info.IsDir() {
+		return fmt.Errorf("generate auth-service API permissions output path %s is a directory", output)
 	}
 	return nil
 }

--- a/local/local-runtime-manager/auth_service_test.go
+++ b/local/local-runtime-manager/auth_service_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -109,6 +110,7 @@ func TestAuthServiceInstallRequirementsUsesUVOnly(t *testing.T) {
 
 func TestAuthServiceGenerateAPIPermissionsUsesRuntimeOutput(t *testing.T) {
 	repo := t.TempDir()
+	t.Setenv(runtimeRootEnvVar, filepath.Join(repo, "runtime"))
 	writeComposeFixture(t, repo)
 	_, paths, err := NewRuntimeConfig(defaultProfileValue(), repo)
 	if err != nil {
@@ -150,4 +152,31 @@ func TestAuthServiceGenerateAPIPermissionsUsesRuntimeOutput(t *testing.T) {
 	}
 	runner.assertCommandCount(1)
 	assertEnvContains(t, authServiceEnv(RuntimeConfig{}, paths), authServicePermissionsEnvVar+"="+output)
+}
+
+func TestAuthServiceGenerateAPIPermissionsPreservesOutputStatError(t *testing.T) {
+	repo := t.TempDir()
+	t.Setenv(runtimeRootEnvVar, filepath.Join(repo, "runtime"))
+	writeComposeFixture(t, repo)
+	_, paths, err := NewRuntimeConfig(defaultProfileValue(), repo)
+	if err != nil {
+		t.Fatalf("runtime config: %v", err)
+	}
+	if err := paths.EnsureAllDirs(); err != nil {
+		t.Fatalf("ensure runtime dirs: %v", err)
+	}
+
+	runner := &fakeRunner{t: t}
+	runner.handlers = append(runner.handlers, func(Command) (CommandResult, error) {
+		return CommandResult{}, nil
+	})
+
+	manager := NewAuthServiceManager(runner)
+	err = manager.generateAPIPermissions(context.Background(), paths)
+	if !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("generate API permissions error = %v, want wrapped os.ErrNotExist", err)
+	}
+	if !strings.Contains(err.Error(), "output file error") {
+		t.Fatalf("generate API permissions error = %q, want output file context", err)
+	}
 }

--- a/local/local-runtime-manager/auth_service_test.go
+++ b/local/local-runtime-manager/auth_service_test.go
@@ -106,3 +106,48 @@ func TestAuthServiceInstallRequirementsUsesUVOnly(t *testing.T) {
 	}
 	runner.assertCommandCount(1)
 }
+
+func TestAuthServiceGenerateAPIPermissionsUsesRuntimeOutput(t *testing.T) {
+	repo := t.TempDir()
+	writeComposeFixture(t, repo)
+	_, paths, err := NewRuntimeConfig(defaultProfileValue(), repo)
+	if err != nil {
+		t.Fatalf("runtime config: %v", err)
+	}
+	if err := paths.EnsureAllDirs(); err != nil {
+		t.Fatalf("ensure runtime dirs: %v", err)
+	}
+
+	script := filepath.Join(repo, "backend", "scripts", "extract_api_permissions.py")
+	if err := os.MkdirAll(filepath.Dir(script), 0o755); err != nil {
+		t.Fatalf("mkdir scripts dir: %v", err)
+	}
+	if err := os.WriteFile(script, []byte("# fixture\n"), 0o644); err != nil {
+		t.Fatalf("write permission extractor: %v", err)
+	}
+
+	output := authServicePermissionsPath(paths)
+	runner := &fakeRunner{t: t}
+	runner.handlers = append(runner.handlers, func(cmd Command) (CommandResult, error) {
+		assertCommand(t, cmd,
+			authServicePythonPath(paths),
+			script,
+			"--output", output,
+			"--exclude", "scripts,core,vendor",
+			filepath.Join(repo, "backend", "core"),
+			filepath.Join(repo, "backend", "auth-service"),
+			filepath.Join(repo, "backend", "scan-control-plane"),
+		)
+		if err := os.WriteFile(output, []byte("[]\n"), 0o600); err != nil {
+			t.Fatalf("write generated permissions: %v", err)
+		}
+		return CommandResult{}, nil
+	})
+
+	manager := NewAuthServiceManager(runner)
+	if err := manager.generateAPIPermissions(context.Background(), paths); err != nil {
+		t.Fatalf("generate API permissions: %v", err)
+	}
+	runner.assertCommandCount(1)
+	assertEnvContains(t, authServiceEnv(RuntimeConfig{}, paths), authServicePermissionsEnvVar+"="+output)
+}


### PR DESCRIPTION
## What changed

- Generate the API permission map before starting auth-service in the local runtime and load it through `LAZYMIND_AUTH_API_PERMISSIONS_FILE`.
- Synchronize the local administrator session once before the first authenticated frontend request.
- Hold the local session gate and Axios requests until session initialization finishes.
- Add local-runtime-manager coverage for permission-map generation and environment wiring.

## Root cause

The cloud auth-service image generates `api_permissions.json` during its build, but the local runtime did not. When a stored token was expired or invalid, auth-service treated unmatched core routes as anonymously allowed. local-proxy then forwarded the request without trusted identity claims, and core returned `X-User-Id is required`.

The frontend also considered any stored token sufficient to render the application, so first-load requests could race ahead of local administrator session restoration.

## Impact

Local and desktop startup now use the same route-permission source as cloud mode. First-load requests wait for a valid local session, and expired tokens are rejected at the gateway with `401 Unauthorized` instead of reaching core without `X-User-Id`.

## Validation

- `go test ./...` in `local/local-runtime-manager`
- `go test ./...` in `local/local-proxy`
- Full `make local-down` / `make local-up` restart
- Confirmed the generated permission map contains the affected model-provider and user-preference routes
- Confirmed an invalid token returns `401 {"detail":"Unauthorized"}` from local-proxy
- Confirmed first browser load completes without `X-User-Id` or HTTP 400 errors
- `git diff --check`

Full frontend TypeScript checking remains blocked by existing generated-client and legacy component errors unrelated to this change.
