### PR TITLE
feat(parsing): Dynamic block size based on embedding size

### DIFF
--- a/algorithm/lazymind/parsing/engine/transform/general_parser.py
+++ b/algorithm/lazymind/parsing/engine/transform/general_parser.py
@@ -81,40 +81,89 @@ class GeneralParser(NodeTransform):
             return f'![{alt_text}]({url})'
         return IMAGE_PATTERN.sub(_replace, text)
 
+    def _rfind_sentence_end(self, window: str) -> int:
+        '''Return index of the last sentence-ending . / 。, or -1.
+
+        '.' only counts when it ends the window or is followed by whitespace,
+        so decimals (2.5) and extensions (.png) are ignored.
+        '''
+        best = window.rfind('。')
+        pos = -1
+        start = 0
+        while True:
+            idx = window.find('.', start)
+            if idx < 0:
+                break
+            nxt = window[idx + 1] if idx + 1 < len(window) else ''
+            if nxt == '' or nxt.isspace():
+                pos = idx
+            start = idx + 1
+        return max(best, pos)
+
+    def _split_back_to_period(self, text: str, max_length: int) -> List[str]:
+        '''Split overlong text, cutting back to the previous sentence end when possible.'''
+        chunks: List[str] = []
+        start = 0
+        n = len(text)
+        while start < n:
+            end = min(start + max_length, n)
+            if end >= n:
+                chunks.append(text[start:])
+                break
+            window = text[start:end]
+            sent = self._rfind_sentence_end(window)
+            cut = sent + 1 if sent >= 0 else max_length
+            chunks.append(text[start:start + cut])
+            start += cut
+        return chunks
+
     def _split(self, text: str, max_length: int | None = None) -> List[str]:
         if not text:
             return []
         max_length = max_length or self._max_length
         if len(text) <= max_length:
             return [text]
-        result_chunks = []
-        parts = text.split(self._split_by)
 
-        current_chunk = []
-        current_len = 0
-        for part in parts:
-            part_len = len(part)
-            if part_len > max_length:
-                if current_chunk:
-                    result_chunks.append(self._split_by.join(current_chunk))
-                    current_chunk = []
-                    current_len = 0
-                for i in range(0, part_len, max_length):
-                    result_chunks.append(part[i:i + max_length])
+        result_chunks: List[str] = []
+        buf = ''
+        for part in text.split(self._split_by):
+            if len(part) > max_length and not buf:
+                result_chunks.extend(self._split_back_to_period(part, max_length))
                 continue
-            add_sep = self._len_split if current_chunk else 0
-            if current_len + part_len + add_sep > max_length:
-                if current_chunk:
-                    result_chunks.append(self._split_by.join(current_chunk))
-                current_chunk = [part]
-                current_len = part_len
+
+            candidate = part if not buf else f'{buf}{self._split_by}{part}'
+            if len(candidate) <= max_length:
+                buf = candidate
+                continue
+
+            # Overflow across \\n: prefer sentence end inside the max_length window so we
+            # do not close on a mid-sentence wrap like "shared\\nexperts."
+            window = candidate[:max_length]
+            sent = self._rfind_sentence_end(window)
+            if sent >= 0:
+                result_chunks.append(candidate[:sent + 1])
+                remainder = candidate[sent + 1:]
+                if remainder.startswith(self._split_by):
+                    remainder = remainder[self._len_split:]
+                if len(remainder) > max_length:
+                    pieces = self._split_back_to_period(remainder, max_length)
+                    result_chunks.extend(pieces[:-1])
+                    buf = pieces[-1]
+                else:
+                    buf = remainder
+            elif buf:
+                result_chunks.append(buf)
+                buf = part
             else:
-                if current_chunk:
-                    current_len += self._len_split
-                current_chunk.append(part)
-                current_len += part_len
-        if current_chunk:
-            result_chunks.append(self._split_by.join(current_chunk))
+                pieces = self._split_back_to_period(candidate, max_length)
+                result_chunks.extend(pieces[:-1])
+                buf = pieces[-1]
+
+        if buf:
+            if len(buf) > max_length:
+                result_chunks.extend(self._split_back_to_period(buf, max_length))
+            else:
+                result_chunks.append(buf)
         return result_chunks
 
     def forward(self, document: DocNode, **kwargs) -> List[DocNode]:

--- a/algorithm/lazymind/parsing/engine/transform/general_parser.py
+++ b/algorithm/lazymind/parsing/engine/transform/general_parser.py
@@ -4,15 +4,51 @@ import copy
 from typing import List
 from urllib.parse import urlparse
 
-from lazyllm import pipeline, LOG
+from lazyllm import pipeline, LOG, globals as lazyllm_globals
 from lazyllm.tools.rag import NodeTransform
 from lazyllm.tools.rag.doc_node import DocNode
 
 from lazymind.config import config as _cfg
+from lazymind.parsing.engine.utils import spawn_child_doc_node
 
 
 IMAGE_PREFIX = _cfg['rag_image_path_prefix']
 IMAGE_PATTERN = re.compile(r'!\[([^\]]*)\]\(([^)]+)\)')
+_TOKEN_LIMIT_PATTERN = re.compile(r'^([1-9][0-9]*)([KM])?$')
+_EMBED_CHUNK_LENGTH_BY_MAX_INPUT_TOKENS = {
+    512: 384,
+    1024: 896,
+    2048: 1920,
+}
+
+
+def _parse_token_limit(value) -> int | None:
+    if isinstance(value, int) and value > 0:
+        return value
+    if not isinstance(value, str):
+        return None
+    match = _TOKEN_LIMIT_PATTERN.fullmatch(value.strip().upper())
+    if not match:
+        return None
+    amount = int(match.group(1))
+    suffix = match.group(2)
+    return amount * {'K': 1_000, 'M': 1_000_000}.get(suffix, 1)
+
+
+def _runtime_embed_max_input_tokens() -> int | None:
+    try:
+        configs = lazyllm_globals['config'].get('dynamic_model_configs')
+    except AssertionError:
+        return None
+    if not isinstance(configs, dict):
+        return None
+    embed_main = configs.get('embed_main')
+    if not isinstance(embed_main, dict):
+        return None
+    embed_config = embed_main.get('embed')
+    if not isinstance(embed_config, dict):
+        return None
+    return _parse_token_limit(embed_config.get('max_input_tokens'))
 
 
 def is_url(s):
@@ -45,10 +81,11 @@ class GeneralParser(NodeTransform):
             return f'![{alt_text}]({url})'
         return IMAGE_PATTERN.sub(_replace, text)
 
-    def _split(self, text: str) -> List[str]:
+    def _split(self, text: str, max_length: int | None = None) -> List[str]:
         if not text:
             return []
-        if len(text) <= self._max_length:
+        max_length = max_length or self._max_length
+        if len(text) <= max_length:
             return [text]
         result_chunks = []
         parts = text.split(self._split_by)
@@ -57,16 +94,16 @@ class GeneralParser(NodeTransform):
         current_len = 0
         for part in parts:
             part_len = len(part)
-            if part_len > self._max_length:
+            if part_len > max_length:
                 if current_chunk:
                     result_chunks.append(self._split_by.join(current_chunk))
                     current_chunk = []
                     current_len = 0
-                for i in range(0, part_len, self._max_length):
-                    result_chunks.append(part[i:i + self._max_length])
+                for i in range(0, part_len, max_length):
+                    result_chunks.append(part[i:i + max_length])
                 continue
             add_sep = self._len_split if current_chunk else 0
-            if current_len + part_len + add_sep > self._max_length:
+            if current_len + part_len + add_sep > max_length:
                 if current_chunk:
                     result_chunks.append(self._split_by.join(current_chunk))
                 current_chunk = [part]
@@ -83,13 +120,25 @@ class GeneralParser(NodeTransform):
     def forward(self, document: DocNode, **kwargs) -> List[DocNode]:
         metadata = document.metadata
         global_metadata = document.global_metadata
+        max_input_tokens = _runtime_embed_max_input_tokens()
+        max_length = self._max_length
+        if max_input_tokens is not None:
+            max_length = min(
+                max_length,
+                _EMBED_CHUNK_LENGTH_BY_MAX_INPUT_TOKENS.get(max_input_tokens, max_length),
+            )
+        LOG.info(
+            f'[EMBED_CHUNK_SIZE] group=block configured_max_length={self._max_length} '
+            f'embed_max_input_tokens={max_input_tokens} effective_max_length={max_length}'
+        )
 
-        ppl = pipeline(self._image_path_transform, self._split)
+        ppl = pipeline(self._image_path_transform, lambda text: self._split(text, max_length=max_length))
         content = ppl(document.text or '')
 
         return [
-            DocNode(
+            spawn_child_doc_node(
+                document,
                 text=chunk,
                 metadata=copy.deepcopy(metadata),
-                global_metadata=copy.deepcopy(global_metadata)
+                global_metadata=copy.deepcopy(global_metadata),
             ) for chunk in content]

--- a/algorithm/lazymind/parsing/engine/transform/general_parser.py
+++ b/algorithm/lazymind/parsing/engine/transform/general_parser.py
@@ -127,10 +127,6 @@ class GeneralParser(NodeTransform):
                 max_length,
                 _EMBED_CHUNK_LENGTH_BY_MAX_INPUT_TOKENS.get(max_input_tokens, max_length),
             )
