### PR TITLE
docs: clarify Google Drive OAuth setup

### DIFF
--- a/frontend/src/i18n/locales/en-US.ts
+++ b/frontend/src/i18n/locales/en-US.ts
@@ -2404,15 +2404,27 @@ const enUS = {
       steps: {
         openConsoleTitle: "Create or select a Google Cloud project",
         openConsoleDesc:
-          "Sign in to Google Cloud Console and create a new project or select an existing project that will hold the LazyMind OAuth configuration.",
+          "Sign in to Google Cloud Console and create a new project or select an existing project that will hold the LazyMind OAuth configuration. If you do not have a project, open the project selector and click New Project.",
+        openConsoleProjectName:
+          "Use a project name such as LazyMind OAuth. Keep Organization and Location at their defaults when there is no special requirement.",
+        openConsoleProjectId:
+          "The project ID can stay as Google's generated value. After creation, verify that the project selector at the top still points to this project.",
         enableApiTitle: "Enable Google Drive API",
         enableApiDesc:
           "In APIs and services, enable Google Drive API for the selected project. LazyMind calls the official Google Drive API for search, find, and read operations.",
+        enableApiSearch:
+          "If the Drive API page does not open directly, go to APIs & Services > Library, search for Google Drive API, open it, and click Enable.",
+        enableApiConfirmProject:
+          "Before enabling the API, verify again that the selected project is the project you just created or selected.",
         consentTitle: "Configure OAuth consent screen",
         consentDesc:
           "Open Audience in Google Auth Platform, verify that the selected project owns the OAuth client, then configure the app audience and test users.",
         consentUserType:
           "Choose External for personal Google accounts, or Internal if your Google Workspace organization restricts the app to members.",
+        consentAppInfo:
+          "Use LazyMind as the app name and select your current email as the user support email. Logo, homepage, privacy policy, and terms can be skipped or left empty during testing when the page allows it.",
+        consentContact:
+          "Use your current email as the developer contact email. Keep Publishing status as Testing; Google verification is not required for listed test users.",
         consentTestUsers:
           "If the app is in Testing status, click Add users under Test users, add the email that will sign in to Google Drive, save, and wait about one minute before authorizing again.",
         consentRetry:
@@ -2426,6 +2438,8 @@ const enUS = {
           "Application type must be Web application.",
         credentialsName:
           "Use a clear name such as LazyMind Google Drive so it is easy to identify later.",
+        credentialsJavaScriptOrigins:
+          "Authorized JavaScript origins can be left empty. LazyMind only needs Authorized redirect URIs.",
         redirectTitle: "Add the LazyMind callback URL",
         redirectDesc:
           "In Authorized redirect URIs, add the exact callback URL used by the frontend address you open in the browser.",
@@ -2437,9 +2451,13 @@ const enUS = {
           "Google permits HTTP only for localhost, 127.0.0.1, or ::1. Other callbacks must use HTTPS with a public top-level domain, and cannot use 10.x, 172.16-31.x, 192.168.x, or any other raw IP address.",
         redirectRecoveryHint:
           "If the browser and LazyMind run on the same machine, reopen the system through http://localhost or http://127.0.0.1. For LAN or remote access, configure a public HTTPS domain or an HTTPS tunnel such as Cloudflare Tunnel or ngrok, then open LazyMind from the new address. This page will generate the matching callback URI automatically.",
+        redirectQuickTunnelHint:
+          "When using Cloudflare Quick Tunnel, run cloudflared tunnel --url http://localhost:8090 first, open LazyMind from the generated https://*.trycloudflare.com URL, then register the callback shown here, for example https://*.trycloudflare.com/oauth/googledrive/data-source/callback.",
         copyCredentialsTitle: "Copy Client ID and Client Secret",
         copyCredentialsDesc:
           "After the Web client is created, copy the OAuth Client ID and Client Secret. Keep the secret private.",
+        copyPopup:
+          "After clicking Create, Google shows a result popup. Copy both Client ID and Client Secret before closing it. You can also reopen the Web client later from Credentials.",
         copyClientId:
           "Client ID maps to the OAuth Client ID field in LazyMind.",
         copyClientSecret:

--- a/frontend/src/i18n/locales/zh-CN.ts
+++ b/frontend/src/i18n/locales/zh-CN.ts
@@ -2338,15 +2338,27 @@ const zhCN = {
       steps: {
         openConsoleTitle: "创建或选择 Google Cloud 项目",
         openConsoleDesc:
-          "登录 Google Cloud Console，创建一个新项目，或选择已有项目来保存 LazyMind 使用的 OAuth 配置。",
+          "登录 Google Cloud Console，创建一个新项目，或选择已有项目来保存 LazyMind 使用的 OAuth 配置。没有现成项目时，点击项目下拉框，再点击“新建项目”。",
+        openConsoleProjectName:
+          "项目名称可填写 LazyMind OAuth；组织/位置没有要求时保持默认即可。",
+        openConsoleProjectId:
+          "项目 ID 可保持 Google 自动生成；创建后确认页面顶部项目选择器仍选中这个项目。",
         enableApiTitle: "启用 Google Drive API",
         enableApiDesc:
           "在 API 和服务中，为当前项目启用 Google Drive API。LazyMind 会调用 Google Drive 官方 API 完成 search、find 和 read。",
+        enableApiSearch:
+          "如果没有直接打开到 Drive API 页面，进入“API 和服务 > 库”，搜索 Google Drive API，打开后点击“启用”。",
+        enableApiConfirmProject:
+          "启用前再次确认右上角/顶部项目是刚才创建或选择的项目，避免把 API 开到别的项目里。",
         consentTitle: "配置 OAuth 同意屏幕",
         consentDesc:
           "进入 Google Auth Platform 的 Audience，确认当前项目和 OAuth 客户端所属项目一致，再配置应用受众和测试用户。",
         consentUserType:
           "个人 Google 账号请选择 External；如果是 Google Workspace 且只允许组织内成员使用，可以选择 Internal。",
+        consentAppInfo:
+          "应用名称可填写 LazyMind；用户支持邮箱选择当前登录邮箱；Logo、主页、隐私政策、服务条款在测试阶段可先留空或按页面要求跳过。",
+        consentContact:
+          "开发者联系邮箱填写当前登录邮箱。发布状态保持 Testing，不需要提交 Google 验证即可让测试用户授权。",
         consentTestUsers:
           "如果应用处于 Testing 状态，在 Test users 中点击 Add users，添加实际登录 Google Drive 的邮箱并保存；等待约一分钟后再授权，否则 Google 会返回 access_denied。",
         consentRetry:
@@ -2360,6 +2372,8 @@ const zhCN = {
           "Application type 必须选择 Web application。",
         credentialsName:
           "建议命名为 LazyMind Google Drive，方便后续在 Google Cloud 和 LazyMind 中识别。",
+        credentialsJavaScriptOrigins:
+          "Authorized JavaScript origins 可以留空；LazyMind 只需要配置 Authorized redirect URIs。",
         redirectTitle: "添加 LazyMind 回调地址",
         redirectDesc:
           "在 Authorized redirect URIs 中添加 LazyMind 前端实际使用的 OAuth 回调地址，必须和浏览器打开的系统地址一致。",
@@ -2371,9 +2385,13 @@ const zhCN = {
           "Google 仅允许 localhost、127.0.0.1 或 ::1 使用 HTTP；其他回调必须使用带公共顶级域名的 HTTPS，并且不能使用 10.x、172.16-31.x、192.168.x 或其他原始 IP 地址。",
         redirectRecoveryHint:
           "如果浏览器和 LazyMind 在同一台机器上，请改用 http://localhost 或 http://127.0.0.1 打开系统；如果通过局域网或远程访问，请配置 HTTPS 公共域名或 Cloudflare Tunnel/ngrok 等 HTTPS 隧道，再从新地址打开系统。页面会自动生成对应的回调 URI。",
+        redirectQuickTunnelHint:
+          "使用 Cloudflare Quick Tunnel 时，先运行 cloudflared tunnel --url http://localhost:8090，然后从生成的 https://*.trycloudflare.com 打开 LazyMind，并把本页展示的 https://*.trycloudflare.com/oauth/googledrive/data-source/callback 填到 Authorized redirect URIs。",
         copyCredentialsTitle: "复制 Client ID 和 Client Secret",
         copyCredentialsDesc:
           "Web 客户端创建完成后，复制 OAuth Client ID 和 Client Secret。Client Secret 需要保密。",
+        copyPopup:
+          "点击 Create 后，Google 会弹出创建结果；先复制 Client ID 和 Client Secret，再关闭弹窗。关闭后也可以在 Credentials 页面重新打开这个 Web client 查看。",
         copyClientId:
           "Client ID 对应 LazyMind 弹窗中的 OAuth Client ID 字段。",
         copyClientSecret:

--- a/frontend/src/modules/modelProvider/pages/GoogleDriveSetupGuide.tsx
+++ b/frontend/src/modules/modelProvider/pages/GoogleDriveSetupGuide.tsx
@@ -42,12 +42,20 @@ function buildGuideSteps(t: TFunction): GuideStep[] {
       description: t(stepKey("openConsoleDesc")),
       linkLabel: t("admin.dataSourceGoogleDriveSetupGuide.openConsole"),
       linkHref: GOOGLE_CLOUD_CONSOLE_URL,
+      details: [
+        t(stepKey("openConsoleProjectName")),
+        t(stepKey("openConsoleProjectId")),
+      ],
     },
     {
       title: t(stepKey("enableApiTitle")),
       description: t(stepKey("enableApiDesc")),
       linkLabel: t("admin.dataSourceGoogleDriveSetupGuide.openDriveApi"),
       linkHref: GOOGLE_DRIVE_API_URL,
+      details: [
+        t(stepKey("enableApiSearch")),
+        t(stepKey("enableApiConfirmProject")),
+      ],
     },
     {
       title: t(stepKey("consentTitle")),
@@ -56,6 +64,8 @@ function buildGuideSteps(t: TFunction): GuideStep[] {
       linkHref: GOOGLE_AUTH_AUDIENCE_URL,
       details: [
         t(stepKey("consentUserType")),
+        t(stepKey("consentAppInfo")),
+        t(stepKey("consentContact")),
         t(stepKey("consentTestUsers")),
         t(stepKey("consentRetry")),
         t(stepKey("consentScopes")),
@@ -69,6 +79,7 @@ function buildGuideSteps(t: TFunction): GuideStep[] {
       details: [
         t(stepKey("credentialsType")),
         t(stepKey("credentialsName")),
+        t(stepKey("credentialsJavaScriptOrigins")),
       ],
     },
     {
@@ -84,12 +95,14 @@ function buildGuideSteps(t: TFunction): GuideStep[] {
         }),
         t(stepKey(redirectUriSupported ? "redirectOriginHint" : "redirectUnsupportedHint")),
         t(stepKey(redirectUriSupported ? "redirectHttpsHint" : "redirectRecoveryHint")),
+        t(stepKey("redirectQuickTunnelHint")),
       ],
     },
     {
       title: t(stepKey("copyCredentialsTitle")),
       description: t(stepKey("copyCredentialsDesc")),
       details: [
+        t(stepKey("copyPopup")),
         t(stepKey("copyClientId")),
         t(stepKey("copyClientSecret")),
       ],


### PR DESCRIPTION
## Summary
- Expand the Google Drive setup guide with concrete Google Cloud project, API library, OAuth consent, and Web client configuration steps.
- Clarify that Authorized JavaScript origins can be empty and LazyMind only needs the redirect URI.
- Add Cloudflare Quick Tunnel guidance and copy-client-credentials hints in both Chinese and English.

## Validation
- `git diff --check -- frontend/src/modules/modelProvider/pages/GoogleDriveSetupGuide.tsx frontend/src/i18n/locales/zh-CN.ts frontend/src/i18n/locales/en-US.ts`
- `/Users/huangchongjin/LazyRAG/tests/frontend/node_modules/.bin/vitest run googleDriveCloudDocuments.test.js`
- Docker frontend page smoke at `http://localhost:8091/cloud-documents/docs/google-drive-setup?from=google-drive-provider`