### PR TITLE
feat(agent): expand tool rounds for plugins and subagents

### DIFF
--- a/algorithm/lazymind/chat/engine/agent_runtime/executor.py
+++ b/algorithm/lazymind/chat/engine/agent_runtime/executor.py
@@ -12,6 +12,19 @@ from .models import AgentRole, AgentRunPlan
 from .tool_limit_control import tool_limit_decision_coordinator
 
 
+_EXPANDED_BUDGET_TOOLS = {
+    'advance_step',
+    'advance_step_and_hand_off',
+    'create_plugin_draft',
+    'create_subagent',
+}
+
+
+def _requires_expanded_budget(tool_name: str) -> bool:
+    """Return whether invoking this tool starts plugin or SubAgent work."""
+    return tool_name in _EXPANDED_BUDGET_TOOLS or tool_name.startswith('trigger_')
+
+
 class ToolCallGuard:
     """Stop selected tools from looping after failures without limiting successful work."""
 
@@ -20,6 +33,11 @@ class ToolCallGuard:
         self._failure_limits = dict(failure_limits or {})
         self._failed_signatures: set[str] = set()
         self._consecutive_failures: dict[str, int] = {}
+        self._expanded_budget_triggered = False
+
+    @property
+    def expanded_budget_triggered(self) -> bool:
+        return self._expanded_budget_triggered
 
     def __getattr__(self, name: str) -> Any:
         return getattr(self._manager, name)
@@ -77,6 +95,8 @@ class ToolCallGuard:
         for index, tool_call in enumerate(tool_calls):
             function = tool_call.get('function') or {}
             name = str(function.get('name') or '')
+            if _requires_expanded_budget(name):
+                self._expanded_budget_triggered = True
             signature = self._signature(tool_call)
             guarded = name in self._failure_limits
             if guarded and signature in self._failed_signatures:
@@ -151,6 +171,16 @@ class AgentExecutor:
         from lazymind.chat.lazyllm_tool_docs import ensure_lazyllm_tool_docs
 
         options = plan.execution_options
+        tool_guard: ToolCallGuard | None = None
+
+        def _on_max_retries(output: Any, used_rounds: int, current_limit: int) -> int | None:
+            return tool_limit_decision_coordinator.on_max_retries(
+                output,
+                used_rounds,
+                current_limit,
+                auto_expand=bool(tool_guard and tool_guard.expanded_budget_triggered),
+            )
+
         kwargs = {
             'stream': True,
             'max_retries': options.max_retries or _cfg['max_retries'],
@@ -158,7 +188,7 @@ class AgentExecutor:
             'force_summarize': True,
             'force_summarize_context': plan.force_summarize_context,
             'on_max_retries': (
-                tool_limit_decision_coordinator.on_max_retries
+                _on_max_retries
                 if plan.role == AgentRole.CHAT else None
             ),
         }
@@ -179,9 +209,10 @@ class AgentExecutor:
             prompt=plan.prompt.system_prompt,
             **kwargs,
         )
