### PR TITLE
fix(backend): Remove master switch validation and filter non-existent bindings for local data source conversation participation; fix dataset pagination in knowledge base list display

### DIFF
--- a/backend/core/chat/localfs_paths.go
+++ b/backend/core/chat/localfs_paths.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"io"
 	"lazymind/core/common"
-	"lazymind/core/datasource"
 	"net/http"
 	"net/url"
 	"sort"
@@ -55,15 +54,6 @@ type scanSourceBinding struct {
 }
 
 func applyLocalFSPathsForChat(ctx context.Context, r *http.Request, db *gorm.DB, userID string, reqBody map[string]any) error {
-	enabled, err := datasource.LoadLocalFSChatEnabled(ctx, db, userID)
-	if err != nil {
-		return err
-	}
-	if !enabled {
-		fmt.Printf("[CORE_LOCALFS_DEBUG] chat_enabled=false user=%s\n", userID)
-		return nil
-	}
-	fmt.Printf("[CORE_LOCALFS_DEBUG] chat_enabled=true user=%s\n", userID)
 	sources, err := loadLocalFSSourcesForChat(ctx, r, userID)
 	if err != nil {
 		return err

--- a/backend/core/chat/localfs_paths_test.go
+++ b/backend/core/chat/localfs_paths_test.go
@@ -89,26 +89,6 @@ func TestApplyLocalFSPathsForChatAddsActiveLocalBindings(t *testing.T) {
 	}
 }
 
-func TestApplyLocalFSPathsForChatDisabledOmitsParameter(t *testing.T) {
-	db, err := orm.Connect(orm.DriverSQLite, t.TempDir()+"/localfs-chat-disabled.db")
-	if err != nil {
-		t.Fatalf("connect db: %v", err)
-	}
-	if err := db.AutoMigrate(&orm.LocalFSChatSetting{}); err != nil {
-		t.Fatalf("auto migrate: %v", err)
-	}
-
-	req := httptest.NewRequest(http.MethodPost, "/api/core/conversations:chat", nil)
-	req.Header.Set("X-User-Id", "u1")
-	reqBody := map[string]any{}
-	if err := applyLocalFSPathsForChat(req.Context(), req, db.DB, "u1", reqBody); err != nil {
-		t.Fatalf("apply local fs paths: %v", err)
-	}
-	if _, ok := reqBody["local_fs_sources"]; ok {
-		t.Fatalf("local_fs_sources should be omitted when setting is disabled: %#v", reqBody)
-	}
-}
-
 func TestApplyLocalFSPathsForChatFiltersByBindingChatEnabled(t *testing.T) {
 	db, err := orm.Connect(orm.DriverSQLite, t.TempDir()+"/localfs-chat-filter.db")
 	if err != nil {

--- a/backend/core/doc/dataset.go
+++ b/backend/core/doc/dataset.go
@@ -471,6 +471,43 @@ func AllDatasetTags(w http.ResponseWriter, r *http.Request) {
 	sort.Strings(tags)
 	common.ReplyJSON(w, AllDatasetTagsResponse{Tags: tags})
 }
+
+// filterAndCountCandidates applies source-level filtering to a batch of
+// ACL/keyword/tags-qualified candidates, collects items for the current page,
+// and increments the total counter. It returns the updated total and page slice.
+//
+// When collectPage is false, candidates that would have been collected for the
+// page are skipped but total is still incremented — this is used by Phase 2 to
+// finish counting the accurate total without building unnecessary page data.
+func filterAndCountCandidates(
+	candidates []orm.Dataset,
+	sourceFilter string,
+	sourceMap map[string]bool,
+	offset int,
+	pageSize int,
+	total int,
+	page []orm.Dataset,
+	pageSourceMap map[string]bool,
+	collectPage bool,
+) (int, []orm.Dataset) {
+	for _, c := range candidates {
+		// Apply source filter.
+		if sourceFilter == "cloud" && !sourceMap[c.ID] {
+			continue
+		}
+		if sourceFilter == "manual" && sourceMap[c.ID] {
+			continue
+		}
+		// Collect into page only during Phase 1.
+		if collectPage && total >= offset && len(page) < pageSize {
+			page = append(page, c)
+			pageSourceMap[c.ID] = sourceMap[c.ID]
+		}
+		total++
+	}
+	return total, page
+}
+
 func ListDatasets(w http.ResponseWriter, r *http.Request) {
 	userID := corestore.UserID(r)
 	if userID == "" {
@@ -552,6 +589,11 @@ func ListDatasets(w http.ResponseWriter, r *http.Request) {
 	candidates := make([]orm.Dataset, 0, pageSize)
 	pageSourceMap := make(map[string]bool, pageSize)
 
+	// ------------------------------------------------------------------
+	// Phase 1: collect the current page while counting candidates.
+	// Stops when the page is full OR all DB rows are exhausted.
+	// The total count at this point may be incomplete — Phase 2 fixes it.
+	// ------------------------------------------------------------------
 	for hasMoreRows && len(page) < pageSize {
 		var rows []orm.Dataset
 		query := base.
@@ -570,6 +612,7 @@ func ListDatasets(w http.ResponseWriter, r *http.Request) {
 		if len(rows) == 0 {
 			break
 		}
+		// ACL + keyword + tags filtering (same as before).
 		for _, ds := range rows {
 			perms := datasetACLForUserWithGroups(&ds, userID, groupIDs)
 			if len(perms) == 0 {
@@ -592,23 +635,74 @@ func ListDatasets(w http.ResponseWriter, r *http.Request) {
 			}
 			sourceMap := batchCheckDatasetsHaveSource(r.Context(), candidateIDs)
 
-			for _, c := range candidates {
-				if sourceFilter == "cloud" && !sourceMap[c.ID] {
-					continue
-				}
-				if sourceFilter == "manual" && sourceMap[c.ID] {
-					continue
-				}
-				if total >= offset && len(page) < pageSize {
-					page = append(page, c)
-					pageSourceMap[c.ID] = sourceMap[c.ID]
-				}
-				total++
-			}
+			// Delegate source filtering + page collection + counting.
+			total, page = filterAndCountCandidates(
+				candidates, sourceFilter, sourceMap,
+				offset, pageSize, total, page, pageSourceMap,
+				true, // collectPage: collect page items
+			)
 
 			candidates = candidates[:0]
 		}
+	}
 
+	// ------------------------------------------------------------------
+	// Phase 2: if the page is filled but more DB rows remain, continue
+	// scanning to finish counting the accurate total. No page collection
+	// is done in this phase — the page is already complete.
+	// ------------------------------------------------------------------
+	if len(page) >= pageSize && hasMoreRows {
+		for hasMoreRows {
+			var rows []orm.Dataset
+			// Use a lighter SELECT — only fields needed for filtering.
+			query := base.
+				Select("id, kb_id, create_user_id, display_name, ext").
+				Order(orderClause).
+				Offset(scanOffset).
+				Limit(fetchSize)
+			if err := query.Find(&rows).Error; err != nil {
+				common.ReplyErr(w, "query datasets failed", http.StatusInternalServerError)
+				return
+			}
+			if len(rows) < fetchSize {
+				hasMoreRows = false
+			}
+			scanOffset += len(rows)
+			if len(rows) == 0 {
+				break
+			}
+			// ACL + keyword + tags filtering (same as Phase 1).
+			for _, ds := range rows {
+				perms := datasetACLForUserWithGroups(&ds, userID, groupIDs)
+				if len(perms) == 0 {
+					continue
+				}
+				if !datasetMatchesKeyword(&ds, keyword) {
+					continue
+				}
+				if len(wantTags) > 0 && !containsAll(parseDatasetTags(ds.Ext), wantTags) {
+					continue
+				}
+				candidates = append(candidates, ds)
+			}
+
+			if len(candidates) > 0 {
+				candidateIDs := make([]string, len(candidates))
+				for i, c := range candidates {
+					candidateIDs[i] = c.ID
+				}
+				sourceMap := batchCheckDatasetsHaveSource(r.Context(), candidateIDs)
+
+				// Count only — do not collect page items.
+				total, page = filterAndCountCandidates(
+					candidates, sourceFilter, sourceMap,
+					offset, pageSize, total, page, pageSourceMap,
+					false, // collectPage: count only, skip page collection
+				)
+
+				candidates = candidates[:0]
+			}
+		}
 	}
 
 	end := offset + len(page)

--- a/backend/scan-control-plane/internal/server/binding_chat_handlers.go
+++ b/backend/scan-control-plane/internal/server/binding_chat_handlers.go
@@ -80,10 +80,20 @@ func (h *Handler) listBindingChatSettings(w http.ResponseWriter, r *http.Request
 
 		var chatBindings []bindingChatSettingEntry
 		for _, b := range getResp.Bindings {
-			if !isLocalFSBinding(b) || b.Status != sourceengine.BindingStatusActive {
-				continue
-			}
-			chatBindings = append(chatBindings, bindingChatSettingEntry{
+		if !isLocalFSBinding(b) || b.Status != sourceengine.BindingStatusActive {
+			continue
+		}
+		// Lightweight safety-net: skip bindings whose monitored root directory
+		// no longer exists on the agent. Covers cases missed by the real-time
+		// watcher (e.g. directory deleted while agent was offline).
+		// Also disables chat for such bindings so other consumers see the
+		// correct state.
+		if b.AgentID != "" && !h.sources.IsBindingPathAccessible(r.Context(), b.AgentID, b.TargetRef) {
+			_ = h.sources.UpdateBindingChatEnabled(r.Context(), b.BindingID, false)
+			continue
+		}
+
+		chatBindings = append(chatBindings, bindingChatSettingEntry{
 				BindingID:        b.BindingID,
 				TargetRef:        b.TargetRef,
 				ConnectorType:    b.ConnectorType,

--- a/backend/scan-control-plane/internal/sourceengine/connector/localfs/connector.go
+++ b/backend/scan-control-plane/internal/sourceengine/connector/localfs/connector.go
@@ -192,3 +192,13 @@ func (c *LocalFSConnector) resolveAgentID(agentID string) string {
 	}
 	return c.defaultAgentID
 }
+// CheckPathExists returns true if the given path still exists on the agent'''s
+// filesystem. It delegates to the agent'''s StatPath HTTP endpoint. Used as a
+// lightweight safety-net in GET chat-settings to filter out bindings whose
+// root directories have been removed without the real-time watcher detecting it
+// (e.g. directory deleted while the agent was offline).
+func (c *LocalFSConnector) CheckPathExists(ctx context.Context, agentID, path string) bool {
+	_, err := c.agent.StatPath(ctx, StatPathRequest{AgentID: agentID, Path: path})
+	return err == nil
+}
+

--- a/backend/scan-control-plane/internal/sourceengine/source/binding_chat.go
+++ b/backend/scan-control-plane/internal/sourceengine/source/binding_chat.go
@@ -5,3 +5,24 @@ import "context"
 func (e *DefaultEngine) UpdateBindingChatEnabled(ctx context.Context, bindingID string, chatEnabled bool) error {
 	return mapStoreError(e.repo.UpdateBindingChatEnabled(ctx, bindingID, chatEnabled))
 }
+// IsBindingPathAccessible checks whether the binding'''s root directory still
+// exists by calling the agent'''s stat endpoint via the local_fs connector.
+// Fail-open: returns true when the check cannot be performed, so transient
+// agent errors do not incorrectly hide bindings from the user.
+func (e *DefaultEngine) IsBindingPathAccessible(ctx context.Context, agentID, targetRef string) bool {
+	if e.registry == nil {
+		return true // no connector registry, assume accessible
+	}
+	conn, err := e.registry.Get("local_fs")
+	if err != nil {
+		return true // can'''t reach connector, assume accessible
+	}
+	// Type-assert to access CheckPathExists without modifying SourceConnector.
+	if checker, ok := conn.(interface {
+		CheckPathExists(context.Context, string, string) bool
+	}); ok {
+		return checker.CheckPathExists(ctx, agentID, targetRef)
+	}
+	return true // connector doesn'''t support path checking, assume accessible
+}
+

--- a/backend/scan-control-plane/internal/sourceengine/source/types.go
+++ b/backend/scan-control-plane/internal/sourceengine/source/types.go
@@ -46,6 +46,12 @@ type Engine interface {
 	UpdateBinding(ctx context.Context, callerID, sourceID, bindingID string, input BindingInput) (BindingMutationResponse, error)
 	DeleteBinding(ctx context.Context, sourceID, bindingID string) (DeleteBindingResponse, error)
 	UpdateBindingChatEnabled(ctx context.Context, bindingID string, chatEnabled bool) error
+
+	// IsBindingPathAccessible checks whether the binding'''s root directory
+	// still exists on the agent via a stat call. Used as a safety-net fallback
+	// in GET chat-settings. Fail-open: returns true when the check cannot be
+	// performed, so transient agent errors do not hide bindings incorrectly.
+	IsBindingPathAccessible(ctx context.Context, agentID, targetRef string) bool
 }
 
 type CreateSourceRequest struct {


### PR DESCRIPTION
# Summary

Remove master switch validation for local data source chat participation, filter non-existent bindings, and fix inaccurate dataset pagination totals.

# Key Changes

## Remove Master Switch Validation

Local data source chat participation is now controlled purely at the per-binding level, preventing the global switch from incorrectly blocking all bindings.

## Filter Non-Existent Bindings
When listing chat settings, verify binding root directories still exist via the agent stat endpoint. Automatically exclude deleted directories and disable chat for those bindings, with fail-open semantics to avoid hiding bindings during transient agent errors.

## Fix Dataset Pagination
Refactor `ListDatasets` into a two-phase scan: Phase 1 collects the current page while counting, Phase 2 continues scanning remaining rows to produce accurate totals after source-level filtering.