### PR TITLE
fix: validate Google Drive OAuth redirect URI

### DIFF
--- a/frontend/src/i18n/locales/en-US.ts
+++ b/frontend/src/i18n/locales/en-US.ts
@@ -434,6 +434,10 @@ const enUS = {
       googleDriveConfigTitle: "Configure Google Drive OAuth",
       googleDriveAuthorize: "Save and Authorize",
       googleDriveConfigHint: "Enable the Drive API in Google Cloud Console and add this exact address to the OAuth Web client's authorized redirect URIs: {{callbackUrl}}",
+      googleDriveRedirectReadyTitle: "OAuth callback URL is ready",
+      googleDriveInvalidRedirectTitle: "The current address cannot be used for Google OAuth",
+      googleDriveInvalidRedirectHint:
+        "Google will reject {{callbackUrl}}. HTTP is allowed only for localhost, 127.0.0.1, or ::1. Other environments require HTTPS on a public domain and cannot use a raw IP address. Reopen LazyMind through a local loopback URL or an HTTPS domain/tunnel.",
       googleDriveSetupGuideAction: "Setup Guide",
       googleDriveClientIdRequired: "Enter the OAuth Client ID",
       googleDriveClientSecretRequired: "Enter the OAuth Client Secret",
@@ -2123,6 +2127,10 @@ const enUS = {
     dataSourceGoogleDriveCallbackLabel: "Current OAuth callback URL",
     dataSourceGoogleDriveHttpsHint:
       "Register the exact URL above in the Google OAuth Web client. Use HTTPS in production; localhost or 127.0.0.1 may use HTTP under Google's local development rules.",
+    dataSourceGoogleDriveInvalidCallbackTitle:
+      "Google will reject the current address",
+    dataSourceGoogleDriveInvalidCallbackHint:
+      "Google OAuth Web clients do not accept HTTP private-network addresses or raw-IP redirects. For same-machine testing, open LazyMind through http://localhost or http://127.0.0.1. For LAN, remote, or production access, configure a public HTTPS domain or HTTPS tunnel and reopen this page from that address.",
     dataSourceTypeDatabase: "External Database",
     dataSourceTypeDatabaseDesc:
       "Connect MySQL or PostgreSQL with a read-only account for direct chat queries.",
@@ -2390,7 +2398,9 @@ const enUS = {
       openDriveApi: "Open Google Drive API",
       openCredentials: "Open Credentials",
       openAudience: "Open Google Auth Platform Audience",
+      openRedirectRules: "View Google's Redirect URI rules",
       callbackUrl: "Authorized redirect URI: {{uri}}",
+      unsupportedCallbackUrl: "The current address cannot be registered as a Google OAuth callback: {{uri}}",
       steps: {
         openConsoleTitle: "Create or select a Google Cloud project",
         openConsoleDesc:
@@ -2423,6 +2433,10 @@ const enUS = {
           "If you open LazyMind with 127.0.0.1 or a deployment domain instead of localhost, replace the origin in the callback URL with that same browser origin.",
         redirectHttpsHint:
           "Use HTTPS for production domains. Local development may use an exactly registered http://localhost or http://127.0.0.1 URL in a Google Web OAuth client. Scheme, host, port, and path must all match.",
+        redirectUnsupportedHint:
+          "Google permits HTTP only for localhost, 127.0.0.1, or ::1. Other callbacks must use HTTPS with a public top-level domain, and cannot use 10.x, 172.16-31.x, 192.168.x, or any other raw IP address.",
+        redirectRecoveryHint:
+          "If the browser and LazyMind run on the same machine, reopen the system through http://localhost or http://127.0.0.1. For LAN or remote access, configure a public HTTPS domain or an HTTPS tunnel such as Cloudflare Tunnel or ngrok, then open LazyMind from the new address. This page will generate the matching callback URI automatically.",
         copyCredentialsTitle: "Copy Client ID and Client Secret",
         copyCredentialsDesc:
           "After the Web client is created, copy the OAuth Client ID and Client Secret. Keep the secret private.",

--- a/frontend/src/i18n/locales/zh-CN.ts
+++ b/frontend/src/i18n/locales/zh-CN.ts
@@ -403,6 +403,10 @@ const zhCN = {
       googleDriveConfigTitle: "配置 Google Drive OAuth",
       googleDriveAuthorize: "保存并授权",
       googleDriveConfigHint: "在 Google Cloud Console 启用 Drive API，并将以下地址完整加入 OAuth Web 客户端的授权重定向 URI：{{callbackUrl}}",
+      googleDriveRedirectReadyTitle: "OAuth 回调地址可用",
+      googleDriveInvalidRedirectTitle: "当前访问地址不能用于 Google OAuth",
+      googleDriveInvalidRedirectHint:
+        "Google 不接受 {{callbackUrl}}。HTTP 仅允许 localhost、127.0.0.1 或 ::1；其他环境必须使用带公共域名的 HTTPS，且不能使用原始 IP 地址。请通过本机回环地址或 HTTPS 域名/隧道重新打开 LazyMind。",
       googleDriveSetupGuideAction: "接入教程",
       googleDriveClientIdRequired: "请输入 OAuth Client ID",
       googleDriveClientSecretRequired: "请输入 OAuth Client Secret",
@@ -2079,6 +2083,10 @@ const zhCN = {
     dataSourceGoogleDriveCallbackLabel: "当前 OAuth 回调地址",
     dataSourceGoogleDriveHttpsHint:
       "请将上方地址完整登记到 Google OAuth Web 客户端。生产部署使用 HTTPS；本地 localhost 或 127.0.0.1 可按 Google 本地开发规则使用 HTTP。",
+    dataSourceGoogleDriveInvalidCallbackTitle:
+      "当前地址会被 Google 拒绝",
+    dataSourceGoogleDriveInvalidCallbackHint:
+      "Google OAuth Web 客户端不允许 HTTP 内网地址或原始 IP 回调。本机测试请通过 http://localhost 或 http://127.0.0.1 打开 LazyMind；局域网、远程或生产部署请先配置 HTTPS 公共域名或 HTTPS 隧道，再从该地址重新打开本页。",
     dataSourceTypeDatabase: "外部数据库",
     dataSourceTypeDatabaseDesc: "通过只读账号连接 MySQL 或 PostgreSQL，供聊天直接查询。",
     dataSourceTypeStepIntro: "当前支持本地文件 / 本地目录、飞书、Notion、Google Drive 和外部数据库接入，请选择后进入连接配置。",
@@ -2323,7 +2331,9 @@ const zhCN = {
       openDriveApi: "打开 Google Drive API",
       openCredentials: "打开凭据页面",
       openAudience: "打开 Google Auth Platform Audience",
+      openRedirectRules: "查看 Google Redirect URI 规则",
       callbackUrl: "授权重定向 URI：{{uri}}",
+      unsupportedCallbackUrl: "当前地址不能登记为 Google OAuth 回调：{{uri}}",
       steps: {
         openConsoleTitle: "创建或选择 Google Cloud 项目",
         openConsoleDesc:
@@ -2356,6 +2366,10 @@ const zhCN = {
           "如果你用 127.0.0.1 或部署域名打开 LazyMind，而不是 localhost，请把回调地址中的 origin 替换成同一个浏览器 origin。",
         redirectHttpsHint:
           "生产域名应使用 HTTPS；本地开发可使用 Google Web OAuth 客户端中精确登记的 http://localhost 或 http://127.0.0.1 地址。协议、主机、端口和路径必须完全一致。",
+        redirectUnsupportedHint:
+          "Google 仅允许 localhost、127.0.0.1 或 ::1 使用 HTTP；其他回调必须使用带公共顶级域名的 HTTPS，并且不能使用 10.x、172.16-31.x、192.168.x 或其他原始 IP 地址。",
+        redirectRecoveryHint:
+          "如果浏览器和 LazyMind 在同一台机器上，请改用 http://localhost 或 http://127.0.0.1 打开系统；如果通过局域网或远程访问，请配置 HTTPS 公共域名或 Cloudflare Tunnel/ngrok 等 HTTPS 隧道，再从新地址打开系统。页面会自动生成对应的回调 URI。",
         copyCredentialsTitle: "复制 Client ID 和 Client Secret",
         copyCredentialsDesc:
           "Web 客户端创建完成后，复制 OAuth Client ID 和 Client Secret。Client Secret 需要保密。",

--- a/frontend/src/modules/dataSource/oauth/redirectUri.ts
+++ b/frontend/src/modules/dataSource/oauth/redirectUri.ts
@@ -1,0 +1,36 @@
+function isLoopbackHostname(hostname: string) {
+  const normalized = hostname.toLowerCase().replace(/^\[|\]$/g, "");
+  return normalized === "localhost" || normalized === "127.0.0.1" || normalized === "::1";
+}
+
+function isRawIpHostname(hostname: string) {
+  const normalized = hostname.toLowerCase().replace(/^\[|\]$/g, "");
+  return /^(?:\d{1,3}\.){3}\d{1,3}$/.test(normalized) || normalized.includes(":");
+}
+
+function hasPublicDomainShape(hostname: string) {
+  const normalized = hostname.toLowerCase().replace(/\.$/, "");
+  return (
+    normalized.includes(".") &&
+    !normalized.endsWith(".local") &&
+    !normalized.endsWith(".localhost") &&
+    !normalized.endsWith(".internal") &&
+    !normalized.endsWith(".lan")
+  );
+}
+
+export function isGoogleOAuthRedirectUriSupported(value: string) {
+  try {
+    const url = new URL(value);
+    if (isLoopbackHostname(url.hostname)) {
+      return url.protocol === "http:" || url.protocol === "https:";
+    }
+    return (
+      url.protocol === "https:" &&
+      !isRawIpHostname(url.hostname) &&
+      hasPublicDomainShape(url.hostname)
+    );
+  } catch {
+    return false;
+  }
+}

--- a/frontend/src/modules/dataSource/oauth/urls.ts
+++ b/frontend/src/modules/dataSource/oauth/urls.ts
@@ -1,6 +1,7 @@
 import { loadPendingCloudOAuthSession } from "./storage";
 import type { CloudDataSourceProvider } from "./types";
 import { getCloudDocumentsUrl } from "@/modules/modelProvider/utils/cloudDocumentUrls";
+export { isGoogleOAuthRedirectUriSupported } from "./redirectUri";
 
 function getBaseName() {
   return ((window as Window & { BASENAME?: string }).BASENAME || "").trim();

--- a/frontend/src/modules/modelProvider/components/GoogleDriveConnectionSection.tsx
+++ b/frontend/src/modules/modelProvider/components/GoogleDriveConnectionSection.tsx
@@ -1,11 +1,14 @@
 import { useCallback, useEffect, useState } from "react";
-import { Button, Form, Input, Modal, Space, Tag, message } from "antd";
+import { Alert, Button, Form, Input, Modal, Space, Tag, message } from "antd";
 import { DeleteOutlined, FileTextOutlined, GoogleOutlined, LinkOutlined, SettingOutlined } from "@ant-design/icons";
 import { useTranslation } from "react-i18next";
 
 import { dataSourceCloudOauthApi } from "@/modules/dataSource/api/clients";
 import { unwrapApiData } from "@/modules/dataSource/api/unwrap";
-import { getCloudDataSourceCallbackUrl } from "@/modules/dataSource/oauth/urls";
+import {
+  getCloudDataSourceCallbackUrl,
+  isGoogleOAuthRedirectUriSupported,
+} from "@/modules/dataSource/oauth/urls";
 import {
   CLOUD_DATA_SOURCE_OAUTH_CHANNEL,
   consumeCloudDataSourceOAuthResult,
@@ -38,6 +41,7 @@ export default function GoogleDriveConnectionSection() {
   const [saving, setSaving] = useState(false);
   const [secretConfigured, setSecretConfigured] = useState(false);
   const callbackUrl = getCloudDataSourceCallbackUrl("googledrive");
+  const callbackUrlSupported = isGoogleOAuthRedirectUriSupported(callbackUrl);
 
   const refreshConnection = useCallback(async () => {
     setLoading(true);
@@ -106,6 +110,10 @@ export default function GoogleDriveConnectionSection() {
   };
 
   const connect = async () => {
+    if (!callbackUrlSupported) {
+      message.error(t("modelProvider.external.googleDriveInvalidRedirectTitle"));
+      return;
+    }
     try {
       const values = await form.validateFields();
       const clientSecret = values.clientSecret?.trim() || "";
@@ -208,6 +216,7 @@ export default function GoogleDriveConnectionSection() {
         confirmLoading={saving}
         onCancel={() => setModalOpen(false)}
         onOk={() => void connect()}
+        okButtonProps={{ disabled: !callbackUrlSupported }}
       >
         <Form form={form} layout="vertical">
           <Form.Item
@@ -230,9 +239,16 @@ export default function GoogleDriveConnectionSection() {
               placeholder={secretConfigured ? t("modelProvider.external.googleDriveSecretConfigured") : undefined}
             />
           </Form.Item>
-          <p className="google-drive-connection-hint">
-            {t("modelProvider.external.googleDriveConfigHint", { callbackUrl })}
-          </p>
+          <Alert
+            showIcon
+            type={callbackUrlSupported ? "info" : "error"}
+            message={callbackUrlSupported
+              ? t("modelProvider.external.googleDriveRedirectReadyTitle")
+              : t("modelProvider.external.googleDriveInvalidRedirectTitle")}
+            description={callbackUrlSupported
+              ? t("modelProvider.external.googleDriveConfigHint", { callbackUrl })
+              : t("modelProvider.external.googleDriveInvalidRedirectHint", { callbackUrl })}
+          />
           <p className="google-drive-connection-guide">
             <a
               href={`${CLOUD_DOCUMENTS_GOOGLE_DRIVE_SETUP_PATH}?from=google-drive-provider`}

--- a/frontend/src/modules/modelProvider/pages/GoogleDriveConnectionPage.tsx
+++ b/frontend/src/modules/modelProvider/pages/GoogleDriveConnectionPage.tsx
@@ -1,10 +1,13 @@
 import { ArrowLeftOutlined, GoogleOutlined } from "@ant-design/icons";
-import { Button, Typography } from "antd";
+import { Alert, Button, Typography } from "antd";
 import { useTranslation } from "react-i18next";
 import { useNavigate } from "react-router-dom";
 
 import GoogleDriveConnectionSection from "@/modules/modelProvider/components/GoogleDriveConnectionSection";
-import { getCloudDataSourceCallbackUrl } from "@/modules/dataSource/oauth/urls";
+import {
+  getCloudDataSourceCallbackUrl,
+  isGoogleOAuthRedirectUriSupported,
+} from "@/modules/dataSource/oauth/urls";
 import { CLOUD_DOCUMENTS_PATH } from "@/modules/modelProvider/utils/cloudDocumentUrls";
 import "@/modules/modelProvider/index.scss";
 import "./googleDriveConnectionPage.scss";
@@ -15,6 +18,7 @@ export default function GoogleDriveConnectionPage() {
   const { t } = useTranslation();
   const navigate = useNavigate();
   const callbackUrl = getCloudDataSourceCallbackUrl("googledrive");
+  const callbackUrlSupported = isGoogleOAuthRedirectUriSupported(callbackUrl);
 
   return (
     <div className="google-drive-provider-page">
@@ -36,12 +40,19 @@ export default function GoogleDriveConnectionPage() {
       </header>
 
       <main className="google-drive-provider-content">
-        <div className="google-drive-provider-callback">
+        <div className={`google-drive-provider-callback${callbackUrlSupported ? "" : " is-invalid"}`}>
           <Text strong>{t("admin.dataSourceGoogleDriveCallbackLabel")}</Text>
           <code>{callbackUrl}</code>
-          <Paragraph>
-            {t("admin.dataSourceGoogleDriveHttpsHint")}
-          </Paragraph>
+          {callbackUrlSupported ? (
+            <Paragraph>{t("admin.dataSourceGoogleDriveHttpsHint")}</Paragraph>
+          ) : (
+            <Alert
+              showIcon
+              type="error"
+              message={t("admin.dataSourceGoogleDriveInvalidCallbackTitle")}
+              description={t("admin.dataSourceGoogleDriveInvalidCallbackHint")}
+            />
+          )}
         </div>
         <GoogleDriveConnectionSection />
       </main>

--- a/frontend/src/modules/modelProvider/pages/GoogleDriveSetupGuide.tsx
+++ b/frontend/src/modules/modelProvider/pages/GoogleDriveSetupGuide.tsx
@@ -11,6 +11,7 @@ import {
   getAppUrl,
   getCloudDataSourceCallbackUrl,
   getDataSourceManagementUrl,
+  isGoogleOAuthRedirectUriSupported,
 } from "@/modules/dataSource/oauth/urls";
 import { CLOUD_DOCUMENTS_GOOGLE_DRIVE_PATH } from "@/modules/modelProvider/utils/cloudDocumentUrls";
 import "./feishuSetupGuide.scss";
@@ -21,6 +22,7 @@ const GOOGLE_CLOUD_CONSOLE_URL = "https://console.cloud.google.com/apis/dashboar
 const GOOGLE_DRIVE_API_URL = "https://console.cloud.google.com/apis/library/drive.googleapis.com";
 const GOOGLE_CLOUD_CREDENTIALS_URL = "https://console.cloud.google.com/apis/credentials";
 const GOOGLE_AUTH_AUDIENCE_URL = "https://console.cloud.google.com/auth/audience";
+const GOOGLE_OAUTH_CLIENT_HELP_URL = "https://support.google.com/cloud/answer/15549257";
 
 type GuideStep = {
   title: string;
@@ -33,6 +35,7 @@ type GuideStep = {
 function buildGuideSteps(t: TFunction): GuideStep[] {
   const stepKey = (key: string) => `admin.dataSourceGoogleDriveSetupGuide.steps.${key}`;
   const redirectUri = getCloudDataSourceCallbackUrl("googledrive");
+  const redirectUriSupported = isGoogleOAuthRedirectUriSupported(redirectUri);
   return [
     {
       title: t(stepKey("openConsoleTitle")),
@@ -71,12 +74,16 @@ function buildGuideSteps(t: TFunction): GuideStep[] {
     {
       title: t(stepKey("redirectTitle")),
       description: t(stepKey("redirectDesc")),
+      linkLabel: t("admin.dataSourceGoogleDriveSetupGuide.openRedirectRules"),
+      linkHref: GOOGLE_OAUTH_CLIENT_HELP_URL,
       details: [
-        t("admin.dataSourceGoogleDriveSetupGuide.callbackUrl", {
+        t(redirectUriSupported
+          ? "admin.dataSourceGoogleDriveSetupGuide.callbackUrl"
+          : "admin.dataSourceGoogleDriveSetupGuide.unsupportedCallbackUrl", {
           uri: redirectUri,
         }),
-        t(stepKey("redirectOriginHint")),
-        t(stepKey("redirectHttpsHint")),
+        t(stepKey(redirectUriSupported ? "redirectOriginHint" : "redirectUnsupportedHint")),
+        t(stepKey(redirectUriSupported ? "redirectHttpsHint" : "redirectRecoveryHint")),
       ],
     },
     {

--- a/frontend/src/modules/modelProvider/pages/googleDriveConnectionPage.scss
+++ b/frontend/src/modules/modelProvider/pages/googleDriveConnectionPage.scss
@@ -74,10 +74,20 @@
     color: #1f3a5f;
   }
 
+  &.is-invalid code {
+    border-color: #ffccc7;
+    background: #fff2f0;
+    color: #a8071a;
+  }
+
   p {
     margin: 8px 0 0;
     color: #64748b;
     font-size: 13px;
+  }
+
+  .ant-alert {
+    margin-top: 10px;
   }
 }
 

--- a/tests/frontend/googleDriveCloudDocuments.test.js
+++ b/tests/frontend/googleDriveCloudDocuments.test.js
@@ -1,5 +1,6 @@
 import { readFileSync } from 'node:fs';
 import { describe, expect, it } from 'vitest';
+import { isGoogleOAuthRedirectUriSupported } from '../../frontend/src/modules/dataSource/oauth/redirectUri.ts';
 
 describe('Google Drive cloud-document placement', () => {
   it('keeps authorization under cloud documents rather than system tools', () => {
@@ -29,5 +30,63 @@ describe('Google Drive cloud-document placement', () => {
     expect(guide).toContain('https://console.cloud.google.com/auth/audience');
     expect(zhLocale).toContain('点击 Add users');
     expect(zhLocale).toContain('重新点击“连接 Google Drive”');
+  });
+
+  it('accepts only Google-compatible redirect URI origins', () => {
+    expect(isGoogleOAuthRedirectUriSupported(
+      'http://localhost:8090/oauth/googledrive/data-source/callback',
+    )).toBe(true);
+    expect(isGoogleOAuthRedirectUriSupported(
+      'http://127.0.0.1:8090/oauth/googledrive/data-source/callback',
+    )).toBe(true);
+    expect(isGoogleOAuthRedirectUriSupported(
+      'http://[::1]:8090/oauth/googledrive/data-source/callback',
+    )).toBe(true);
+    expect(isGoogleOAuthRedirectUriSupported(
+      'https://lazymind.example.com/oauth/googledrive/data-source/callback',
+    )).toBe(true);
+
+    expect(isGoogleOAuthRedirectUriSupported(
+      'http://10.210.0.49:5023/oauth/googledrive/data-source/callback',
+    )).toBe(false);
+    expect(isGoogleOAuthRedirectUriSupported(
+      'https://10.210.0.49:5023/oauth/googledrive/data-source/callback',
+    )).toBe(false);
+    expect(isGoogleOAuthRedirectUriSupported(
+      'http://lazymind.example.com/oauth/googledrive/data-source/callback',
+    )).toBe(false);
+    expect(isGoogleOAuthRedirectUriSupported(
+      'https://lazymind.local/oauth/googledrive/data-source/callback',
+    )).toBe(false);
+  });
+
+  it('blocks authorization when the current callback URL is unsupported', () => {
+    const connectionSection = readFileSync(
+      new URL(
+        '../../frontend/src/modules/modelProvider/components/GoogleDriveConnectionSection.tsx',
+        import.meta.url,
+      ),
+      'utf8',
+    );
+    const connectionPage = readFileSync(
+      new URL(
+        '../../frontend/src/modules/modelProvider/pages/GoogleDriveConnectionPage.tsx',
+        import.meta.url,
+      ),
+      'utf8',
+    );
+    const guide = readFileSync(
+      new URL(
+        '../../frontend/src/modules/modelProvider/pages/GoogleDriveSetupGuide.tsx',
+        import.meta.url,
+      ),
+      'utf8',
+    );
+
+    expect(connectionSection).toContain('okButtonProps={{ disabled: !callbackUrlSupported }}');
+    expect(connectionSection).toContain('googleDriveInvalidRedirectHint');
+    expect(connectionPage).toContain('dataSourceGoogleDriveInvalidCallbackHint');
+    expect(guide).toContain('redirectUnsupportedHint');
+    expect(guide).toContain('redirectRecoveryHint');
   });
 });


### PR DESCRIPTION
## Summary

- validate the generated Google Drive OAuth callback before starting authorization
- allow loopback HTTP callbacks for local development and require HTTPS with a domain name elsewhere
- block raw LAN/private IP callbacks and show actionable Chinese/English recovery guidance
- link the setup guide to Google's official redirect URI requirements

## Root cause

LazyMind derived the callback from `window.location.origin` and presented any origin as registrable. Opening the app through a LAN address such as `http://10.210.0.49:5023` therefore generated a redirect URI that Google rejects.

## Validation

- `googleDriveCloudDocuments.test.js`: 4 passed
- frontend production build: passed
- `git diff --check`: passed

Full-repository `tsc --noEmit` still reports pre-existing generated-client and unrelated module errors; none involve the changed files.