### PR TITLE
bug(parse): Better block splitting logic

### DIFF
--- a/algorithm/lazymind/common/runtime_models.inner.yaml
+++ b/algorithm/lazymind/common/runtime_models.inner.yaml
@@ -1,32 +1,29 @@
-# Runtime model config for ECS/internal services (static, all endpoints pre-configured).
-# yaml key = AutoModel(model=...) lookup name; name field = actual model name sent to the API.
-
 llm:
   - source: openai
     type: llm
     name: minimax-m27
-    url: http://106.75.235.251:9000/v1/
+    url: http://172.24.176.1:49090/v1/
     api_key: ${LAZYLLM_MINIMAX_API_KEY}
 
 evo_llm:
   - source: openai
     type: llm
     name: lazyllm
-    url: http://10.119.21.177:8000/v1/
+    url: http://172.24.176.1:48000/v1/
     skip_auth: true
 
 reranker:
   - source: openai
     type: rerank
     name: Qwen3-Reranker-8B
-    url: http://10.119.17.248:8331/v1
+    url: http://172.24.176.1:48331/v1
     skip_auth: true
 
 embed_main:
   - source: openai
     type: embed
     name: lazyllm
-    url: http://10.119.29.245:9800/v1/embeddings
+    url: http://172.24.176.1:22341/v1/embeddings
     skip_auth: true
 
 # Cross-modal (image) embed shared by image nodes and image-only retrieval branch.
@@ -34,7 +31,7 @@ embed_image:
   - source: openai
     type: cross_modal_embed
     name: siglip
-    url: http://10.119.21.178:34335/embeddings
+    url: http://172.24.176.1:43435/embeddings
     skip_auth: true
 
 # Vision-language model for image-aware query rewriting and vision_extractor tool.
@@ -42,7 +39,7 @@ vlm:
   - source: openai
     type: vlm
     name: lazyllm
-    url: http://10.119.16.10:36324/v1/
+    url: http://172.24.176.1:46517/v1/
     skip_auth: true
 
 speech_to_text:

--- a/algorithm/lazymind/parsing/engine/transform/general_parser.py
+++ b/algorithm/lazymind/parsing/engine/transform/general_parser.py
@@ -51,6 +51,25 @@ def _runtime_embed_max_input_tokens() -> int | None:
     return _parse_token_limit(embed_config.get('max_input_tokens'))
 
 
+def _lines_for_chunk(lines, chunk: str) -> list | None:
+    '''Redistribute parent layout lines onto a text chunk.
+
+    Keep only lines whose content is contained in the chunk. Drop the key when
+    nothing matches so LineSplitter does not treat a stale parent-wide line list
+    as this chunk's layout lines.
+    '''
+    if not isinstance(lines, list) or not lines or not chunk:
+        return None
+    matched = []
+    for line in lines:
+        if not isinstance(line, dict):
+            continue
+        content = line.get('content') or ''
+        if content and content in chunk:
+            matched.append(copy.deepcopy(line))
+    return matched or None
+
+
 def is_url(s):
     try:
         res = urlparse(s)
@@ -180,10 +199,18 @@ class GeneralParser(NodeTransform):
         ppl = pipeline(self._image_path_transform, lambda text: self._split(text, max_length=max_length))
         content = ppl(document.text or '')
 
-        return [
-            spawn_child_doc_node(
+        children = []
+        for chunk in content:
+            child_metadata = copy.deepcopy(metadata)
+            chunk_lines = _lines_for_chunk(child_metadata.get('lines'), chunk)
+            if chunk_lines is not None:
+                child_metadata['lines'] = chunk_lines
+            else:
+                child_metadata.pop('lines', None)
+            children.append(spawn_child_doc_node(
                 document,
                 text=chunk,
-                metadata=copy.deepcopy(metadata),
+                metadata=child_metadata,
                 global_metadata=copy.deepcopy(global_metadata),
-            ) for chunk in content]
+            ))
+        return children

--- a/algorithm/lazymind/parsing/engine/transform/para_parser.py
+++ b/algorithm/lazymind/parsing/engine/transform/para_parser.py
@@ -1,7 +1,7 @@
 import copy
