### PR TITLE
fix(writer): simplify preparation output and approval flow

### DIFF
--- a/algorithm/lazymind/chat/engine/tools/writer.py
+++ b/algorithm/lazymind/chat/engine/tools/writer.py
@@ -14,7 +14,6 @@ from lazyllm.tools.writer.data_models import (
     InputResource,
     SectionInstruction,
     TargetDocument,
-    WriterAuthoring,
     WriterBlock,
     WriterDocument,
     WritingTask,
@@ -57,7 +56,7 @@ def build_writer_status_ir(status: str, content: str, *, source: str) -> str:
         metadata={'source': source, 'kind': 'step_status', 'status': status},
         ui_editable=False,
     )
-    return document.model_dump_json()
+    return document.model_dump_json(exclude_defaults=True)
 
 
 def _json_dumps(value: Any) -> str:
@@ -217,7 +216,7 @@ class WriterToolkitBase:
     def build_writing_task(self, query: str) -> str:
         """Build a writing task from the user's original request."""
         task = WritingTask(query=query, task_type='write')
-        return _json_dumps(task.model_dump())
+        return _json_dumps(task.model_dump(exclude_defaults=True))
 
     def build_resources(
         self,
@@ -309,7 +308,7 @@ class WriterToolkitBase:
             scope='auto',
             target_document=target_document,
         )
-        return _json_dumps(task.model_dump())
+        return _json_dumps(task.model_dump(exclude_defaults=True))
 
     def build_revision_task(
         self,
@@ -329,7 +328,7 @@ class WriterToolkitBase:
         return self.build_revise_task(
             query=query,
             target_document_json=(
-                _json_dumps(target.model_dump()) if target else ''
+                _json_dumps(target.model_dump(exclude_defaults=True)) if target else ''
             ),
         )
 
@@ -401,7 +400,9 @@ class WriterToolkitBase:
         result = WriterPlanningTools(
             llm=AutoModel(model='llm'), artifact_store=str(root),
         ).generate_outline(task=task_path, context=context_path)
-        return _set_document_editable(_primary_data(result), stage='outline').model_dump_json()
+        return _set_document_editable(
+            _primary_data(result), stage='outline',
+        ).model_dump_json(exclude_defaults=True)
 
     def prepare_outline(self, source_document_json: str) -> str:
         """Normalize a supplied document into an editable outline."""
@@ -418,10 +419,16 @@ class WriterToolkitBase:
             block.content = lines[0]
             block.spans = []
             block.numbering['level'] = 1
-            block.authoring = block.authoring or WriterAuthoring()
-            if len(lines) > 1 and not block.authoring.constraints.section_goal:
-                block.authoring.constraints.section_goal = '\n'.join(lines[1:])
-        return _set_document_editable(document, stage='outline').model_dump_json()
+            if len(lines) > 1:
+                block.children.insert(0, WriterBlock(
+                    node_id=f'{block.node_id}-description',
+                    type='paragraph',
+                    content='\n'.join(lines[1:]),
+                    stage='outline',
+                ))
+        return _set_document_editable(
+            document, stage='outline',
+        ).model_dump_json(exclude_defaults=True)
 
     def generate_section_instructions(
         self,
@@ -592,7 +599,7 @@ class WriterToolkitBase:
             stage='final',
         )
         return _json_dumps({
-            'final_document': final_document.model_dump(),
+            'final_document': final_document.model_dump(exclude_defaults=True),
             'final_document_md': markdown,
         })
 
@@ -749,7 +756,7 @@ class WriterToolkitBase:
         )
         return _json_dumps({
             'patch_result': _primary_data(result),
-            'revised_document': revised.model_dump(),
+            'revised_document': revised.model_dump(exclude_defaults=True),
         })
 
     def apply_revision(
@@ -804,7 +811,7 @@ class WriterToolkitBase:
         ).document_to_docir(target)
         return _json_dumps({
             'source_document': _primary_data(result),
-            'target_document': target.model_dump(),
+            'target_document': target.model_dump(exclude_defaults=True),
         })
 
     def create_document(self, title: str, parent_uri: str = '') -> str:
@@ -844,7 +851,7 @@ class WriterToolkitBase:
         )
         return _json_dumps({
             'publish_result': _primary_data(result),
-            'published_document': persisted.model_dump(),
+            'published_document': persisted.model_dump(exclude_defaults=True),
             'published_link': _published_link(target),
         })
 
