### PR TITLE
Feat/fix prompt usage count

### DIFF
--- a/backend/core/chat/prompt.go
+++ b/backend/core/chat/prompt.go
@@ -702,11 +702,15 @@ func UsePrompt(w http.ResponseWriter, r *http.Request) {
 		common.ReplyErr(w, "record prompt usage failed", http.StatusInternalServerError)
 		return
 	}
-	_ = corestore.DB().Where("create_user_id = ? AND prompt_id = ?", userID, promptID).First(&state).Error
+	var savedState orm.PromptUserState
+	if err := corestore.DB().Where("create_user_id = ? AND prompt_id = ?", userID, promptID).First(&savedState).Error; err != nil {
+		common.ReplyErr(w, "query prompt usage failed", http.StatusInternalServerError)
+		return
+	}
 	writePromptJSON(w, http.StatusOK, promptStateResponse{
 		ID:         promptID,
-		IsFavorite: state.IsFavorite,
-		UsageCount: state.UsageCount,
-		LastUsedAt: state.LastUsedAt,
+		IsFavorite: savedState.IsFavorite,
+		UsageCount: savedState.UsageCount,
+		LastUsedAt: savedState.LastUsedAt,
 	})
 }

--- a/backend/core/chat/prompt.go
+++ b/backend/core/chat/prompt.go
@@ -13,6 +13,7 @@ import (
 	"lazymind/core/algo"
 	"lazymind/core/common"
 	"lazymind/core/common/orm"
+	"lazymind/core/log"
 	"lazymind/core/modelconfig"
 	corestore "lazymind/core/store"
 
@@ -667,6 +668,22 @@ func UnfavoritePrompt(w http.ResponseWriter, r *http.Request) {
 	setPromptFavorite(w, r, false)
 }
 
+func promptUsageConflictClause(now time.Time) clause.OnConflict {
+	return clause.OnConflict{
+		Columns: []clause.Column{{Name: "create_user_id"}, {Name: "prompt_id"}},
+		DoUpdates: clause.Assignments(map[string]any{
+			"usage_count": gorm.Expr(
+				"? + ?",
+				clause.Column{Table: orm.PromptUserState{}.TableName(), Name: "usage_count"},
+				1,
+			),
+			"last_used_at": now,
+			"updated_at":   now,
+			"deleted_at":   nil,
+		}),
+	}
+}
+
 func UsePrompt(w http.ResponseWriter, r *http.Request) {
 	promptID := promptNameFromPath(r)
 	userID := corestore.UserID(r)
@@ -690,15 +707,8 @@ func UsePrompt(w http.ResponseWriter, r *http.Request) {
 		CreatedAt:      now,
 		UpdatedAt:      now,
 	}
-	if err := corestore.DB().Clauses(clause.OnConflict{
-		Columns: []clause.Column{{Name: "create_user_id"}, {Name: "prompt_id"}},
-		DoUpdates: clause.Assignments(map[string]any{
-			"usage_count":  gorm.Expr("usage_count + ?", 1),
-			"last_used_at": now,
-			"updated_at":   now,
-			"deleted_at":   nil,
-		}),
-	}).Create(&state).Error; err != nil {
+	if err := corestore.DB().Clauses(promptUsageConflictClause(now)).Create(&state).Error; err != nil {
+		log.Logger.Error().Err(err).Str("prompt_id", promptID).Msg("record prompt usage failed")
 		common.ReplyErr(w, "record prompt usage failed", http.StatusInternalServerError)
 		return
 	}

--- a/backend/core/chat/prompt_test.go
+++ b/backend/core/chat/prompt_test.go
@@ -13,6 +13,8 @@ import (
 	"time"
 
 	"github.com/gorilla/mux"
+	"gorm.io/driver/postgres"
+	"gorm.io/gorm"
 
 	"lazymind/core/common/orm"
 	corestore "lazymind/core/store"
@@ -30,6 +32,39 @@ func newPromptTestDB(t *testing.T) *orm.DB {
 		t.Fatalf("auto migrate: %v", err)
 	}
 	return db
+}
+
+func TestPromptUsageUpsertQualifiesPostgresUsageCount(t *testing.T) {
+	db, err := gorm.Open(postgres.New(postgres.Config{
+		DSN: "host=localhost user=postgres dbname=core sslmode=disable",
+	}), &gorm.Config{
+		DryRun:                 true,
+		DisableAutomaticPing:   true,
+		SkipDefaultTransaction: true,
+	})
+	if err != nil {
+		t.Fatalf("open postgres dry-run db: %v", err)
+	}
+
+	now := time.Date(2026, time.July, 17, 8, 0, 0, 0, time.UTC)
+	state := orm.PromptUserState{
+		ID:             "pus_test",
+		PromptID:       "preset-document-summary",
+		UsageCount:     1,
+		LastUsedAt:     &now,
+		CreateUserID:   "u1",
+		CreateUserName: "Prompt Tester",
+		CreatedAt:      now,
+		UpdatedAt:      now,
+	}
+	statement := db.Clauses(promptUsageConflictClause(now)).Create(&state).Statement
+	if statement.Error != nil {
+		t.Fatalf("build postgres upsert: %v", statement.Error)
+	}
+	sql := statement.SQL.String()
+	if !strings.Contains(sql, `"prompt_user_states"."usage_count" +`) {
+		t.Fatalf("usage_count is not qualified in postgres upsert: %s", sql)
+	}
 }
 
 func TestPolishPromptCallsRewrite(t *testing.T) {

--- a/backend/core/chat/prompt_test.go
+++ b/backend/core/chat/prompt_test.go
@@ -167,8 +167,16 @@ func TestPromptLibraryFavoriteAndUsage(t *testing.T) {
 		}
 	}
 	for i := 0; i < 2; i++ {
-		if rec := request(UsePrompt, "u1"); rec.Code != http.StatusOK {
+		rec := request(UsePrompt, "u1")
+		if rec.Code != http.StatusOK {
 			t.Fatalf("use attempt %d failed: status=%d body=%s", i+1, rec.Code, rec.Body.String())
+		}
+		var stateResp promptStateResponse
+		if err := json.Unmarshal(rec.Body.Bytes(), &stateResp); err != nil {
+			t.Fatalf("decode use attempt %d response: %v", i+1, err)
+		}
+		if stateResp.ID != "preset-general-qa" || !stateResp.IsFavorite || stateResp.UsageCount != int64(i+1) || stateResp.LastUsedAt == nil {
+			t.Fatalf("unexpected use attempt %d response: %#v", i+1, stateResp)
 		}
 	}
 


### PR DESCRIPTION
Fix prompt usage tracking by returning the persisted count and using a PostgreSQL-safe atomic increment, with regression tests added.