+import re
 from dataclasses import dataclass
 from typing import Callable, List, Optional, Sequence, Tuple
-from pathlib import Path
 from pydantic import Field, PrivateAttr
 
 from lazyllm.tools.rag import NodeTransform, DocNode
@@ -57,10 +57,94 @@ def split_by_char() -> Callable[[str], List[str]]:
 
 
 SENTENCE_CHUNK_OVERLAP = 200
+# Used by ParagraphSplitter secondary chunking. NormalLineSplitter uses
+# _split_by_sentence_punct so English decimals / versions (2.5, Qwen2.5) stay intact.
 CHUNKING_REGEX = r'[^。？?！!.\n]+[。？?！!.\n]*|[。？?！!.\n]+'
 DEFAULT_PARAGRAPH_SEP = '\n\n\n'
 
 DEFAULT_CHUNK_SIZE = 1024
+
+# Soft hyphenation at EOL: "understand-\\ning". Captures the right-hand fragment
+# so we can tell real compounds ("state-of-\\nthe-art") from break hyphens.
+_HYPHEN_EOL_RE = re.compile(r'-\n([^\n]*)')
+
+
+def _is_pdf_reader_node(node: DocNode) -> bool:
+    '''PDFReader tags each page with page_label and has no OCR layout fields.'''
+    return 'page_label' in (node.metadata or {})
+
+
+def _unwrap_soft_newlines(text: str) -> str:
+    '''Join PDF/visual soft wraps before sentence splitting.
+
+    Only for PDFReader output (pypdf extract_text keeps layout \\n and EOL
+    hyphenation). Preserve blank-line paragraph breaks (\\n\\n).
+    '''
+    if not text:
+        return text
+
+    def _dehyphenate(match: re.Match) -> str:
+        right = match.group(1)
+        before = match.string[:match.start()]
+        left_token = before.rsplit(None, 1)[-1] if before.strip() else ''
+        # Real compounds already contain '-' on either side of the break; keep it.
+        # Soft hyphenation (understand-\\ning) has no '-' in either fragment.
+        if '-' in left_token or '-' in right.split(None, 1)[0]:
+            return '-' + right
+        return right
+
+    text = _HYPHEN_EOL_RE.sub(_dehyphenate, text)
+    # single newlines -> space; preserve paragraph breaks
+    text = re.sub(r'(?<!\n)\n(?!\n)', ' ', text)
+    text = re.sub(r'[ \t]+', ' ', text)
+    return text
+
+
+def _split_by_sentence_punct(text: str) -> List[str]:
+    '''Split on sentence-ending punctuation without breaking decimals/versions.
+
+    '.' only ends a sentence when it is at EOF or followed by whitespace
+    (same rule as GeneralParser._rfind_sentence_end). Soft newlines are not
+    sentence boundaries — unwrap them first via _unwrap_soft_newlines when
+    the source is PDFReader.
+    '''
+    if not text:
+        return []
+    parts: List[str] = []
+    start = 0
+    n = len(text)
+    for i, ch in enumerate(text):
+        if ch in '。？?！!':
+            parts.append(text[start:i + 1])
+            start = i + 1
+            continue
+        if ch != '.':
+            continue
+        nxt = text[i + 1] if i + 1 < n else ''
+        if nxt == '' or nxt.isspace():
+            parts.append(text[start:i + 1])
+            start = i + 1
+    if start < n:
+        parts.append(text[start:])
+    return parts
+
+
+def _lines_for_sentence(lines, sentence: str) -> list | None:
+    '''Keep layout lines whose content is fully contained in this sentence.
+
+    Block-wide fake lines (content == whole block) will not match any sentence
+    and are dropped so children do not inherit parent-level layout metadata.
+    '''
+    if not isinstance(lines, list) or not lines or not sentence:
+        return None
+    matched = []
+    for line in lines:
+        if not isinstance(line, dict):
+            continue
+        content = line.get('content') or ''
+        if content and content in sentence:
+            matched.append(copy.deepcopy(line))
+    return matched or None
 
 
 @dataclass