@@ -918,7 +925,7 @@ class WriterToolkitBase:
         published = _set_document_editable(_primary_data(refreshed), stage='final')
         return _json_dumps({
             'publish_result': _primary_data(write_result),
-            'published_document': published.model_dump(),
+            'published_document': published.model_dump(exclude_defaults=True),
             'published_link': _published_link(target),
         })
 

--- a/algorithm/lazymind/chat/plugin/plugin_manager.py
+++ b/algorithm/lazymind/chat/plugin/plugin_manager.py
@@ -1077,6 +1077,17 @@ def build_cold_start_tools(
                     }, ensure_ascii=False)
 
                 static_advancement = plugin_mode == 'auto'
+                first_step_default_approval = (
+                    'required'
+                    if plugin_loader.get_step_mode(
+                        resolved_plugin_id, result['first_step_id']
+                    ) == 'human'
+                    else 'not_required'
+                )
+                inline_auto_step = (
+                    plugin_mode == 'dynamic'
+                    and first_step_default_approval == 'not_required'
+                )
                 launch_plan: Dict[str, Any] = {
                     'first_step_id': result['first_step_id'],
                     'normalized_request': result['normalized_request'],
@@ -1086,20 +1097,20 @@ def build_cold_start_tools(
                         'hand_off': True,
                         'advance_tool': 'advance_step_and_hand_off',
                     })
+                elif inline_auto_step:
+                    launch_plan.update({
+                        'hand_off': False,
+                        'advance_tool': 'advance_step',
+                    })
                 step_name_index = _build_step_name_index(resolved_plugin_id)