-        agent._tools_manager = ToolCallGuard(
+        tool_guard = ToolCallGuard(
             agent._tools_manager, options.tool_failure_limits,
         )
+        agent._tools_manager = tool_guard
         # Restore lazy Toolkit activation before the streaming helper takes over.
         # Relying only on ReactAgent._pre_process makes restoration dependent on
         # llm_chat_history surviving the helper/framework call path.

--- a/algorithm/lazymind/chat/engine/agent_runtime/executor.py
+++ b/algorithm/lazymind/chat/engine/agent_runtime/executor.py
@@ -28,16 +28,17 @@ def _requires_expanded_budget(tool_name: str) -> bool:
 class ToolCallGuard:
     """Stop selected tools from looping after failures without limiting successful work."""
 
-    def __init__(self, manager: Any, failure_limits: dict[str, int] | None = None):
+    def __init__(
+        self,
+        manager: Any,
+        failure_limits: dict[str, int] | None = None,
+        expanded_round_limit: int | None = None,
+    ):
         self._manager = manager
         self._failure_limits = dict(failure_limits or {})
         self._failed_signatures: set[str] = set()
         self._consecutive_failures: dict[str, int] = {}
-        self._expanded_budget_triggered = False
-
-    @property
-    def expanded_budget_triggered(self) -> bool:
-        return self._expanded_budget_triggered
+        self._expanded_round_limit = expanded_round_limit
 
     def __getattr__(self, name: str) -> Any:
         return getattr(self._manager, name)
@@ -96,7 +97,17 @@ class ToolCallGuard:
             function = tool_call.get('function') or {}
             name = str(function.get('name') or '')
             if _requires_expanded_budget(name):
-                self._expanded_budget_triggered = True
+                workspace = lazyllm.locals.get('_lazyllm_agent', {}).get('workspace')
+                if (
+                    isinstance(workspace, dict)
+                    and self._expanded_round_limit is not None
+                    and workspace.get('_react_round_limit') != self._expanded_round_limit
+                ):
+                    workspace['_react_round_limit'] = self._expanded_round_limit
+                    lazyllm.LOG.info(
+                        f'ChatAgent used tool={name}; automatically expanding '
+                        f'tool round limit to {self._expanded_round_limit}.'
+                    )
             signature = self._signature(tool_call)
             guarded = name in self._failure_limits
             if guarded and signature in self._failed_signatures:
@@ -171,16 +182,6 @@ class AgentExecutor:
         from lazymind.chat.lazyllm_tool_docs import ensure_lazyllm_tool_docs
 
         options = plan.execution_options
-        tool_guard: ToolCallGuard | None = None
-
-        def _on_max_retries(output: Any, used_rounds: int, current_limit: int) -> int | None:
-            return tool_limit_decision_coordinator.on_max_retries(
-                output,
-                used_rounds,
-                current_limit,
-                auto_expand=bool(tool_guard and tool_guard.expanded_budget_triggered),
-            )
-
         kwargs = {
             'stream': True,
             'max_retries': options.max_retries or _cfg['max_retries'],
@@ -188,7 +189,7 @@ class AgentExecutor:
             'force_summarize': True,
             'force_summarize_context': plan.force_summarize_context,
             'on_max_retries': (
-                _on_max_retries
+                tool_limit_decision_coordinator.on_max_retries
                 if plan.role == AgentRole.CHAT else None
             ),
         }
@@ -209,10 +210,11 @@ class AgentExecutor:
             prompt=plan.prompt.system_prompt,
             **kwargs,
         )