@@ -88,30 +172,32 @@ class NormalLineSplitter(NodeTransform):
 
         return out_para
 
-    def _split_text(self, text: str) -> List[str]:
-        def _split_fun(text: str):
-            fun = split_by_regex(CHUNKING_REGEX)
-            return fun(text)
-
-        text_list = _split_fun(text=text)
-        return self._split_para(text_list)
+    def _split_text(self, text: str, *, unwrap_soft_newlines: bool = False) -> List[str]:
+        if unwrap_soft_newlines:
+            text = _unwrap_soft_newlines(text)
+        return self._split_para(_split_by_sentence_punct(text))
 
     def forward(self, document: DocNode, **kwargs) -> List[DocNode]:
         result = []
         nodes = document if isinstance(document, list) else [document]
         for node in nodes:
-            metadata = node.metadata
             global_metadata = node.global_metadata
-            split_text = self._split_text(node.text)
-            result.extend([
-                spawn_child_doc_node(
+            unwrap = _is_pdf_reader_node(node)
+            split_text = self._split_text(node.text, unwrap_soft_newlines=unwrap)
+            parent_lines = node.metadata.get('lines')
+            for text in split_text:
+                child_metadata = copy.deepcopy(node.metadata)
+                chunk_lines = _lines_for_sentence(parent_lines, text)
+                if chunk_lines is not None:
+                    child_metadata['lines'] = chunk_lines
+                else:
+                    child_metadata.pop('lines', None)
+                result.append(spawn_child_doc_node(
                     node,
                     text=text,
-                    metadata=copy.deepcopy(metadata),
+                    metadata=child_metadata,
                     global_metadata=copy.deepcopy(global_metadata),
-                )
-                for text in split_text
-            ])
+                ))
         return result
 
 
@@ -437,18 +523,15 @@ class LineSplitter(NodeTransform):
     def __init__(self, **kwargs):
         super().__init__()
         self._normal_spliter = NormalLineSplitter()
-        self._mineru_spliter = MineruLineSplitter()
 
     def sig_fields(self) -> dict:
         return {}
 
     def forward(self, document: DocNode, **kwargs) -> List[DocNode]:
+        # line group is "sentence slice": always split by sentence punctuation.
+        # Mineru layout lines vary in visual length and are not sentence boundaries.
         result = []
         nodes = document if isinstance(document, list) else [document]
         for node in nodes:
-            file_type = Path(node.global_metadata.get('file_name', '')).suffix
-            if file_type.lower() == '.pdf' and node.metadata.get('lines'):
-                result.extend(self._mineru_spliter(node))
-            else:
-                result.extend(self._normal_spliter(node))
+            result.extend(self._normal_spliter(node))
         return result

--- a/algorithm/lazymind/parsing/engine/transform/post_func.py
+++ b/algorithm/lazymind/parsing/engine/transform/post_func.py
@@ -666,12 +666,16 @@ class GroupNodeParser(ModuleBase):
 
         # create new node, inheriting metadata from original node
         new_node = DocNode(text=content, metadata=copy.deepcopy(metadata))
-        new_node.metadata['lines'] = [{
-            'content': new_node._content,
-            'bbox': new_node.metadata.get('bbox', []),
-            'type': new_node.metadata.get('type', 'text'),
-            'page': new_node.metadata.get('page', 0),
-        }]
+        new_node.metadata['lines'] = _layout_lines_for_text(
+            metadata.get('lines'),
+            content,
+            fallback_chunks=current_chunks,
+            default_bbox=new_node.metadata.get('bbox', []),
+            default_type=new_node.metadata.get('type', 'text'),
+            default_page=new_node.metadata.get('page', 0),
+        )
+        if not new_node.metadata['lines']:
+            new_node.metadata.pop('lines', None)
 
         return new_node
 
@@ -711,6 +715,61 @@ class GroupNodeParser(ModuleBase):
                 return True
 
         return False
