### PR TITLE
修复 Windows Desktop 启动白屏、runtime 残留与安装升级流程

### DIFF
--- a/desktop/electron/src/installer-warmup.js
+++ b/desktop/electron/src/installer-warmup.js
@@ -1,0 +1,80 @@
+function serializeWarmupError(error) {
+  if (error instanceof Error) {
+    return error.stack || error.message;
+  }
+  return String(error);
+}
+
+function assertMaintenanceRuntimeReady(status) {
+  if (status?.overallStatus !== "ready" || !status?.config?.frontendPort) {
+    throw new Error(`maintenance runtime did not become ready (status=${status?.overallStatus || "unknown"})`);
+  }
+}
+
+function assertMaintenanceRuntimeStopped(status) {
+  const activeServices = Object.entries(status?.services || {})
+    .filter(([, service]) => service?.status !== "stopped")
+    .map(([name, service]) => `${name}=${service?.status || "unknown"}`);
+  if (status?.overallStatus !== "stopped" || status?.ownerMatched !== true || activeServices.length > 0) {
+    const details = activeServices.length > 0 ? `; services=${activeServices.join(",")}` : "";
+    throw new Error(
+      `maintenance runtime did not stop cleanly (status=${status?.overallStatus || "unknown"}, ownerMatched=${Boolean(status?.ownerMatched)}${details})`,
+    );
+  }
+}
+
+async function runInstallerWarmupLifecycle({
+  startRuntime,
+  readStatus,
+  createRenderer,
+  loadRenderer,
+  stopRuntime,
+  disposeRenderer,
+  log,
+  formatError = serializeWarmupError,
+}) {
+  let renderer;
+  let primaryError = null;
+  let cleanupError = null;
+
+  try {
+    await startRuntime();
+    const status = await readStatus();
+    assertMaintenanceRuntimeReady(status);
+    renderer = createRenderer();
+    await loadRenderer(renderer, status);
+    log("runtime and renderer warmup completed");
+  } catch (error) {
+    primaryError = error;
+    log(`warmup failed: ${formatError(error)}`);
+  }
+
+  try {
+    log("stopping maintenance runtime");
+    await stopRuntime();
+    const stoppedStatus = await readStatus();
+    assertMaintenanceRuntimeStopped(stoppedStatus);
+    log("maintenance runtime stopped and verified");
+  } catch (error) {
+    cleanupError = error;
+    log(`maintenance runtime shutdown failed: ${formatError(error)}`);
+  } finally {
+    if (renderer) {
+      disposeRenderer(renderer);
+      log("warmup renderer disposed");
+    }
+  }
+
+  if (primaryError) {
+    throw primaryError;
+  }
+  if (cleanupError) {
+    throw cleanupError;
+  }
+}
+
+module.exports = {
+  assertMaintenanceRuntimeReady,
+  assertMaintenanceRuntimeStopped,
+  runInstallerWarmupLifecycle,
+};

--- a/desktop/electron/src/main.js
+++ b/desktop/electron/src/main.js
@@ -40,6 +40,7 @@ const startupLogPath = path.join(desktopLogsDir, "desktop-startup.log");
 const sidecarPath = process.env.LAZYMIND_DESKTOP_SIDECAR ||
   path.join(runtimeResourcesRoot, "bin", `local-runtime-manager${isWindows ? ".exe" : ""}`);
 const maxStartupLogEntries = 1200;
+const maxSidecarFailureBytes = 32 * 1024;
 const desktopShutdownTimeout = process.env.LAZYMIND_DESKTOP_SHUTDOWN_TIMEOUT || "20s";
 const forceExitDelayMs = 1500;
 const rendererReadyTimeoutMs = 30 * 1000;
@@ -49,6 +50,9 @@ let startupWindow;
 let rendererReadyWait;
 let runtimeProcess;
 let runtimeProcessExit = null;
+let sidecarStderrTail = "";
+let sidecarStructuredFailure = "";
+let sidecarEventBuffer = "";
 let guardProcess;
 let guardPID = 0;
 let guardWatchTimer;
