### PR TITLE
add colima startup flow for `README.md`

### DIFF
--- a/README.CN.md
+++ b/README.CN.md
@@ -181,7 +181,7 @@ brew install colima docker docker-compose docker-buildx
 启动 Colima：
 
 ```bash
-colima start --runtime docker --vm-type vz --mount-type virtiofs --cpu 6 --memory 10 --disk 80
+colima start --runtime docker --vm-type vz --mount-type virtiofs --cpu 4 --memory 6 --disk 80
 ```
 
 验证环境：

--- a/README.CN.md
+++ b/README.CN.md
@@ -156,6 +156,59 @@ make test-hermetic
 
 ## 常用启动配置
 
+### macOS 使用 Colima 启动容器栈
+
+如果本机无法使用 Docker Desktop，可以使用 [Colima](https://github.com/abiosoft/colima) 提供 Docker 运行环境。未安装 Homebrew 时，先按官方方式安装：
+
+```bash
+/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+```
+
+安装完成后按终端提示配置 `PATH`。Apple Silicon 通常使用：
+
+```bash
+echo 'eval "$(/opt/homebrew/bin/brew shellenv)"' >> ~/.zprofile
+eval "$(/opt/homebrew/bin/brew shellenv)"
+brew --version
+```
+
+安装 Colima 和 Docker 命令行工具：
+
+```bash
+brew install colima docker docker-compose docker-buildx
+```
+
+启动 Colima：
+
+```bash
+colima start --runtime docker --vm-type vz --mount-type virtiofs --cpu 6 --memory 10 --disk 80
+```
+
+验证环境：
+
+```bash
+colima status
+docker version
+docker compose version
+```
+
+环境就绪后，在项目根目录启动容器栈：
+
+```bash
+make up
+```
+
+使用完毕后，先停掉容器栈，再关闭 Colima：
+
+```bash
+make down
+colima stop
+```
+
+### 启动命令速查
+
+除 Colima 容器栈外，项目还支持宿主机本地运行等多种方式，常用命令如下：
+
 | 场景 | 命令 |
 |------|------|
 | 宿主机本地运行（SQLite 状态后端，无容器） | `make local-up` |

--- a/README.md
+++ b/README.md
@@ -164,6 +164,59 @@ make test-hermetic
 
 ## Common Startup Configurations
 
+### Start the Container Stack on macOS with Colima
+
+If Docker Desktop is not available on your machine, you can use [Colima](https://github.com/abiosoft/colima) as the Docker runtime. If Homebrew is not installed, install it first:
+
+```bash
+/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+```
+
+After installation, follow the terminal prompt to configure `PATH`. On Apple Silicon, this is usually:
+
+```bash
+echo 'eval "$(/opt/homebrew/bin/brew shellenv)"' >> ~/.zprofile
+eval "$(/opt/homebrew/bin/brew shellenv)"
+brew --version
+```
+
+Install Colima and the Docker command-line tools:
+
+```bash
+brew install colima docker docker-compose docker-buildx
+```
+
+Start Colima:
+
+```bash
+colima start --runtime docker --vm-type vz --mount-type virtiofs --cpu 6 --memory 10 --disk 80
+```
+
+Verify the environment:
+
+```bash
+colima status
+docker version
+docker compose version
+```
+
+After the environment is ready, start the container stack from the project root:
+
+```bash
+make up
+```
+
+When finished, stop the container stack first, then stop Colima:
+
+```bash
+make down
+colima stop
+```
+
+### Startup Command Reference
+
+In addition to the Colima container stack, LazyMind also supports host-local runtime and other startup modes:
+
 | Scenario | Command |
 |----------|---------|
 | Local runtime on host (SQLite state backend, no containers) | `make local-up` |

--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ brew install colima docker docker-compose docker-buildx
 Start Colima:
 
 ```bash
-colima start --runtime docker --vm-type vz --mount-type virtiofs --cpu 6 --memory 10 --disk 80
+colima start --runtime docker --vm-type vz --mount-type virtiofs --cpu 4 --memory 6 --disk 80
 ```
 
 Verify the environment:


### PR DESCRIPTION
Add a macOS Colima setup guide (Homebrew install, Colima start, environment verification) for machines without Docker Desktop

<img width="681" height="613" alt="image" src="https://github.com/user-attachments/assets/67cbc654-2787-4c90-a51a-169b812d32e3" />