+
+
+def _line_content(line) -> str:
+    if isinstance(line, dict):
+        return line.get('content') or ''
+    return str(line) if line is not None else ''
+
+
+def _filter_lines_in_text(lines, text: str) -> list:
+    '''Keep layout lines whose content is contained in text.'''
+    if not isinstance(lines, list) or not lines or not text:
+        return []
+    matched = []
+    for line in lines:
+        content = _line_content(line)
+        if content and content in text:
+            matched.append(copy.deepcopy(line) if isinstance(line, dict) else {
+                'content': content, 'bbox': [], 'type': 'text', 'page': 0,
+            })
+    return matched
+
+
+def _layout_lines_for_text(
+    lines,
+    text: str,
+    *,
+    fallback_chunks=None,
+    default_bbox=None,
+    default_type='text',
+    default_page=0,
+) -> list:
+    '''Build layout lines for a text span without inventing a paragraph-sized fake line.
+
+    Prefer original mineru/layout lines that belong to this text. Otherwise, when
+    fallback_chunks has multiple real pieces, use those. Never emit a single entry
+    that merely duplicates the whole text blob.
+    '''
+    matched = _filter_lines_in_text(lines, text)
+    if matched:
+        return matched
+
+    chunks = [str(c) for c in (fallback_chunks or []) if str(c).strip()]
+    if len(chunks) <= 1:
+        return []
+
+    bbox = copy.deepcopy(default_bbox) if isinstance(default_bbox, list) else (default_bbox or [])
+    return [
+        {
+            'content': chunk,
+            'bbox': copy.deepcopy(bbox) if isinstance(bbox, list) else bbox,
+            'type': default_type,
+            'page': default_page,
+        }
+        for chunk in chunks
+    ]
 
 
 class MergeNodeParser(ModuleBase):
@@ -757,15 +816,17 @@ class MergeNodeParser(ModuleBase):
                 table_image_map = merge_table_image_maps(table_image_map, node.metadata['table_image_map'])
             if node.metadata.get('page', None) is not None and node.metadata.get('bbox', None):
                 bboxs.append([node.metadata.get('page')] + node.metadata.get('bbox'))
-                lines.append({
-                    'content': node._content,
-                    'bbox': node.metadata.get('bbox', []),
-                    'type': node.metadata.get('type', 'text'),
-                    'page': node.metadata.get('page', 0),
-                })
+            # Only keep real layout lines from mineru / upstream. Never invent a
+            # paragraph-sized fake line from node._content (that makes line==block).
+            orig_lines = node.metadata.get('lines')
+            if isinstance(orig_lines, list) and orig_lines:
+                lines.extend(copy.deepcopy(orig_lines))
         if not context:
             return None
-        metadata['lines'] = lines
+        if lines:
+            metadata['lines'] = lines
+        else:
+            metadata.pop('lines', None)
         if table_image_map:
             metadata['table_image_map'] = serialize_table_image_map(table_image_map)
 

--- a/tests/algorithm/parsing/test_general_parser.py
+++ b/tests/algorithm/parsing/test_general_parser.py
@@ -160,3 +160,51 @@ def test_forward_inherits_parent_metadata_exclusions(monkeypatch):
         assert set(chunk.excluded_embed_metadata_keys) == {'page', 'bbox', 'lines'}
         assert set(chunk.excluded_llm_metadata_keys) == {'page', 'bbox', 'lines'}
         assert chunk.get_text(MetadataMode.EMBED) == 'file_name: doc.pdf\n\n' + chunk.text
