### PR TITLE
feat(chat): Update api key validation for suppliers

### DIFF
--- a/algorithm/lazymind/chat/api/model_check_routes.py
+++ b/algorithm/lazymind/chat/api/model_check_routes.py
@@ -1,12 +1,9 @@
 from typing import Annotated, Optional
 
 from fastapi import APIRouter, Body
-import httpx
 import lazyllm
 
 router = APIRouter()
-
-_OFFICIAL_DOUBAO_URL = 'https://ark.cn-beijing.volces.com/api/v3/'
 
 
 @router.post('/api/model/check', summary='Check model provider connectivity')
@@ -17,30 +14,20 @@ async def check_model_connection(
     api_key: Annotated[Optional[str], Body(description='Provider API key')] = None,
 ):
     try:
-        if url == _OFFICIAL_DOUBAO_URL:
-            async with httpx.AsyncClient(timeout=30.0) as client:
-                response = await client.get(
-                    f'{url}models',
-                    headers={'Authorization': f'Bearer {api_key}'},
-                )
-            if not (200 <= response.status_code < 300):
-                raise RuntimeError(f'HTTP {response.status_code}: {response.text}')
-            result = response.text
-        else:
-            module = lazyllm.OnlineModule(
-                model=model,
-                source=source,
-                url=url,
-                api_key=api_key,
-            )
-            result = module('hi')
+        module = lazyllm.OnlineModule(
+            model=model,
+            source=source,
+            url=url,
+            api_key=api_key,
+        )
+        if not module._validate_api_key():
+            raise RuntimeError('API key validation failed')
         return {
             'success': True,
             'message': 'model connection is available',
             'model': model,
             'source': source,
             'url': url,
-            'result': result,
         }
     except Exception as exc:
         return {

--- a/algorithm/lazymind/chat/service/component/tool_registry.py
+++ b/algorithm/lazymind/chat/service/component/tool_registry.py
@@ -507,7 +507,9 @@ DEFAULT_TOOLS: list[ToolConfig] = [
     ToolConfig(
         name='video_generator',
         label='文生视频',
+        label_en='Video Generator',
         description='根据文字描述生成视频，可选首帧参考图；同轮多次调用并行，视频侧最多同时3路',
+        description_en='Generate videos from text descriptions, with optional first-frame reference images.',
         tool=video_generator, module='content',
         model_role='video_generator',
         capability_id='video_generation',
@@ -518,7 +520,9 @@ DEFAULT_TOOLS: list[ToolConfig] = [
     ToolConfig(
         name='video_to_gif',
         label='视频转GIF',
+        label_en='GIF Converter',
         description='将本地视频转换为 GIF 动图；同轮多次调用并行，GIF 侧最多同时3路',
+        description_en='Convert local videos to GIF animations.',
         tool=video_to_gif, module='content',
         capability_id='video_to_gif',
         input_schema={'url': 'string'}, output_schema={'image': 'file'},

--- a/frontend/src/modules/chat/components/TaskCenter/index.tsx
+++ b/frontend/src/modules/chat/components/TaskCenter/index.tsx
@@ -275,36 +275,21 @@ function ArtifactGrid({ artifacts }: { artifacts: TaskArtifact[] }) {
   });
   const fileListImages = fileListItems.filter((item) => item.isImage);
   const fileListFiles = fileListItems.filter((item) => !item.isImage);
+  const previewImages = [...imageUrls, ...fileListImages].filter(
+    (image, index, items) =>
+      items.findIndex((candidate) => candidate.src === image.src) === index,
+  );
 
   const total =
-    imageUrls.length + fileListItems.length + files.length + texts.length;
+    previewImages.length + fileListFiles.length + files.length + texts.length;
 
   return (
     <CollapsibleSection title={`${t("taskCenter.artifacts")} (${total})`}>
       <div className="task-artifacts-inner">
-        {(imageUrls.length > 0 || fileListImages.length > 0) && (
+        {previewImages.length > 0 && (
           <div className="task-artifacts-grid">
             <Image.PreviewGroup>
-              {imageUrls.map((img) => (
-                <div className="task-artifact-preview" key={img.key}>
-                  <Image
-                    src={img.src}
-                    width={64}
-                    height={64}
-                    className="task-artifact-thumb"
-                  />
-                  <a
-                    href={img.src}
-                    download={img.filename}
-                    className="task-artifact-preview-download"
-                    title={`${t("taskCenter.download")} ${img.filename}`}
-                    onClick={(event) => event.stopPropagation()}
-                  >
-                    <DownloadOutlined />
-                  </a>
-                </div>
-              ))}
-              {fileListImages.map((img) => (
+              {previewImages.map((img) => (
                 <div className="task-artifact-preview" key={img.key}>
                   <Image
                     src={img.src}

--- a/tests/algorithm/chat/test_model_check_routes.py
+++ b/tests/algorithm/chat/test_model_check_routes.py
@@ -3,79 +3,13 @@ import asyncio
 from lazymind.chat.api import model_check_routes
 
 
-class _FakeResponse:
-    def __init__(self, status_code: int, text: str):
-        self.status_code = status_code
-        self.text = text
-
-
-class _FakeAsyncClient:
-    def __init__(self, response: _FakeResponse, *, timeout: float):
-        self.response = response
-        self.timeout = timeout
-        self.requests = []
-
-    async def __aenter__(self):
-        return self
-
-    async def __aexit__(self, exc_type, exc, tb):
-        return False
-
-    async def get(self, url, *, headers):
-        self.requests.append((url, headers))
-        return self.response
-
-
-def test_official_doubao_url_uses_models_endpoint(monkeypatch):
-    client = _FakeAsyncClient(_FakeResponse(200, '{"data":[]}'), timeout=30.0)
-    monkeypatch.setattr(
-        model_check_routes.httpx,
-        'AsyncClient',
-        lambda timeout: client,
-    )
-
-    result = asyncio.run(model_check_routes.check_model_connection(
-        source='Doubao',
-        url='https://ark.cn-beijing.volces.com/api/v3/',
-        api_key='test-key',
-    ))
-
-    assert result['success'] is True
-    assert client.requests == [(
-        'https://ark.cn-beijing.volces.com/api/v3/models',
-        {'Authorization': 'Bearer test-key'},
-    )]
-
-
-def test_official_doubao_check_rejects_auth_failure(monkeypatch):
-    client = _FakeAsyncClient(
-        _FakeResponse(401, '{"message":"invalid key"}'),
-        timeout=30.0,
-    )
-    monkeypatch.setattr(
-        model_check_routes.httpx,
-        'AsyncClient',
-        lambda timeout: client,
-    )
-
-    result = asyncio.run(model_check_routes.check_model_connection(
-        source='Doubao',
-        url='https://ark.cn-beijing.volces.com/api/v3/',
-        api_key='test-key',
-    ))
-
-    assert result['success'] is False
-    assert 'HTTP 401' in result['message']
-    assert client.requests[0][0] == 'https://ark.cn-beijing.volces.com/api/v3/models'
-
-
-def test_custom_url_does_not_use_models_endpoint(monkeypatch):
-    called = {'online': False}
+def test_check_uses_validate_api_key(monkeypatch):
+    called = {'validate': False}
 
     class _FakeModule:
-        def __call__(self, prompt):
-            called['online'] = True
-            return 'ok'
+        def _validate_api_key(self):
+            called['validate'] = True
+            return True
 
     monkeypatch.setattr(
         model_check_routes.lazyllm,
@@ -85,9 +19,30 @@ def test_custom_url_does_not_use_models_endpoint(monkeypatch):
 
     result = asyncio.run(model_check_routes.check_model_connection(
         source='Doubao',
-        url='https://ark.example/api/v3/',
+        url='https://ark.cn-beijing.volces.com/api/v3/',
         api_key='test-key',
     ))
 
     assert result['success'] is True
-    assert called['online'] is True
+    assert called['validate'] is True
+
+
+def test_check_rejects_failed_validation(monkeypatch):
+    class _FakeModule:
+        def _validate_api_key(self):
+            return False
+
+    monkeypatch.setattr(
+        model_check_routes.lazyllm,
+        'OnlineModule',
+        lambda **kwargs: _FakeModule(),
+    )
+
+    result = asyncio.run(model_check_routes.check_model_connection(
+        source='OpenAI',
+        url='https://api.openai.com/v1/',
+        api_key='bad-key',
+    ))
+
+    assert result['success'] is False
+    assert 'API key validation failed' in result['message']


### PR DESCRIPTION
# 使用 `/models` 进行api key验证 避免key因为没开通老逻辑的llm模型导致验证失败

# 全部供应商验证通过
<img width="1212" height="754" alt="image" src="https://github.com/user-attachments/assets/70b4be16-6d37-4bc7-95a1-6eb4b5888016" />
<img width="1227" height="828" alt="image" src="https://github.com/user-attachments/assets/3822d70c-8d55-4b56-81fe-6bf19f3ddbc3" />
<img width="1251" height="177" alt="image" src="https://github.com/user-attachments/assets/e6630557-14e5-454d-821a-ab20ea970a33" />