@@ -86,6 +90,7 @@ function sidecarEnv() {
     ...process.env,
     LAZYMIND_RUNTIME_PROFILE: "desktop",
     LAZYMIND_RUNTIME_OWNER_TOKEN: ownerToken,
+    LAZYMIND_DESKTOP_OWNER_PID: String(process.pid),
     LAZYMIND_RUNTIME_RESOURCES_ROOT: runtimeResourcesRoot,
     LAZYMIND_LOCAL_NETWORK_PROFILE: "localhost",
     LAZYMIND_LOCAL_PROXY_ADDRESS: "127.0.0.1",
@@ -191,6 +196,39 @@ function appendStartupLog(source, line) {
 
 function appendStartupChunk(source, chunk) {
   String(chunk).split(/\r?\n/).forEach((line) => appendStartupLog(source, line));
+}
+
+function captureSidecarChunk(source, chunk) {
+  const text = String(chunk);
+  appendStartupChunk(source, text);
+  if (source === "sidecar.stderr") {
+    sidecarStderrTail = `${sidecarStderrTail}${text}`.slice(-maxSidecarFailureBytes);
+  }
+  if (source !== "sidecar.stdout") {
+    return;
+  }
+  const eventText = `${sidecarEventBuffer}${text}`;
+  const lines = eventText.split(/\r?\n/);
+  sidecarEventBuffer = lines.pop() || "";
+  for (const line of lines) {
+    const marker = "[startup-event] ";
+    const markerIndex = line.indexOf(marker);
+    if (markerIndex < 0) {
+      continue;
+    }
+    try {
+      const event = JSON.parse(line.slice(markerIndex + marker.length));
+      if (["phase.failed", "startup.failed"].includes(event?.event) && event?.error) {
+        sidecarStructuredFailure = String(event.error);
+      }
+    } catch {
+      // Keep the raw line in desktop-startup.log; stderr remains the fallback.
+    }
+  }
+}
+
+function sidecarFailureDetail() {
+  return sidecarStructuredFailure.trim() || sidecarStderrTail.trim();
 }
 
 function updateStartupState(patch) {
@@ -523,6 +561,9 @@ function startRuntime() {
   resetStartupLogsForRun();
   ensureDesktopLogDirs();
   runtimeProcessExit = null;
+  sidecarStderrTail = "";
+  sidecarStructuredFailure = "";
+  sidecarEventBuffer = "";
   updateStartupState({
     status: "starting",
     phase: "Starting sidecar",
@@ -537,15 +578,18 @@ function startRuntime() {
     detached: false,
     windowsHide: isWindows,
   });
-  runtimeProcess.stdout?.on("data", (chunk) => appendStartupChunk("sidecar", chunk));
-  runtimeProcess.stderr?.on("data", (chunk) => appendStartupChunk("sidecar", chunk));
+  runtimeProcess.stdout?.on("data", (chunk) => captureSidecarChunk("sidecar.stdout", chunk));
+  runtimeProcess.stderr?.on("data", (chunk) => captureSidecarChunk("sidecar.stderr", chunk));
   runtimeProcess.once("error", (error) => {
-    runtimeProcessExit = { error: serializeError(error) };
+    runtimeProcessExit = { error: serializeError(error), detail: serializeError(error) };
     runtimeProcess = null;
     setStartupFailure(error, "Could not start desktop runtime sidecar");
   });
-  runtimeProcess.once("exit", (code, signal) => {
-    runtimeProcessExit = { code, signal, at: new Date().toISOString() };
+  // `close` fires after stdout/stderr are drained, so the final Go error cannot
+  // race with ownership/status handling below.
+  runtimeProcess.once("close", (code, signal) => {
+    const detail = sidecarFailureDetail() || runtimeProcessExit?.detail || "";
+    runtimeProcessExit = { code, signal, at: new Date().toISOString(), detail };
     appendStartupLog("sidecar", `local-runtime-manager exited with code ${code ?? "null"} signal ${signal ?? "null"}`);
     runtimeProcess = null;
     if (startupState.status !== "ready" && startupState.status !== "failed") {

--- a/desktop/electron/src/main.js
+++ b/desktop/electron/src/main.js
@@ -4,7 +4,7 @@ const { randomUUID } = require("node:crypto");
 const fs = require("node:fs");
 const path = require("node:path");
 const { resolveWindowsDesktopPaths } = require("./desktop-paths");
-const { runtimeExitFailureMessage, statusFailureMessage } = require("./runtime-status");
+const { desktopRuntimeReady, runtimeExitFailureMessage, statusFailureMessage } = require("./runtime-status");
 
 const isWindows = process.platform === "win32";
 const isInstallerWarmup = isWindows && process.argv.includes("--installer-warmup");
@@ -42,8 +42,11 @@ const sidecarPath = process.env.LAZYMIND_DESKTOP_SIDECAR ||
 const maxStartupLogEntries = 1200;
 const desktopShutdownTimeout = process.env.LAZYMIND_DESKTOP_SHUTDOWN_TIMEOUT || "20s";
 const forceExitDelayMs = 1500;
+const rendererReadyTimeoutMs = 30 * 1000;
 
 let mainWindow;
+let startupWindow;
+let rendererReadyWait;
 let runtimeProcess;
 let runtimeProcessExit = null;
 let guardProcess;
@@ -234,10 +237,10 @@ function startupDiagnosticsSnapshot() {
 }
 
 function broadcastStartupDiagnostics(extra = {}) {
-  if (!mainWindow || mainWindow.isDestroyed()) {
+  if (!startupWindow || startupWindow.isDestroyed()) {
     return;
   }
-  mainWindow.webContents.send("lazymind:startupDiagnosticsUpdate", {
+  startupWindow.webContents.send("lazymind:startupDiagnosticsUpdate", {
     ...startupDiagnosticsSnapshot(),
     ...extra,
   });
@@ -567,8 +570,12 @@ function beginFastQuit(reason = "quit") {
     spawnDetachedShutdownHelper(reason);
   }
   detachRuntimeMonitor();
-  if (mainWindow && !mainWindow.isDestroyed()) {
-    mainWindow.destroy();
+  rendererReadyWait?.cancel();
+  rendererReadyWait = undefined;
+  for (const window of [mainWindow, startupWindow]) {
+    if (window && !window.isDestroyed()) {
+      window.destroy();
+    }
   }
   setTimeout(() => {
     app.exit(0);
@@ -599,7 +606,7 @@ async function waitForRuntimeReady() {
       if (status.overallStatus === "ready" && !belongsToDesktop) {
         throw new Error(`A ${status.profile || "different"} LazyMind runtime is already running. Stop it before opening Desktop.`);
       }
-      const ownedReady = status.overallStatus === "ready" && belongsToDesktop && status.ownerMatched;
+      const ownedReady = desktopRuntimeReady(status, belongsToDesktop);
       const phase = ownedReady ? "Ready" : `Waiting (${status.overallStatus || "unknown"})`;
       updateStartupState({
         status: ownedReady ? "ready" : (status.overallStatus || "starting"),
@@ -882,12 +889,14 @@ function loadingHTML() {
 </html>`;
 }
 
-async function createWindow() {
-  mainWindow = new BrowserWindow({
+function browserWindowOptions(show = true) {
+  return {
     width: 1440,
     height: 960,
     minWidth: 1120,
     minHeight: 760,
+    show,
+    backgroundColor: "#f7f8fa",
     title: "LazyMind",
     icon: isWindows
       ? (isPackaged ? path.join(process.resourcesPath, "LazyMind.ico") : process.env.LAZYMIND_DESKTOP_WINDOWS_ICON)
@@ -898,23 +907,106 @@ async function createWindow() {
       nodeIntegration: false,
       sandbox: false,
     },
-  });
-  mainWindow.on("close", (event) => {
+  };
+}
+
+function attachManagedClose(window) {
+  window.on("close", (event) => {
     if (allowWindowClose) {
       return;
     }
     event.preventDefault();
     beginFastQuit("window close");
   });
-  await mainWindow.loadURL(`data:text/html;charset=utf-8,${encodeURIComponent(loadingHTML())}`);
+}
+
+function activeWindow() {
+  if (startupWindow && !startupWindow.isDestroyed() && startupWindow.isVisible()) {
+    return startupWindow;
+  }
+  if (mainWindow && !mainWindow.isDestroyed()) {
+    return mainWindow;
+  }
+  return startupWindow;
+}
+
+function createRendererReadyWait(window) {
+  let settled = false;
+  let resolvePromise;
+  let rejectPromise;
+  const promise = new Promise((resolve, reject) => {
+    resolvePromise = resolve;
+    rejectPromise = reject;
+  });
+  const timer = setTimeout(() => {
+    if (settled) return;
+    settled = true;
+    rejectPromise(new Error("LazyMind Chat did not render within 30 seconds"));
+  }, rendererReadyTimeoutMs);
+  return {
+    window,
+    promise,
+    notify() {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      resolvePromise();
+    },
+    cancel() {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      resolvePromise();
+    },
+  };
+}
+
+async function createWindow() {
+  startupWindow = new BrowserWindow(browserWindowOptions(true));
+  attachManagedClose(startupWindow);
+  await startupWindow.loadURL(`data:text/html;charset=utf-8,${encodeURIComponent(loadingHTML())}`);
   broadcastStartupDiagnostics();
   try {
     const status = await waitForRuntimeReady();
-    await mainWindow.loadURL(`http://127.0.0.1:${status.config.frontendPort}`);
+    mainWindow = new BrowserWindow(browserWindowOptions(false));
+    attachManagedClose(mainWindow);
+    rendererReadyWait = createRendererReadyWait(mainWindow);
+    await Promise.all([
+      mainWindow.loadURL(`http://127.0.0.1:${status.config.frontendPort}/agent/chat/home`),
+      rendererReadyWait.promise,
+    ]);
+    rendererReadyWait.cancel();
+    rendererReadyWait = undefined;
+    if (isQuitting) {
+      return;
+    }
+    startupWindow.removeAllListeners("close");
+    startupWindow.hide();
+    mainWindow.show();
+    mainWindow.focus();
+    startupWindow.destroy();
+    startupWindow = undefined;
   } catch (error) {
+    rendererReadyWait?.cancel();
+    rendererReadyWait = undefined;
+    if (mainWindow && !mainWindow.isDestroyed()) {
+      mainWindow.removeAllListeners("close");
+      mainWindow.destroy();
+    }
+    mainWindow = undefined;
     setStartupFailure(error);
   }
 }
+
+ipcMain.on("lazymind:renderer-ready", (event) => {
+  if (!rendererReadyWait || rendererReadyWait.window.isDestroyed()) {
+    return;
+  }
+  if (event.sender !== rendererReadyWait.window.webContents) {
+    return;
+  }
+  rendererReadyWait.notify();
+});
 
 ipcMain.handle("lazymind:runtimeStatus", () => readStatus());
 ipcMain.handle("lazymind:restartRuntime", async () => {
@@ -946,7 +1038,7 @@ ipcMain.handle("lazymind:openDataDir", async () => {
   await shell.openPath(target);
 });
 ipcMain.handle("lazymind:selectFolder", async () => {
-  const result = await dialog.showOpenDialog(mainWindow, { properties: ["openDirectory"] });
+  const result = await dialog.showOpenDialog(activeWindow(), { properties: ["openDirectory"] });
   return result.canceled ? null : result.filePaths[0];
 });
 ipcMain.handle("lazymind:startupDiagnostics", () => startupDiagnosticsSnapshot());
@@ -984,14 +1076,15 @@ if (!hasSingleInstanceLock) {
   }
 } else {
   app.on("second-instance", () => {
-    if (!mainWindow || mainWindow.isDestroyed()) {
+    const window = activeWindow();
+    if (!window || window.isDestroyed()) {
       return;
     }
-    if (mainWindow.isMinimized()) {
-      mainWindow.restore();
+    if (window.isMinimized()) {
+      window.restore();
     }
-    mainWindow.show();
-    mainWindow.focus();
+    window.show();
+    window.focus();
   });
   app.whenReady().then(() => {
     if (isWindows) {

--- a/desktop/electron/src/main.js
+++ b/desktop/electron/src/main.js
@@ -5,6 +5,7 @@ const fs = require("node:fs");
 const path = require("node:path");
 const { resolveWindowsDesktopPaths } = require("./desktop-paths");
 const { desktopRuntimeReady, runtimeExitFailureMessage, statusFailureMessage } = require("./runtime-status");
+const { runInstallerWarmupLifecycle } = require("./installer-warmup");
 
 const isWindows = process.platform === "win32";
 const isInstallerWarmup = isWindows && process.argv.includes("--installer-warmup");
@@ -309,60 +310,46 @@ async function runInstallerWarmup() {
     fs.mkdirSync(desktopLogsDir, { recursive: true });
     fs.appendFileSync(warmupLogPath, `[${new Date().toISOString()}] ${message}\n`);
   };
-  let warmupWindow;
-  let activeError = null;
   log(`starting offline installer warmup with timeout ${timeoutSeconds}s`);
-  try {
-    await runSidecar("up", maintenanceArgs, {
+  await runInstallerWarmupLifecycle({
+    startRuntime: () => runSidecar("up", maintenanceArgs, {
       timeout: timeoutSeconds * 1000,
-    });
-    const status = await readStatus();
-    if (status.overallStatus !== "ready" || !status.config?.frontendPort) {
-      throw new Error(`maintenance runtime did not become ready (status=${status.overallStatus || "unknown"})`);
-    }
-
-    warmupWindow = new BrowserWindow({
+    }),
+    readStatus,
+    createRenderer: () => new BrowserWindow({
       show: false,
       webPreferences: {
         contextIsolation: true,
         nodeIntegration: false,
         sandbox: true,
       },
-    });
-    warmupWindow.webContents.session.webRequest.onBeforeRequest((details, callback) => {
-      try {
-        const url = new URL(details.url);
-        const allowed = url.protocol === "data:" ||
-          ((url.protocol === "http:" || url.protocol === "ws:") &&
-            (url.hostname === "127.0.0.1" || url.hostname === "localhost"));
-        callback({ cancel: !allowed });
-      } catch {
-        callback({ cancel: true });
-      }
-    });
-    await warmupWindow.loadURL(`http://127.0.0.1:${status.config.frontendPort}`);
-    log("runtime and renderer warmup completed");
-  } catch (error) {
-    log(`warmup failed: ${serializeError(error)}`);
-    activeError = error;
-    throw error;
-  } finally {
-    if (warmupWindow && !warmupWindow.isDestroyed()) {
-      warmupWindow.destroy();
-    }
-    try {
-      await runSidecar("down", maintenanceArgs, {
-        env: { ...sidecarEnv(), LAZYMIND_LOCAL_DOWN_TIMEOUT: "120s" },
-        timeout: 130000,
+    }),
+    loadRenderer: async (warmupWindow, status) => {
+      warmupWindow.webContents.session.webRequest.onBeforeRequest((details, callback) => {
+        try {
+          const url = new URL(details.url);
+          const allowed = url.protocol === "data:" ||
+            ((url.protocol === "http:" || url.protocol === "ws:") &&
+              (url.hostname === "127.0.0.1" || url.hostname === "localhost"));
+          callback({ cancel: !allowed });
+        } catch {
+          callback({ cancel: true });
+        }
       });
-      log("maintenance runtime stopped");
-    } catch (error) {
-      log(`maintenance runtime shutdown failed: ${serializeError(error)}`);
-      if (!activeError) {
-        throw error;
+      await warmupWindow.loadURL(`http://127.0.0.1:${status.config.frontendPort}`);
+    },
+    stopRuntime: () => runSidecar("down", maintenanceArgs, {
+      env: { ...sidecarEnv(), LAZYMIND_LOCAL_DOWN_TIMEOUT: "120s" },
+      timeout: 130000,
+    }),
+    disposeRenderer: (warmupWindow) => {
+      if (!warmupWindow.isDestroyed()) {
+        warmupWindow.destroy();
       }
-    }
-  }
+    },
+    log,
+    formatError: serializeError,
+  });
 }
 
 function startGuard() {
@@ -1146,6 +1133,9 @@ if (!hasSingleInstanceLock) {
     return createWindow();
   });
   app.on("window-all-closed", () => {
+    if (isInstallerWarmup) {
+      return;
+    }
     app.quit();
   });
   app.on("before-quit", (event) => {

--- a/desktop/electron/src/main.js
+++ b/desktop/electron/src/main.js
@@ -999,6 +999,9 @@ async function createWindow() {
   broadcastStartupDiagnostics();
   try {
     const status = await waitForRuntimeReady();
+    if (isQuitting) {
+      return;
+    }
     mainWindow = new BrowserWindow(browserWindowOptions(false));
     attachManagedClose(mainWindow);
     rendererReadyWait = createRendererReadyWait(mainWindow);

--- a/desktop/electron/src/preload.js
+++ b/desktop/electron/src/preload.js
@@ -8,6 +8,7 @@ contextBridge.exposeInMainWorld("lazymindDesktop", {
   resetRuntime: (scope) => ipcRenderer.invoke("lazymind:resetRuntime", scope),
   selectFolder: () => ipcRenderer.invoke("lazymind:selectFolder"),
   exportDiagnostics: () => ipcRenderer.invoke("lazymind:exportDiagnostics"),
+  notifyAppReady: () => ipcRenderer.send("lazymind:renderer-ready"),
   startupDiagnostics: () => ipcRenderer.invoke("lazymind:startupDiagnostics"),
   copyStartupLogs: () => ipcRenderer.invoke("lazymind:copyStartupLogs"),
   onStartupDiagnosticsUpdate: (handler) => {

--- a/desktop/electron/src/runtime-status.js
+++ b/desktop/electron/src/runtime-status.js
@@ -44,6 +44,10 @@ function runtimeExitFailureMessage(status, belongsToDesktop, runtimeProcessExit)
   if (!runtimeProcessExit) {
     return "";
   }
+  const sidecarDetail = String(runtimeProcessExit.detail || runtimeProcessExit.error || "").trim();
+  if (sidecarDetail && (runtimeProcessExit.code !== 0 || runtimeProcessExit.error)) {
+    return sidecarDetail;
+  }
   if (status?.overallStatus === "ready" && belongsToDesktop && !status.ownerMatched) {
     return "Another LazyMind Desktop instance owns the running local runtime. Close it before opening Desktop again.";
   }

--- a/desktop/electron/src/runtime-status.js
+++ b/desktop/electron/src/runtime-status.js
@@ -1,3 +1,36 @@
+const requiredDesktopServices = [
+  "process-supervisor",
+  "local-proxy",
+  "auth-service",
+  "core",
+  "scan-control-plane",
+  "file-watcher",
+  "lazyllm-doc-server",
+  "lazyllm-parse-server",
+  "lazyllm-parse-worker",
+  "lazyllm-algo",
+  "chat",
+  "frontend",
+];
+
+function desktopRuntimeReady(status, belongsToDesktop) {
+  if (
+    status?.overallStatus !== "ready" ||
+    !belongsToDesktop ||
+    !status.ownerMatched ||
+    !status.config?.frontendPort
+  ) {
+    return false;
+  }
+  const services = status.services || {};
+  const vectorStore = status.config?.modeProfile?.VectorStore || status.config?.modeProfile?.vectorStore;
+  const managedVectorStore = vectorStore?.ManagedProcess ?? vectorStore?.managedProcess;
+  const required = managedVectorStore
+    ? [...requiredDesktopServices, "milvus-lite"]
+    : requiredDesktopServices;
+  return required.every((name) => ["running", "ready"].includes(services[name]?.status));
+}
+
 function statusFailureMessage(status) {
   const summary = status?.overallStatus ? `Runtime status is ${status.overallStatus}` : "Runtime did not become ready";
   const failedServices = Object.entries(status?.services || {})
@@ -23,4 +56,4 @@ function runtimeExitFailureMessage(status, belongsToDesktop, runtimeProcessExit)
   return "";
 }
 
-module.exports = { runtimeExitFailureMessage, statusFailureMessage };
+module.exports = { desktopRuntimeReady, requiredDesktopServices, runtimeExitFailureMessage, statusFailureMessage };

--- a/desktop/installer/installer.nsh
+++ b/desktop/installer/installer.nsh
@@ -14,6 +14,8 @@
     Var InstallPurgeRadio
     Var InstalledVersion
     Var IsManualUpgrade
+    Var LegacyUninstallString
+    Var UpgradeUninstaller
   !else
     Var UninstallDataChoice
     Var UninstallKeepRadio
@@ -34,8 +36,12 @@
   LangString LMProgramOnly ${LANG_SIMPCHINESE} "只卸载程序（推荐）"
   LangString LMProgramAndData ${LANG_ENGLISH} "Uninstall the program and delete Local AppData"
   LangString LMProgramAndData ${LANG_SIMPCHINESE} "卸载程序并清除 Local AppData"
-  LangString LMCloseApp ${LANG_ENGLISH} "LazyMind or its local runtime is still running. Close it normally, then click Retry. Setup will not force-stop it."
-  LangString LMCloseApp ${LANG_SIMPCHINESE} "LazyMind 或本地运行时仍在运行。请正常关闭后点击“重试”；安装程序不会强制结束进程。"
+  LangString LMProcessScanFailed ${LANG_ENGLISH} "LazyMind process detection failed. Setup cannot safely continue."
+  LangString LMProcessScanFailed ${LANG_SIMPCHINESE} "LazyMind 进程检测失败，安装程序无法安全继续。"
+  LangString LMForceStopFailed ${LANG_ENGLISH} "Some LazyMind processes could not be force-closed. Setup cannot safely continue."
+  LangString LMForceStopFailed ${LANG_SIMPCHINESE} "部分 LazyMind 进程无法强制关闭，安装程序无法安全继续。"
+  LangString LMUpgradeRepairFailed ${LANG_ENGLISH} "The previous LazyMind uninstaller could not be updated for a safe upgrade. Setup cannot continue."
+  LangString LMUpgradeRepairFailed ${LANG_SIMPCHINESE} "无法更新旧版 LazyMind 卸载程序以安全升级，安装程序无法继续。"
   LangString LMPurgeFailed ${LANG_ENGLISH} "Local AppData could not be safely removed. No path outside LocalAppData\LazyMind was touched."
   LangString LMPurgeFailed ${LANG_SIMPCHINESE} "无法安全清除 Local AppData。未操作 LocalAppData\LazyMind 之外的任何路径。"
   LangString LMWarmupFailed ${LANG_ENGLISH} "LazyMind warmup failed or timed out. Retry retries warmup, Ignore skips it, and Abort cancels setup."
@@ -113,8 +119,11 @@
   StrCpy $IsManualUpgrade "0"
   StrCpy $InstallerHelper "$PLUGINSDIR\lazymind-installer-maintenance.exe"
   File /oname=$PLUGINSDIR\lazymind-installer-maintenance.exe "${BUILD_RESOURCES_DIR}\lazymind-installer-maintenance.exe"
+  StrCpy $UpgradeUninstaller "$PLUGINSDIR\lazymind-upgrade-uninstaller.exe"
+  File /oname=$PLUGINSDIR\lazymind-upgrade-uninstaller.exe "${UNINSTALLER_OUT_FILE}"
 
   ReadRegStr $InstalledVersion HKCU "${UNINSTALL_REGISTRY_KEY}" "DisplayVersion"
+  ReadRegStr $LegacyUninstallString HKCU "${UNINSTALL_REGISTRY_KEY}" "UninstallString"
   ${If} $InstalledVersion != ""
     ${VersionCompare} $InstalledVersion "${VERSION}" $0
     ${If} $0 == "1"
@@ -146,18 +155,89 @@
 !macroend
 
 !macro customCheckAppRunning
+    ; Silent upgrade uninstallers call this macro before customUnInit. Always
+    ; initialize the helper here so the check does not depend on hook order.
+    InitPluginsDir
+    StrCpy $InstallerHelper "$PLUGINSDIR\lazymind-installer-maintenance.exe"
+    File /oname=$PLUGINSDIR\lazymind-installer-maintenance.exe "${BUILD_RESOURCES_DIR}\lazymind-installer-maintenance.exe"
+
+    StrCpy $2 0
   LMCheckStopped:
-    nsExec::ExecToStack '"$InstallerHelper" check-stopped'
+    nsExec::ExecToStack '"$InstallerHelper" check-stopped --install-dir "$INSTDIR"'
+    Pop $0
+    Pop $1
+    ${If} $0 == 10
+      DetailPrint "Running LazyMind processes: $1"
+      IntOp $2 $2 + 1
+      ${If} $2 > 3
+        DetailPrint "LazyMind processes restarted repeatedly after force-stop: $1"
+        MessageBox MB_OK|MB_ICONSTOP "$(LMForceStopFailed)$\r$\n$1" /SD IDOK
+        SetErrorLevel 7
+        Quit
+      ${EndIf}
+      Goto LMForceStop
+    ${ElseIf} $0 != 0
+      DetailPrint "LazyMind process detection failed: $1"
+      MessageBox MB_OK|MB_ICONSTOP "$(LMProcessScanFailed)$\r$\n$1" /SD IDOK
+      SetErrorLevel 6
+      Quit
+    ${EndIf}
+    Goto LMProcessCheckDone
+
+  LMForceStop:
+    DetailPrint "Force-closing running LazyMind processes..."
+    nsExec::ExecToStack '"$InstallerHelper" force-stop --install-dir "$INSTDIR"'
     Pop $0
     Pop $1
     ${If} $0 != 0
-      ${If} ${Silent}
-        SetErrorLevel 5
-        Quit
-      ${EndIf}
-      MessageBox MB_RETRYCANCEL|MB_ICONEXCLAMATION "$(LMCloseApp)$\r$\n$1" IDRETRY LMCheckStopped
+      DetailPrint "LazyMind force-stop failed: $1"
+      MessageBox MB_OK|MB_ICONSTOP "$(LMForceStopFailed)$\r$\n$1" /SD IDOK
+      SetErrorLevel 7
       Quit
     ${EndIf}
+    DetailPrint "LazyMind processes were force-closed: $1"
+    Goto LMCheckStopped
+
+  LMProcessCheckDone:
+    ; electron-builder invokes an existing uninstaller silently during an
+    ; upgrade. Older LazyMind uninstallers initialized their helper too late
+    ; and always failed that path. Replace only the old program uninstaller
+    ; with this build's fixed one before electron-builder invokes it.
+    !ifndef BUILD_UNINSTALLER
+      ${If} $LegacyUninstallString != ""
+      ${OrIf} $InstalledVersion != ""
+        DetailPrint "Updating the previous LazyMind uninstaller for upgrade compatibility..."
+        CreateDirectory "$INSTDIR"
+        ClearErrors
+        CopyFiles /SILENT "$UpgradeUninstaller" "$INSTDIR\${UNINSTALL_FILENAME}"
+        ${If} ${Errors}
+          Goto LMUpgradeRepairFailed
+        ${EndIf}
+        ; Repair stale registrations too: the previous install may have left
+        ; its registry entry after the uninstaller file was removed.
+        ClearErrors
+        WriteRegStr HKCU "${UNINSTALL_REGISTRY_KEY}" "UninstallString" '"$INSTDIR\${UNINSTALL_FILENAME}"'
+        ${If} ${Errors}
+          Goto LMUpgradeRepairFailed
+        ${EndIf}
+        ClearErrors
+        ReadRegStr $0 HKCU "${UNINSTALL_REGISTRY_KEY}" "UninstallString"
+        ${If} ${Errors}
+          Goto LMUpgradeRepairFailed
+        ${ElseIf} $0 != '"$INSTDIR\${UNINSTALL_FILENAME}"'
+          Goto LMUpgradeRepairFailed
+        ${EndIf}
+        Goto LMUpgradeRepairDone
+
+      LMUpgradeRepairFailed:
+        DetailPrint "Could not update the previous LazyMind uninstaller at $INSTDIR\${UNINSTALL_FILENAME}."
+        MessageBox MB_OK|MB_ICONSTOP "$(LMUpgradeRepairFailed)$\r$\n$INSTDIR\${UNINSTALL_FILENAME}" /SD IDOK
+        SetErrorLevel 8
+        Quit
+
+      LMUpgradeRepairDone:
+      ${EndIf}
+    !endif
 !macroend
 
 !macro customInstall
@@ -173,8 +253,45 @@
   ${EndIf}
 
   LMWarmupRetry:
-    ExecWait '"$INSTDIR\${APP_EXECUTABLE_FILENAME}" --installer-warmup --timeout-seconds 900' $0
-    ${If} $0 != 0
+    ExecWait '"$INSTDIR\${APP_EXECUTABLE_FILENAME}" --installer-warmup --timeout-seconds 900' $3
+    StrCpy $2 0
+    StrCpy $4 0
+
+  LMWarmupCheckStopped:
+    nsExec::ExecToStack '"$InstallerHelper" check-stopped --install-dir "$INSTDIR"'
+    Pop $0
+    Pop $1
+    ${If} $0 == 10
+      StrCpy $4 1
+      IntOp $2 $2 + 1
+      DetailPrint "Warmup left running LazyMind processes: $1"
+      ${If} $2 > 3
+        MessageBox MB_OK|MB_ICONSTOP "$(LMForceStopFailed)$\r$\n$1" /SD IDOK
+        SetErrorLevel 7
+        Quit
+      ${EndIf}
+      DetailPrint "Force-closing processes left by installer warmup..."
+      nsExec::ExecToStack '"$InstallerHelper" force-stop --install-dir "$INSTDIR"'
+      Pop $0
+      Pop $1
+      ${If} $0 != 0
+        MessageBox MB_OK|MB_ICONSTOP "$(LMForceStopFailed)$\r$\n$1" /SD IDOK
+        SetErrorLevel 7
+        Quit
+      ${EndIf}
+      Goto LMWarmupCheckStopped
+    ${ElseIf} $0 != 0
+      MessageBox MB_OK|MB_ICONSTOP "$(LMProcessScanFailed)$\r$\n$1" /SD IDOK
+      SetErrorLevel 6
+      Quit
+    ${EndIf}
+
+    ; Returning success while leaving processes behind is itself a warmup
+    ; failure, even though the processes were force-closed above.
+    ${If} $4 == 1
+      StrCpy $3 4
+    ${EndIf}
+    ${If} $3 != 0
       ${If} ${Silent}
         SetErrorLevel 4
         Quit

--- a/desktop/scripts/desktop-build.test.mjs
+++ b/desktop/scripts/desktop-build.test.mjs
@@ -10,6 +10,8 @@ const scriptsDir = path.dirname(fileURLToPath(import.meta.url));
 const manifestScript = path.join(scriptsDir, "write-runtime-manifest.mjs");
 const iconScript = path.join(scriptsDir, "generate-windows-icon.mjs");
 const icnsSource = path.join(scriptsDir, "..", "electron", "assets", "LazyMind.icns");
+const electronMainScript = path.join(scriptsDir, "..", "electron", "src", "main.js");
+const electronBuilderConfig = path.join(scriptsDir, "..", "electron", "electron-builder.config.cjs");
 const installerScript = path.join(scriptsDir, "..", "installer", "installer.nsh");
 
 function nsisMacro(source, name) {
@@ -117,4 +119,27 @@ test("Windows installer verifies and force-cleans processes left by warmup", () 
     /\$0 == 10[\s\S]*force-stop --install-dir "\$INSTDIR"[\s\S]*Goto LMWarmupCheckStopped/,
   );
   assert.match(install, /\$4 == 1[\s\S]*StrCpy \$3 4[\s\S]*\$3 != 0/);
+});
+
+test("Desktop does not create the Chat window after shutdown begins", () => {
+  const source = readFileSync(electronMainScript, "utf8");
+  const start = source.indexOf("async function createWindow()");
+  const end = source.indexOf('ipcMain.on("lazymind:renderer-ready"', start);
+  assert.ok(start >= 0 && end > start, "could not locate createWindow");
+  const createWindow = source.slice(start, end);
+
+  assert.match(
+    createWindow,
+    /const status = await waitForRuntimeReady\(\);\s*if \(isQuitting\) \{\s*return;\s*\}\s*mainWindow = new BrowserWindow/,
+    "shutdown must be rechecked before creating the hidden Chat window",
+  );
+});
+
+test("Windows installer path policy matches the maintenance helper trust boundary", () => {
+  const source = readFileSync(electronBuilderConfig, "utf8");
+  assert.match(
+    source,
+    /allowToChangeInstallationDirectory:\s*false/,
+    "custom install directories require an authenticated path policy in installer-maintenance",
+  );
 });

--- a/desktop/scripts/desktop-build.test.mjs
+++ b/desktop/scripts/desktop-build.test.mjs
@@ -10,6 +10,13 @@ const scriptsDir = path.dirname(fileURLToPath(import.meta.url));
 const manifestScript = path.join(scriptsDir, "write-runtime-manifest.mjs");
 const iconScript = path.join(scriptsDir, "generate-windows-icon.mjs");
 const icnsSource = path.join(scriptsDir, "..", "electron", "assets", "LazyMind.icns");
+const installerScript = path.join(scriptsDir, "..", "installer", "installer.nsh");
+
+function nsisMacro(source, name) {
+  const match = source.match(new RegExp(`!macro ${name}\\b([\\s\\S]*?)!macroend`));
+  assert.ok(match, `missing NSIS macro ${name}`);
+  return match[1];
+}
 
 for (const target of [
   { platform: "darwin", arch: "arm64", suffix: "" },
@@ -57,4 +64,57 @@ test("generates a multi-resolution Windows ICO from the macOS icon", () => {
   } finally {
     rmSync(root, { recursive: true, force: true });
   }
+});
+
+test("Windows installer force-stops LazyMind before invoking an old uninstaller", () => {
+  const source = readFileSync(installerScript, "utf8");
+  const check = nsisMacro(source, "customCheckAppRunning");
+
+  assert.match(
+    check,
+    /InitPluginsDir[\s\S]*File \/oname=\$PLUGINSDIR\\lazymind-installer-maintenance\.exe[\s\S]*check-stopped --install-dir "\$INSTDIR"/,
+    "the app-running hook must initialize its own helper before the silent-uninstall check",
+  );
+  assert.match(check, /\$0 == 10[\s\S]*force-stop --install-dir "\$INSTDIR"[\s\S]*Goto LMCheckStopped/);
+  assert.doesNotMatch(check, /MB_RETRYCANCEL|LMCloseApp/);
+  assert.match(source, /LangString LMProcessScanFailed[\s\S]*LangString LMForceStopFailed/);
+});
+
+test("Windows installer replaces legacy uninstallers with the fixed embedded uninstaller", () => {
+  const source = readFileSync(installerScript, "utf8");
+  const init = nsisMacro(source, "customInit");
+  const check = nsisMacro(source, "customCheckAppRunning");
+
+  assert.match(
+    init,
+    /File \/oname=\$PLUGINSDIR\\lazymind-upgrade-uninstaller\.exe "\$\{UNINSTALLER_OUT_FILE\}"/,
+  );
+  assert.match(init, /ReadRegStr \$LegacyUninstallString HKCU "\$\{UNINSTALL_REGISTRY_KEY\}" "UninstallString"/);
+  assert.match(
+    check,
+    /LMProcessCheckDone:[\s\S]*!ifndef BUILD_UNINSTALLER[\s\S]*\$LegacyUninstallString != ""[\s\S]*\$InstalledVersion != ""[\s\S]*CopyFiles \/SILENT "\$UpgradeUninstaller" "\$INSTDIR\\\$\{UNINSTALL_FILENAME\}"/,
+    "the compatibility replacement must run only in the installer after process cleanup",
+  );
+  assert.match(
+    check,
+    /WriteRegStr HKCU "\$\{UNINSTALL_REGISTRY_KEY\}" "UninstallString" '\"\$INSTDIR\\\$\{UNINSTALL_FILENAME\}\"'/,
+    "stale uninstall registrations must be redirected to the repaired uninstaller",
+  );
+  assert.match(check, /ReadRegStr \$0 HKCU "\$\{UNINSTALL_REGISTRY_KEY\}" "UninstallString"[\s\S]*LMUpgradeRepairFailed/);
+  assert.match(check, /LMUpgradeRepairFailed[\s\S]*SetErrorLevel 8/);
+});
+
+test("Windows installer verifies and force-cleans processes left by warmup", () => {
+  const source = readFileSync(installerScript, "utf8");
+  const install = nsisMacro(source, "customInstall");
+
+  assert.match(
+    install,
+    /ExecWait[^\n]+--installer-warmup[^\n]+\$3[\s\S]*LMWarmupCheckStopped:[\s\S]*check-stopped --install-dir "\$INSTDIR"/,
+  );
+  assert.match(
+    install,
+    /\$0 == 10[\s\S]*force-stop --install-dir "\$INSTDIR"[\s\S]*Goto LMWarmupCheckStopped/,
+  );
+  assert.match(install, /\$4 == 1[\s\S]*StrCpy \$3 4[\s\S]*\$3 != 0/);
 });

--- a/desktop/scripts/installer-warmup.test.mjs
+++ b/desktop/scripts/installer-warmup.test.mjs
@@ -1,0 +1,107 @@
+import assert from "node:assert/strict";
+import { createRequire } from "node:module";
+import test from "node:test";
+
+const require = createRequire(import.meta.url);
+const {
+  assertMaintenanceRuntimeStopped,
+  runInstallerWarmupLifecycle,
+} = require("../electron/src/installer-warmup.js");
+
+function readyStatus() {
+  return {
+    overallStatus: "ready",
+    ownerMatched: true,
+    config: { frontendPort: 8090 },
+    services: { frontend: { status: "running" } },
+  };
+}
+
+function stoppedStatus() {
+  return {
+    overallStatus: "stopped",
+    ownerMatched: true,
+    config: { frontendPort: 8090 },
+    services: {
+      frontend: { status: "stopped" },
+      "process-supervisor": { status: "stopped" },
+    },
+  };
+}
+
+function deferred() {
+  let resolve;
+  let reject;
+  const promise = new Promise((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, resolve, reject };
+}
+
+test("installer warmup waits for verified runtime shutdown before disposing its renderer", async () => {
+  const events = [];
+  const shutdown = deferred();
+  let statusReads = 0;
+  const run = runInstallerWarmupLifecycle({
+    startRuntime: async () => events.push("start"),
+    readStatus: async () => (++statusReads === 1 ? readyStatus() : stoppedStatus()),
+    createRenderer: () => ({ id: "renderer" }),
+    loadRenderer: async () => events.push("render"),
+    stopRuntime: async () => {
+      events.push("stop-started");
+      await shutdown.promise;
+      events.push("stop-finished");
+    },
+    disposeRenderer: () => events.push("disposed"),
+    log: () => {},
+  });
+
+  await new Promise((resolve) => setImmediate(resolve));
+  assert.deepEqual(events, ["start", "render", "stop-started"]);
+  shutdown.resolve();
+  await run;
+  assert.deepEqual(events, ["start", "render", "stop-started", "stop-finished", "disposed"]);
+});
+
+test("installer warmup still cleans up after renderer failure", async () => {
+  const events = [];
+  let statusReads = 0;
+  await assert.rejects(runInstallerWarmupLifecycle({
+    startRuntime: async () => events.push("start"),
+    readStatus: async () => (++statusReads === 1 ? readyStatus() : stoppedStatus()),
+    createRenderer: () => ({ id: "renderer" }),
+    loadRenderer: async () => {
+      events.push("render");
+      throw new Error("renderer failed");
+    },
+    stopRuntime: async () => events.push("stop"),
+    disposeRenderer: () => events.push("disposed"),
+    log: () => {},
+  }), /renderer failed/);
+  assert.deepEqual(events, ["start", "render", "stop", "disposed"]);
+});
+
+test("installer warmup fails when shutdown cannot be verified", async () => {
+  let statusReads = 0;
+  await assert.rejects(runInstallerWarmupLifecycle({
+    startRuntime: async () => {},
+    readStatus: async () => (++statusReads === 1 ? readyStatus() : {
+      ...stoppedStatus(),
+      overallStatus: "ready",
+      services: { frontend: { status: "running" } },
+    }),
+    createRenderer: () => ({}),
+    loadRenderer: async () => {},
+    stopRuntime: async () => {},
+    disposeRenderer: () => {},
+    log: () => {},
+  }), /did not stop cleanly/);
+});
+
+test("maintenance stopped verification rejects mismatched ownership", () => {
+  assert.throws(
+    () => assertMaintenanceRuntimeStopped({ ...stoppedStatus(), ownerMatched: false }),
+    /ownerMatched=false/,
+  );
+});

--- a/desktop/scripts/runtime-status.test.mjs
+++ b/desktop/scripts/runtime-status.test.mjs
@@ -52,6 +52,20 @@ test("fails fast when a ready Desktop runtime has a stale owner", () => {
   assert.match(message, /Another LazyMind Desktop instance owns/);
 });
 
+test("preserves a concrete sidecar failure instead of masking it with stale ownership", () => {
+  const message = runtimeExitFailureMessage(
+    { overallStatus: "ready", ownerMatched: false },
+    true,
+    {
+      code: 1,
+      detail: "replace relocatable desktop Python executable: the file is being used by another process",
+    },
+  );
+
+  assert.match(message, /file is being used by another process/);
+  assert.doesNotMatch(message, /Another LazyMind Desktop instance owns/);
+});
+
 test("does not reject a ready runtime owned by this Desktop instance", () => {
   const message = runtimeExitFailureMessage(
     { overallStatus: "ready", ownerMatched: true },

--- a/desktop/scripts/runtime-status.test.mjs
+++ b/desktop/scripts/runtime-status.test.mjs
@@ -3,7 +3,44 @@ import test from "node:test";
 import { createRequire } from "node:module";
 
 const require = createRequire(import.meta.url);
-const { runtimeExitFailureMessage } = require("../electron/src/runtime-status.js");
+const {
+  desktopRuntimeReady,
+  requiredDesktopServices,
+  runtimeExitFailureMessage,
+} = require("../electron/src/runtime-status.js");
+
+function readyDesktopStatus(overrides = {}) {
+  return {
+    overallStatus: "ready",
+    ownerMatched: true,
+    config: { frontendPort: 8080, modeProfile: { VectorStore: { ManagedProcess: false } } },
+    services: Object.fromEntries(requiredDesktopServices.map((name) => [name, { status: "running" }])),
+    ...overrides,
+  };
+}
+
+test("opens Desktop only after every required service is ready", () => {
+  assert.equal(desktopRuntimeReady(readyDesktopStatus(), true), true);
+
+  const status = readyDesktopStatus();
+  status.services["file-watcher"] = { status: "starting" };
+  assert.equal(desktopRuntimeReady(status, true), false);
+});
+
+test("requires a managed Milvus process to be ready", () => {
+  const status = readyDesktopStatus({
+    config: { frontendPort: 8080, modeProfile: { VectorStore: { ManagedProcess: true } } },
+  });
+  assert.equal(desktopRuntimeReady(status, true), false);
+
+  status.services["milvus-lite"] = { status: "running" };
+  assert.equal(desktopRuntimeReady(status, true), true);
+});
+
+test("rejects a complete runtime that is not owned by this Desktop", () => {
+  assert.equal(desktopRuntimeReady(readyDesktopStatus(), false), false);
+  assert.equal(desktopRuntimeReady(readyDesktopStatus({ ownerMatched: false }), true), false);
+});
 
 test("fails fast when a ready Desktop runtime has a stale owner", () => {
   const message = runtimeExitFailureMessage(

--- a/frontend/src/modules/chat/pages/home/index.tsx
+++ b/frontend/src/modules/chat/pages/home/index.tsx
@@ -1,7 +1,23 @@
+import { useEffect } from "react";
 import NewChatPage from "../newChat";
 import "./index.scss";
 
 function Home() {
+  useEffect(() => {
+    let secondFrame: number | undefined;
+    const firstFrame = window.requestAnimationFrame(() => {
+      secondFrame = window.requestAnimationFrame(() => {
+        window.lazymindDesktop?.notifyAppReady?.();
+      });
+    });
+    return () => {
+      window.cancelAnimationFrame(firstFrame);
+      if (secondFrame !== undefined) {
+        window.cancelAnimationFrame(secondFrame);
+      }
+    };
+  }, []);
+
   return (
     <div className="chat-wrapper">
       <div className="chat-content">

--- a/frontend/src/vite-env.d.ts
+++ b/frontend/src/vite-env.d.ts
@@ -23,6 +23,7 @@ declare global {
       resetRuntime?: (scope?: "kb" | "all") => Promise<unknown> | unknown;
       selectFolder?: () => Promise<string | null> | string | null;
       exportDiagnostics?: () => Promise<string> | string;
+      notifyAppReady?: () => void;
     };
   }
 }

--- a/local/local-runtime-manager/cmd/installer-maintenance/main_windows.go
+++ b/local/local-runtime-manager/cmd/installer-maintenance/main_windows.go
@@ -1,51 +1,117 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"io/fs"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
-	"syscall"
 	"time"
-	"unsafe"
 
+	"github.com/mesotron7x/LazyMind/local/local-runtime-manager/internal/winprocess"
 	"golang.org/x/sys/windows"
 )
 
-const appDataLeaf = "LazyMind"
+const (
+	appDataLeaf       = "LazyMind"
+	runningExitCode   = 10
+	processScanLimit  = 10 * time.Second
+	processStopLimit  = 15 * time.Second
+	maintenanceLogDir = "Logs"
+	registryReadTries = 6
+	registryReadDelay = 50 * time.Millisecond
+)
 
 type processRegistry struct {
 	Processes []processRecord `json:"processes"`
 }
 
 type processRecord struct {
+	Service string `json:"service"`
 	PID     int    `json:"pid"`
 	StartID uint64 `json:"startId,omitempty"`
 }
 
+type runningProcess struct {
+	Service     string
+	PID         int
+	StartID     uint64
+	Executable  string
+	MatchReason string
+}
+
+type commandOptions struct {
+	Command    string
+	InstallDir string
+}
+
 func main() {
-	if len(os.Args) != 2 {
-		fatalf("usage: lazymind-installer-maintenance check-stopped|purge-local-data")
+	opts, err := parseCommandOptions(os.Args[1:])
+	if err != nil {
+		fatalf("%v", err)
 	}
 	root, err := localAppDataRoot()
 	if err != nil {
 		fatalf("resolve Local AppData: %v", err)
 	}
-	switch os.Args[1] {
+	switch opts.Command {
 	case "check-stopped":
-		if err := checkStopped(root); err != nil {
-			fatalf("%v", err)
+		started := time.Now()
+		processes, err := discoverRunningProcesses(root, opts.InstallDir)
+		if err != nil {
+			logMaintenance(root, "scan failed after %s: %v", time.Since(started).Round(time.Millisecond), err)
+			fatalf("scan LazyMind processes: %v", err)
+		}
+		if len(processes) > 0 {
+			summary := processSummary(processes)
+			logMaintenance(root, "scan completed in %s; found %d running process(es): %s", time.Since(started).Round(time.Millisecond), len(processes), summary)
+			_, _ = fmt.Fprintln(os.Stderr, summary)
+			os.Exit(runningExitCode)
+		}
+		logMaintenance(root, "scan completed in %s; no running LazyMind processes found", time.Since(started).Round(time.Millisecond))
+	case "force-stop":
+		started := time.Now()
+		processes, err := forceStop(root, opts.InstallDir)
+		if err != nil {
+			logMaintenance(root, "force-stop failed after %s: %v", time.Since(started).Round(time.Millisecond), err)
+			fatalf("force-stop LazyMind processes: %v", err)
+		}
+		summary := processSummary(processes)
+		logMaintenance(root, "force-stop completed in %s; stopped %d LazyMind process(es): %s", time.Since(started).Round(time.Millisecond), len(processes), summary)
+		if len(processes) > 0 {
+			_, _ = fmt.Fprintln(os.Stdout, processSummary(processes))
 		}
 	case "purge-local-data":
 		if err := purgeLocalData(root); err != nil {
 			fatalf("purge %s: %v", root, err)
 		}
 	default:
-		fatalf("unsupported command %q", os.Args[1])
+		fatalf("unsupported command %q", opts.Command)
 	}
+}
+
+func parseCommandOptions(args []string) (commandOptions, error) {
+	if len(args) == 0 {
+		return commandOptions{}, errors.New("usage: lazymind-installer-maintenance check-stopped|force-stop|purge-local-data [--install-dir <path>]")
+	}
+	opts := commandOptions{Command: args[0]}
+	for index := 1; index < len(args); index++ {
+		switch args[index] {
+		case "--install-dir":
+			index++
+			if index >= len(args) || strings.TrimSpace(args[index]) == "" {
+				return commandOptions{}, errors.New("--install-dir requires a path")
+			}
+			opts.InstallDir = filepath.Clean(args[index])
+		default:
+			return commandOptions{}, fmt.Errorf("unsupported argument %q", args[index])
+		}
+	}
+	return opts, nil
 }
 
 func fatalf(format string, args ...any) {
@@ -63,90 +129,251 @@ func localAppDataRoot() (string, error) {
 
 func localAppDataTarget(base string) (string, error) {
 	base = filepath.Clean(base)
-	if base == "" || base == "." || filepath.IsAbs(base) == false {
+	if base == "" || base == "." || !filepath.IsAbs(base) {
 		return "", fmt.Errorf("invalid Local AppData path %q", base)
 	}
 	return filepath.Join(base, appDataLeaf), nil
 }
 
+func readProcessRegistry(root string) (processRegistry, error) {
+	path := filepath.Join(root, "run", "processes.json")
+	var lastErr error
+	for attempt := 1; attempt <= registryReadTries; attempt++ {
+		raw, err := os.ReadFile(path)
+		if err != nil {
+			if errors.Is(err, fs.ErrNotExist) {
+				return processRegistry{}, nil
+			}
+			lastErr = err
+		} else {
+			var registry processRegistry
+			if err := json.Unmarshal(raw, &registry); err == nil {
+				return registry, nil
+			} else {
+				lastErr = err
+			}
+		}
+		if attempt < registryReadTries {
+			time.Sleep(registryReadDelay)
+		}
+	}
+	return processRegistry{}, fmt.Errorf("read runtime process registry after %d attempts: %w", registryReadTries, lastErr)
+}
+
 func checkStopped(root string) error {
-	running, err := processNamed("LazyMind.exe")
+	processes, err := discoverRunningProcesses(root, "")
 	if err != nil {
 		return err
 	}
-	if running {
-		return errors.New("LazyMind.exe is still running")
-	}
-	raw, err := os.ReadFile(filepath.Join(root, "run", "processes.json"))
-	if err != nil {
-		if errors.Is(err, fs.ErrNotExist) {
-			return nil
-		}
-		return err
-	}
-	var registry processRegistry
-	if err := json.Unmarshal(raw, &registry); err != nil {
-		return fmt.Errorf("read runtime process registry: %w", err)
-	}
-	for _, process := range registry.Processes {
-		if process.PID > 0 && processMatchesStartIdentity(uint32(process.PID), process.StartID) {
-			return fmt.Errorf("LazyMind runtime process %d is still running", process.PID)
-		}
+	if len(processes) > 0 {
+		return fmt.Errorf("LazyMind is still running: %s", processSummary(processes))
 	}
 	return nil
 }
 
-func processNamed(name string) (bool, error) {
-	snapshot, err := windows.CreateToolhelp32Snapshot(windows.TH32CS_SNAPPROCESS, 0)
+func discoverRunningProcesses(root, installDir string) ([]runningProcess, error) {
+	installDir, err := trustedInstallDir(root, installDir)
 	if err != nil {
-		return false, err
+		return nil, err
 	}
-	defer windows.CloseHandle(snapshot)
-	entry := windows.ProcessEntry32{Size: uint32(unsafeSizeofProcessEntry32())}
-	err = windows.Process32First(snapshot, &entry)
-	for err == nil {
-		if strings.EqualFold(windows.UTF16ToString(entry.ExeFile[:]), name) {
-			return true, nil
+	registry, err := readProcessRegistry(root)
+	if err != nil {
+		return nil, err
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), processScanLimit)
+	defer cancel()
+	inventory, err := winprocess.Snapshot(ctx)
+	if err != nil {
+		return nil, err
+	}
+	sessionID, err := winprocess.CurrentSession(inventory, os.Getpid())
+	if err != nil {
+		return nil, err
+	}
+	excluded := winprocess.ExcludedAncestors(inventory, os.Getpid())
+	registered := make(map[int]processRecord, len(registry.Processes))
+	executableRoots := compactRoots(root, installDir)
+	for _, record := range registry.Processes {
+		if record.PID > 0 {
+			registered[record.PID] = record
 		}
-		err = windows.Process32Next(snapshot, &entry)
 	}
-	if errors.Is(err, syscall.ERROR_NO_MORE_FILES) {
-		return false, nil
+	byPID := make(map[int]runningProcess)
+	for _, process := range inventory {
+		pid := int(process.ProcessID)
+		if pid <= 0 || excluded[pid] {
+			continue
+		}
+		record, registeredPID := registered[pid]
+		reason, matched := matchLazyMindProcess(process, record, registeredPID, process.SessionID == sessionID, executableRoots)
+		if !matched {
+			continue
+		}
+		executable := strings.TrimSpace(winprocess.Text(process.ExecutablePath))
+		service := strings.TrimSpace(record.Service)
+		if service == "" {
+			if strings.EqualFold(filepath.Base(executable), "LazyMind.exe") {
+				service = "desktop"
+			} else {
+				service = "local-runtime-orphan"
+			}
+		}
+		byPID[pid] = runningProcess{
+			Service:     service,
+			PID:         pid,
+			StartID:     process.StartID,
+			Executable:  executable,
+			MatchReason: reason,
+		}
 	}
-	return false, err
+	processes := make([]runningProcess, 0, len(byPID))
+	for _, process := range byPID {
+		processes = append(processes, process)
+	}
+	sort.Slice(processes, func(i, j int) bool { return processes[i].PID < processes[j].PID })
+	return processes, nil
 }
 
-// Kept behind a helper so the structure size is supplied exactly as required by Toolhelp32.
-func unsafeSizeofProcessEntry32() uintptr {
-	var entry windows.ProcessEntry32
-	return unsafe.Sizeof(entry)
+func matchLazyMindProcess(process winprocess.Info, record processRecord, registeredPID bool, sameSession bool, executableRoots []string) (string, bool) {
+	if registeredPID && record.StartID != 0 && process.StartID == record.StartID {
+		return "registered-pid-start-id", true
+	}
+	executable := strings.TrimSpace(winprocess.Text(process.ExecutablePath))
+	if executableMatchesRoots(executable, executableRoots) {
+		return "executable-under-owned-root", true
+	}
+	if sameSession && strings.EqualFold(filepath.Base(executable), "LazyMind.exe") {
+		return "desktop-executable-name", true
+	}
+	return "", false
+}
+
+func trustedInstallDir(root, candidate string) (string, error) {
+	candidate = strings.TrimSpace(candidate)
+	if candidate == "" {
+		return "", nil
+	}
+	root = filepath.Clean(root)
+	if !filepath.IsAbs(root) || !strings.EqualFold(filepath.Base(root), appDataLeaf) {
+		return "", fmt.Errorf("invalid LazyMind Local AppData root %q", root)
+	}
+	expected := filepath.Join(filepath.Dir(root), "Programs", appDataLeaf)
+	candidate = filepath.Clean(candidate)
+	if !filepath.IsAbs(candidate) || !strings.EqualFold(candidate, expected) {
+		return "", fmt.Errorf("untrusted LazyMind install directory %q; expected %q", candidate, expected)
+	}
+	return expected, nil
+}
+
+func compactRoots(values ...string) []string {
+	roots := make([]string, 0, len(values))
+	for _, value := range values {
+		roots = appendUniqueRoot(roots, value)
+	}
+	return roots
+}
+
+func appendUniqueRoot(roots []string, value string) []string {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return roots
+	}
+	value = strings.ToLower(filepath.Clean(value))
+	if value == "." || !filepath.IsAbs(value) {
+		return roots
+	}
+	for _, root := range roots {
+		if root == value {
+			return roots
+		}
+	}
+	return append(roots, value)
+}
+
+func executableMatchesRoots(executable string, roots []string) bool {
+	executable = strings.ToLower(filepath.Clean(strings.TrimSpace(executable)))
+	if executable == "" || executable == "." || !filepath.IsAbs(executable) {
+		return false
+	}
+	for _, root := range roots {
+		if executable == root || strings.HasPrefix(executable, root+string(filepath.Separator)) {
+			return true
+		}
+	}
+	return false
+}
+
+func processSummary(processes []runningProcess) string {
+	parts := make([]string, 0, len(processes))
+	for _, process := range processes {
+		name := strings.TrimSpace(process.Service)
+		if name == "" {
+			name = filepath.Base(process.Executable)
+		}
+		if name == "" {
+			name = "unknown"
+		}
+		executable := filepath.Base(process.Executable)
+		if executable == "" || executable == "." {
+			executable = "unknown"
+		}
+		parts = append(parts, fmt.Sprintf("%s(pid=%d, exe=%s, reason=%s)", name, process.PID, executable, process.MatchReason))
+	}
+	return strings.Join(parts, ", ")
+}
+
+func forceStop(root, installDir string) ([]runningProcess, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), processStopLimit)
+	defer cancel()
+	stopped := make([]runningProcess, 0)
+	seen := make(map[int]bool)
+	deadline := time.Now().Add(processStopLimit)
+	for {
+		processes, err := discoverRunningProcesses(root, installDir)
+		if err != nil {
+			return stopped, err
+		}
+		if len(processes) == 0 {
+			_ = os.Remove(filepath.Join(root, "run", "processes.json"))
+			return stopped, nil
+		}
+		if time.Now().After(deadline) {
+			return stopped, fmt.Errorf("processes still running after %s: %s", processStopLimit, processSummary(processes))
+		}
+		for _, process := range processes {
+			if !seen[process.PID] {
+				stopped = append(stopped, process)
+				seen[process.PID] = true
+			}
+			if err := winprocess.ForceKillTree(ctx, process.PID, process.StartID); errors.Is(err, winprocess.ErrProcessIdentityChanged) {
+				continue
+			} else if err != nil {
+				return stopped, fmt.Errorf("stop %s pid %d: %w", process.Service, process.PID, err)
+			}
+		}
+		time.Sleep(250 * time.Millisecond)
+	}
 }
 
 func processAlive(pid uint32) bool {
-	handle, err := windows.OpenProcess(windows.SYNCHRONIZE, false, pid)
-	if err != nil {
-		return false
-	}
-	defer windows.CloseHandle(handle)
-	state, err := windows.WaitForSingleObject(handle, 0)
-	return err == nil && state == uint32(windows.WAIT_TIMEOUT)
+	return winprocess.Alive(int(pid))
 }
 
 func processStartIdentity(pid uint32) uint64 {
-	handle, err := windows.OpenProcess(windows.PROCESS_QUERY_LIMITED_INFORMATION, false, pid)
-	if err != nil {
-		return 0
-	}
-	defer windows.CloseHandle(handle)
-	var created, exited, kernel, user windows.Filetime
-	if err := windows.GetProcessTimes(handle, &created, &exited, &kernel, &user); err != nil {
-		return 0
-	}
-	return uint64(created.HighDateTime)<<32 | uint64(created.LowDateTime)
+	return winprocess.StartIdentity(int(pid))
 }
 
-func processMatchesStartIdentity(pid uint32, expected uint64) bool {
-	return expected != 0 && processAlive(pid) && processStartIdentity(pid) == expected
+func logMaintenance(root, format string, args ...any) {
+	path := filepath.Join(root, maintenanceLogDir, "desktop", "installer-maintenance.log")
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return
+	}
+	file, err := os.OpenFile(path, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o600)
+	if err != nil {
+		return
+	}
+	defer file.Close()
+	_, _ = fmt.Fprintf(file, "[%s] %s\n", time.Now().UTC().Format(time.RFC3339), fmt.Sprintf(format, args...))
 }
 
 func purgeLocalData(target string) error {

--- a/local/local-runtime-manager/cmd/installer-maintenance/main_windows.go
+++ b/local/local-runtime-manager/cmd/installer-maintenance/main_windows.go
@@ -257,6 +257,11 @@ func trustedInstallDir(root, candidate string) (string, error) {
 	if !filepath.IsAbs(root) || !strings.EqualFold(filepath.Base(root), appDataLeaf) {
 		return "", fmt.Errorf("invalid LazyMind Local AppData root %q", root)
 	}
+	// This path is an authorization boundary for terminating every executable
+	// below it, not just a convenience validation. The Desktop installer does
+	// not allow a custom install directory. If that product policy changes, the
+	// helper must authenticate a registered install path instead of trusting a
+	// caller-controlled directory merely because its base name is LazyMind.
 	expected := filepath.Join(filepath.Dir(root), "Programs", appDataLeaf)
 	candidate = filepath.Clean(candidate)
 	if !filepath.IsAbs(candidate) || !strings.EqualFold(candidate, expected) {

--- a/local/local-runtime-manager/cmd/installer-maintenance/main_windows_test.go
+++ b/local/local-runtime-manager/cmd/installer-maintenance/main_windows_test.go
@@ -3,8 +3,12 @@ package main
 import (
 	"encoding/json"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"testing"
+	"time"
+
+	"github.com/mesotron7x/LazyMind/local/local-runtime-manager/internal/winprocess"
 )
 
 func TestLocalAppDataTargetIsFixedChild(t *testing.T) {
@@ -29,13 +33,18 @@ func TestProcessAliveDetectsCurrentProcess(t *testing.T) {
 
 func TestCheckStoppedValidatesRegistryProcessStartIdentity(t *testing.T) {
 	root := t.TempDir()
-	startID := processStartIdentity(uint32(os.Getpid()))
+	cmd := startInstallerMaintenanceHelperProcess(t)
+	startID := processStartIdentity(uint32(cmd.Process.Pid))
 	if startID == 0 {
-		t.Fatal("could not read current process start identity")
+		t.Fatal("could not read child process start identity")
 	}
 	writeRegistry := func(id uint64) {
 		t.Helper()
-		registry := processRegistry{Processes: []processRecord{{PID: os.Getpid(), StartID: id}}}
+		registry := processRegistry{Processes: []processRecord{{
+			Service: "test-runtime",
+			PID:     cmd.Process.Pid,
+			StartID: id,
+		}}}
 		raw, err := json.Marshal(registry)
 		if err != nil {
 			t.Fatal(err)
@@ -56,6 +65,197 @@ func TestCheckStoppedValidatesRegistryProcessStartIdentity(t *testing.T) {
 	if err := checkStopped(root); err == nil {
 		t.Fatal("matching live runtime process did not block setup")
 	}
+}
+
+func TestForceStopTerminatesRegisteredProcess(t *testing.T) {
+	root := t.TempDir()
+	cmd := startInstallerMaintenanceHelperProcess(t)
+	startID := processStartIdentity(uint32(cmd.Process.Pid))
+	if startID == 0 {
+		t.Fatal("could not read child process start identity")
+	}
+	registry := processRegistry{Processes: []processRecord{{
+		Service: "test-runtime",
+		PID:     cmd.Process.Pid,
+		StartID: startID,
+	}}}
+	raw, err := json.Marshal(registry)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(root, "run"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "run", "processes.json"), raw, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	stopped, err := forceStop(root, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(stopped) != 1 || stopped[0].PID != cmd.Process.Pid {
+		t.Fatalf("stopped = %#v, want pid %d", stopped, cmd.Process.Pid)
+	}
+	if stopped[0].MatchReason != "registered-pid-start-id" {
+		t.Fatalf("match reason = %q", stopped[0].MatchReason)
+	}
+	if processAlive(uint32(cmd.Process.Pid)) {
+		t.Fatal("registered child process is still alive")
+	}
+	if _, err := os.Stat(filepath.Join(root, "run", "processes.json")); !os.IsNotExist(err) {
+		t.Fatalf("process registry was not removed: %v", err)
+	}
+}
+
+func TestInstallerMaintenanceHelperProcess(t *testing.T) {
+	if os.Getenv("LAZYMIND_INSTALLER_HELPER_PROCESS") != "1" {
+		return
+	}
+	time.Sleep(time.Minute)
+}
+
+func startInstallerMaintenanceHelperProcess(t *testing.T) *exec.Cmd {
+	t.Helper()
+	cmd := exec.Command(os.Args[0], "-test.run=^TestInstallerMaintenanceHelperProcess$")
+	cmd.Env = append(os.Environ(), "LAZYMIND_INSTALLER_HELPER_PROCESS=1")
+	if err := cmd.Start(); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		_ = cmd.Process.Kill()
+		_, _ = cmd.Process.Wait()
+	})
+	return cmd
+}
+
+func TestParseCommandOptions(t *testing.T) {
+	installDir := filepath.Join(`C:\Users\test\AppData\Local\Programs`, "LazyMind")
+	opts, err := parseCommandOptions([]string{"force-stop", "--install-dir", installDir})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if opts.Command != "force-stop" || opts.InstallDir != filepath.Clean(installDir) {
+		t.Fatalf("options = %#v", opts)
+	}
+	if _, err := parseCommandOptions(nil); err == nil {
+		t.Fatal("missing command was accepted")
+	}
+	if _, err := parseCommandOptions([]string{"force-stop", "--install-dir"}); err == nil {
+		t.Fatal("missing install directory was accepted")
+	}
+	if _, err := parseCommandOptions([]string{"force-stop", "--unknown"}); err == nil {
+		t.Fatal("unknown argument was accepted")
+	}
+}
+
+func TestMatchLazyMindProcessMatchesExecutableUnderInstallDir(t *testing.T) {
+	installDir := filepath.Join(`C:\Users\test\AppData\Local\Programs`, "LazyMind")
+	process := processInfo(1002, filepath.Join(installDir, "resources", "runtime", "bin", "auth-service.exe"))
+	roots := compactRoots(installDir)
+	reason, matched := matchLazyMindProcess(process, processRecord{}, false, true, roots)
+	if !matched || reason != "executable-under-owned-root" {
+		t.Fatalf("matched=%v reason=%q", matched, reason)
+	}
+}
+
+func TestExecutableRootMatchRequiresPathBoundary(t *testing.T) {
+	installDir := filepath.Join(`C:\Users\test\AppData\Local\Programs`, "LazyMind")
+	lookalike := installDir + "-tools" + string(filepath.Separator) + "worker.exe"
+	process := processInfo(1004, lookalike)
+	roots := compactRoots(installDir)
+	reason, matched := matchLazyMindProcess(process, processRecord{}, false, true, roots)
+	if matched {
+		t.Fatalf("lookalike root matched with reason %q", reason)
+	}
+}
+
+func TestRepoRootDoesNotAuthorizeArbitraryExecutable(t *testing.T) {
+	installDir := filepath.Join(`C:\Users\test\AppData\Local\Programs`, "LazyMind")
+	repoRoot := filepath.Join(`C:\Users\test\src`, "LazyMind")
+	process := processInfo(1005, filepath.Join(repoRoot, "tools", "unrelated.exe"))
+	reason, matched := matchLazyMindProcess(process, processRecord{}, false, true, compactRoots(installDir))
+	if matched {
+		t.Fatalf("arbitrary repo executable matched with reason %q", reason)
+	}
+}
+
+func TestRegisteredProcessRequiresMatchingStartIdentity(t *testing.T) {
+	process := processInfo(1006, `C:\Python311\python.exe`)
+	record := processRecord{Service: "auth-service", PID: 1006, StartID: 456}
+	if reason, matched := matchLazyMindProcess(process, record, true, false, nil); matched {
+		t.Fatalf("reused registered PID matched with reason %q", reason)
+	}
+	process.StartID = 456
+	if reason, matched := matchLazyMindProcess(process, record, true, false, nil); !matched || reason != "registered-pid-start-id" {
+		t.Fatalf("matching registered PID: matched=%v reason=%q", matched, reason)
+	}
+}
+
+func TestCrossSessionMatchRequiresRegistrationOrTrustedExecutableRoot(t *testing.T) {
+	installDir := filepath.Join(`C:\Users\test\AppData\Local\Programs`, "LazyMind")
+	roots := compactRoots(installDir)
+	owned := processInfo(1007, filepath.Join(installDir, "resources", "runtime", "bin", "local-runtime-manager.exe"))
+	if reason, matched := matchLazyMindProcess(owned, processRecord{}, false, false, roots); !matched || reason != "executable-under-owned-root" {
+		t.Fatalf("cross-session owned process: matched=%v reason=%q", matched, reason)
+	}
+	untrusted := processInfo(1008, `D:\OtherUser\LazyMind.exe`)
+	if reason, matched := matchLazyMindProcess(untrusted, processRecord{}, false, false, roots); matched {
+		t.Fatalf("cross-session name-only process matched with reason %q", reason)
+	}
+}
+
+func TestTrustedInstallDirAcceptsOnlyDefaultPerUserPath(t *testing.T) {
+	base := t.TempDir()
+	root := filepath.Join(base, appDataLeaf)
+	expected := filepath.Join(base, "Programs", appDataLeaf)
+	if got, err := trustedInstallDir(root, expected); err != nil || got != expected {
+		t.Fatalf("trusted install dir = %q, err=%v", got, err)
+	}
+	if _, err := trustedInstallDir(root, filepath.Join(base, "Programs", "Other")); err == nil {
+		t.Fatal("unexpected install directory was trusted")
+	}
+	if _, err := trustedInstallDir(root, `C:\Windows`); err == nil {
+		t.Fatal("system directory was trusted as the install directory")
+	}
+}
+
+func TestReadProcessRegistryRetriesTransientPartialWrite(t *testing.T) {
+	root := t.TempDir()
+	path := filepath.Join(root, "run", "processes.json")
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(`{"processes":[`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	done := make(chan error, 1)
+	go func() {
+		time.Sleep(registryReadDelay + 10*time.Millisecond)
+		done <- os.WriteFile(path, []byte(`{"processes":[{"service":"core","pid":42,"startId":99}]}`), 0o600)
+	}()
+	registry, err := readProcessRegistry(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := <-done; err != nil {
+		t.Fatal(err)
+	}
+	if len(registry.Processes) != 1 || registry.Processes[0].StartID != 99 {
+		t.Fatalf("registry = %#v", registry)
+	}
+}
+
+func processInfo(pid uint32, executable string) winprocess.Info {
+	return winprocess.Info{
+		ProcessID:      pid,
+		StartID:        123,
+		ExecutablePath: stringPointer(executable),
+	}
+}
+
+func stringPointer(value string) *string {
+	return &value
 }
 
 func TestPurgeLocalDataDoesNotTouchSiblingData(t *testing.T) {

--- a/local/local-runtime-manager/frontend.go
+++ b/local/local-runtime-manager/frontend.go
@@ -136,9 +136,11 @@ func (m *FrontendManager) Down(ctx context.Context, cfg RuntimeConfig, paths Run
 	if len(frontendRecords) == 0 {
 		return nil
 	}
-	err := stopLocalProcessRecords(ctx, frontendRecords)
+	if err := stopLocalProcessRecords(ctx, frontendRecords); err != nil {
+		return err
+	}
 	cleanupLocalProcessRecords(paths, frontendRecords)
-	return err
+	return nil
 }
 
 func frontendBuildEnv() []string {

--- a/local/local-runtime-manager/internal/winprocess/process_windows.go
+++ b/local/local-runtime-manager/internal/winprocess/process_windows.go
@@ -1,0 +1,204 @@
+//go:build windows
+
+package winprocess
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"syscall"
+	"unsafe"
+
+	"golang.org/x/sys/windows"
+)
+
+type Info struct {
+	ProcessID       uint32  `json:"ProcessId"`
+	ParentProcessID uint32  `json:"ParentProcessId"`
+	SessionID       uint32  `json:"SessionId"`
+	StartID         uint64  `json:"StartId"`
+	ExecutablePath  *string `json:"ExecutablePath"`
+}
+
+var ErrProcessIdentityChanged = errors.New("process identity changed")
+
+func Snapshot(ctx context.Context) ([]Info, error) {
+	snapshot, err := windows.CreateToolhelp32Snapshot(windows.TH32CS_SNAPPROCESS, 0)
+	if err != nil {
+		return nil, err
+	}
+	defer windows.CloseHandle(snapshot)
+
+	entry := windows.ProcessEntry32{Size: uint32(unsafe.Sizeof(windows.ProcessEntry32{}))}
+	if err := windows.Process32First(snapshot, &entry); err != nil {
+		if errors.Is(err, syscall.ERROR_NO_MORE_FILES) {
+			return []Info{}, nil
+		}
+		return nil, err
+	}
+	processes := make([]Info, 0, 128)
+	for {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+		fallback := windows.UTF16ToString(entry.ExeFile[:])
+		executable, startID := queryProcessDetails(entry.ProcessID, fallback)
+		sessionID := uint32(0)
+		_ = windows.ProcessIdToSessionId(entry.ProcessID, &sessionID)
+		processes = append(processes, Info{
+			ProcessID:       entry.ProcessID,
+			ParentProcessID: entry.ParentProcessID,
+			SessionID:       sessionID,
+			StartID:         startID,
+			ExecutablePath:  &executable,
+		})
+		if err := windows.Process32Next(snapshot, &entry); err != nil {
+			if errors.Is(err, syscall.ERROR_NO_MORE_FILES) {
+				break
+			}
+			return nil, err
+		}
+	}
+	return processes, nil
+}
+
+func queryProcessDetails(pid uint32, fallback string) (string, uint64) {
+	handle, err := windows.OpenProcess(windows.PROCESS_QUERY_LIMITED_INFORMATION, false, pid)
+	if err != nil {
+		return fallback, 0
+	}
+	defer windows.CloseHandle(handle)
+	executable := fallback
+	buffer := make([]uint16, 32768)
+	size := uint32(len(buffer))
+	if err := windows.QueryFullProcessImageName(handle, 0, &buffer[0], &size); err == nil && size > 0 {
+		executable = windows.UTF16ToString(buffer[:size])
+	}
+	return executable, startIdentityFromHandle(handle)
+}
+
+func Text(value *string) string {
+	if value == nil {
+		return ""
+	}
+	return *value
+}
+
+func Alive(pid int) bool {
+	if pid <= 0 {
+		return false
+	}
+	handle, err := windows.OpenProcess(windows.PROCESS_QUERY_LIMITED_INFORMATION, false, uint32(pid))
+	if err == nil {
+		defer windows.CloseHandle(handle)
+		var code uint32
+		return windows.GetExitCodeProcess(handle, &code) == nil && code == 259
+	}
+	snapshot, snapshotErr := windows.CreateToolhelp32Snapshot(windows.TH32CS_SNAPPROCESS, 0)
+	if snapshotErr != nil {
+		return false
+	}
+	defer windows.CloseHandle(snapshot)
+	entry := windows.ProcessEntry32{Size: uint32(unsafe.Sizeof(windows.ProcessEntry32{}))}
+	if snapshotErr = windows.Process32First(snapshot, &entry); snapshotErr != nil {
+		return false
+	}
+	for {
+		if entry.ProcessID == uint32(pid) {
+			return true
+		}
+		if snapshotErr = windows.Process32Next(snapshot, &entry); snapshotErr != nil {
+			return false
+		}
+	}
+}
+
+func StartIdentity(pid int) uint64 {
+	if pid <= 0 {
+		return 0
+	}
+	handle, err := windows.OpenProcess(windows.PROCESS_QUERY_LIMITED_INFORMATION, false, uint32(pid))
+	if err != nil {
+		return 0
+	}
+	defer windows.CloseHandle(handle)
+	return startIdentityFromHandle(handle)
+}
+
+func startIdentityFromHandle(handle windows.Handle) uint64 {
+	var created, exited, kernel, user windows.Filetime
+	if err := windows.GetProcessTimes(handle, &created, &exited, &kernel, &user); err != nil {
+		return 0
+	}
+	return uint64(created.HighDateTime)<<32 | uint64(created.LowDateTime)
+}
+
+func ForceKillTree(ctx context.Context, pid int, expectedStartID uint64) error {
+	if pid <= 0 || !Alive(pid) {
+		return nil
+	}
+	if expectedStartID == 0 {
+		return errors.New("cannot safely stop process because its start identity is unavailable")
+	}
+	currentStartID := StartIdentity(pid)
+	if currentStartID == 0 {
+		if !Alive(pid) {
+			return nil
+		}
+		return errors.New("cannot verify process start identity before force-stop")
+	}
+	if currentStartID != expectedStartID {
+		return ErrProcessIdentityChanged
+	}
+	systemDirectory, err := windows.GetSystemDirectory()
+	if err != nil {
+		return fmt.Errorf("resolve Windows system directory: %w", err)
+	}
+	cmd := exec.CommandContext(ctx, filepath.Join(systemDirectory, "taskkill.exe"), "/PID", strconv.Itoa(pid), "/T", "/F")
+	cmd.SysProcAttr = &syscall.SysProcAttr{CreationFlags: windows.CREATE_NEW_PROCESS_GROUP | windows.CREATE_NO_WINDOW, HideWindow: true}
+	output, err := cmd.CombinedOutput()
+	if err == nil || !matchesStartIdentity(pid, expectedStartID) {
+		return nil
+	}
+	if ctx.Err() != nil {
+		return ctx.Err()
+	}
+	message := strings.TrimSpace(string(output))
+	if message == "" {
+		message = err.Error()
+	}
+	return errors.New(message)
+}
+
+func matchesStartIdentity(pid int, expected uint64) bool {
+	return expected != 0 && Alive(pid) && StartIdentity(pid) == expected
+}
+
+func CurrentSession(processes []Info, pid int) (uint32, error) {
+	var sessionID uint32
+	if pid > 0 && windows.ProcessIdToSessionId(uint32(pid), &sessionID) == nil {
+		return sessionID, nil
+	}
+	for _, process := range processes {
+		if int(process.ProcessID) == pid {
+			return process.SessionID, nil
+		}
+	}
+	return 0, fmt.Errorf("process %d is missing from Windows process inventory", pid)
+}
+
+func ExcludedAncestors(processes []Info, pid int) map[int]bool {
+	parents := make(map[int]int, len(processes))
+	for _, process := range processes {
+		parents[int(process.ProcessID)] = int(process.ParentProcessID)
+	}
+	excluded := map[int]bool{}
+	for current := pid; current > 0 && !excluded[current]; current = parents[current] {
+		excluded[current] = true
+	}
+	return excluded
+}

--- a/local/local-runtime-manager/internal/winprocess/process_windows_test.go
+++ b/local/local-runtime-manager/internal/winprocess/process_windows_test.go
@@ -1,0 +1,95 @@
+//go:build windows
+
+package winprocess
+
+import (
+	"context"
+	"errors"
+	"os"
+	"os/exec"
+	"testing"
+	"time"
+)
+
+func TestExcludedAncestorsExcludesOnlySelfAndAncestorChain(t *testing.T) {
+	processes := []Info{
+		{ProcessID: 10, ParentProcessID: 0},
+		{ProcessID: 20, ParentProcessID: 10},
+		{ProcessID: 30, ParentProcessID: 20},
+		{ProcessID: 40, ParentProcessID: 20},
+		{ProcessID: 50, ParentProcessID: 40},
+	}
+	excluded := ExcludedAncestors(processes, 30)
+	for _, pid := range []int{10, 20, 30} {
+		if !excluded[pid] {
+			t.Errorf("pid %d was not excluded", pid)
+		}
+	}
+	for _, pid := range []int{40, 50} {
+		if excluded[pid] {
+			t.Errorf("sibling/descendant pid %d was unexpectedly excluded", pid)
+		}
+	}
+}
+
+func TestExcludedAncestorsStopsAtParentCycle(t *testing.T) {
+	processes := []Info{
+		{ProcessID: 10, ParentProcessID: 20},
+		{ProcessID: 20, ParentProcessID: 10},
+	}
+	excluded := ExcludedAncestors(processes, 10)
+	if !excluded[10] || !excluded[20] || len(excluded) != 2 {
+		t.Fatalf("excluded = %#v", excluded)
+	}
+}
+
+func TestSnapshotPairsCurrentExecutableWithStartIdentity(t *testing.T) {
+	processes, err := Snapshot(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	wantStartID := StartIdentity(os.Getpid())
+	for _, process := range processes {
+		if int(process.ProcessID) != os.Getpid() {
+			continue
+		}
+		if process.StartID == 0 || process.StartID != wantStartID {
+			t.Fatalf("snapshot start identity = %d, want %d", process.StartID, wantStartID)
+		}
+		if Text(process.ExecutablePath) == "" {
+			t.Fatal("snapshot executable path is empty")
+		}
+		return
+	}
+	t.Fatal("current process is missing from snapshot")
+}
+
+func TestForceKillTreeRejectsReusedPIDIdentity(t *testing.T) {
+	cmd := exec.Command(os.Args[0], "-test.run=^TestWinprocessHelperProcess$")
+	cmd.Env = append(os.Environ(), "LAZYMIND_WINPROCESS_HELPER=1")
+	if err := cmd.Start(); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		_ = cmd.Process.Kill()
+		_, _ = cmd.Process.Wait()
+	})
+	startID := StartIdentity(cmd.Process.Pid)
+	if startID == 0 {
+		t.Fatal("could not read helper process start identity")
+	}
+	err := ForceKillTree(context.Background(), cmd.Process.Pid, startID+1)
+	if !errors.Is(err, ErrProcessIdentityChanged) {
+		t.Fatalf("ForceKillTree error = %v", err)
+	}
+	if !Alive(cmd.Process.Pid) {
+		t.Fatal("identity mismatch terminated the replacement process")
+	}
+}
+
+func TestWinprocessHelperProcess(t *testing.T) {
+	if os.Getenv("LAZYMIND_WINPROCESS_HELPER") != "1" {
+		return
+	}
+	time.Sleep(time.Minute)
+}

--- a/local/local-runtime-manager/manager.go
+++ b/local/local-runtime-manager/manager.go
@@ -30,6 +30,7 @@ type RuntimeManager struct {
 	waitHostReady             func(context.Context, RuntimeConfig, []AlgorithmServiceSpec) error
 	runtimeReady              func(context.Context, RuntimeConfig, RuntimePaths) bool
 	processScanner            localProcessScanner
+	relocatePythonVenvs       func(RuntimeConfig, RuntimePaths) error
 	pollInterval              time.Duration
 	upTimeout                 time.Duration
 	downTimeout               time.Duration
@@ -65,6 +66,7 @@ func NewRuntimeManager(r CommandRunner, execPath string) *RuntimeManager {
 		waitHostReady:             waitForHostAlgorithmReadiness,
 		runtimeReady:              nil,
 		processScanner:            scanLocalRuntimeProcesses,
+		relocatePythonVenvs:       relocateDesktopPythonVenvs,
 		pollInterval:              2 * time.Second,
 		upTimeout:                 envDuration(localUpTimeoutEnvVar, time.Duration(defaultLocalUpTimeout)*time.Second),
 		downTimeout:               envDuration(localDownTimeoutEnvVar, time.Duration(defaultLocalDownTimeout)*time.Second),
@@ -96,6 +98,23 @@ func (m *RuntimeManager) progressf(format string, args ...any) {
 	_, _ = fmt.Fprintf(m.out, format+"\n", args...)
 }
 
+func (m *RuntimeManager) startupEvent(event, phase string, startedAt time.Time, eventErr error) {
+	payload := map[string]any{
+		"event":     event,
+		"phase":     phase,
+		"timestamp": m.now().UTC().Format(time.RFC3339Nano),
+	}
+	if !startedAt.IsZero() {
+		payload["elapsedMs"] = m.now().Sub(startedAt).Milliseconds()
+	}
+	if eventErr != nil {
+		payload["error"] = eventErr.Error()
+	}
+	if raw, err := json.Marshal(payload); err == nil {
+		m.progressf("[startup-event] %s", raw)
+	}
+}
+
 func randomHexToken() (string, error) {
 	raw := make([]byte, 16)
 	if _, err := rand.Read(raw); err != nil {
@@ -104,15 +123,21 @@ func randomHexToken() (string, error) {
 	return hex.EncodeToString(raw), nil
 }
 
-func (m *RuntimeManager) Up(ctx context.Context, cfg RuntimeConfig, paths RuntimePaths) error {
+func (m *RuntimeManager) Up(ctx context.Context, cfg RuntimeConfig, paths RuntimePaths) (resultErr error) {
+	startupStartedAt := m.now()
+	m.startupEvent("startup.started", "startup", startupStartedAt, nil)
+	defer func() {
+		if resultErr != nil {
+			m.startupEvent("startup.failed", "startup", startupStartedAt, resultErr)
+			return
+		}
+		m.startupEvent("startup.completed", "startup", startupStartedAt, nil)
+	}()
 	if err := validateRequestedRuntimeOwner(cfg); err != nil {
 		return err
 	}
 	freshCfg := cfg
 	if err := ensureRuntimeDirs(cfg, paths); err != nil {
-		return err
-	}
-	if err := relocateDesktopPythonVenvs(cfg, paths); err != nil {
 		return err
 	}
 	state, err := readOrNewState(paths, cfg)
@@ -128,27 +153,6 @@ func (m *RuntimeManager) Up(ctx context.Context, cfg RuntimeConfig, paths Runtim
 	if m.isExistingRuntimeRunning(ctx, state, stateCfg, paths) {
 		return m.reportExistingRuntime(ctx, state, stateCfg, paths)
 	}
-	if err := m.stopStaleRuntimeIfNeeded(ctx, state, stateCfg, paths); err != nil {
-		return err
-	}
-	if err := m.killStaleRuntimeProcesses(ctx, cfg, paths); err != nil {
-		return err
-	}
-	freshCfg, paths, err = NewRuntimeConfigWithOptions(RuntimeConfigOptions{
-		Profile:         cfg.Profile,
-		MaintenanceMode: cfg.MaintenanceMode,
-		OwnerToken:      cfg.OwnerToken,
-		RepoRoot:        paths.RepoRoot,
-		RuntimeRoot:     cfg.RuntimeRoot,
-		ResourcesRoot:   cfg.ResourcesRoot,
-	})
-	if err != nil {
-		return err
-	}
-	if err := ensureRuntimeDirs(freshCfg, paths); err != nil {
-		return err
-	}
-
 	releaseLock, err := acquireUpLock(paths)
 	if err != nil {
 		return err
@@ -188,6 +192,15 @@ func (m *RuntimeManager) Up(ctx context.Context, cfg RuntimeConfig, paths Runtim
 	if err := ensureRuntimeDirs(freshCfg, paths); err != nil {
 		return err
 	}
+	relocationStartedAt := m.now()
+	m.progressf("checking relocatable desktop Python environments")
+	m.startupEvent("phase.started", "python-relocation", relocationStartedAt, nil)
+	if err := m.relocatePythonVenvs(freshCfg, paths); err != nil {
+		m.startupEvent("phase.failed", "python-relocation", relocationStartedAt, err)
+		return fmt.Errorf("desktop Python relocation failed after %s: %w", m.now().Sub(relocationStartedAt).Round(time.Millisecond), err)
+	}
+	m.startupEvent("phase.completed", "python-relocation", relocationStartedAt, nil)
+	m.progressf("desktop Python environment check completed in %s", m.now().Sub(relocationStartedAt).Round(time.Millisecond))
 	cfg = freshCfg
 	plan := buildRuntimeProcessPlan(cfg)
 	if err := validatePinnedLocalPorts(cfg); err != nil {
@@ -776,14 +789,34 @@ func (m *RuntimeManager) stopStaleRuntimeIfNeeded(ctx context.Context, state Run
 }
 
 func (m *RuntimeManager) killStaleRuntimeProcesses(ctx context.Context, cfg RuntimeConfig, paths RuntimePaths) error {
-	records := discoverLocalRuntimeProcesses(paths, cfg, m.processScanner)
-	if len(records) == 0 {
-		return nil
+	startedAt := m.now()
+	for pass := 1; ; pass++ {
+		records, err := discoverLocalRuntimeProcessesChecked(paths, cfg, m.processScanner)
+		if err != nil {
+			return err
+		}
+		if len(records) == 0 {
+			if pass > 1 {
+				m.progressf("orphan process cleanup verified in %s", m.now().Sub(startedAt).Round(time.Millisecond))
+			}
+			return nil
+		}
+		m.progressf("stopping %d orphan local runtime process(es), pass %d: %s", len(records), pass, summarizeLocalProcessRecords(records))
+		if err := stopLocalProcessRecords(ctx, records); err != nil {
+			return err
+		}
+		cleanupLocalProcessRecords(paths, records)
+		if m.now().Sub(startedAt) >= 15*time.Second {
+			remaining, scanErr := discoverLocalRuntimeProcessesChecked(paths, cfg, m.processScanner)
+			if scanErr != nil {
+				return scanErr
+			}
+			if len(remaining) > 0 {
+				return fmt.Errorf("local runtime process cleanup timed out after 15s: %s", summarizeLocalProcessRecords(remaining))
+			}
+			return nil
+		}
 	}
-	m.progressf("stopping %d orphan local runtime process(es) for this repo", len(records))
-	err := stopLocalProcessRecords(ctx, records)
-	cleanupLocalProcessRecords(paths, records)
-	return err
 }
 
 func (m *RuntimeManager) stopProcessComposeSupervisor(ctx context.Context, paths RuntimePaths) error {

--- a/local/local-runtime-manager/manager.go
+++ b/local/local-runtime-manager/manager.go
@@ -232,6 +232,7 @@ func (m *RuntimeManager) Up(ctx context.Context, cfg RuntimeConfig, paths Runtim
 	state.ProcessCompose.TokenFile = paths.RunDirTokenFile
 	state.Config = snapshotRuntimeConfig(cfg)
 	state = newStateWithServiceStatus(state, cfg, "starting")
+	state.OverallStatus = "starting"
 	if err := writeRuntimeState(paths.StateFile, state); err != nil {
 		return err
 	}
@@ -1183,7 +1184,6 @@ func (m *RuntimeManager) Status(ctx context.Context, cfg RuntimeConfig, paths Ru
 	plan := buildRuntimeProcessPlan(cfg)
 
 	if m.probeAPI(state.ProcessCompose.APIPort, 500*time.Millisecond) {
-		resp.OverallStatus = "ready"
 		s := resp.Services[processComposeServiceName]
 		s.Status = "running"
 		resp.Services[processComposeServiceName] = s
@@ -1215,9 +1215,7 @@ func (m *RuntimeManager) Status(ctx context.Context, cfg RuntimeConfig, paths Ru
 			}
 			resp.Services[spec.Name] = svc
 		}
-		if !hostHealthy {
-			resp.OverallStatus = "stale"
-		}
+		resp.OverallStatus = processComposeRuntimeStatus(state.OverallStatus, hostHealthy)
 	} else {
 		if m.checkRuntimeReady(ctx, cfg, paths) {
 			resp.OverallStatus = "ready"
@@ -1250,6 +1248,30 @@ func (m *RuntimeManager) Status(ctx context.Context, cfg RuntimeConfig, paths Ru
 		return "", err
 	}
 	return string(b), nil
+}
+
+func updateProbedService(services map[string]RuntimeServiceState, name string, healthy bool) bool {
+	service := services[name]
+	service.Kind = "host-process"
+	if healthy {
+		service.Status = "running"
+		services[name] = service
+		return true
+	}
+	if service.Status == "running" || service.Status == "starting" {
+		service.Status = "stale"
+	} else {
+		service.Status = "stopped"
+	}
+	services[name] = service
+	return false
+}
+
+func processComposeRuntimeStatus(stateStatus string, hostHealthy bool) string {
+	if !hostHealthy {
+		return "stale"
+	}
+	return stateStatus
 }
 
 func (m *RuntimeManager) humanStatus(resp StatusResponse) string {

--- a/local/local-runtime-manager/manager_test.go
+++ b/local/local-runtime-manager/manager_test.go
@@ -890,6 +890,50 @@ func TestRuntimeManagerUpRequiresBundledLazyLLMSourceInDesktopProfile(t *testing
 	runner.assertCommandCount(0)
 }
 
+func TestRuntimeManagerUpRejectsForeignOwnerBeforePythonRelocation(t *testing.T) {
+	repo := t.TempDir()
+	writeComposeFixture(t, repo)
+	cfg, paths, err := NewRuntimeConfigWithOptions(RuntimeConfigOptions{
+		Profile:       "desktop",
+		OwnerToken:    "new-desktop-owner",
+		RepoRoot:      repo,
+		RuntimeRoot:   filepath.Join(t.TempDir(), "runtime"),
+		ResourcesRoot: filepath.Join(t.TempDir(), "resources"),
+	})
+	if err != nil {
+		t.Fatalf("runtime config: %v", err)
+	}
+	if err := paths.EnsureAllDirs(); err != nil {
+		t.Fatalf("ensure dirs: %v", err)
+	}
+	state := defaultRuntimeState(cfg, cfg.ProcessComposePort, paths.RunDirTokenFile)
+	state.OwnerToken = "old-desktop-owner"
+	state.OverallStatus = "running"
+	state.Services[processComposeServiceName] = RuntimeServiceState{Kind: "host-supervisor", Status: "running"}
+	if err := writeRuntimeState(paths.StateFile, state); err != nil {
+		t.Fatalf("write state: %v", err)
+	}
+	manager := NewRuntimeManager(&fakeRunner{t: t}, filepath.Join(paths.BinDir, "local-runtime-manager"))
+	manager.probeAPI = func(int, time.Duration) bool { return true }
+	relocated := false
+	manager.relocatePythonVenvs = func(RuntimeConfig, RuntimePaths) error {
+		relocated = true
+		return nil
+	}
+	var output strings.Builder
+	manager.SetOutput(&output, &output)
+	err = manager.Up(context.Background(), cfg, paths)
+	if err == nil || !strings.Contains(err.Error(), "another application instance") {
+		t.Fatalf("runtime manager up error = %v, want owner conflict", err)
+	}
+	if relocated {
+		t.Fatal("Python relocation ran before active owner rejection")
+	}
+	if !strings.Contains(output.String(), `"event":"startup.failed"`) || !strings.Contains(output.String(), "another application instance") {
+		t.Fatalf("startup output did not preserve ownership failure: %s", output.String())
+	}
+}
+
 func TestStatusMigratesLegacyDockerStackState(t *testing.T) {
 	repo := t.TempDir()
 	writeComposeFixture(t, repo)

--- a/local/local-runtime-manager/manager_test.go
+++ b/local/local-runtime-manager/manager_test.go
@@ -925,6 +925,56 @@ func TestStatusMigratesLegacyDockerStackState(t *testing.T) {
 	}
 }
 
+func TestUpdateProbedServiceMarksStartingServiceStale(t *testing.T) {
+	services := map[string]RuntimeServiceState{
+		scanControlPlaneProcessName: {Kind: "host-process", Status: "starting"},
+	}
+
+	if updateProbedService(services, scanControlPlaneProcessName, false) {
+		t.Fatal("unhealthy service reported healthy")
+	}
+	if got := services[scanControlPlaneProcessName].Status; got != "stale" {
+		t.Fatalf("status = %q, want stale", got)
+	}
+}
+
+func TestUpdateProbedServiceRejectsStoppedService(t *testing.T) {
+	services := map[string]RuntimeServiceState{
+		fileWatcherProcessName: {Kind: "host-process", Status: "stopped"},
+	}
+
+	if updateProbedService(services, fileWatcherProcessName, false) {
+		t.Fatal("stopped service reported healthy")
+	}
+	if got := services[fileWatcherProcessName].Status; got != "stopped" {
+		t.Fatalf("status = %q, want stopped", got)
+	}
+}
+
+func TestUpdateProbedServiceMarksHealthyServiceRunning(t *testing.T) {
+	services := map[string]RuntimeServiceState{}
+
+	if !updateProbedService(services, scanControlPlaneProcessName, true) {
+		t.Fatal("healthy service reported unhealthy")
+	}
+	service := services[scanControlPlaneProcessName]
+	if service.Status != "running" || service.Kind != "host-process" {
+		t.Fatalf("service = %+v, want running host-process", service)
+	}
+}
+
+func TestProcessComposeRuntimeStatusWaitsForAuthoritativeReady(t *testing.T) {
+	if got := processComposeRuntimeStatus("starting", true); got != "starting" {
+		t.Fatalf("status = %q, want starting", got)
+	}
+	if got := processComposeRuntimeStatus("ready", true); got != "ready" {
+		t.Fatalf("status = %q, want ready", got)
+	}
+	if got := processComposeRuntimeStatus("ready", false); got != "stale" {
+		t.Fatalf("status = %q, want stale", got)
+	}
+}
+
 func TestDerivedToolInstallPathsUseLocalBuildRoot(t *testing.T) {
 	repo := t.TempDir()
 	writeComposeFixture(t, repo)

--- a/local/local-runtime-manager/process_scan.go
+++ b/local/local-runtime-manager/process_scan.go
@@ -2,14 +2,21 @@ package main
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"sort"
+	"strings"
 	"time"
 )
 
 type localProcessScanner func(RuntimePaths) ([]LocalProcessRecord, error)
 
 func discoverLocalRuntimeProcesses(paths RuntimePaths, cfg RuntimeConfig, scanner localProcessScanner) []LocalProcessRecord {
+	records, _ := discoverLocalRuntimeProcessesChecked(paths, cfg, scanner)
+	return records
+}
+
+func discoverLocalRuntimeProcessesChecked(paths RuntimePaths, cfg RuntimeConfig, scanner localProcessScanner) ([]LocalProcessRecord, error) {
 	records := make([]LocalProcessRecord, 0, 32)
 	records = append(records, pidFileRecords(paths, cfg)...)
 	if registry, err := readLocalProcessRegistry(paths); err == nil {
@@ -22,10 +29,12 @@ func discoverLocalRuntimeProcesses(paths RuntimePaths, cfg RuntimeConfig, scanne
 	if scanner == nil {
 		scanner = scanLocalRuntimeProcesses
 	}
-	if scanned, err := scanner(paths); err == nil {
-		records = append(records, scanned...)
+	scanned, err := scanner(paths)
+	if err != nil {
+		return dedupeProcessRecords(records, paths), fmt.Errorf("scan local runtime processes: %w", err)
 	}
-	return dedupeProcessRecords(records, paths)
+	records = append(records, scanned...)
+	return dedupeProcessRecords(records, paths), nil
 }
 
 func localProcessBelongsToRuntime(record LocalProcessRecord, paths RuntimePaths) bool {
@@ -66,41 +75,101 @@ func dedupeProcessRecords(records []LocalProcessRecord, paths RuntimePaths) []Lo
 }
 
 func stopLocalProcessRecords(ctx context.Context, records []LocalProcessRecord) error {
+	return stopLocalProcessRecordsWith(ctx, records, processStopOptions{
+		interrupt:       interruptProcess,
+		forceKill:       forceKillProcessTree,
+		alive:           processAlive,
+		gracefulTimeout: 10 * time.Second,
+		forceTimeout:    5 * time.Second,
+		pollInterval:    250 * time.Millisecond,
+	})
+}
+
+type processStopOptions struct {
+	interrupt       func(int) error
+	forceKill       func(int) error
+	alive           func(int) bool
+	gracefulTimeout time.Duration
+	forceTimeout    time.Duration
+	pollInterval    time.Duration
+}
+
+func stopLocalProcessRecordsWith(ctx context.Context, records []LocalProcessRecord, options processStopOptions) error {
 	if len(records) == 0 {
 		return nil
 	}
 	for _, record := range records {
-		_ = interruptProcess(record.PID)
+		_ = options.interrupt(record.PID)
 	}
-	deadline := time.NewTimer(10 * time.Second)
+	deadline := time.NewTimer(options.gracefulTimeout)
 	defer deadline.Stop()
-	ticker := time.NewTicker(250 * time.Millisecond)
+	ticker := time.NewTicker(options.pollInterval)
 	defer ticker.Stop()
 	for {
-		alive := false
-		for _, record := range records {
-			if processAlive(record.PID) {
-				alive = true
-				break
-			}
-		}
-		if !alive {
+		remaining := aliveLocalProcessRecords(records, options.alive)
+		if len(remaining) == 0 {
 			return nil
 		}
 		select {
 		case <-ctx.Done():
-			for _, record := range records {
-				_ = forceKillProcessTree(record.PID)
+			for _, record := range remaining {
+				_ = options.forceKill(record.PID)
 			}
 			return ctx.Err()
 		case <-deadline.C:
-			for _, record := range records {
-				_ = forceKillProcessTree(record.PID)
+			for _, record := range remaining {
+				_ = options.forceKill(record.PID)
 			}
-			return nil
+			return waitForStoppedLocalProcessRecords(ctx, records, options)
 		case <-ticker.C:
 		}
 	}
+}
+
+func waitForStoppedLocalProcessRecords(ctx context.Context, records []LocalProcessRecord, options processStopOptions) error {
+	deadline := time.NewTimer(options.forceTimeout)
+	defer deadline.Stop()
+	ticker := time.NewTicker(options.pollInterval)
+	defer ticker.Stop()
+	for {
+		remaining := aliveLocalProcessRecords(records, options.alive)
+		if len(remaining) == 0 {
+			return nil
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-deadline.C:
+			remaining = aliveLocalProcessRecords(records, options.alive)
+			return fmt.Errorf("local runtime processes did not exit after force kill: %s", summarizeLocalProcessRecords(remaining))
+		case <-ticker.C:
+		}
+	}
+}
+
+func aliveLocalProcessRecords(records []LocalProcessRecord, alive func(int) bool) []LocalProcessRecord {
+	remaining := make([]LocalProcessRecord, 0, len(records))
+	for _, record := range records {
+		if alive(record.PID) {
+			remaining = append(remaining, record)
+		}
+	}
+	return remaining
+}
+
+func summarizeLocalProcessRecords(records []LocalProcessRecord) string {
+	if len(records) == 0 {
+		return "none"
+	}
+	parts := make([]string, 0, len(records))
+	for _, record := range records {
+		service := strings.TrimSpace(record.Service)
+		if service == "" {
+			service = "unknown"
+		}
+		parts = append(parts, fmt.Sprintf("%s(pid=%d)", service, record.PID))
+	}
+	return strings.Join(parts, ", ")
 }
 
 func cleanupLocalProcessRecords(paths RuntimePaths, records []LocalProcessRecord) {

--- a/local/local-runtime-manager/process_scan_test.go
+++ b/local/local-runtime-manager/process_scan_test.go
@@ -1,0 +1,56 @@
+package main
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestStopLocalProcessRecordsWaitsAfterForceKill(t *testing.T) {
+	forced := false
+	postKillChecks := 0
+	forceKills := 0
+	records := []LocalProcessRecord{{Service: "auth-service", PID: 1234}}
+	err := stopLocalProcessRecordsWith(context.Background(), records, processStopOptions{
+		interrupt: func(int) error { return nil },
+		forceKill: func(int) error { forceKills++; forced = true; return nil },
+		alive: func(int) bool {
+			if !forced {
+				return true
+			}
+			postKillChecks++
+			return postKillChecks < 3
+		},
+		gracefulTimeout: time.Millisecond,
+		forceTimeout:    20 * time.Millisecond,
+		pollInterval:    time.Millisecond,
+	})
+	if err != nil {
+		t.Fatalf("stop process: %v", err)
+	}
+	if forceKills != 1 {
+		t.Fatalf("force kills = %d, want 1", forceKills)
+	}
+	if postKillChecks < 3 {
+		t.Fatalf("post-kill alive checks = %d, expected verification", postKillChecks)
+	}
+}
+
+func TestStopLocalProcessRecordsReportsStubbornProcess(t *testing.T) {
+	records := []LocalProcessRecord{{Service: "auth-service", PID: 4321}}
+	err := stopLocalProcessRecordsWith(context.Background(), records, processStopOptions{
+		interrupt:       func(int) error { return nil },
+		forceKill:       func(int) error { return nil },
+		alive:           func(int) bool { return true },
+		gracefulTimeout: time.Millisecond,
+		forceTimeout:    3 * time.Millisecond,
+		pollInterval:    time.Millisecond,
+	})
+	if err == nil {
+		t.Fatal("expected stubborn process error")
+	}
+	if !strings.Contains(err.Error(), "auth-service(pid=4321)") {
+		t.Fatalf("error = %q, want service and PID", err)
+	}
+}

--- a/local/local-runtime-manager/process_scan_windows.go
+++ b/local/local-runtime-manager/process_scan_windows.go
@@ -14,6 +14,7 @@ import (
 )
 
 const windowsProcessScanTimeout = 10 * time.Second
+const desktopOwnerPIDEnvVar = "LAZYMIND_DESKTOP_OWNER_PID"
 
 type windowsProcessInfo struct {
 	ProcessID       uint32  `json:"ProcessId"`
@@ -50,6 +51,10 @@ func scanLocalRuntimeProcesses(paths RuntimePaths) ([]LocalProcessRecord, error)
 	for pid := parents[os.Getpid()]; pid > 0 && !excluded[pid]; pid = parents[pid] {
 		excluded[pid] = true
 	}
+	ownerPID, _ := strconv.Atoi(strings.TrimSpace(os.Getenv(desktopOwnerPIDEnvVar)))
+	if ownerPID > 0 {
+		excludeProcessTree(excluded, parents, ownerPID)
+	}
 	records := make([]LocalProcessRecord, 0, len(processes))
 	for _, process := range processes {
 		pid := int(process.ProcessID)
@@ -71,6 +76,23 @@ func scanLocalRuntimeProcesses(paths RuntimePaths) ([]LocalProcessRecord, error)
 		})
 	}
 	return records, nil
+}
+
+func excludeProcessTree(excluded map[int]bool, parents map[int]int, rootPID int) {
+	if rootPID <= 0 {
+		return
+	}
+	excluded[rootPID] = true
+	for pid := range parents {
+		seen := map[int]bool{}
+		for ancestor := pid; ancestor > 0 && !seen[ancestor]; ancestor = parents[ancestor] {
+			if ancestor == rootPID {
+				excluded[pid] = true
+				break
+			}
+			seen[ancestor] = true
+		}
+	}
 }
 
 func nullableText(value *string) string {

--- a/local/local-runtime-manager/process_scan_windows_test.go
+++ b/local/local-runtime-manager/process_scan_windows_test.go
@@ -1,0 +1,28 @@
+//go:build windows
+
+package main
+
+import "testing"
+
+func TestExcludeProcessTreeExcludesDesktopOwnerDescendantsOnly(t *testing.T) {
+	parents := map[int]int{
+		100: 1,
+		110: 100,
+		111: 110,
+		120: 100,
+		200: 1,
+		210: 200,
+	}
+	excluded := map[int]bool{}
+	excludeProcessTree(excluded, parents, 100)
+	for _, pid := range []int{100, 110, 111, 120} {
+		if !excluded[pid] {
+			t.Fatalf("owner process tree PID %d was not excluded", pid)
+		}
+	}
+	for _, pid := range []int{1, 200, 210} {
+		if excluded[pid] {
+			t.Fatalf("unrelated PID %d was excluded", pid)
+		}
+	}
+}

--- a/local/local-runtime-manager/python_venv_windows.go
+++ b/local/local-runtime-manager/python_venv_windows.go
@@ -3,10 +3,20 @@
 package main
 
 import (
+	"bytes"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
+
+	"golang.org/x/sys/windows"
+)
+
+const (
+	desktopPythonReplaceTimeout = 5 * time.Second
+	desktopPythonReplacePoll    = 250 * time.Millisecond
 )
 
 func relocateDesktopPythonVenvs(cfg RuntimeConfig, paths RuntimePaths) error {
@@ -41,7 +51,7 @@ func relocateDesktopPythonVenvs(cfg RuntimeConfig, paths RuntimePaths) error {
 		if !rewritten {
 			return fmt.Errorf("desktop Python venv config has no home entry: %s", configPath)
 		}
-		if err := os.WriteFile(configPath, []byte(strings.Join(lines, "\n")), 0o644); err != nil {
+		if err := replaceRelocatableFileIfChanged(configPath, []byte(strings.Join(lines, "\n")), 0o644, desktopPythonReplaceTimeout); err != nil {
 			return fmt.Errorf("rewrite desktop Python venv config %s: %w", configPath, err)
 		}
 		entries, err := os.ReadDir(newHome)
@@ -59,10 +69,73 @@ func relocateDesktopPythonVenvs(cfg RuntimeConfig, paths RuntimePaths) error {
 				return fmt.Errorf("read bundled desktop Python executable %s: %w", source, readErr)
 			}
 			destination := filepath.Join(venv, "Scripts", name)
-			if err := os.WriteFile(destination, rawExecutable, 0o755); err != nil {
+			if err := replaceRelocatableFileIfChanged(destination, rawExecutable, 0o755, desktopPythonReplaceTimeout); err != nil {
 				return fmt.Errorf("replace relocatable desktop Python executable %s: %w", destination, err)
 			}
 		}
 	}
 	return nil
+}
+
+func replaceRelocatableFileIfChanged(destination string, content []byte, mode os.FileMode, timeout time.Duration) error {
+	temp, err := os.CreateTemp(filepath.Dir(destination), "."+filepath.Base(destination)+".tmp-*")
+	if err != nil {
+		return err
+	}
+	tempPath := temp.Name()
+	defer os.Remove(tempPath)
+	if _, err := temp.Write(content); err != nil {
+		_ = temp.Close()
+		return err
+	}
+	if err := temp.Sync(); err != nil {
+		_ = temp.Close()
+		return err
+	}
+	if err := temp.Close(); err != nil {
+		return err
+	}
+	if err := os.Chmod(tempPath, mode); err != nil {
+		return err
+	}
+
+	deadline := time.Now().Add(timeout)
+	for {
+		current, readErr := os.ReadFile(destination)
+		if readErr == nil && bytes.Equal(current, content) {
+			return nil
+		}
+		if readErr != nil && !os.IsNotExist(readErr) && !isWindowsFileBusy(readErr) {
+			return readErr
+		}
+		if readErr == nil || os.IsNotExist(readErr) {
+			source, sourceErr := windows.UTF16PtrFromString(tempPath)
+			if sourceErr != nil {
+				return sourceErr
+			}
+			target, targetErr := windows.UTF16PtrFromString(destination)
+			if targetErr != nil {
+				return targetErr
+			}
+			err = windows.MoveFileEx(source, target, windows.MOVEFILE_REPLACE_EXISTING|windows.MOVEFILE_WRITE_THROUGH)
+			if err == nil {
+				return nil
+			}
+			if !isWindowsFileBusy(err) {
+				return err
+			}
+		} else {
+			err = readErr
+		}
+		if timeout <= 0 || time.Now().Add(desktopPythonReplacePoll).After(deadline) {
+			return fmt.Errorf("file is still locked after %s: %w", timeout, err)
+		}
+		time.Sleep(desktopPythonReplacePoll)
+	}
+}
+
+func isWindowsFileBusy(err error) bool {
+	return errors.Is(err, windows.ERROR_SHARING_VIOLATION) ||
+		errors.Is(err, windows.ERROR_LOCK_VIOLATION) ||
+		errors.Is(err, windows.ERROR_ACCESS_DENIED)
 }

--- a/local/local-runtime-manager/python_venv_windows_test.go
+++ b/local/local-runtime-manager/python_venv_windows_test.go
@@ -7,6 +7,9 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
+
+	"golang.org/x/sys/windows"
 )
 
 func TestRelocateDesktopPythonVenvs(t *testing.T) {
@@ -56,5 +59,71 @@ func TestRelocateDesktopPythonVenvs(t *testing.T) {
 		if string(python) != "bundled-python" {
 			t.Fatalf("relocated Python executable = %q", python)
 		}
+	}
+}
+
+func TestRelocateDesktopPythonVenvsSkipsUnchangedReadOnlyFiles(t *testing.T) {
+	root := t.TempDir()
+	paths := RuntimePaths{
+		PythonRuntimeDir:   filepath.Join(root, "runtimes", "python"),
+		AuthServiceVenvDir: filepath.Join(root, "deps", "python", "auth-service"),
+		AlgorithmVenv:      filepath.Join(root, "deps", "python", "algorithm-missing"),
+	}
+	homeName := "cpython-3.11-windows-x86_64-none"
+	home := filepath.Join(paths.PythonRuntimeDir, homeName)
+	venv := paths.AuthServiceVenvDir
+	if err := os.MkdirAll(home, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(venv, "Scripts"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	pythonPath := filepath.Join(venv, "Scripts", "python.exe")
+	configPath := filepath.Join(venv, "pyvenv.cfg")
+	if err := os.WriteFile(filepath.Join(home, "python.exe"), []byte("bundled-python"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(pythonPath, []byte("bundled-python"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(configPath, []byte("home = "+home+"\nversion_info = 3.11\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(pythonPath, 0o444); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(configPath, 0o444); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		_ = os.Chmod(pythonPath, 0o644)
+		_ = os.Chmod(configPath, 0o644)
+	})
+	if err := relocateDesktopPythonVenvs(RuntimeConfig{Profile: "desktop"}, paths); err != nil {
+		t.Fatalf("unchanged relocation: %v", err)
+	}
+}
+
+func TestReplaceRelocatableFileReportsWindowsFileLock(t *testing.T) {
+	destination := filepath.Join(t.TempDir(), "python.exe")
+	if err := os.WriteFile(destination, []byte("old-python"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	name, err := windows.UTF16PtrFromString(destination)
+	if err != nil {
+		t.Fatal(err)
+	}
+	handle, err := windows.CreateFile(name, windows.GENERIC_READ, 0, nil, windows.OPEN_EXISTING, windows.FILE_ATTRIBUTE_NORMAL, 0)
+	if err != nil {
+		t.Fatalf("lock destination: %v", err)
+	}
+	defer windows.CloseHandle(handle)
+
+	err = replaceRelocatableFileIfChanged(destination, []byte("new-python"), 0o755, 10*time.Millisecond)
+	if err == nil {
+		t.Fatal("expected locked file replacement to fail")
+	}
+	if !strings.Contains(err.Error(), "still locked") {
+		t.Fatalf("replacement error = %q, want actionable lock detail", err)
 	}
 }


### PR DESCRIPTION
## Why

Windows Desktop 的启动与升级链路存在三个相互关联的问题：

1. runtime 尚未完全就绪、Chat 页面尚未完成首屏渲染时，启动窗口可能提前消失，用户会看到长时间白屏。
2. installer warmup 销毁隐藏窗口时会触发 Electron 退出，导致 runtime 的 `down` 尚未完成安装器就收到成功退出码。残留的 maintenance runtime 持有旧 owner token，首次正常启动因此报错“active desktop runtime belongs to another application instance”。
3. 安装、升级和卸载期间对前台 Electron、后台 runtime 及旧版卸载器的处理不够可靠，可能出现进程无法关闭、旧卸载器阻塞升级或清理结果无法诊断的问题。

## What

- 启动窗口持续显示到完整 runtime ready、Chat 路由加载并完成可见首屏渲染，再切换到主窗口。
- 增加结构化启动阶段、耗时、组件状态和具体失败原因日志，避免 ownership 等真实错误被通用状态覆盖。
- 修复 installer warmup 生命周期：必须完成 runtime shutdown 并验证 `stopped` 后才能销毁 renderer 和退出。
- 安装器在 warmup 后再次扫描进程；发现残留时强制关闭并复验，Retry/Ignore 不再携带残留继续。
- 加强安装、升级、卸载的 Windows 进程识别与清理，支持 PID 启动标识、可信安装目录和跨会话进程检查。
- 自动修复旧卸载器和卸载注册信息，避免历史版本阻塞静默升级。
- 加强 Python venv relocation、runtime orphan cleanup 与相关诊断。

## How

- Electron 使用启动窗口与隐藏主窗口分离的交接流程，通过 renderer-ready IPC 确认 Chat Home 已真实渲染。
- sidecar 输出结构化 startup events，Electron 保留 stderr 和具体 phase failure，并持续展示完整启动状态。
- 将 installer warmup 编排拆成可测试的生命周期模块，固定执行顺序为：启动 runtime → 加载隐藏 renderer → 停止 runtime → 校验 stopped → 销毁 renderer → 返回退出码。
- NSIS 通过 installer-maintenance helper 执行 `check-stopped / force-stop / check-stopped` 闭环；清理失败时安装直接失败。
- Windows process inventory 同时校验进程路径、PID StartID、session 和注册记录，降低 PID 复用或同名进程导致的误杀风险。

## 验证

- Desktop Node 测试：22/22 通过。
- `local/local-runtime-manager`：`go test ./...` 全部通过。
- Windows packaged installer warmup smoke 通过：
  - 日志包含 `maintenance runtime stopped and verified`
  - runtime state 为 `stopped`
  - maintenance helper post-check 返回 0，无后台进程残留
- 成功构建并校验 Windows x64 installer 与 portable ZIP，打包后的 `app.asar` 包含本次生命周期修复。