+
+
+def test_forward_redistributes_layout_lines_per_chunk(monkeypatch):
+    monkeypatch.setattr(general_parser_module, 'IMAGE_PREFIX', '/assets/images/')
+    parser = GeneralParser(max_length=20, split_by='\n')
+    node = DocNode(
+        text='alpha line here\nbeta line here\ngamma trailing',
+        metadata={
+            'file_name': 'doc.pdf',
+            'page': 1,
+            'bbox': [0, 0, 10, 10],
+            'lines': [
+                {'content': 'alpha line here', 'bbox': [0, 0, 10, 3], 'type': 'text', 'page': 1},
+                {'content': 'beta line here', 'bbox': [0, 4, 10, 7], 'type': 'text', 'page': 1},
+                {'content': 'gamma trailing', 'bbox': [0, 8, 10, 10], 'type': 'text', 'page': 1},
+            ],
+        },
+    )
+
+    chunks = parser.forward(node)
+
+    assert len(chunks) >= 2
+    for chunk in chunks:
+        lines = chunk.metadata.get('lines') or []
+        assert all(ln['content'] in chunk.text for ln in lines)
+
+
+def test_forward_drops_parent_wide_fake_line_on_split(monkeypatch):
+    monkeypatch.setattr(general_parser_module, 'IMAGE_PREFIX', '/assets/images/')
+    parser = GeneralParser(max_length=20, split_by='\n')
+    full = 'alpha line here\nbeta line here\ngamma trailing'
+    node = DocNode(
+        text=full,
+        metadata={
+            'file_name': 'doc.pdf',
+            'page': 1,
+            'bbox': [0, 0, 10, 10],
+            # Coarse fake line equal to the whole parent text.
+            'lines': [{'content': full, 'bbox': [0, 0, 10, 10], 'type': 'text', 'page': 1}],
+        },
+    )
+
+    chunks = parser.forward(node)
+
+    assert len(chunks) >= 2
+    for chunk in chunks:
+        # Parent-wide fake line is not contained in any partial chunk.
+        assert 'lines' not in chunk.metadata

--- a/tests/algorithm/parsing/test_para_parser.py
+++ b/tests/algorithm/parsing/test_para_parser.py
@@ -34,10 +34,11 @@ def test_sentence_tokenizer_splitter_returns_strings():
 def test_normal_line_splitter_splits_sentences_and_merges_short_prefixes():
     splitter = NormalLineSplitter()
 
+    # Non-PDF: keep semantic newlines; short prefix is merged into the next sentence.
     assert splitter._split_text('短。\n这是一个较长的句子。') == ['短。\n这是一个较长的句子。']
     assert splitter._split_text('这是一个足够长的第一句。\n第二句也足够长？') == [
-        '这是一个足够长的第一句。\n',
-        '第二句也足够长？',
+        '这是一个足够长的第一句。',
+        '\n第二句也足够长？',
     ]
 
 
@@ -52,7 +53,7 @@ def test_line_splitter_uses_normal_sentence_splitter_for_non_pdf():
 
     assert isinstance(result, list)
     assert all(isinstance(item, DocNode) for item in result)
-    assert [item.text for item in result] == ['这是一个足够长的第一句。\n', '第二句也足够长？']
+    assert [item.text for item in result] == ['这是一个足够长的第一句。', '\n第二句也足够长？']
     assert result[0].metadata == {'file_name': 'note.md', 'page': 1}
     assert result[0].metadata is not node.metadata
 
@@ -86,21 +87,157 @@ def test_mineru_line_splitter_expands_line_metadata():
     assert result[1].metadata['type'] == 'table'
 
 
-def test_line_splitter_uses_mineru_lines_for_pdf():
+def test_line_splitter_sentence_splits_pdf_even_with_layout_lines():
+    text = (
+        '这是一个足够长的第一句，用来触发句级切分。'
+        '这是一个足够长的第二句，确认不会走版面行。'
+    )
     node = DocNode(
-        text='merged text',
+        text=text,
         metadata={
             'file_name': 'paper.pdf',
             'docid': 'doc-1',
-            'lines': [{'content': 'line one', 'type': 'text', 'page': 2, 'bbox': [1, 2, 3, 4]}],
+            # Layout lines are intentionally one blob; sentence slice must ignore them.
+            'lines': [{'content': text, 'type': 'text', 'page': 2, 'bbox': [1, 2, 3, 4]}],
         },
         global_metadata={'file_name': 'paper.pdf'},
     )
 
     result = LineSplitter().forward(node)
 