-        LOG.info(
-            f'[EMBED_CHUNK_SIZE] group=block configured_max_length={self._max_length} '
-            f'embed_max_input_tokens={max_input_tokens} effective_max_length={max_length}'
-        )
 
         ppl = pipeline(self._image_path_transform, lambda text: self._split(text, max_length=max_length))
         content = ppl(document.text or '')

--- a/algorithm/lazymind/parsing/engine/transform/para_parser.py
+++ b/algorithm/lazymind/parsing/engine/transform/para_parser.py
@@ -4,9 +4,9 @@ from typing import Callable, List, Optional, Sequence, Tuple
 from pathlib import Path
 from pydantic import Field, PrivateAttr
 
-from lazyllm.tools.rag import NodeTransform
+from lazyllm.tools.rag import NodeTransform, DocNode
 from lazyllm.module import ModuleBase
-from lazyllm.tools.rag import DocNode
+from lazymind.parsing.engine.utils import spawn_child_doc_node
 
 
 def split_by_regex(regex: str) -> Callable[[str], List[str]]:
@@ -104,7 +104,8 @@ class NormalLineSplitter(NodeTransform):
             global_metadata = node.global_metadata
             split_text = self._split_text(node.text)
             result.extend([
-                DocNode(
+                spawn_child_doc_node(
+                    node,
                     text=text,
                     metadata=copy.deepcopy(metadata),
                     global_metadata=copy.deepcopy(global_metadata),
@@ -423,9 +424,12 @@ class MineruLineSplitter(NodeTransform):
             lines = _metadata.pop('lines', [])
             for line in lines:
                 metadata = {'type': line.get('type', 'text'), 'page': line.get('page', 0), 'bbox': line.get('bbox', [])}
-                result.append(DocNode(text=line.get('content', ''),
-                                      metadata=_metadata | metadata,
-                                      global_metadata=copy.deepcopy(global_metadata)))
+                result.append(spawn_child_doc_node(
+                    node,
+                    text=line.get('content', ''),
+                    metadata=_metadata | metadata,
+                    global_metadata=copy.deepcopy(global_metadata),
+                ))
         return result
 
 

--- a/algorithm/lazymind/parsing/engine/utils.py
+++ b/algorithm/lazymind/parsing/engine/utils.py
@@ -1,6 +1,27 @@
+import copy
 from pathlib import Path
 
 from lazyllm.thirdparty import PIL
+from lazyllm.tools.rag.doc_node import DocNode
+
+
+def spawn_child_doc_node(
+    parent: DocNode,
+    *,
+    text: str,
+    metadata: dict | None = None,
+    global_metadata: dict | None = None,
+) -> DocNode:
+    child = DocNode(
+        text=text,
+        metadata=metadata if metadata is not None else copy.deepcopy(parent.metadata),
+        global_metadata=(
+            global_metadata if global_metadata is not None else copy.deepcopy(parent.global_metadata)
+        ),
+    )
+    child.excluded_embed_metadata_keys = parent.excluded_embed_metadata_keys[:]
+    child.excluded_llm_metadata_keys = parent.excluded_llm_metadata_keys[:]
+    return child
 
 
 def _safe_name(value: str) -> str:

--- a/backend/core/config/model_catalog.yaml
+++ b/backend/core/config/model_catalog.yaml
@@ -155,6 +155,7 @@ model_providers:
           max_input_tokens: "32K"
         - name: doubao-embedding-text-240715
           type: embed
+          max_input_tokens: "4096"
         - name: doubao-embedding-vision-241215
           type: cross_modal_embed
         - name: doubao-seed-1-6-250615
@@ -258,8 +259,10 @@ model_providers:
           type: text2image
         - name: Embedding-2
           type: embed
+          max_input_tokens: "512"
         - name: Embedding-3
           type: embed
+          max_input_tokens: "3072"
         - name: GLM-4-Flash-250414
           type: llm
           max_input_tokens: "128K"
@@ -555,10 +558,13 @@ model_providers:
           type: rerank
         - name: text-embedding-3-large
           type: embed
+          max_input_tokens: "8192"
         - name: text-embedding-3-small
           type: embed
+          max_input_tokens: "8192"
         - name: text-embedding-ada-002
           type: embed
+          max_input_tokens: "8192"
         - name: tts-1
           type: tts
         - name: tts-1-hd
@@ -797,16 +803,22 @@ model_providers:
           type: stt
         - name: text-embedding-async-v1
           type: embed
+          max_input_tokens: "2048"
         - name: text-embedding-async-v2
           type: embed
+          max_input_tokens: "2048"
         - name: text-embedding-v1
           type: embed
+          max_input_tokens: "2048"
         - name: text-embedding-v2
           type: embed
+          max_input_tokens: "2048"
         - name: text-embedding-v3
           type: embed
+          max_input_tokens: "8192"
         - name: text-embedding-v4
           type: embed
+          max_input_tokens: "8192"
         - name: tongyi-embedding-vision-flash
           type: cross_modal_embed
         - name: tongyi-embedding-vision-flash-2026-03-06
@@ -1005,6 +1017,7 @@ model_providers:
           max_input_tokens: "32K"
         - name: nova-embedding-stable
           type: embed
+          max_input_tokens: "512"
         - name: deepseek-v4-flash
           type: llm
           max_input_tokens: "1M"
@@ -1224,20 +1237,28 @@ model_providers:
           type: cross_modal_embed
         - name: Qwen/Qwen3-Embedding-8B
           type: embed
+          max_input_tokens: "32768"
         - name: Qwen/Qwen3-Embedding-4B
           type: embed
+          max_input_tokens: "32768"
         - name: Qwen/Qwen3-Embedding-0.6B
           type: embed
+          max_input_tokens: "32768"
         - name: BAAI/bge-m3
           type: embed
+          max_input_tokens: "8192"
         - name: BAAI/bge-large-zh-v1.5
           type: embed
+          max_input_tokens: "512"
         - name: BAAI/bge-large-en-v1.5
           type: embed
+          max_input_tokens: "512"
         - name: netease-youdao/bce-embedding-base_v1
           type: embed
+          max_input_tokens: "512"
         - name: Pro/BAAI/bge-m3
           type: embed
+          max_input_tokens: "8192"
         - name: Qwen/Qwen3-VL-Reranker-8B
           type: rerank
         - name: Qwen/Qwen3-Reranker-8B

--- a/backend/core/modelconfig/model_config.go
+++ b/backend/core/modelconfig/model_config.go
@@ -57,8 +57,8 @@ func LoadLLMConfig(ctx context.Context, db *gorm.DB, userID string) (map[string]
 				"m.provider_name, "+
 				"m.name AS model_name, "+
 				"g.base_url, "+
-			"g.api_key, "+
-			"m.max_input_tokens",
+				"g.api_key, "+
+				"m.max_input_tokens",
 		).
 		Joins(
 			"JOIN user_model_provider_group_models m ON "+
@@ -93,8 +93,8 @@ func LoadLLMConfig(ctx context.Context, db *gorm.DB, userID string) (map[string]
 				"m.provider_name, "+
 				"m.name AS model_name, "+
 				"g.base_url, "+
-			"g.api_key, "+
-			"m.max_input_tokens",
+				"g.api_key, "+
+				"m.max_input_tokens",
 		).
 		Joins(
 			"JOIN user_model_provider_group_models m ON "+

--- a/backend/core/modelconfig/model_config.go
+++ b/backend/core/modelconfig/model_config.go
@@ -10,11 +10,12 @@ import (
 )
 
 type SelectedRuntimeModel struct {
-	ModelType    string
-	ProviderName string
-	ModelName    string
-	BaseURL      string
-	APIKey       string
+	ModelType      string
+	ProviderName   string
+	ModelName      string
+	BaseURL        string
+	APIKey         string
+	MaxInputTokens *string
 }
 
 // LoadMaxInputTokens returns the configured context window for a runtime model role.
@@ -56,7 +57,8 @@ func LoadLLMConfig(ctx context.Context, db *gorm.DB, userID string) (map[string]
 				"m.provider_name, "+
 				"m.name AS model_name, "+
 				"g.base_url, "+
-				"g.api_key",
+			"g.api_key, "+
+			"m.max_input_tokens",
 		).
 		Joins(
 			"JOIN user_model_provider_group_models m ON "+
@@ -91,7 +93,8 @@ func LoadLLMConfig(ctx context.Context, db *gorm.DB, userID string) (map[string]
 				"m.provider_name, "+
 				"m.name AS model_name, "+
 				"g.base_url, "+
-				"g.api_key",
+			"g.api_key, "+
+			"m.max_input_tokens",
 		).
 		Joins(
 			"JOIN user_model_provider_group_models m ON "+
@@ -269,6 +272,9 @@ func BuildLLMConfig(rows []SelectedRuntimeModel) map[string]any {
 			"model":    row.ModelName,
 			"base_url": row.BaseURL,
 			"api_key":  row.APIKey,
+		}
+		if row.MaxInputTokens != nil {
+			cfg["max_input_tokens"] = *row.MaxInputTokens
 		}
 		out[strings.ToLower(strings.TrimSpace(row.ModelType))] = cfg
 	}

--- a/backend/core/modelprovider/seed.go
+++ b/backend/core/modelprovider/seed.go
@@ -42,7 +42,7 @@ type modelCatalog map[string]catalogSection
 
 var endpointPathMarkers = []string{"/embeddings", "/rerank", "/embed"}
 
-var maxInputTokensPattern = regexp.MustCompile(`^[1-9][0-9]*(K|M)$`)
+var maxInputTokensPattern = regexp.MustCompile(`^[1-9][0-9]*([KM])?$`)
 
 // normalizeBaseURL appends a trailing slash to generic API roots; endpoint-specific URLs are kept as-is.
 func normalizeBaseURL(raw string) string {
@@ -135,12 +135,12 @@ func upsertDefaultModel(tx *gorm.DB, now time.Time, providerID, providerName str
 		return errors.New("model name and type are required")
 	}
 	if item.MaxInputTokens != nil {
-		if modelType != "llm" && modelType != "vlm" {
-			return errors.New("model max_input_tokens is only supported for llm or vlm models")
+		if modelType != "llm" && modelType != "vlm" && modelType != "embed" {
+			return errors.New("model max_input_tokens is only supported for llm, vlm, or embed models")
 		}
 		maxInputTokens := strings.ToUpper(strings.TrimSpace(*item.MaxInputTokens))
 		if !maxInputTokensPattern.MatchString(maxInputTokens) {
-			return errors.New("model max_input_tokens must use a positive K or M value, for example 128K or 1M")
+			return errors.New("model max_input_tokens must be a positive integer or use a K or M suffix, for example 512, 128K, or 1M")
 		}
 		item.MaxInputTokens = &maxInputTokens
 	}

--- a/backend/core/openapi_registry.go
+++ b/backend/core/openapi_registry.go
@@ -899,7 +899,7 @@ type listModelProviderGroupModelsOpenAPIItem struct {
 	GroupName                string  `json:"group_name"`
 	BaseURL                  string  `json:"base_url"`
 	IsDefault                bool    `json:"is_default"`
-	MaxInputTokens           *string `json:"max_input_tokens" desc:"Maximum catalog LLM or VLM input context window, for example 128K or 1M; null for other, custom, or unknown models" nullable:"true"`
+	MaxInputTokens           *string `json:"max_input_tokens" desc:"Maximum catalog LLM, VLM, or embedding-model input context window, for example 512, 128K, or 1M; null for other, custom, or unknown models" nullable:"true"`
 }
 
 type listModelProviderGroupModelsOpenAPIResponse struct {
@@ -919,7 +919,7 @@ type selectedModelOpenAPIItem struct {
 	ProviderName             string  `json:"provider_name"`
 	GroupName                string  `json:"group_name"`
 	BaseURL                  string  `json:"base_url"`
-	MaxInputTokens           *string `json:"max_input_tokens" desc:"Maximum selected catalog LLM or VLM input context window, for example 128K or 1M; null for other, custom, or unknown models" nullable:"true"`
+	MaxInputTokens           *string `json:"max_input_tokens" desc:"Maximum selected catalog LLM, VLM, or embedding-model input context window, for example 512, 128K, or 1M; null for other, custom, or unknown models" nullable:"true"`
 }
 
 type listSelectedModelsOpenAPIResponse struct {
@@ -3287,7 +3287,7 @@ func registeredCoreOperations() []openAPIOperation {
 			Method:      "GET",
 			Path:        "/model_providers/models",
 			Summary:     "List current user's models by model_type",
-			Description: "Requires query model_type (e.g. llm or vlm). Returns all non-deleted user_model_provider_group_models for the current user with that model_type across all providers and groups. Each item includes nullable max_input_tokens, the catalog LLM or VLM model's maximum input context window expressed as a string such as 128K or 1M; other, custom, or unknown models return null. Ordered by user_model_provider_id, group id, then name. Same items as GET .../groups/{group_id}/models.",
+			Description: "Requires query model_type (e.g. llm, vlm, or embed). Returns all non-deleted user_model_provider_group_models for the current user with that model_type across all providers and groups. Each item includes nullable max_input_tokens, the catalog model's maximum input context window expressed as a string such as 512, 128K, or 1M; custom or unknown models return null. Ordered by user_model_provider_id, group id, then name. Same items as GET .../groups/{group_id}/models.",
 			Tags:        []string{"model_providers"},
 			QueryParams: listUserModelsByModelTypeQueryParams{},
 			Responses:   map[int]openAPIResponse{200: resp("Models list", listModelProviderGroupModelsOpenAPIResponse{})},
@@ -3296,7 +3296,7 @@ func registeredCoreOperations() []openAPIOperation {
 			Method:      "GET",
 			Path:        "/model_providers/selected_models",
 			Summary:     "Get selected models by model_type",
-			Description: "Returns the current user's selected model for each model_type. Each selection includes nullable max_input_tokens, the selected catalog LLM or VLM model's maximum input context window expressed as a string such as 128K or 1M; other, custom, or unknown models return null.",
+			Description: "Returns the current user's selected model for each model_type. Each selection includes nullable max_input_tokens, the selected catalog model's maximum input context window expressed as a string such as 512, 128K, or 1M; custom or unknown models return null.",
 			Tags:        []string{"model_providers"},
 			Responses:   map[int]openAPIResponse{200: resp("Selected models", listSelectedModelsOpenAPIResponse{})},
 		},
@@ -3351,7 +3351,7 @@ func registeredCoreOperations() []openAPIOperation {
 			Method:      "GET",
 			Path:        "/model_providers/{model_provider_id}/groups/{group_id}/models",
 			Summary:     "List models under a connection group",
-			Description: "Lists non-deleted user_model_provider_group_models for the group. Each item includes is_default (true when copied from default_models seeding; false for user-added models) and nullable max_input_tokens, the catalog LLM or VLM model's maximum input context window expressed as a string such as 128K or 1M. Other, custom, or unknown models return null.",
+			Description: "Lists non-deleted user_model_provider_group_models for the group. Each item includes is_default (true when copied from default_models seeding; false for user-added models) and nullable max_input_tokens, the catalog model's maximum input context window expressed as a string such as 512, 128K, or 1M. Custom or unknown models return null.",
 			Tags:        []string{"model_providers"},
 			PathParams:  modelProviderGroupByIDPathParams{},
 			Responses:   map[int]openAPIResponse{200: resp("Group models list", listModelProviderGroupModelsOpenAPIResponse{})},

--- a/docs/plan/ppt/html-to-png-pptx-pipeline.md
+++ b/docs/plan/ppt/html-to-png-pptx-pipeline.md
@@ -1,35 +1,19 @@
-# HTML → PNG → PPTX 轻量导出方案
+# HTML → PNG → PPTX 导出方案
 
-> 目标：前端一键把 sn-ppt / ppt-multi-styles 生成的 HTML 幻灯片导出为 PNG，再由算法侧（或后端转发）拼成 PPTX。**不依赖 3.5GB Playwright Docker 镜像**。
+> 目标：基于 **pptx skill** 生成的 HTML 幻灯片，在前端一键导出 PNG，并由后端/算法侧拼接为 PPTX。HTML 原文件与 PNG 预览一并保留。
 
-## 背景
-
-当前 sn-ppt-standard 的 `export_pptx/html_to_pptx.mjs` 链路：
+## 总体流程
 
 ```text
-HTML → Playwright/Chromium DOM 解析 → pptxgenjs → PPTX
+pptx skill 生成 deck
+  → pages/page_001.html ... page_NNN.html
+  → 前端 [导出 PPT]：html-to-image 按页截图
+  → Go core：鉴权、落盘 preview/*.png
+  → Python chat：python-pptx 拼接 deck.pptx
+  → 返回下载链接
 ```
 
-问题：
-
-- 生产环境需要 Playwright + Chromium（镜像 ~3.5GB，或额外 ~280MB 浏览器缓存）
-- WSL/容器内还常缺系统库（`libnspr4`、`libglib` 等）
-- 与 LazyMind 主栈（Go core + Python chat）耦合弱，难以在前端产品化
-
-已有可复用资产：
-
-| 资产 | 位置 | 能力 |
-|------|------|------|
-| 前端 HTML→PNG 原型 | `html-to-png-tool/` | `html-to-image`，npm 仅 ~58MB |
-| PNG→PPTX 脚本 | `skills/sn_ppt/sn-ppt-creative/scripts/build_pptx.py` | `python-pptx`，每页满版 16:9 |
-| HTML 生成流水线 | `skills/sn_ppt/sn-ppt-standard/scripts/run_stage.py` | 产出 `pages/page_*.html` |
-| 文件落盘 | Go core `LAZYMIND_UPLOAD_ROOT` | 已有 upload / signed URL 机制 |
-
-结论：**前端负责渲染截图，算法侧负责 PPTX 拼接**，是更轻、更稳的产品化路径。
-
----
-
-## 推荐架构
+## 架构
 
 ```text
 ┌─────────────┐     ① html-to-image      ┌──────────────┐
@@ -52,11 +36,34 @@ HTML → Playwright/Chromium DOM 解析 → pptxgenjs → PPTX
 
 ### 职责划分
 
-| 层 | 职责 | 不做 |
-|----|------|------|
-| **前端** | 加载 HTML、按页截图、上传 PNG、展示进度/下载 | 不拼 PPTX、不跑 Playwright |
-| **Go core** | 鉴权、deck 路径校验、文件落盘、调用 Python、返回 signed URL | 不做 DOM 解析 |
-| **Python 算法侧** | `build_pptx` 拼接、写 `deck.pptx`、可选保留 HTML/PNG | 不生成 HTML 内容 |
+| 层 | 职责 |
+|----|------|
+| **pptx skill** | 生成 `task_pack` / `outline` / `pages/page_*.html` |
+| **前端** | 加载 HTML、按页截图、上传 PNG、展示进度与下载 |
+| **Go core** | 鉴权、deck 路径校验、PNG 落盘、调用 Python、返回 signed URL |
+| **Python chat** | 读取 `preview/*.png`，按页序拼接 `deck.pptx` |
+
+---
+
+## Deck 目录约定
+
+pptx skill 产出目录结构：
+
+```text
+ppt_decks/{deck_id}/
+  task_pack.json
+  outline.json
+  style_spec.json
+  pages/
+    page_001.html
+    page_002.html
+    ...
+  preview/              # 前端导出后写入
+    page_001.png
+    page_002.png
+    ...
+  {deck_id}.pptx        # 算法侧拼接产物
+```
 
 ---
 
@@ -64,22 +71,22 @@ HTML → Playwright/Chromium DOM 解析 → pptxgenjs → PPTX
 
 ### 入口
 
-在 PPT 预览页（或 chat artifact 预览）增加按钮：
+在 PPT 预览页或 chat artifact 预览区提供：
 
 ```text
 [导出 PNG]  [导出 PPT]
 ```
 
-- **导出 PNG**：仅前端 `html-to-image`，zip 下载或直接存 `preview/`
-- **导出 PPT**：PNG 上传 + 调后端拼接
+- **导出 PNG**：浏览器内 `html-to-image` 截图，支持逐页下载或打包下载
+- **导出 PPT**：截图后上传 PNG，调用后端拼接 PPTX
 
 ### 技术选型
 
-- 库：`html-to-image`（已验证，核心包 ~520KB）
+- 库：`html-to-image`
 - 截图目标：`.wrapper`（1600×900，`pixelRatio: 2`）
-- 离屏渲染：隐藏 `iframe` 逐页加载 `/decks/{deck_id}/pages/page_NNN.html`
+- 渲染方式：隐藏 `iframe` 逐页加载 deck 内 HTML
 
-### 前端伪代码
+### 核心接口（前端）
 
 ```ts
 async function exportDeckToPng(deckId: string, pageNames: string[]) {
@@ -96,28 +103,28 @@ async function exportDeckToPptx(deckId: string, blobs: Blob[]) {
   form.append('deck_id', deckId);
   blobs.forEach((b, i) => form.append('pages', b, `page_${String(i + 1).padStart(3, '0')}.png`));
   const res = await fetch('/api/core/ppt/decks:export', { method: 'POST', body: form });
-  return res.json(); // { pptx_url, deck_id }
+  return res.json();
 }
 ```
 
-### 注意点
+### 渲染约定
 
-- 远程字体/CDN：HTML 应优先本地字体 fallback（sn-ppt 已要求）
-- ECharts：需等 `window.__pptxChartsReady` 或额外 `setTimeout` 再截图
-- 跨域：HTML/静态资源需同域或通过 core 静态路由提供
+- HTML 页面使用固定画布 `.wrapper`（16:9）
+- 含 ECharts 的页面：等待图表 ready 标记后再截图
+- HTML 与静态资源通过同域路由提供，避免跨域截图失败
 
 ---
 
-## 后端（Go core）设计
+## Go core 设计
 
-### API 草案
+### API
 
 ```http
 POST /api/core/ppt/decks:export
 Authorization: Bearer ...
 Content-Type: multipart/form-data
 
-deck_id=cyberpunk_ai_minimax
+deck_id={deck_id}
 pages=@page_001.png
 pages=@page_002.png
 ...
@@ -127,48 +134,58 @@ pages=@page_002.png
 
 ```json
 {
-  "deck_id": "cyberpunk_ai_minimax",
-  "pptx_path": "/var/lib/lazymind/uploads/ppt_decks/cyberpunk_ai_minimax/deck.pptx",
-  "pptx_url": "https://.../signed-url/deck.pptx",
+  "deck_id": "my_deck_20260722_120000",
+  "pptx_url": "https://.../signed-url/my_deck.pptx",
   "page_count": 4,
+  "preview_dir": ".../preview/",
   "html_dir": ".../pages/"
 }
 ```
 
-### Go core 流程
+### 处理流程
 
-1. RBAC：校验用户对 deck / conversation / artifact 的读权限
-2. 校验：`page_count`、单文件大小、总大小上限（建议单页 ≤2MB，总计 ≤20MB）
+1. RBAC：校验用户对 deck / conversation / artifact 的访问权限
+2. 校验：`page_count`、单文件与总大小上限（建议单页 ≤ 2MB，总计 ≤ 20MB）
 3. 落盘：`{upload_root}/ppt_decks/{deck_id}/preview/page_NNN.png`
-4. 调 Python：`POST http://chat:8046/api/ppt/build`（内网）
-5. 返回 signed download URL
+4. 调用 Python：`POST http://chat:8046/api/ppt/build`
+5. 返回 `pptx` 的 signed download URL
 
-### 为何经 Go core 而不是前端直连 Python
+### 设计原则
 
-- 统一鉴权（Kong + RBAC）
-- 统一 upload 路径与 ACL
-- 与现有 chat / artifact 链路一致
+- 统一走 Kong + RBAC 鉴权
+- 统一使用 `LAZYMIND_UPLOAD_ROOT` 落盘
+- 与 chat / artifact 生命周期保持一致
 
 ---
 
-## 算法侧（Python chat）设计
+## Python chat 设计
 
-### API 草案
+### API
 
 ```http
 POST /api/ppt/build
 Content-Type: application/json
 
 {
-  "deck_dir": "/var/lib/lazymind/uploads/ppt_decks/cyberpunk_ai_minimax",
-  "deck_id": "cyberpunk_ai_minimax",
-  "output": "/var/lib/lazymind/uploads/ppt_decks/cyberpunk_ai_minimax/deck.pptx"
+  "deck_dir": "/var/lib/lazymind/uploads/ppt_decks/my_deck_20260722_120000",
+  "deck_id": "my_deck_20260722_120000",
+  "output": "/var/lib/lazymind/uploads/ppt_decks/my_deck_20260722_120000/my_deck.pptx"
 }
 ```
 
-### 实现
+响应：
 
-复用 `skills/sn_ppt/sn-ppt-creative/scripts/build_pptx.py` 逻辑：
+```json
+{
+  "status": "ok",
+  "deck_id": "my_deck_20260722_120000",
+  "output": ".../my_deck.pptx",
+  "page_count": 4,
+  "included_pages": [1, 2, 3, 4]
+}
+```
+
+### 拼接逻辑
 
 ```python
 # algorithm/lazymind/chat/engine/ppt/build_pptx.py
@@ -179,128 +196,111 @@ SLIDE_W = Inches(13.333)  # 16:9
 SLIDE_H = Inches(7.5)
 
 def build_pptx_from_pngs(deck_dir: Path, output: Path) -> dict:
-    # 读 outline.json 或按 page_001..page_NNN 排序
-    # 每页 add_picture 满版
+    # 1. 读取 outline.json 确定页序；若无则按 page_001..page_NNN 排序
+    # 2. 读取 preview/page_NNN.png
+    # 3. 每页创建空白 slide，满版贴图
+    # 4. 保存 output
     ...
 ```
 
-依赖：`python-pptx`（轻量，~数 MB，algorithm 镜像可加入）
+页序规则：
 
-### 可选增强
+- 优先读 `outline.json` 的 `page_no`
+- 否则按 `page_001.png`、`page_002.png` 字典序
 
-- 若 `pages/*.html` 存在但 PNG 缺失：返回 400，提示前端先截图
-- 若 PNG 存在但 HTML 更新过：以 PNG 为准（截图即所见即所得）
-- 后续可加 `preview/` + `deck.pptx` 一并作为 artifact 回传 chat
+依赖：`python-pptx`
 
 ---
 
-## 与 sn-ppt skill 的衔接
-
-### 现有流水线
+## 与 pptx skill 的衔接
 
 ```text
-sn-ppt-entry → sn-ppt-standard → pages/page_*.html
-                                      ↓
-                              （新）前端导出 PNG
-                                      ↓
-                              Python build_pptx → deck.pptx
+用户触发 pptx skill
+  → 生成 HTML pages
+  → 前端展示预览
+  → 用户点击 [导出 PPT]
+  → 前端截图 PNG
+  → 后端拼接 PPTX
+  → artifact 回传 pptx_url + 保留 html/png
 ```
 
-### 替换关系
+导出完成后，chat 侧可追加 artifact：
 
-| 旧路径 | 新路径 |
-|--------|--------|
-| `run_stage.py export` + Playwright | 前端 `html-to-image` + `build_pptx.py` |
-| `html_to_pptx.mjs` DOM 抽取 | 整页 PNG 满版贴入（视觉保真更高） |
-| 3.5GB Docker | 浏览器 + python-pptx |
-
-trade-off：
-
-- **优点**：部署轻、效果稳定、HTML 原文件保留
-- **缺点**：PPTX 内是图片页，不可编辑文字（与 creative 模式一致）
+```json
+{
+  "type": "pptx",
+  "deck_id": "my_deck_20260722_120000",
+  "pptx_url": "...",
+  "page_count": 4,
+  "html_pages": ["page_001.html", "page_002.html"],
+  "preview_pages": ["page_001.png", "page_002.png"]
+}
+```
 
 ---
 
 ## 分阶段实施
 
-### Phase 0 — 已完成（原型）
+### Phase 1 — MVP
 
-- [x] `html-to-png-tool/` 前端工具
-- [x] CLI `batch-export.mjs`（Playwright 容器批量 PNG）
-- [x] 验证 `cyberpunk_ai_minimax` 4 页导出效果
+1. 前端：抽取 `html-to-png-tool` 为 `frontend/src/modules/ppt/export/`
+2. Python：实现 `build_pptx_from_pngs()` + `/api/ppt/build`
+3. Go core：实现 `POST /ppt/decks:export`
+4. UI：PPT 预览页增加「导出 PPT」按钮
 
-### Phase 1 — MVP（1～2 天）
+验收：点击一次按钮，获得可打开的 PPTX，且 `pages/` 与 `preview/` 均保留。
 
-1. 前端：把 `html-to-png-tool` 核心逻辑抽成 `frontend/src/modules/ppt/export/` 组件
-2. Python：新增 `build_pptx_from_pngs()` + `/api/ppt/build` 路由
-3. Go core：新增 `POST /ppt/decks:export` 转发 + 落盘
-4. 前端按钮：「导出 PPT」打通全链路
+### Phase 2 — 产品化
 
-验收：用户在 UI 点击一次，得到可打开的 4 页 PPTX + 保留 HTML/PNG。
+1. pptx skill 生成完成后自动挂载预览与导出入口
+2. deck 与 `conversation_id` / `task_id` 绑定
+3. SSE 进度：`export_started` → `png_uploaded` → `pptx_ready`
+4. 缺页、上传失败、图表未渲染等错误提示
 
-### Phase 2 — 产品化（2～3 天）
+### Phase 3 — 增强
 
-1. 接入 chat artifact：sn-ppt 生成完成后自动出现「预览 / 导出 PPT」
-2. deck 生命周期：与 `conversation_id` / `task_id` 绑定
-3. 进度 SSE：`export_started` → `png_uploaded` → `pptx_ready`
-4. 错误处理：ECharts 未渲染完、缺页、上传失败
-
-### Phase 3 — 可选优化
-
-1. 前端 Web Worker 并行截图多页
-2. 后端异步任务（大 deck >10 页）
-3. 可选「可编辑 PPT」路由到 MiniMax `pptx-generator`（native 元素，非 PNG）
+1. 前端 Web Worker 并行截图
+2. 大 deck（>10 页）走后端异步任务
+3. 支持仅导出 PNG、仅导出 PPTX、PNG+PPTX 打包下载
 
 ---
 
-## 依赖与体积对比
-
-| 方案 | npm / Python 包 | 浏览器/运行时 | 总计量级 |
-|------|-----------------|---------------|----------|
-| **本方案（前端 PNG + python-pptx）** | ~58MB npm + ~5MB python-pptx | 用户浏览器 | **~65MB** |
-| Playwright Docker 镜像 | ~15MB npm | Chromium in image | **~3.5GB** |
-| Puppeteer 独立下载 | ~58MB npm | Chrome cache | **~650MB** |
-
----
-
-## 风险与对策
-
-| 风险 | 对策 |
-|------|------|
-| 浏览器截图与 Playwright 导出视觉不一致 | 以浏览器截图为准；统一 1600×900 + pixelRatio:2 |
-| ECharts 未渲染完 | 等待 `__pptxChartsReady` 或固定 delay |
-| 大 deck 上传慢 | 分页上传 + 进度条；后端异步拼接 |
-| PPTX 不可编辑 | UI 明确标注「图片型 PPT」；需要可编辑时走 MiniMax 路线 |
-| 安全 | 限制 deck 路径、文件类型、大小；RBAC 校验 |
-
----
-
-## 建议目录结构（落地后）
+## 目录结构（落地后）
 
 ```text
 frontend/src/modules/ppt/
   export/
-    renderPageToPng.ts      # html-to-image 封装
-    uploadDeckPngs.ts       # 调 core API
-    ExportPptButton.tsx     # UI 按钮
+    renderPageToPng.ts
+    uploadDeckPngs.ts
+    ExportPptButton.tsx
 
 backend/core/ppt/
-  handler.go                # POST /ppt/decks:export
-  service.go                # 落盘 + 调 chat
+  handler.go
+  service.go
 
 algorithm/lazymind/chat/
-  api/ppt_routes.py         # POST /api/ppt/build
-  engine/ppt/build_pptx.py  # python-pptx 拼接
+  api/ppt_routes.py
+  engine/ppt/build_pptx.py
+
+html-to-png-tool/          # 本地调试工具（可保留）
 ```
 
 ---
 
-## 结论
+## 依赖清单
 
-**可以设计成「前端一个按钮 → HTML 转 PNG → 算法侧/后端拼 PPT」**，且比现有 Playwright 导出链路更适合 LazyMind 生产部署：
+| 组件 | 依赖 | 说明 |
+|------|------|------|
+| 前端截图 | `html-to-image` | 浏览器内 DOM → PNG |
+| 后端拼接 | `python-pptx` | PNG 满版贴入 16:9 slide |
+| 存储 | Go core upload | 已有 `LAZYMIND_UPLOAD_ROOT` |
 
-1. 前端：`html-to-image`（轻量，已有原型）
-2. Go core：鉴权 + 落盘 + 转发（复用现有 upload 体系）
-3. Python：`build_pptx.py` 逻辑（已有 sn-ppt-creative 脚本可参考）
+---
 
-建议 **Phase 1 优先做 Go core 转发 + Python build_pptx**，前端按钮直接复用 `html-to-png-tool/src/main.ts` 的核心逻辑。
+## 验收标准
+
+1. pptx skill 生成 N 页 HTML 后，前端可逐页预览
+2. 点击「导出 PPT」后，生成 N 页可打开的 PPTX
+3. `pages/*.html` 与 `preview/*.png` 原样保留
+4. 导出链路经 Go core 鉴权，返回 signed URL
+5. 页序与 `outline.json` 一致

--- a/docs/plan/ppt/html-to-png-pptx-pipeline.md
+++ b/docs/plan/ppt/html-to-png-pptx-pipeline.md
@@ -1,0 +1,306 @@
+# HTML → PNG → PPTX 轻量导出方案
+
+> 目标：前端一键把 sn-ppt / ppt-multi-styles 生成的 HTML 幻灯片导出为 PNG，再由算法侧（或后端转发）拼成 PPTX。**不依赖 3.5GB Playwright Docker 镜像**。
+
+## 背景
+
+当前 sn-ppt-standard 的 `export_pptx/html_to_pptx.mjs` 链路：
+
+```text
+HTML → Playwright/Chromium DOM 解析 → pptxgenjs → PPTX
+```
+
+问题：
+
+- 生产环境需要 Playwright + Chromium（镜像 ~3.5GB，或额外 ~280MB 浏览器缓存）
+- WSL/容器内还常缺系统库（`libnspr4`、`libglib` 等）
+- 与 LazyMind 主栈（Go core + Python chat）耦合弱，难以在前端产品化
+
+已有可复用资产：
+
+| 资产 | 位置 | 能力 |
+|------|------|------|
+| 前端 HTML→PNG 原型 | `html-to-png-tool/` | `html-to-image`，npm 仅 ~58MB |
+| PNG→PPTX 脚本 | `skills/sn_ppt/sn-ppt-creative/scripts/build_pptx.py` | `python-pptx`，每页满版 16:9 |
+| HTML 生成流水线 | `skills/sn_ppt/sn-ppt-standard/scripts/run_stage.py` | 产出 `pages/page_*.html` |
+| 文件落盘 | Go core `LAZYMIND_UPLOAD_ROOT` | 已有 upload / signed URL 机制 |
+
+结论：**前端负责渲染截图，算法侧负责 PPTX 拼接**，是更轻、更稳的产品化路径。
+
+---
+
+## 推荐架构
+
+```text
+┌─────────────┐     ① html-to-image      ┌──────────────┐
+│  前端 React  │ ──────────────────────► │  PNG blobs   │
+│  [导出 PPT]  │     (浏览器内 .wrapper)  │  page_001..N │
+└──────┬──────┘                          └──────┬───────┘
+       │ ② multipart/form-data                     │
+       ▼                                           ▼
+┌─────────────┐     ③ 转发/落盘          ┌──────────────┐
+│  Go core    │ ──────────────────────► │ deck_dir/    │
+│  POST /ppt  │                         │ preview/*.png│
+└──────┬──────┘                          └──────┬───────┘
+       │ ④ 调用算法侧                            │
+       ▼                                           ▼
+┌─────────────┐     ⑤ python-pptx        ┌──────────────┐
+│ Python chat │ ──────────────────────► │  deck.pptx   │
+│ build_pptx  │                         │  + 下载 URL  │
+└─────────────┘                          └──────────────┘
+```
+
+### 职责划分
+
+| 层 | 职责 | 不做 |
+|----|------|------|
+| **前端** | 加载 HTML、按页截图、上传 PNG、展示进度/下载 | 不拼 PPTX、不跑 Playwright |
+| **Go core** | 鉴权、deck 路径校验、文件落盘、调用 Python、返回 signed URL | 不做 DOM 解析 |
+| **Python 算法侧** | `build_pptx` 拼接、写 `deck.pptx`、可选保留 HTML/PNG | 不生成 HTML 内容 |
+
+---
+
+## 前端设计
+
+### 入口
+
+在 PPT 预览页（或 chat artifact 预览）增加按钮：
+
+```text
+[导出 PNG]  [导出 PPT]
+```
+
+- **导出 PNG**：仅前端 `html-to-image`，zip 下载或直接存 `preview/`
+- **导出 PPT**：PNG 上传 + 调后端拼接
+
+### 技术选型
+
+- 库：`html-to-image`（已验证，核心包 ~520KB）
+- 截图目标：`.wrapper`（1600×900，`pixelRatio: 2`）
+- 离屏渲染：隐藏 `iframe` 逐页加载 `/decks/{deck_id}/pages/page_NNN.html`
+
+### 前端伪代码
+
+```ts
+async function exportDeckToPng(deckId: string, pageNames: string[]) {
+  const blobs: Blob[] = [];
+  for (const name of pageNames) {
+    const blob = await renderPageToPng(`/decks/${deckId}/pages/${name}`);
+    blobs.push(blob);
+  }
+  return blobs;
+}
+
+async function exportDeckToPptx(deckId: string, blobs: Blob[]) {
+  const form = new FormData();
+  form.append('deck_id', deckId);
+  blobs.forEach((b, i) => form.append('pages', b, `page_${String(i + 1).padStart(3, '0')}.png`));
+  const res = await fetch('/api/core/ppt/decks:export', { method: 'POST', body: form });
+  return res.json(); // { pptx_url, deck_id }
+}
+```
+
+### 注意点
+
+- 远程字体/CDN：HTML 应优先本地字体 fallback（sn-ppt 已要求）
+- ECharts：需等 `window.__pptxChartsReady` 或额外 `setTimeout` 再截图
+- 跨域：HTML/静态资源需同域或通过 core 静态路由提供
+
+---
+
+## 后端（Go core）设计
+
+### API 草案
+
+```http
+POST /api/core/ppt/decks:export
+Authorization: Bearer ...
+Content-Type: multipart/form-data
+
+deck_id=cyberpunk_ai_minimax
+pages=@page_001.png
+pages=@page_002.png
+...
+```
+
+响应：
+
+```json
+{
+  "deck_id": "cyberpunk_ai_minimax",
+  "pptx_path": "/var/lib/lazymind/uploads/ppt_decks/cyberpunk_ai_minimax/deck.pptx",
+  "pptx_url": "https://.../signed-url/deck.pptx",
+  "page_count": 4,
+  "html_dir": ".../pages/"
+}
+```
+
+### Go core 流程
+
+1. RBAC：校验用户对 deck / conversation / artifact 的读权限
+2. 校验：`page_count`、单文件大小、总大小上限（建议单页 ≤2MB，总计 ≤20MB）
+3. 落盘：`{upload_root}/ppt_decks/{deck_id}/preview/page_NNN.png`
+4. 调 Python：`POST http://chat:8046/api/ppt/build`（内网）
+5. 返回 signed download URL
+
+### 为何经 Go core 而不是前端直连 Python
+
+- 统一鉴权（Kong + RBAC）
+- 统一 upload 路径与 ACL
+- 与现有 chat / artifact 链路一致
+
+---
+
+## 算法侧（Python chat）设计
+
+### API 草案
+
+```http
+POST /api/ppt/build
+Content-Type: application/json
+
+{
+  "deck_dir": "/var/lib/lazymind/uploads/ppt_decks/cyberpunk_ai_minimax",
+  "deck_id": "cyberpunk_ai_minimax",
+  "output": "/var/lib/lazymind/uploads/ppt_decks/cyberpunk_ai_minimax/deck.pptx"
+}
+```
+
+### 实现
+
+复用 `skills/sn_ppt/sn-ppt-creative/scripts/build_pptx.py` 逻辑：
+
+```python
+# algorithm/lazymind/chat/engine/ppt/build_pptx.py
+from pptx import Presentation
+from pptx.util import Inches
+
+SLIDE_W = Inches(13.333)  # 16:9
+SLIDE_H = Inches(7.5)
+
+def build_pptx_from_pngs(deck_dir: Path, output: Path) -> dict:
+    # 读 outline.json 或按 page_001..page_NNN 排序
+    # 每页 add_picture 满版
+    ...
+```
+
+依赖：`python-pptx`（轻量，~数 MB，algorithm 镜像可加入）
+
+### 可选增强
+
+- 若 `pages/*.html` 存在但 PNG 缺失：返回 400，提示前端先截图
+- 若 PNG 存在但 HTML 更新过：以 PNG 为准（截图即所见即所得）
+- 后续可加 `preview/` + `deck.pptx` 一并作为 artifact 回传 chat
+
+---
+
+## 与 sn-ppt skill 的衔接
+
+### 现有流水线
+
+```text
+sn-ppt-entry → sn-ppt-standard → pages/page_*.html
+                                      ↓
+                              （新）前端导出 PNG
+                                      ↓
+                              Python build_pptx → deck.pptx
+```
+
+### 替换关系
+
+| 旧路径 | 新路径 |
+|--------|--------|
+| `run_stage.py export` + Playwright | 前端 `html-to-image` + `build_pptx.py` |
+| `html_to_pptx.mjs` DOM 抽取 | 整页 PNG 满版贴入（视觉保真更高） |
+| 3.5GB Docker | 浏览器 + python-pptx |
+
+trade-off：
+
+- **优点**：部署轻、效果稳定、HTML 原文件保留
+- **缺点**：PPTX 内是图片页，不可编辑文字（与 creative 模式一致）
+
+---
+
+## 分阶段实施
+
+### Phase 0 — 已完成（原型）
+
+- [x] `html-to-png-tool/` 前端工具
+- [x] CLI `batch-export.mjs`（Playwright 容器批量 PNG）
+- [x] 验证 `cyberpunk_ai_minimax` 4 页导出效果
+
+### Phase 1 — MVP（1～2 天）
+
+1. 前端：把 `html-to-png-tool` 核心逻辑抽成 `frontend/src/modules/ppt/export/` 组件
+2. Python：新增 `build_pptx_from_pngs()` + `/api/ppt/build` 路由
+3. Go core：新增 `POST /ppt/decks:export` 转发 + 落盘
+4. 前端按钮：「导出 PPT」打通全链路
+
+验收：用户在 UI 点击一次，得到可打开的 4 页 PPTX + 保留 HTML/PNG。
+
+### Phase 2 — 产品化（2～3 天）
+
+1. 接入 chat artifact：sn-ppt 生成完成后自动出现「预览 / 导出 PPT」
+2. deck 生命周期：与 `conversation_id` / `task_id` 绑定
+3. 进度 SSE：`export_started` → `png_uploaded` → `pptx_ready`
+4. 错误处理：ECharts 未渲染完、缺页、上传失败
+
+### Phase 3 — 可选优化
+
+1. 前端 Web Worker 并行截图多页
+2. 后端异步任务（大 deck >10 页）
+3. 可选「可编辑 PPT」路由到 MiniMax `pptx-generator`（native 元素，非 PNG）
+
+---
+
+## 依赖与体积对比
+
+| 方案 | npm / Python 包 | 浏览器/运行时 | 总计量级 |
+|------|-----------------|---------------|----------|
+| **本方案（前端 PNG + python-pptx）** | ~58MB npm + ~5MB python-pptx | 用户浏览器 | **~65MB** |
+| Playwright Docker 镜像 | ~15MB npm | Chromium in image | **~3.5GB** |
+| Puppeteer 独立下载 | ~58MB npm | Chrome cache | **~650MB** |
+
+---
+
+## 风险与对策
+
+| 风险 | 对策 |
+|------|------|
+| 浏览器截图与 Playwright 导出视觉不一致 | 以浏览器截图为准；统一 1600×900 + pixelRatio:2 |
+| ECharts 未渲染完 | 等待 `__pptxChartsReady` 或固定 delay |
+| 大 deck 上传慢 | 分页上传 + 进度条；后端异步拼接 |
+| PPTX 不可编辑 | UI 明确标注「图片型 PPT」；需要可编辑时走 MiniMax 路线 |
+| 安全 | 限制 deck 路径、文件类型、大小；RBAC 校验 |
+
+---
+
+## 建议目录结构（落地后）
+
+```text
+frontend/src/modules/ppt/
+  export/
+    renderPageToPng.ts      # html-to-image 封装
+    uploadDeckPngs.ts       # 调 core API
+    ExportPptButton.tsx     # UI 按钮
+
+backend/core/ppt/
+  handler.go                # POST /ppt/decks:export
+  service.go                # 落盘 + 调 chat
+
+algorithm/lazymind/chat/
+  api/ppt_routes.py         # POST /api/ppt/build
+  engine/ppt/build_pptx.py  # python-pptx 拼接
+```
+
+---
+
+## 结论
+
+**可以设计成「前端一个按钮 → HTML 转 PNG → 算法侧/后端拼 PPT」**，且比现有 Playwright 导出链路更适合 LazyMind 生产部署：
+
+1. 前端：`html-to-image`（轻量，已有原型）
+2. Go core：鉴权 + 落盘 + 转发（复用现有 upload 体系）
+3. Python：`build_pptx.py` 逻辑（已有 sn-ppt-creative 脚本可参考）
+
+建议 **Phase 1 优先做 Go core 转发 + Python build_pptx**，前端按钮直接复用 `html-to-png-tool/src/main.ts` 的核心逻辑。

--- a/frontend/src/modules/chat/components/PluginPanel/SlotComponents.tsx
+++ b/frontend/src/modules/chat/components/PluginPanel/SlotComponents.tsx
@@ -907,6 +907,7 @@ interface SlotImageProps {
   /** Called when the user clicks the reference (cite) button. */
   onReference?: (slot: SlotRevision) => void;
   readOnly?: boolean;
+  hideMutationActions?: boolean;
 }
 
 export function SlotImage({
@@ -919,6 +920,7 @@ export function SlotImage({
   onRefresh,
   onReference,
   readOnly,
+  hideMutationActions,
 }: SlotImageProps) {
   const raw = slot.artifact_value;
   const { displayUrl: url, pending, hasSource } = useSlotImageUrl(raw);
@@ -1009,12 +1011,13 @@ export function SlotImage({
   }
 
   const hasActions = Boolean(sessionId && slotId && slot.list_index !== undefined) && !readOnly;
+  const showMutationActions = hasActions && !hideMutationActions;
 
   // Overlays rendered directly on top of the image (no separate action bar)
   const overlays = hasActions ? (
     <>
       {/* Delete + Upload buttons — top-right, shown on hover via CSS */}
-      {confirmDelete ? (
+      {showMutationActions && (confirmDelete ? (
         <span className='plugin-slot__delete-confirm plugin-slot__delete-confirm--overlay'>
           <span className='plugin-slot__delete-confirm-text'>{tr('chat.slots.confirmDeleteQuestion')}</span>
           <button
@@ -1046,7 +1049,7 @@ export function SlotImage({
             aria-label={tr('chat.slots.deleteImage')}
           >×</button>
         </span>
-      )}
+      ))}
 
       {/* Version badge — bottom-left, always visible, overlaid on image */}
       {revisionCount !== undefined && revisionCount > 0 && (
@@ -1091,7 +1094,7 @@ export function SlotImage({
           {overlays}
         </div>
         {/* Hidden file input */}
-        {hasActions && (
+        {showMutationActions && (
           <input
             ref={fileInputRef}
             type='file'
@@ -2136,6 +2139,7 @@ export function SlotRenderer({
   onRefresh,
   onReference,
   readOnly,
+  hideImageMutationActions,
 }: {
   slot: SlotRevision;
   cardMode?: boolean;
@@ -2147,6 +2151,7 @@ export function SlotRenderer({
   onRefresh?: () => void;
   onReference?: (slot: SlotRevision) => void;
   readOnly?: boolean;
+  hideImageMutationActions?: boolean;
 }) {
   useTranslation();
   if (slot.artifact_value === undefined || slot.artifact_value === null) {
@@ -2166,6 +2171,7 @@ export function SlotRenderer({
         onRefresh={onRefresh}
         onReference={onReference}
         readOnly={readOnly}
+        hideMutationActions={hideImageMutationActions}
       />
     );
   }

--- a/frontend/src/modules/chat/components/PluginPanel/index.tsx
+++ b/frontend/src/modules/chat/components/PluginPanel/index.tsx
@@ -427,6 +427,7 @@ function InnerTabsCell({
   sortOrder,
   onRefresh,
   onReference,
+  hideImageMutationActions,
 }: {
   tabsNode: InnerTabsNode;
   tab: TabDef;
@@ -435,6 +436,7 @@ function InnerTabsCell({
   sortOrder: number;
   onRefresh?: () => void;
   onReference?: (slot: SlotRevision) => void;
+  hideImageMutationActions?: boolean;
 }) {
   const [activeIdx, setActiveIdx] = useState(0);
 
@@ -475,6 +477,7 @@ function InnerTabsCell({
                 revisionCount={rev.revision_count}
                 onRefresh={onRefresh}
                 onReference={onReference}
+                hideImageMutationActions={hideImageMutationActions}
               />
             ) : (
               <div className='composite-cell__empty'>—</div>
@@ -509,6 +512,7 @@ function CompositeSlotGrid({
     buildColumns(tab),
     resolveVisibleSlotIds(tab, session),
   );
+  const hideImageMutationActions = tab.id === 'result';
 
   // Compute total weight for flex proportions.
   const totalWeight = columns.reduce((s, c) => s + c.weight, 0) || 1;
@@ -549,6 +553,7 @@ function CompositeSlotGrid({
                     sortOrder={sortOrder}
                     onRefresh={onRefresh}
                     onReference={onReference}
+                    hideImageMutationActions={hideImageMutationActions}
                   />
                 </div>
               );
@@ -574,6 +579,7 @@ function CompositeSlotGrid({
                     revisionCount={rev.revision_count}
                     onRefresh={onRefresh}
                     onReference={onReference}
+                    hideImageMutationActions={hideImageMutationActions}
                   />
                 ) : (
                   <div className='composite-grid__cell-empty'>—</div>

--- a/tests/algorithm/parsing/test_general_parser.py
+++ b/tests/algorithm/parsing/test_general_parser.py
@@ -2,6 +2,7 @@ import re
 
 import pytest
 from lazyllm.tools.rag import DocNode
+from lazyllm.tools.rag.doc_node import MetadataMode
 
 from lazymind.parsing.engine.transform import general_parser as general_parser_module
 from lazymind.parsing.engine.transform.general_parser import GeneralParser, is_url
@@ -45,6 +46,33 @@ def test_split_prefers_separator_and_force_splits_long_parts():
     assert parser._split('') == []
 
 
+def test_forward_reduces_chunk_size_for_selected_embedding_limit(monkeypatch):
+    parser = GeneralParser(max_length=2048, split_by='\n')
+    monkeypatch.setattr(general_parser_module, '_runtime_embed_max_input_tokens', lambda: 512)
+
+    chunks = parser.forward(DocNode(text='a' * 769))
+
+    assert [len(chunk.text) for chunk in chunks] == [384, 384, 1]
+
+
+def test_forward_uses_fixed_chunk_size_for_2048_token_embedding(monkeypatch):
+    parser = GeneralParser(max_length=2048, split_by='\n')
+    monkeypatch.setattr(general_parser_module, '_runtime_embed_max_input_tokens', lambda: 2048)
+
+    chunks = parser.forward(DocNode(text='a' * 1921))
+
+    assert [len(chunk.text) for chunk in chunks] == [1920, 1]
+
+
+def test_forward_uses_default_chunk_size_without_embedding_limit(monkeypatch):
+    parser = GeneralParser(max_length=2048, split_by='\n')
+    monkeypatch.setattr(general_parser_module, '_runtime_embed_max_input_tokens', lambda: None)
+
+    chunks = parser.forward(DocNode(text='a' * 2048))
+
+    assert [len(chunk.text) for chunk in chunks] == [2048]
+
+
 def test_general_parser_rejects_invalid_constructor_args():
     with pytest.raises(AssertionError, match='max_length'):
         GeneralParser(max_length=0)
@@ -73,3 +101,22 @@ def test_forward_transforms_images_splits_and_copies_metadata(monkeypatch):
     assert chunks[0].metadata['nested'] is not metadata['nested']
     assert chunks[0].global_metadata == global_metadata
     assert chunks[0].global_metadata is not global_metadata
+
+
+def test_forward_inherits_parent_metadata_exclusions(monkeypatch):
+    monkeypatch.setattr(general_parser_module, 'IMAGE_PREFIX', '/assets/images/')
+    parser = GeneralParser(max_length=12, split_by='\n')
+    node = DocNode(
+        text='first chunk\nsecond chunk',
+        metadata={'file_name': 'doc.pdf', 'page': 1, 'bbox': [0, 0, 1, 1], 'lines': [{'content': 'x'}]},
+    )
+    node.excluded_embed_metadata_keys = ['page', 'bbox', 'lines']
+    node.excluded_llm_metadata_keys = ['page', 'bbox', 'lines']
+
+    chunks = parser.forward(node)
+
+    assert len(chunks) == 2
+    for chunk in chunks:
+        assert set(chunk.excluded_embed_metadata_keys) == {'page', 'bbox', 'lines'}
+        assert set(chunk.excluded_llm_metadata_keys) == {'page', 'bbox', 'lines'}
+        assert chunk.get_text(MetadataMode.EMBED) == 'file_name: doc.pdf\n\n' + chunk.text

--- a/tests/algorithm/parsing/test_general_parser.py
+++ b/tests/algorithm/parsing/test_general_parser.py
@@ -38,12 +38,52 @@ def test_image_path_transform_prefixes_only_relative_paths(monkeypatch):
     assert image_urls == ['/assets/images/tables/a.png', 'https://example.test/b.png', 'lazyllm://image/c.png']
 
 
-def test_split_prefers_separator_and_force_splits_long_parts():
+def test_split_prefers_separator_and_hard_splits_long_parts():
     parser = GeneralParser(max_length=6, split_by='\n')
 
     assert parser._split('aa\nbbb\nc') == ['aa\nbbb', 'c']
     assert parser._split('abcdefgh') == ['abcdef', 'gh']
     assert parser._split('') == []
+
+
+def test_split_back_to_period():
+    parser = GeneralParser(max_length=20, split_by='\n')
+
+    assert parser._split('一二三四五六七八九十。后面还有很多文字内容继续写下去吧') == [
+        '一二三四五六七八九十。',
+        '后面还有很多文字内容继续写下去吧',
+    ]
+    assert parser._split('Sentence one. Sentence two continues with more words here.') == [
+        'Sentence one.',
+        ' Sentence two contin',
+        'ues with more words ',
+        'here.',
+    ]
+
+    text = ('前' * 12) + '。' + ('后' * 15)
+    assert parser._split(text) == [('前' * 12) + '。', '后' * 15]
+
+    # Early period is still used; no minimum-cut guard.
+    early = '短。' + ('后' * 20)
+    assert GeneralParser(max_length=10, split_by='\n')._split(early) == [
+        '短。',
+        '后' * 10,
+        '后' * 10,
+    ]
+
+
+def test_split_backs_to_period_across_newline_wrap():
+    # PDF/OCR often wraps mid-sentence with \\n; do not close the chunk there.
+    parser = GeneralParser(max_length=80, split_by='\n')
+    text = (
+        'Intro sentence. Unlike Qwen2.5-MoE, the Qwen3-MoE design excludes shared\n'
+        'experts. Following text stays here.'
+    )
+
+    chunks = parser._split(text)
+
+    assert not any(chunk.rstrip().endswith('shared') for chunk in chunks)
+    assert any('shared\nexperts.' in chunk for chunk in chunks)
 
 
 def test_forward_reduces_chunk_size_for_selected_embedding_limit(monkeypatch):

--- a/tests/algorithm/parsing/test_para_parser.py
+++ b/tests/algorithm/parsing/test_para_parser.py
@@ -115,7 +115,7 @@ def test_normal_line_splitter_inherits_parent_metadata_exclusions():
     result = NormalLineSplitter().forward(node)
 
     for child in result:
-        assert child.excluded_embed_metadata_keys == ['page', 'bbox']
+        assert set(child.excluded_embed_metadata_keys) == {'page', 'bbox'}
         assert child.get_text(MetadataMode.EMBED).startswith('file_name: note.md\n\n')
 
 
@@ -133,7 +133,7 @@ def test_mineru_line_splitter_inherits_parent_metadata_exclusions():
 
     result = MineruLineSplitter().forward(node)
 
-    assert result[0].excluded_embed_metadata_keys == ['lines', 'type', 'page', 'bbox']
+    assert set(result[0].excluded_embed_metadata_keys) == {'lines', 'type', 'page', 'bbox'}
     assert result[0].get_text(MetadataMode.EMBED) == 'file_name: paper.pdf\n\nline one'
 
 

--- a/tests/algorithm/parsing/test_para_parser.py
+++ b/tests/algorithm/parsing/test_para_parser.py
@@ -1,4 +1,5 @@
 from lazyllm.tools.rag import DocNode
+from lazyllm.tools.rag.doc_node import MetadataMode
 
 from lazymind.parsing.engine.transform.para_parser import (
     LineSplitter,
@@ -100,6 +101,40 @@ def test_line_splitter_uses_mineru_lines_for_pdf():
 
     assert [item.text for item in result] == ['line one']
     assert result[0].metadata['page'] == 2
+
+
+def test_normal_line_splitter_inherits_parent_metadata_exclusions():
+    node = DocNode(
+        text='这是一个足够长的第一句。\n第二句也足够长？',
+        metadata={'file_name': 'note.md', 'page': 1, 'bbox': [0, 0, 1, 1]},
+        global_metadata={'file_name': 'note.md'},
+    )
+    node.excluded_embed_metadata_keys = ['page', 'bbox']
+    node.excluded_llm_metadata_keys = ['page', 'bbox']
+
+    result = NormalLineSplitter().forward(node)
+
+    for child in result:
+        assert child.excluded_embed_metadata_keys == ['page', 'bbox']
+        assert child.get_text(MetadataMode.EMBED).startswith('file_name: note.md\n\n')
+
+
+def test_mineru_line_splitter_inherits_parent_metadata_exclusions():
+    node = DocNode(
+        text='merged text',
+        metadata={
+            'file_name': 'paper.pdf',
+            'lines': [{'content': 'line one', 'type': 'text', 'page': 2, 'bbox': [1, 2, 3, 4]}],
+        },
+        global_metadata={'file_name': 'paper.pdf'},
+    )
+    node.excluded_embed_metadata_keys = ['lines', 'type', 'page', 'bbox']
+    node.excluded_llm_metadata_keys = ['lines', 'type', 'page', 'bbox']
+
+    result = MineruLineSplitter().forward(node)
+
+    assert result[0].excluded_embed_metadata_keys == ['lines', 'type', 'page', 'bbox']
+    assert result[0].get_text(MetadataMode.EMBED) == 'file_name: paper.pdf\n\nline one'
 
 
 def test_paragraph_splitter_splits_by_paragraph_and_applies_overlap():

--- a/tests/evo/conftest.py
+++ b/tests/evo/conftest.py
@@ -1,15 +1,16 @@
+import json
 import sys
 from pathlib import Path
 
-import json
 import pytest
-from algorithm.config import config
 
 _ROOT = Path(__file__).resolve().parent.parent.parent
 for _p in (_ROOT, _ROOT / 'algorithm'):
     s = str(_p)
     if s not in sys.path:
         sys.path.insert(0, s)
+
+from lazymind.config import config  # noqa: E402
 
 
 @pytest.fixture(autouse=True)


### PR DESCRIPTION
# 文本切块基于已配置的模型动态改变。（预留128给metadata）

bge 最大 512 时

<img width="1088" height="74" alt="img_v3_0213q_95f761fd-9926-4c25-a152-1a2529c574fg" src="https://github.com/user-attachments/assets/7080ddad-5e6a-42fc-a698-de2920bce323" />

text-emb 最大2048 时

<img width="1094" height="50" alt="img_v3_0213q_61a014f3-5055-4af2-9943-865d4c1a61ag" src="https://github.com/user-attachments/assets/974a4bfb-3a02-4214-8c4b-b9fa051d6536" />

# 优化切块逻辑

超长block切块时会找到上一个 `. ` 多余字符会放到下一个block

## Before

<img width="642" height="430" alt="img_v3_0213s_2b0bf052-cfc7-4d65-8ddb-e6ba92db894g" src="https://github.com/user-attachments/assets/69ed20c3-4d0e-4c0e-a0de-5db5afbb8f41" />



## After

<img width="726" height="442" alt="img_v3_0213s_0521565a-35d7-4709-9097-03e835ed656g" src="https://github.com/user-attachments/assets/b0a5c29b-00be-43d1-9b32-4fe0ba428622" />