-                first_step_default_approval = (
-                    'required'
-                    if plugin_loader.get_step_mode(
-                        resolved_plugin_id, result['first_step_id']
-                    ) == 'human'
-                    else 'not_required'
-                )
                 prepared = {
                     **snapshot,
                     'must_advance': True,
                     'advance_committed': False,
-                    'requires_hand_off_choice': not static_advancement,
-                    'fallback_hand_off': True,
+                    'requires_hand_off_choice': not (
+                        static_advancement or inline_auto_step
+                    ),
+                    'fallback_hand_off': not inline_auto_step,
                     'step_name_index': step_name_index,
                     'launch_plan': launch_plan,
                     'scenario': resolved_spec.scenario_md,
@@ -1107,7 +1118,7 @@ def build_cold_start_tools(
                 cfg['prepared_plugin'] = prepared
                 cfg.update(runtime_meta)
                 visible_launch_plan = dict(launch_plan)
-                if static_advancement:
+                if static_advancement or inline_auto_step:
                     visible_launch_plan.pop('hand_off', None)
                     instruction = (
                         'You MUST now call the advancement tool named by launch_plan in this '
@@ -1635,7 +1646,8 @@ def build_advance_step_tool(
 
     advance_step.__doc__ = (
         'Start one or more Ready workflow steps synchronously and return their results.\n\n'
-        'Use only when the user explicitly requests multiple workflow steps, for example\n'
+        'Use when the selected step has default approval `not_required`, or when the user\n'
+        'explicitly requests multiple workflow steps, for example\n'
         '"帮我执行 N 步", "连续执行到 X", "一次性执行完", "run N steps",\n'
         '"continue through X", or "run all steps". A complete-deliverable request alone\n'
         'does not authorize this synchronous tool.\n'
@@ -1936,21 +1948,31 @@ def _build_cold_execution_policy(plugin_mode: str) -> str:
     return (
         '## Current Workflow Launch Policy [AUTHORITATIVE]\n'
         'After a trigger returns ready, it provides a compact index of every workflow step, '
-        'the valid first step, and that first step\'s default approval. You must still infer '
-        'the execution scope from the user\'s words; approval metadata does not choose the tool. '
+        'the valid first step, that first step\'s default approval, and a launch_plan. '
+        'When launch_plan names an advancement tool, call that tool exactly. Otherwise infer '
+        'the execution scope from the user\'s words. '
         'Match any user-named '
         'target boundary against the full id/name index. The index contains names only and '
         'does not imply order or reachability.\n'
-        '- DEFAULT: use `advance_step_and_hand_off` for the first step.\n'
-        '- Use `advance_step` only when the user explicitly requests more than one workflow '
-        'step, such as "帮我执行 N 步", "连续执行到 X", "一次性执行完", '
+        '- If the selected Ready step has default approval `not_required`, use `advance_step`.\n'
+        '- If the completed step explicitly directs automatic continuation based on its result, '
+        'use `advance_step_and_hand_off` for the directed Ready step and stop.\n'
+        '- Otherwise, use `advance_step_and_hand_off` for the first step by default.\n'
+        '- For any other step whose default approval is required, use `advance_step` only when the user '
+        'explicitly requests more than one workflow step, such as "帮我执行 N 步", "连续执行到 X", "一次性执行完", '
         '"run N steps", "continue through X", or "run the whole workflow without stopping".\n'
         '- Asking for a complete article, image, report, or other final deliverable does NOT '
         'by itself request multi-step or uninterrupted execution.\n'
         'Always start only the first_step_id returned by the trigger. After each synchronous '
         '`advance_step` result, use only the newly returned reachable-step details and repeat '
-        'the decision. Continue synchronously through prerequisites; when the named boundary '
-        'itself becomes a valid target, start it with `advance_step_and_hand_off` and stop.'
+        'the decision. Continue automatically through `not_required` steps. When the completed '
+        'step explicitly directs automatic continuation based on its result, such as a preparation '
+        'step confirming that no source file exists, start the directed Ready step with '
+        '`advance_step_and_hand_off` and stop. '
+        'Otherwise, when the next Ready step requires approval and the user did not explicitly '
+        'request continuous execution, stop and present the completed result without starting '
+        'that step. When the user named a boundary, start that boundary with '
+        '`advance_step_and_hand_off` and stop.'
     )
 
 
@@ -2331,13 +2353,16 @@ def _build_mode_guidance(
         'with a separate user_input/runtime_instruction for every step. Do not issue repeated\n'
         'single-step calls for the same frontier. Never include a Blocked node or a downstream\n'
         'node that needs another batch item\'s future output. Running an attempted step again remains single-step.\n\n'
-        '### Rule 3 — Dynamic mode defaults to hand-off\n'
-        'DEFAULT: call `advance_step_and_hand_off` and stop after starting the selected Ready step(s).\n'
-        'Use `advance_step` only when the latest query or persisted session intent explicitly asks\n'
+        '### Rule 3 — Dynamic mode honors step approval\n'
+        'If the selected Ready step has `[default approval: not_required]`, call `advance_step`\n'
+        'and continue from its result without asking the user for confirmation.\n'
+        'Otherwise, call `advance_step_and_hand_off` and stop after starting the selected Ready step(s).\n'
+        'For steps whose default approval is required, use `advance_step` only when the latest\n'
+        'query or persisted session intent explicitly asks\n'
         'to execute multiple workflow steps, for example "帮我执行 N 步", "连续执行到 X",\n'
         '"一次性执行完", "run N steps", "continue through X", or "run all steps".\n'
         'A request for a complete deliverable or a named workflow is NOT a request for continuous\n'
-        'execution. Step approval annotations are context only and never override this dynamic-mode default.\n'
+        'execution by itself; the not_required approval exception above still applies.\n'
         'When several independent Ready steps form the same frontier, pass them in one call to the\n'
         'chosen tool; the number of parallel Ready nodes does not itself imply continuous execution.\n\n'
         'If the user clearly asks to proceed with the existing workflow and\n'

--- a/frontend/src/modules/chat/store/pluginPanel.ts
+++ b/frontend/src/modules/chat/store/pluginPanel.ts
@@ -542,9 +542,6 @@ export const usePluginStore = create<PluginStore>()((set, get) => ({
   fetchPluginUI: async (pluginId) => {
     const lang = i18n.language || "";
     const cacheKey = `${pluginId}:${lang}`;
-    // Return cached value if already fetched for this language.
-    const cached = get().pluginUIByPlugin[cacheKey];
-    if (cached) return cached;
     try {
       const res = await PluginInfoApi().getPlugin(pluginId, {
         headers: lang ? { "Accept-Language": lang } : undefined,

--- a/frontend/src/modules/chat/store/pluginPanel.ts
+++ b/frontend/src/modules/chat/store/pluginPanel.ts
@@ -542,6 +542,9 @@ export const usePluginStore = create<PluginStore>()((set, get) => ({
   fetchPluginUI: async (pluginId) => {
     const lang = i18n.language || "";
     const cacheKey = `${pluginId}:${lang}`;
+    // Return cached value if already fetched for this language.
+    const cached = get().pluginUIByPlugin[cacheKey];
+    if (cached) return cached;
     try {
       const res = await PluginInfoApi().getPlugin(pluginId, {
         headers: lang ? { "Accept-Language": lang } : undefined,

--- a/plugins/writer-plugin/plugin.yaml
+++ b/plugins/writer-plugin/plugin.yaml
@@ -181,12 +181,11 @@ slots:
 
 ui:
   tabs:
-    - id: context
+    - id: prepare
       step_id: prepare
-      label: Context
+      label: Preparation
       layout: list
       slots:
-        - id: context_ir
         - id: source_ir
 
     - id: outline
@@ -221,7 +220,7 @@ i18n:
       write_document: {label: 成稿}
       publish: {label: 交付文稿}
     tabs:
-      context: {label: 写作准备}
+      prepare: {label: 写作准备}
       outline: {label: 大纲}
       result: {label: 成稿}
       publish: {label: 交付文稿}
@@ -230,7 +229,7 @@ i18n:
       resource_profiles: {label: 资源画像}
       writing_context: {label: 写作上下文}
       context_ir: {label: 上下文构造结果}
-      source_ir: {label: 来源文档}
+      source_ir: {label: 资源文档}
       target_document: {label: 云文档目标}
       outline_ir: {label: 大纲}
       section_instructions: {label: 章节规划}

--- a/plugins/writer-plugin/scenario/state.yml
+++ b/plugins/writer-plugin/scenario/state.yml
@@ -35,6 +35,7 @@ transitions:
 steps:
   prepare:
     label: 写作准备
+    mode: auto
     route: choice
     prompt: |
       {{runtime_instruction}}
@@ -80,6 +81,9 @@ steps:
       required next step. Use "next step: outline revision" for stage="outline", and
       "next step: full-document revision" for stage="draft" or stage="final". This
       routing information must be stated even when the user did not ask to see it.
+      When source_ir does not exist, explicitly state: "No source file was provided.
+      Continue directly to outline without requesting confirmation." Do not emit this
+      instruction when source_ir exists.
     tools:
       - kb
       - cloud_files


### PR DESCRIPTION
## 改动概览

本 PR 适配精简后的 Writer IR，调整写作准备步骤的结果展示和动态审批行为：准备阶段只展示资源文档；没有来源文档时自动完成准备并进入大纲；存在来源文档或后续步骤需要审批时继续保留人工确认边界。改动覆盖 Algorithm、writer-plugin 和 LazyLLM submodule，不包含前端代码修改。

## 写作能力

### 适配统一 Writer IR

- 更新 LazyLLM submodule 到 `ffcad18f`，接入删除 `WriterAuthoring` / `WriterConstraints`、省略默认字段后的 Writer IR。
- LazyMind Writer 工具移除 `WriterAuthoring` 依赖，`prepare_outline` 将多行章节说明转换为普通段落子 Block，避免生成飞书和正文不存在的特殊字段。
- WritingTask、Outline、Final Document、Revision 和 Publish 等 JSON 输出统一省略默认字段，减少 Artifact 体积和模型上下文开销。

### 写作准备与插件展示

- Writer Plugin 的准备 Tab 只展示 `source_ir`，不再向用户展示内部 `context_ir`。
- 准备步骤名称统一为 `prepare`，将 `source_ir` 的展示名称调整为“资源文档”。
- 保留写作准备步骤本身；有来源文档时正常展示资源文档，没有来源文档时允许准备步骤返回后继续进入大纲。

### 动态审批流程

- `prepare` 设置为自动步骤；当没有来源文档时，步骤结果明确指示直接进入 Outline，不再额外请求用户确认。
- Dynamic 模式根据 Ready Step 的默认审批属性选择推进方式：`not_required` 使用同步 `advance_step`，需要审批的步骤继续使用 handoff。
- 当已完成步骤根据运行结果明确要求自动继续时，启动指定下一步后停止，避免跳过 Outline 等后续人工确认边界。
- 更新通用插件启动和推进策略说明，使步骤默认审批属性与实际调度行为保持一致。

## 验证情况

- `git diff --check` 通过。
- 修改后的 Python 文件 AST 解析、Writer Plugin YAML 解析通过。
- Writer Plugin API 正常加载，步骤为 `prepare → outline → write_document → publish`。
- 准备 Tab 当前仅包含 `source_ir`。
- LazyLLM Writer 数据模型和工具测试：48 passed。