-    assert [item.text for item in result] == ['line one']
-    assert result[0].metadata['page'] == 2
+    assert len(result) == 2
+    assert result[0].text.endswith('。')
+    assert result[1].text.endswith('。')
+    # Block-wide lines must not be copied onto every sentence child.
+    assert all('lines' not in item.metadata for item in result)
+
+
+def test_line_splitter_filters_layout_lines_to_matching_sentences():
+    text = (
+        '这是一个足够长的第一句，用来触发句级切分。'
+        '这是一个足够长的第二句，确认行级元数据过滤。'
+    )
+    line_a = {
+        'content': '这是一个足够长的第一句，用来触发句级切分。',
+        'type': 'text',
+        'page': 1,
+        'bbox': [1, 2, 3, 4],
+    }
+    line_b = {
+        'content': '这是一个足够长的第二句，确认行级元数据过滤。',
+        'type': 'text',
+        'page': 1,
+        'bbox': [5, 6, 7, 8],
+    }
+    node = DocNode(
+        text=text,
+        metadata={'file_name': 'paper.pdf', 'lines': [line_a, line_b]},
+        global_metadata={'file_name': 'paper.pdf'},
+    )
+
+    result = LineSplitter().forward(node)
+
+    assert len(result) == 2
+    assert result[0].metadata['lines'] == [line_a]
+    assert result[1].metadata['lines'] == [line_b]
+
+
+def test_line_splitter_uses_normal_splitter_when_pdf_has_no_lines():
+    text = (
+        '这是一个足够长的第一句，用来触发句级切分。\n'
+        '这是一个足够长的第二句，确认不会原样保留整段。'
+    )
+    node = DocNode(
+        text=text,
+        metadata={
+            'file_name': 'paper.pdf',
+            'type': 'paragraph',
+            'page': 0,
+            'bbox': [1, 2, 3, 4],
+        },
+        global_metadata={'file_name': 'paper.pdf'},
+    )
+
+    result = LineSplitter().forward(node)
+
+    assert len(result) > 1
+    assert all(item.text != text for item in result)
+
+
+def test_line_splitter_sentence_splits_english_pdf_with_layout_lines():
+    text = (
+        '(2) For the Qwen3 MoE base models, our experimental results indicate that: '
+        '(a) Using the same pre-training data, Qwen3 MoE base models can achieve similar '
+        'performance to Qwen3 dense base models with only 1/5 activated parameters. '
+        '(b) Due to the improvements of the Qwen3 MoE architecture, the scale-up of the '
+        'training tokens, and more advanced training strategies, the Qwen3 MoE base models '
+        'can outperform the Qwen2.5 MoE base models with less than 1/2 activated parameters '
+        'and fewer total parameters. (c) Even with 1/10 of the activated parameters of the '
+        'Qwen2.5 dense base model, the Qwen3 MoE base model can achieve comparable '
+        'performance, which brings us significant advantages in inference and training costs.'
+    )
+    node = DocNode(
+        text=text,
+        metadata={
+            'file_name': 'paper.pdf',
+            'lines': [{'content': text, 'type': 'text', 'page': 1, 'bbox': [1, 2, 3, 4]}],
+        },
+        global_metadata={'file_name': 'paper.pdf'},
+    )
+
+    result = LineSplitter().forward(node)
+    texts = [item.text for item in result]
+
+    assert len(texts) == 3
+    assert 'Qwen2.5 MoE' in texts[1]
+    assert 'Qwen2.5 dense' in texts[2]
+    assert not any(t.rstrip().endswith('Qwen2.') for t in texts)
+
+
+def test_normal_line_splitter_keeps_decimals_and_versions():
+    text = 'Qwen2.5 MoE is strong enough here. Next sentence follows with enough length.'
+    assert NormalLineSplitter()._split_text(text) == [
+        'Qwen2.5 MoE is strong enough here.',
+        ' Next sentence follows with enough length.',
+    ]
+
+
+def test_normal_line_splitter_preserves_markdown_newlines_without_unwrap():
+    text = '# Title\n这是一个足够长的第一句。\n- 列表项也足够长。'
+    parts = NormalLineSplitter()._split_text(text)
+    assert parts == ['# Title\n这是一个足够长的第一句。', '\n- 列表项也足够长。']
+
+
+def test_normal_line_splitter_joins_pdfreader_soft_wraps_before_sentence_split():
+    text = (
+        'benchmarks, including tasks in code generation, mathematical reasoning, agent tasks,\n'
+        'etc., competitive against larger MoE models and proprietary models. Compared to its\n'
+        'predecessor Qwen2.5, Qwen3 expands multilingual support from 29 to 119 languages\n'
+        'and dialects, enhancing global accessibility through improved cross-lingual understand-\n'
+        'ing and generation capabilities.'
+    )
+    node = DocNode(
+        text=text,
+        metadata={'page_label': '1', 'file_name': 'paper.pdf'},
+        global_metadata={'file_name': 'paper.pdf'},
+    )
+    parts = [item.text for item in NormalLineSplitter().forward(node)]
+    assert len(parts) == 2
+    assert 'agent tasks, etc., competitive' in parts[0]
+    assert parts[0].endswith('models.')
+    assert 'Compared to its predecessor Qwen2.5' in parts[1]
+    assert 'understanding and generation capabilities.' in parts[1]
+    assert 'understand-' not in parts[1]
+
+
+def test_unwrap_soft_newlines_keeps_compound_hyphens_across_wraps():
+    from lazymind.parsing.engine.transform.para_parser import _unwrap_soft_newlines
+
+    assert _unwrap_soft_newlines('state-of-\nthe-art models') == 'state-of-the-art models'
+    assert _unwrap_soft_newlines('state-\nof-the-art models') == 'state-of-the-art models'
+    assert _unwrap_soft_newlines('cross-lingual understand-\ning capabilities') == (
+        'cross-lingual understanding capabilities'
+    )
 
 
 def test_normal_line_splitter_inherits_parent_metadata_exclusions():

