### PR TITLE
fix(plugin+parse): Fix PPTM parsing, add bbox for img doc node, img plugin preflight check and rendering

### DIFF
--- a/algorithm/lazymind/parsing/engine/transform/post_func.py
+++ b/algorithm/lazymind/parsing/engine/transform/post_func.py
@@ -368,15 +368,11 @@ class ImageNodeLoader(ModuleBase):
             return True
         return bool(_extract_image_path(node))
 
-    def _extract_layout_metadata(self, node: DocNode, image_path: str) -> dict:
+    def _extract_layout_metadata(self, node: DocNode) -> dict:
         metadata = node.metadata or {}
         bbox = copy.deepcopy(metadata.get('bbox', [0, 0, 0, 0]))
         page = metadata.get('page', 0)
         node_type = metadata.get('type', 'image')
-        LOG.info(
-            f'[ImageNodeLoader] inherit node layout image_path={image_path}, '
-            f'page={page}, bbox={bbox}, type={node_type}'
-        )
         return {
             'page': page,
             'bbox': bbox,
@@ -434,7 +430,7 @@ class ImageNodeLoader(ModuleBase):
                         'file_type': 'image',
                         'is_pure_image': True,
                     }
-                    metadata.update(self._extract_layout_metadata(node, image_path))
+                    metadata.update(self._extract_layout_metadata(node))
                     image_nodes.append(ImageDocNode(
                         image_path=normalized_path,
                         metadata=metadata,

--- a/algorithm/lazymind/parsing/engine/transform/post_func.py
+++ b/algorithm/lazymind/parsing/engine/transform/post_func.py
@@ -368,6 +368,27 @@ class ImageNodeLoader(ModuleBase):
             return True
         return bool(_extract_image_path(node))
 
+    def _extract_layout_metadata(self, node: DocNode, image_path: str) -> dict:
+        metadata = node.metadata or {}
+        bbox = copy.deepcopy(metadata.get('bbox', [0, 0, 0, 0]))
+        page = metadata.get('page', 0)
+        node_type = metadata.get('type', 'image')
+        LOG.info(
+            f'[ImageNodeLoader] inherit node layout image_path={image_path}, '
+            f'page={page}, bbox={bbox}, type={node_type}'
+        )
+        return {
+            'page': page,
+            'bbox': bbox,
+            'type': node_type,
+            'lines': [{
+                'content': node.text,
+                'bbox': bbox,
+                'type': node_type,
+                'page': page,
+            }],
+        }
+
     def _normalize_image_file(self, image_path: str) -> str:
         return normalize_image_file(image_path=image_path, normalized_root=self._normalized_root)
 
@@ -413,6 +434,7 @@ class ImageNodeLoader(ModuleBase):
                         'file_type': 'image',
                         'is_pure_image': True,
                     }
+                    metadata.update(self._extract_layout_metadata(node, image_path))
                     image_nodes.append(ImageDocNode(
                         image_path=normalized_path,
                         metadata=metadata,

--- a/backend/core/doc/document.go
+++ b/backend/core/doc/document.go
@@ -2855,7 +2855,7 @@ func documentTypeFromName(name string) string {
 		return "DOCX"
 	case ".csv":
 		return "CSV"
-	case ".pptx":
+	case ".pptx", ".pptm":
 		return "PPTX"
 	case ".ppt":
 		return "PPT"

--- a/backend/core/doc/task_convert.go
+++ b/backend/core/doc/task_convert.go
@@ -131,6 +131,19 @@ func isPresentationDocument(storedPath, contentType, originalFilename string) bo
 	return strings.Contains(ct, "presentationml") || strings.Contains(ct, "powerpoint")
 }
 
+func isOfficialMinerURawPresentation(storedPath, originalFilename string) bool {
+	name := originalFilename
+	if name == "" {
+		name = filepath.Base(storedPath)
+	}
+	switch strings.ToLower(filepath.Ext(name)) {
+	case ".ppt", ".pptx":
+		return true
+	default:
+		return false
+	}
+}
+
 func ocrTypeFromConfig(ocrConfig map[string]any) string {
 	if ocrConfig == nil {
 		return ""
@@ -186,8 +199,9 @@ func documentParseStrategyName(profile documentParseProfile) string {
 }
 
 // needsOfficeConvertBeforeParse decides whether Office-to-PDF conversion runs before parsing.
-// PPT/PPTX/PPTM skip conversion only when official MinerU (mineru.net) is configured so
-// DynamicPDFReader can route them to MineruPPTReader; self-hosted MinerU still converts to PDF.
+// PPT/PPTX skip conversion only when official MinerU (mineru.net) is configured so
+// DynamicPDFReader can route them to MineruPPTReader. PPTM is converted to PDF because
+// the official MinerU upload API does not accept macro-enabled PowerPoint files.
 func needsOfficeConvertBeforeParse(d documentExt, ocrConfig map[string]any, profile documentParseProfile) bool {
 	if !d.ConvertRequired {
 		return false
@@ -208,7 +222,7 @@ func NeedsOfficeConvertForPath(filePath, originalFilename string, ocrConfig map[
 	if !isOfficeDocument(src, "", name) {
 		return false
 	}
-	if isPresentationDocument(src, "", name) && isOfficialMinerU(ocrConfig) {
+	if isOfficialMinerURawPresentation(src, name) && isOfficialMinerU(ocrConfig) {
 		return false
 	}
 	return true

--- a/backend/core/doc/task_convert_test.go
+++ b/backend/core/doc/task_convert_test.go
@@ -15,6 +15,12 @@ func TestNeedsOfficeConvertBeforeParse(t *testing.T) {
 		ContentType:      "application/vnd.openxmlformats-officedocument.presentationml.presentation",
 		ConvertRequired:  true,
 	}
+	pptmExt := documentExt{
+		StoredPath:       "/data/demo.pptm",
+		OriginalFilename: "demo.pptm",
+		ContentType:      "application/vnd.ms-powerpoint.presentation.macroEnabled.12",
+		ConvertRequired:  true,
+	}
 	docExt := documentExt{
 		StoredPath:       "/data/demo.docx",
 		OriginalFilename: "demo.docx",
@@ -43,6 +49,10 @@ func TestNeedsOfficeConvertBeforeParse(t *testing.T) {
 		{"ppt with self-hosted mineru converts", pptExt, selfHostedMineruCfg, true},
 		{"ppt with paddle converts", pptExt, paddleCfg, true},
 		{"ppt without ocr config converts", pptExt, nil, true},
+		{"pptm with official mineru converts", pptmExt, officialMineruCfg, true},
+		{"pptm with self-hosted mineru converts", pptmExt, selfHostedMineruCfg, true},
+		{"pptm with paddle converts", pptmExt, paddleCfg, true},
+		{"pptm without ocr config converts", pptmExt, nil, true},
 		{"docx with official mineru still converts", docExt, officialMineruCfg, true},
 		{"xlsx always converts", xlsxExt, paddleCfg, true},
 		{"xlsx with official mineru still converts", xlsxExt, officialMineruCfg, true},
@@ -68,6 +78,19 @@ func TestParsePathForIngestionPresentationMineru(t *testing.T) {
 	cfg := map[string]any{"ocr_type": "mineru"}
 	if got := parsePathForIngestion(d, cfg, documentParseProfileCloud); got != "/data/demo.pptx" {
 		t.Fatalf("parsePathForIngestion() = %q, want original pptx path", got)
+	}
+}
+
+func TestParsePathForIngestionMacroPresentationMineru(t *testing.T) {
+	d := documentExt{
+		StoredPath:       "/data/demo.pptm",
+		ParseStoredPath:  "/data/demo.pdf",
+		OriginalFilename: "demo.pptm",
+		ConvertRequired:  true,
+	}
+	cfg := map[string]any{"ocr_type": "mineru"}
+	if got := parsePathForIngestion(d, cfg, documentParseProfileCloud); got != "/data/demo.pdf" {
+		t.Fatalf("parsePathForIngestion() = %q, want converted pdf path", got)
 	}
 }
 
@@ -111,6 +134,19 @@ func TestParsePathForIngestionPresentationSelfHostedMineru(t *testing.T) {
 		StoredPath:       "/data/demo.pptx",
 		ParseStoredPath:  "/data/demo.pdf",
 		OriginalFilename: "demo.pptx",
+		ConvertRequired:  true,
+	}
+	cfg := map[string]any{"ocr_type": "mineru", "ocr_url": "http://local-mineru:8000/api/v1/pdf_parse"}
+	if got := parsePathForIngestion(d, cfg, documentParseProfileCloud); got != "/data/demo.pdf" {
+		t.Fatalf("parsePathForIngestion() = %q, want converted pdf path", got)
+	}
+}
+
+func TestParsePathForIngestionMacroPresentationSelfHostedMineru(t *testing.T) {
+	d := documentExt{
+		StoredPath:       "/data/demo.pptm",
+		ParseStoredPath:  "/data/demo.pdf",
+		OriginalFilename: "demo.pptm",
 		ConvertRequired:  true,
 	}
 	cfg := map[string]any{"ocr_type": "mineru", "ocr_url": "http://local-mineru:8000/api/v1/pdf_parse"}

--- a/backend/office-convert-service/main.py
+++ b/backend/office-convert-service/main.py
@@ -24,7 +24,7 @@ app = FastAPI(
     openapi_url='/openapi.json',
 )
 
-OFFICE_EXTENSIONS = {'.doc', '.docx', '.xls', '.xlsx', '.ppt', '.pptx'}
+OFFICE_EXTENSIONS = {'.doc', '.docx', '.xls', '.xlsx', '.ppt', '.pptx', '.pptm'}
 DEFAULT_ALLOWED_ROOTS = '/var/lib/lazymind/uploads'
 DEFAULT_TIMEOUT_SECONDS = 900
 DEFAULT_CONCURRENCY = 4

--- a/frontend/src/i18n/locales/en-US.ts
+++ b/frontend/src/i18n/locales/en-US.ts
@@ -1477,7 +1477,7 @@ const enUS = {
     supportedFolderImport: "Folder import supported",
     supportedZipFile: "Only ZIP archive files are supported (.zip)",
     supportedDocTypes:
-      "PDF, DOCX, DOC, PPT, PPTX, JPG, JPEG, PNG, GIF, BMP, WEBP, TIFF, TIF, IPYNB, EPUB, MD, MBOX, CSV, XLS, XLSX, MP3, MP4, TXT, XML, JSON, JSONL, YAML, YML, HTML, HTM and PY files are supported",
+      "PDF, DOCX, DOC, PPT, PPTX, PPTM, JPG, JPEG, PNG, GIF, BMP, WEBP, TIFF, TIF, IPYNB, EPUB, MD, MBOX, CSV, XLS, XLSX, MP3, MP4, TXT, XML, JSON, JSONL, YAML, YML, HTML, HTM and PY files are supported",
     zipRootOnly: "ZIP archives only support files in the root directory; nested folders will be ignored",
     uploadLimitHint: "Up to 300 files per upload, each file must be under 500MB, total size under 1GB",
     uploadSecurityRiskTip:

--- a/frontend/src/i18n/locales/zh-CN.ts
+++ b/frontend/src/i18n/locales/zh-CN.ts
@@ -1445,7 +1445,7 @@ const zhCN = {
     supportedFolderImport: "支持导入文件夹",
     supportedZipFile: "仅支持 ZIP 类型压缩包文件（.zip）",
     supportedDocTypes:
-      "支持 pdf、docx、doc、ppt、pptx、jpg、jpeg、png、gif、bmp、webp、tiff、tif、ipynb、epub、md、mbox、csv、xls、xlsx、mp3、mp4、txt、xml、json、jsonl、yaml、yml、html、htm、py 类型的文件",
+      "支持 pdf、docx、doc、ppt、pptx、pptm、jpg、jpeg、png、gif、bmp、webp、tiff、tif、ipynb、epub、md、mbox、csv、xls、xlsx、mp3、mp4、txt、xml、json、jsonl、yaml、yml、html、htm、py 类型的文件",
     zipRootOnly: "zip压缩包仅支持根目录的文件，一级及以上文件夹将被忽略",
     uploadLimitHint: "单次上传限制300个文件，单个文件大小不超过500MB，总大小不超过1GB",
     uploadSecurityRiskTip:

--- a/frontend/src/modules/chat/components/PluginPanel/index.tsx
+++ b/frontend/src/modules/chat/components/PluginPanel/index.tsx
@@ -815,6 +815,7 @@ function TabSlotGrid({
   onReference?: (slot: SlotRevision) => void;
   onFocusSortOrder?: (sortOrder: number | undefined) => void;
 }) {
+  const { t } = useTranslation();
   const addFileInputRef = useRef<HTMLInputElement>(null);
   const addingSlotIdRef = useRef<string>('');
   const addingSlotTypeRef = useRef<string>('');

--- a/frontend/src/modules/knowledge/components/FileViewer/index.tsx
+++ b/frontend/src/modules/knowledge/components/FileViewer/index.tsx
@@ -124,7 +124,7 @@ const FileViewer = forwardRef<FileViewerRef, FileViewerProps>((props, ref) => {
     if (["pdf"].includes(fileSuffix)) {
       return "pdf";
     }
-    if (["pptx", "ppt"].includes(fileSuffix)) {
+    if (["pptx", "ppt", "pptm"].includes(fileSuffix)) {
       return "pptx";
     }
     if (["docx", "doc"].includes(fileSuffix)) {

--- a/frontend/src/modules/knowledge/constants/common.tsx
+++ b/frontend/src/modules/knowledge/constants/common.tsx
@@ -129,7 +129,7 @@ export const CARD_PAGE_SIZE = 12;
 export const IMPORT_TASK_POLL_INTERVAL = 5 * 1000;
 
 // export const SUPPORT_SUFFIX = ['txt', 'xml', 'json', 'pdf', 'docx', 'doc', 'html', 'md', 'pptx', 'csv', 'xlsx', 'xls'];
-export const SUPPORT_SUFFIX = ["pdf", "docx", "doc", "pptx", "zip"];
+export const SUPPORT_SUFFIX = ["pdf", "docx", "doc", "pptx", "pptm", "zip"];
 // Unstructured data file suffix.
 export const UNSTRUCTURED_SUFFIX = [
   "txt",
@@ -140,6 +140,7 @@ export const UNSTRUCTURED_SUFFIX = [
   "html",
   "md",
   "pptx",
+  "pptm",
 ];
 // Structured data file suffix.
 export const STRUCTURED_SUFFIX = ["xls", "xlsx", "csv", "jsonl", "parquet"];

--- a/frontend/src/modules/knowledge/pages/detail/components/DragUpload/index.tsx
+++ b/frontend/src/modules/knowledge/pages/detail/components/DragUpload/index.tsx
@@ -28,6 +28,7 @@ export const ALLOWED_FILE_TYPES = [
   "doc",
   "ppt",
   "pptx",
+  "pptm",
   "jpg",
   "jpeg",
   "png",

--- a/frontend/src/modules/knowledge/pages/list/index.tsx
+++ b/frontend/src/modules/knowledge/pages/list/index.tsx
@@ -755,7 +755,7 @@ const KnowledgePage: FC = () => {
             return relArr?.[0];
           }
           if (
-            ["pdf", "docx", "doc", "pptx"].includes(
+            ["pdf", "docx", "doc", "pptx", "pptm"].includes(
               rel_path?.split(".")?.at(-1) ?? "",
             )
           ) {

--- a/plugins/image-plugin/scenario/state.yml
+++ b/plugins/image-plugin/scenario/state.yml
@@ -326,6 +326,8 @@ steps:
         - Else if image_output / a single material / upload exists, reuse THAT same origin
           for all N stickers.
         - Else text-only (no urls) for all N.
+      Origins are owned by collect_materials (image_output). Do NOT re-save image_output
+      here — the graph allows only one producer per material.
 
       Step A — parallel video generation (ONE assistant turn, N tool_calls):
         Emit N separate `video_generator` calls in a single response (not sequential turns).
@@ -353,11 +355,12 @@ steps:
         Per sticker i (caption MUST include the index, e.g. caption='Sticker i'):
           1. optional: save_artifact(key='video_output', content_type='file',
                value=<video path>, source_tool='video_generator', caption='Sticker i')
-          2. if origin exists: save_artifact(key='image_output', content_type='image',
-               value=<origin>, caption='Sticker i')  — NEVER put GIF into image_output
-          3. save_artifact(key='gif_output', content_type='image',
+          2. save_artifact(key='gif_output', content_type='image',
                value=<gif path>, source_tool='video_to_gif', caption='Sticker i')
-        Saving in the same i-order across slots keeps composite rows aligned.
+        Do NOT save image_output (origins already saved by collect_materials).
+        Never put GIF into image_output.
+        Saving gif_output in the same i-order keeps composite rows aligned with
+        existing image_output rows from collect.
         If some generate/gif calls fail, save only successful stickers in index order
         (partial saves OK) and STOP with a concise note.
       Prefer quoting image_markdown from tool results verbatim.
@@ -378,8 +381,6 @@ steps:
     outputs:
       - material: generated_image_output
         required: false
-      - material: image_output
-        required: false
       - material: gif_output
         required: false
       - material: video_output
@@ -388,8 +389,8 @@ steps:
       Still workflows: generated_image_output must be saved (sort_order=1 only for overwrite / still path).
       Animated workflows: gif_output must exist for each successful sticker after
       video_generator → video_to_gif → sequential append saves (omit sort_order on first full run).
-      When an origin exists, image_output must also be appended in the SAME order as gif_output
-      (origin still, NOT the GIF). Never put GIF into image_output.
+      Origins stay in image_output from collect_materials — do NOT re-save image_output here.
+      Never put GIF into image_output.
       Use sort_order=N only when overwriting an existing list row on partial retry.
       N is taken from the user request (default 1).
 


### PR DESCRIPTION
本次修改补充了对 pptm 文件的上传与解析支持：
1. 前端允许选择 pptm，后端针对官方 MinerU 场景（官方暂时不支持pptm 只支持pptx）改为将 pptm 先转换为 PDF，避免官方接口不支持宏启用 PowerPoint 的问题。
2. 同时在图片节点解析时继承页码、bbox 等版面信息，现在点击图片可以跳转 
3. 并调整 image plugin 动图产物保存逻辑，避免重复写入 image_output。导致不能通过检测