-        tool_guard = ToolCallGuard(
-            agent._tools_manager, options.tool_failure_limits,
+        agent._tools_manager = ToolCallGuard(
+            agent._tools_manager,
+            options.tool_failure_limits,
+            max(2, int(_cfg['agentic_expanded_max_rounds'])),
         )
-        agent._tools_manager = tool_guard
         # Restore lazy Toolkit activation before the streaming helper takes over.
         # Relying only on ReactAgent._pre_process makes restoration dependent on
         # llm_chat_history surviving the helper/framework call path.

--- a/algorithm/lazymind/chat/engine/agent_runtime/tool_limit_control.py
+++ b/algorithm/lazymind/chat/engine/agent_runtime/tool_limit_control.py
@@ -65,23 +65,21 @@ class ToolLimitDecisionCoordinator:
             time.sleep(min(0.2, max(0.01, deadline - time.monotonic())))
         return 'summarize'
 
-    def on_max_retries(
-        self,
-        output: Any,
-        used_rounds: int,
-        current_limit: int,
-        *,
-        auto_expand: bool = False,
-    ) -> Optional[int]:
+    def on_max_retries(self, output: Any, used_rounds: int, current_limit: int) -> Optional[int]:
         expanded_max_rounds = max(2, int(config['agentic_expanded_max_rounds']))
         if used_rounds >= expanded_max_rounds:
             return None
-        if auto_expand:
+        workspace = lazyllm.locals.get('_lazyllm_agent', {}).get('workspace')
+        runtime_round_limit = (
+            workspace.get('_react_round_limit')
+            if isinstance(workspace, dict) else None
+        )
+        if isinstance(runtime_round_limit, int) and runtime_round_limit > current_limit:
             lazyllm.LOG.info(
-                f'ChatAgent used a plugin or SubAgent tool; automatically expanding '
-                f'tool round limit from {current_limit} to {expanded_max_rounds}.'
+                f'ChatAgent reached its previous tool round boundary={current_limit}; '
+                f'continuing with expanded limit={runtime_round_limit}.'
             )
-            return expanded_max_rounds
+            return runtime_round_limit
         timeout = max(0, float(config['agentic_tool_limit_wait_timeout']))
         sid = lazyllm.globals._sid
         decision_id = uuid.uuid4().hex

--- a/algorithm/lazymind/chat/engine/agent_runtime/tool_limit_control.py
+++ b/algorithm/lazymind/chat/engine/agent_runtime/tool_limit_control.py
@@ -65,10 +65,23 @@ class ToolLimitDecisionCoordinator:
             time.sleep(min(0.2, max(0.01, deadline - time.monotonic())))
         return 'summarize'
 
-    def on_max_retries(self, output: Any, used_rounds: int, current_limit: int) -> Optional[int]:
+    def on_max_retries(
+        self,
+        output: Any,
+        used_rounds: int,
+        current_limit: int,
+        *,
+        auto_expand: bool = False,
+    ) -> Optional[int]:
         expanded_max_rounds = max(2, int(config['agentic_expanded_max_rounds']))
         if used_rounds >= expanded_max_rounds:
             return None
+        if auto_expand:
+            lazyllm.LOG.info(
+                f'ChatAgent used a plugin or SubAgent tool; automatically expanding '
+                f'tool round limit from {current_limit} to {expanded_max_rounds}.'
+            )
+            return expanded_max_rounds
         timeout = max(0, float(config['agentic_tool_limit_wait_timeout']))
         sid = lazyllm.globals._sid
         decision_id = uuid.uuid4().hex

--- a/algorithm/lazymind/chat/engine/subagent/runner.py
+++ b/algorithm/lazymind/chat/engine/subagent/runner.py
@@ -478,11 +478,7 @@ def _build_subagent_plan(
         force_summarize_context=ctx.objective,
         execution_options=AgentExecutionOptions(
             extra_stop_condition=_make_cancel_stop_condition(),
-            max_retries=(
-                max(1, int(_cfg['agentic_expanded_max_rounds']) - 1)
-                if str((lazyllm.globals.get('agentic_config') or {}).get('thinking_depth') or '').lower() == 'max'
-                else None
-            ),
+            max_retries=max(1, int(_cfg['agentic_expanded_max_rounds']) - 1),
         ),
     )
 

--- a/tests/algorithm/chat/test_agent_executor.py
+++ b/tests/algorithm/chat/test_agent_executor.py
@@ -61,6 +61,8 @@ def test_executor_auto_expands_after_plugin_or_subagent_tool(monkeypatch) -> Non
     agent._tools_manager = MagicMock(return_value=[{'ok': True}])
     constructor = MagicMock(return_value=agent)
     monkeypatch.setattr(executor_mod._agent_mod, 'ReactAgent', constructor)
+    workspace = {}
+    monkeypatch.setitem(executor_mod.lazyllm.locals, '_lazyllm_agent', {'workspace': workspace})
 
     created = AgentExecutor().create_agent('llm', _plan(max_retries=20))
     created._tools_manager([{
@@ -68,6 +70,7 @@ def test_executor_auto_expands_after_plugin_or_subagent_tool(monkeypatch) -> Non
     }])
 
     with executor_mod._cfg.temp('agentic_expanded_max_rounds', 200):
+        assert workspace['_react_round_limit'] == 200
         assert constructor.call_args.kwargs['on_max_retries'](
             None, 21, 21,
         ) == 200

--- a/tests/algorithm/chat/test_agent_executor.py
+++ b/tests/algorithm/chat/test_agent_executor.py
@@ -56,6 +56,23 @@ def test_executor_does_not_pause_subagent_on_round_limit(monkeypatch) -> None:
     assert constructor.call_args.kwargs['on_max_retries'] is None
 
 
+def test_executor_auto_expands_after_plugin_or_subagent_tool(monkeypatch) -> None:
+    agent = MagicMock()
+    agent._tools_manager = MagicMock(return_value=[{'ok': True}])
+    constructor = MagicMock(return_value=agent)
+    monkeypatch.setattr(executor_mod._agent_mod, 'ReactAgent', constructor)
+
+    created = AgentExecutor().create_agent('llm', _plan(max_retries=20))
+    created._tools_manager([{
+        'function': {'name': 'create_subagent', 'arguments': '{}'},
+    }])
+
+    with executor_mod._cfg.temp('agentic_expanded_max_rounds', 200):
+        assert constructor.call_args.kwargs['on_max_retries'](
+            None, 21, 21,
+        ) == 200
+
+
 def test_executor_restores_toolkit_activation_from_history(monkeypatch) -> None:
     agent = MagicMock()
     constructor = MagicMock(return_value=agent)

--- a/tests/algorithm/chat/test_subagent_runner.py
+++ b/tests/algorithm/chat/test_subagent_runner.py
@@ -185,18 +185,19 @@ def test_subagent_plan_preserves_extension_params_without_structured_duplicates(
     assert 'required_output_artifact_keys' not in parameter_section.content
 
 
-def test_subagent_plan_uses_200_rounds_in_max_mode(tmp_path):
+@pytest.mark.parametrize('thinking_depth', ['low', 'medium', 'high', 'max'])
+def test_subagent_plan_uses_200_rounds_in_every_thinking_mode(tmp_path, thinking_depth):
     import lazyllm
     from lazymind.chat.engine.subagent.context import SubAgentContext
 
     ctx = SubAgentContext(
-        task_id='task-max', conversation_id='conv-1', agent_type='research',
-        objective='deep research', params={'_thinking_depth': 'max'}, workspace_path=str(tmp_path),
+        task_id=f'task-{thinking_depth}', conversation_id='conv-1', agent_type='research',
+        objective='deep research', params={'_thinking_depth': thinking_depth}, workspace_path=str(tmp_path),
         input_slots=[], output_slots=[], db=None, emit=lambda _event: None,
     )
     previous = lazyllm.globals.get('agentic_config')
     try:
-        lazyllm.globals['agentic_config'] = {'thinking_depth': 'max'}
+        lazyllm.globals['agentic_config'] = {'thinking_depth': thinking_depth}
         with runner_mod._cfg.temp('agentic_expanded_max_rounds', 200):
             plan = runner_mod._build_subagent_plan(
                 ctx, None, tools=[], tool_prompt_appendices={},

--- a/tests/algorithm/chat/test_tool_call_guard.py
+++ b/tests/algorithm/chat/test_tool_call_guard.py
@@ -90,3 +90,26 @@ def test_unconfigured_stateful_tool_is_not_deduplicated():
     guard([_call('get_task_status', {'task_id': 'task-1'})])
 
     assert len(manager.calls) == 2
+
+
+def test_plugin_and_subagent_tools_enable_expanded_budget():
+    for tool_name in (
+        'trigger_writer',
+        'advance_step',
+        'advance_step_and_hand_off',
+        'create_plugin_draft',
+        'create_subagent',
+    ):
+        guard = ToolCallGuard(_RecordingToolManager())
+
+        guard([_call(tool_name, {})])
+
+        assert guard.expanded_budget_triggered is True
+
+
+def test_ordinary_tools_do_not_enable_expanded_budget():
+    guard = ToolCallGuard(_RecordingToolManager())
+
+    guard([_call('url_fetch', {'url': 'https://example.com'})])
+
+    assert guard.expanded_budget_triggered is False

--- a/tests/algorithm/chat/test_tool_call_guard.py
+++ b/tests/algorithm/chat/test_tool_call_guard.py
@@ -1,3 +1,5 @@
+import lazyllm
+
 from lazymind.chat.engine.agent_runtime.executor import ToolCallGuard
 
 
@@ -92,24 +94,35 @@ def test_unconfigured_stateful_tool_is_not_deduplicated():
     assert len(manager.calls) == 2
 
 
-def test_plugin_and_subagent_tools_enable_expanded_budget():
-    for tool_name in (
-        'trigger_writer',
-        'advance_step',
-        'advance_step_and_hand_off',
-        'create_plugin_draft',
-        'create_subagent',
-    ):
-        guard = ToolCallGuard(_RecordingToolManager())
+def test_plugin_or_subagent_tool_immediately_updates_runtime_round_limit():
+    previous = lazyllm.locals.get('_lazyllm_agent')
+    workspace = {}
+    lazyllm.locals['_lazyllm_agent'] = {'workspace': workspace}
+    try:
+        guard = ToolCallGuard(_RecordingToolManager(), expanded_round_limit=200)
 
-        guard([_call(tool_name, {})])
+        guard([_call('trigger_writer', {})])
 
-        assert guard.expanded_budget_triggered is True
+        assert workspace['_react_round_limit'] == 200
+    finally:
+        if previous is None:
+            lazyllm.locals.pop('_lazyllm_agent', None)
+        else:
+            lazyllm.locals['_lazyllm_agent'] = previous
 
 
 def test_ordinary_tools_do_not_enable_expanded_budget():
-    guard = ToolCallGuard(_RecordingToolManager())
+    previous = lazyllm.locals.get('_lazyllm_agent')
+    workspace = {}
+    lazyllm.locals['_lazyllm_agent'] = {'workspace': workspace}
+    try:
+        guard = ToolCallGuard(_RecordingToolManager(), expanded_round_limit=200)
 
-    guard([_call('url_fetch', {'url': 'https://example.com'})])
+        guard([_call('url_fetch', {'url': 'https://example.com'})])
 
-    assert guard.expanded_budget_triggered is False
+        assert '_react_round_limit' not in workspace
+    finally:
+        if previous is None:
+            lazyllm.locals.pop('_lazyllm_agent', None)
+        else:
+            lazyllm.locals['_lazyllm_agent'] = previous

--- a/tests/algorithm/chat/test_tool_limit_control.py
+++ b/tests/algorithm/chat/test_tool_limit_control.py
@@ -66,15 +66,21 @@ def test_tool_limit_coordinator_continues_same_invocation() -> None:
     assert coordinator.submit(sid, decision_id, 'continue') is False
 
 
-def test_tool_limit_coordinator_auto_expands_plugin_or_subagent_work() -> None:
+def test_tool_limit_coordinator_uses_runtime_expanded_limit() -> None:
     coordinator = ToolLimitDecisionCoordinator()
     lazyllm.globals._init_sid(f'tool-limit-auto-expand-{time.time_ns()}')
     _read_events()
+    previous = lazyllm.locals.get('_lazyllm_agent')
+    lazyllm.locals['_lazyllm_agent'] = {'workspace': {'_react_round_limit': 200}}
 
-    with config.temp('agentic_expanded_max_rounds', 200):
-        assert coordinator.on_max_retries(
-            None, 21, 21, auto_expand=True,
-        ) == 200
+    try:
+        with config.temp('agentic_expanded_max_rounds', 200):
+            assert coordinator.on_max_retries(None, 21, 21) == 200
+    finally:
+        if previous is None:
+            lazyllm.locals.pop('_lazyllm_agent', None)
+        else:
+            lazyllm.locals['_lazyllm_agent'] = previous
 
     assert not [
         item for item in _read_events()

--- a/tests/algorithm/chat/test_tool_limit_control.py
+++ b/tests/algorithm/chat/test_tool_limit_control.py
@@ -64,3 +64,19 @@ def test_tool_limit_coordinator_continues_same_invocation() -> None:
     assert not thread.is_alive()
     assert result['limit'] == 200
     assert coordinator.submit(sid, decision_id, 'continue') is False
+
+
+def test_tool_limit_coordinator_auto_expands_plugin_or_subagent_work() -> None:
+    coordinator = ToolLimitDecisionCoordinator()
+    lazyllm.globals._init_sid(f'tool-limit-auto-expand-{time.time_ns()}')
+    _read_events()
+
+    with config.temp('agentic_expanded_max_rounds', 200):
+        assert coordinator.on_max_retries(
+            None, 21, 21, auto_expand=True,
+        ) == 200
+
+    assert not [
+        item for item in _read_events()
+        if item['tag'] == 'tool_limit_pending'
+    ]


### PR DESCRIPTION
- Keep the default agent retry limit unchanged.
- Automatically expand the current ChatAgent invocation to 200 tool-call rounds after a plugin or SubAgent tool is triggered.
- Give SubAgents 200 rounds across all thinking-depth modes.
 
<img width="791" height="403" alt="image" src="https://github.com/user-attachments/assets/efcaeca1-f3ad-47f6-a881-bb304fa3fb06" />


<img width="934" height="669" alt="img_v3_02144_cdc2c5fb-85ef-43d6-8570-6cd6b2712eeg" src="https://github.com/user-attachments/assets/b20462bf-7332-489f-bc8e-90100322c8ad" />