--- a/tests/algorithm/parsing/test_post_func.py
+++ b/tests/algorithm/parsing/test_post_func.py
@@ -95,7 +95,13 @@ def test_merge_node_parser_merges_text_bbox_lines_and_table_image_map():
     group = [
         DocNode(
             text='first',
-            metadata={'file_name': 'a.pdf', 'page': 1, 'bbox': [10, 20, 30, 40], 'type': 'text'},
+            metadata={
+                'file_name': 'a.pdf',
+                'page': 1,
+                'bbox': [10, 20, 30, 40],
+                'type': 'text',
+                'lines': [{'content': 'first', 'bbox': [10, 20, 30, 40], 'type': 'text', 'page': 1}],
+            },
         ),
         DocNode(
             text='table markdown',
@@ -105,11 +111,18 @@ def test_merge_node_parser_merges_text_bbox_lines_and_table_image_map():
                 'bbox': [5, 25, 35, 45],
                 'type': 'table',
                 'table_image_map': table_map,
+                'lines': [{'content': 'table markdown', 'bbox': [5, 25, 35, 45], 'type': 'table', 'page': 1}],
             },
         ),
         DocNode(
             text='second page',
-            metadata={'file_name': 'a.pdf', 'page': 2, 'bbox': [1, 2, 3, 4], 'type': 'text'},
+            metadata={
+                'file_name': 'a.pdf',
+                'page': 2,
+                'bbox': [1, 2, 3, 4],
+                'type': 'text',
+                'lines': [{'content': 'second page', 'bbox': [1, 2, 3, 4], 'type': 'text', 'page': 2}],
+            },
         ),
     ]
 
@@ -126,6 +139,47 @@ def test_merge_node_parser_merges_text_bbox_lines_and_table_image_map():
     ]
     assert normalize_table_image_map(result[0].metadata['table_image_map']) == [
         {'content': 'table markdown', 'image': '![表](images/table.png)'}
+    ]
+
+
+def test_merge_node_parser_does_not_invent_lines_from_content():
+    group = [
+        DocNode(
+            text='only paragraph',
+            metadata={'file_name': 'a.pdf', 'page': 1, 'bbox': [10, 20, 30, 40], 'type': 'text'},
+        ),
+    ]
+
+    result = MergeNodeParser().forward([group])
+
+    assert result[0].text == 'only paragraph'
+    assert result[0].metadata['bbox'] == [10, 20, 30, 40]
+    assert 'lines' not in result[0].metadata
+
+
+def test_merge_node_parser_preserves_fine_grained_mineru_lines():
+    group = [
+        DocNode(
+            text='paragraph one',
+            metadata={
+                'file_name': 'a.pdf',
+                'page': 1,
+                'bbox': [10, 20, 30, 40],
+                'type': 'text',
+                'lines': [
+                    {'content': 'line a', 'bbox': [10, 20, 30, 25], 'type': 'text', 'page': 1},
+                    {'content': 'line b', 'bbox': [10, 26, 30, 40], 'type': 'text', 'page': 1},
+                ],
+            },
+        ),
+    ]
+
+    result = MergeNodeParser().forward([group])
+
+    assert result[0].text == 'paragraph one'
+    assert result[0].metadata['lines'] == [
+        {'content': 'line a', 'bbox': [10, 20, 30, 25], 'type': 'text', 'page': 1},
+        {'content': 'line b', 'bbox': [10, 26, 30, 40], 'type': 'text', 'page': 1},
     ]
 
 
@@ -158,8 +212,56 @@ def test_group_node_parser_splits_large_table_and_refreshes_table_image_map():
     split_node = result[0][0]
     assert split_node.text.startswith('表1\n')
     assert split_node.text.endswith('注：说明')
-    assert split_node.metadata['lines'][0]['type'] == 'table'
+    assert split_node.metadata.get('type') == 'table'
+    # Split chunks must not invent a single fake line equal to the whole node text.
+    assert (split_node.metadata.get('lines') or []) != [{
+        'content': split_node.text,
+        'bbox': split_node.metadata.get('bbox', []),
+        'type': 'table',
+        'page': split_node.metadata.get('page', 0),
+    }]
     assert normalize_table_image_map(split_node.metadata['table_image_map'])[0]['image'] == '![表](images/table.png)'
+
+
+def test_create_split_node_keeps_newline_pieces_as_lines():
+    node = DocNode(
+        text='alpha\nbeta\ngamma',
+        metadata={'type': 'text', 'page': 1, 'bbox': [1, 2, 3, 4]},
+    )
+
+    split_nodes = GroupNodeParser()._split_large_node(node, max_length=12)
+
+    assert len(split_nodes) >= 1
+    first = split_nodes[0]
+    assert first.text == 'alpha\nbeta'
+    assert first.metadata.get('lines') == [
+        {'content': 'alpha', 'bbox': [1, 2, 3, 4], 'type': 'text', 'page': 1},
+        {'content': 'beta', 'bbox': [1, 2, 3, 4], 'type': 'text', 'page': 1},
+    ]
+
+
+def test_create_split_node_filters_original_mineru_lines_into_chunk():
+    node = DocNode(
+        text='line-a-content\nline-b-content\nline-c-extra',
+        metadata={
+            'type': 'text',
+            'page': 1,
+            'bbox': [1, 2, 3, 4],
+            'lines': [
+                {'content': 'line-a-content', 'bbox': [1, 2, 3, 2], 'type': 'text', 'page': 1},
+                {'content': 'line-b-content', 'bbox': [1, 3, 3, 4], 'type': 'text', 'page': 1},
+                {'content': 'line-c-extra', 'bbox': [1, 5, 3, 6], 'type': 'text', 'page': 1},
+            ],
+        },
+    )
+
+    split_nodes = GroupNodeParser()._split_large_node(node, max_length=20)
+
+    assert split_nodes
+    first = split_nodes[0]
+    assert first.metadata['lines']
+    assert all(ln['content'] in first.text for ln in first.metadata['lines'])
+    assert 'line-c-extra' not in {ln['content'] for ln in first.metadata['lines']} or 'line-c-extra' in first.text
 
 
 def test_group_node_parser_title_relationships_and_toc_detection():


### PR DESCRIPTION
# 解决 line 和 block 切的过于近似的问题

## Mineru 修改后效果

<img width="722" height="756" alt="img_v3_02144_2af64088-f4eb-418a-8077-658d7ac5555g" src="https://github.com/user-attachments/assets/d12f1516-bfc0-4254-b9ba-ab029bfa3c90" />


## Pdfreader 修改后效果

<img width="794" height="846" alt="img_v3_02144_47578e4e-96db-49d9-a614-9b7a5cd9c95g" src="https://github.com/user-attachments/assets/b23d524d-2056-4153-91ea-2adf473e914f" />
