### PR TITLE
fix(chat): unify agent workspace file access

### DIFF
--- a/algorithm/lazymind/chat/engine/tools/chat_artifact.py
+++ b/algorithm/lazymind/chat/engine/tools/chat_artifact.py
@@ -10,6 +10,11 @@ from typing import Any, Dict, Optional
 
 import lazyllm
 from lazyllm.tools.agent.base import _write_agent_data
+from lazyllm.tools.agent.file_tool import (
+    list_dir as _list_dir,
+    read_file as _read_file,
+    write_file as _write_file,
+)
 
 from lazymind.config import config as _cfg
 from lazymind.chat.engine.tools.infra import tool_success
@@ -75,19 +80,20 @@ def _published_file_directory(user_id: str, conversation_id: str, artifact_id: s
     )
 
 
+def _resolve_workspace_path(path: str, user_id: str, conversation_id: str) -> tuple[str, str]:
+    workspace = os.path.realpath(chat_agent_workspace(user_id, conversation_id))
+    candidate = path if os.path.isabs(path) else os.path.join(workspace, path)
+    resolved = os.path.realpath(candidate)
+    if os.path.commonpath((workspace, resolved)) != workspace:
+        raise ValueError('path must stay inside the current main-Agent workspace')
+    return workspace, resolved
+
+
 def _resolve_source_file(path: str, user_id: str, conversation_id: str) -> str:
     raw_path = str(path or '').strip()
     if not raw_path:
         raise ValueError('path is required')
-    workspace = chat_agent_workspace(user_id, conversation_id)
-    candidate = raw_path if os.path.isabs(raw_path) else os.path.join(workspace, raw_path)
-    source = os.path.realpath(candidate)
-    try:
-        in_workspace = os.path.commonpath((workspace, source)) == workspace
-    except ValueError:
-        in_workspace = False
-    if not in_workspace:
-        raise ValueError('path must point to a file inside the main Agent workspace')
+    _, source = _resolve_workspace_path(raw_path, user_id, conversation_id)
     if not os.path.isfile(source):
         raise ValueError('path must point to an existing regular file')
     return source
@@ -199,3 +205,83 @@ def save_chat_file(
         'size': size,
         'message': f"Saved downloadable artifact '{filename}'.",
     })
+
+
+def write_file(
+    path: str,
+    content: str,
+    mode: str = 'overwrite',
+    encoding: str = 'utf-8',
+    create_parents: bool = True,
+    allow_unsafe: bool = False,
+) -> Dict[str, Any]:
+    """Write a text file in the current chat workspace.
+
+    Args:
+        path: Workspace-relative path or absolute path inside the workspace.
+        content: Text to write.
+        mode: "overwrite" or "append".
+        encoding: Text encoding.
+        create_parents: Create parent directories when needed.
+        allow_unsafe: Allow overwriting an existing file.
+    """
+    user_id, conversation_id = _current_artifact_scope()
+    workspace, target = _resolve_workspace_path(path, user_id, conversation_id)
+    return _write_file(
+        target,
+        content,
+        mode=mode,
+        encoding=encoding,
+        root=workspace,
+        create_parents=create_parents,
+        allow_unsafe=allow_unsafe,
+    )
+
+
+def read_file(
+    path: str,
+    start_line: Optional[int] = None,
+    end_line: Optional[int] = None,
+    encoding: str = 'utf-8',
+    errors: str = 'replace',
+    max_chars: int = 200000,
+) -> Dict[str, Any]:
+    """Read a text file from the current chat workspace.
+
+    Args:
+        path: Workspace-relative path or absolute path inside the workspace.
+        start_line: Optional 1-based first line.
+        end_line: Optional 1-based last line.
+        encoding: Text encoding.
+        errors: Decode error handling.
+        max_chars: Maximum returned characters.
+    """
+    user_id, conversation_id = _current_artifact_scope()
+    workspace, source = _resolve_workspace_path(path, user_id, conversation_id)
+    return _read_file(
+        source,
+        start_line=start_line,
+        end_line=end_line,
+        encoding=encoding,
+        errors=errors,
+        root=workspace,
+        max_chars=max_chars,
+    )
+
+
+def list_dir(path: str = '.', recursive: bool = False, max_depth: int = 5) -> Dict[str, Any]:
+    """List files in the current chat workspace.
+
+    Args:
+        path: Workspace-relative directory or absolute directory inside the workspace.
+        recursive: Recursively include descendants.
+        max_depth: Maximum recursive depth.
+    """
+    user_id, conversation_id = _current_artifact_scope()
+    workspace, directory = _resolve_workspace_path(path, user_id, conversation_id)
+    return _list_dir(
+        directory,
+        recursive=recursive,
+        max_depth=max_depth,
+        root=workspace,
+    )

--- a/algorithm/lazymind/chat/service/chat_service.py
+++ b/algorithm/lazymind/chat/service/chat_service.py
@@ -219,9 +219,14 @@ def _build_subagent_chat_tools() -> list:
 
 
 def _build_chat_artifact_tools() -> list:
-    """Tools for artifacts produced directly by the main ChatAgent."""
-    from lazymind.chat.engine.tools.chat_artifact import save_chat_artifact
-    return [save_chat_artifact]
+    """Workspace and artifact tools for the main ChatAgent."""
+    from lazymind.chat.engine.tools.chat_artifact import (
+        list_dir,
+        read_file,
+        save_chat_artifact,
+        write_file,
+    )
+    return [save_chat_artifact, read_file, write_file, list_dir]
 
 
 def _build_user_attachment_tools(has_files: bool) -> list:
@@ -662,6 +667,7 @@ async def _handle_chat_impl(
     ask_user_tools = _build_ask_user_tool() if allow_ask_user else []
     ask_user_configs = [ASK_USER_TOOL_CONFIG] if ask_user_tools else []
     artifact_tools = _build_chat_artifact_tools()
+    workspace = chat_agent_workspace(user_id or '0', conversation_id)
     skill_listing_tools = [build_list_skills_tool(agent.available_skills)]
     all_tools = ([intentwriter] + agent_tools + artifact_tools + subagent_tools + attachment_tools
                  + skill_listing_tools + ask_user_tools + plugin_tools + mcp_tools)
@@ -703,6 +709,19 @@ async def _handle_chat_impl(
         ),
         task_profile=task_profile,
         dynamic_prompt_modules=_cfg['dynamic_prompt_modules'],
+    )
+    prompt_builder.system(
+        'chat_workspace',
+        'Workspace',
+        (
+            f'Use `{workspace}` as the single working directory for all generated and intermediate files. '
+            'When a skill requires an output directory, create it under this workspace and pass its absolute '
+            'path to skill scripts. Treat files outside this workspace as read-only inputs. Use `read_file`, '
+            '`write_file`, and `list_dir` to inspect and update workspace files, then publish completed files '
+            'with `save_chat_artifact`.'
+        ),
+        'agent.workspace',
+        priority=70,
     )
     # Plugin policy historically followed the common system prompt.
     prompt_builder.system(
@@ -792,7 +811,7 @@ async def _handle_chat_impl(
         force_summarize_context=query,
         execution_options=AgentExecutionOptions(
             skills=skill_config,
-            workspace=chat_agent_workspace(user_id or '0', conversation_id),
+            workspace=workspace,
             keep_full_turns=_cfg['agentic_keep_full_turns'],
             fs=FS,
             skills_dir=_cfg['skill_fs_url'],

--- a/algorithm/tests/chat/test_chat_artifact.py
+++ b/algorithm/tests/chat/test_chat_artifact.py
@@ -76,10 +76,27 @@ def test_save_chat_artifact_file_rejects_source_outside_agent_workspace(
         chat_artifact, '_current_artifact_scope', lambda: ('user-1', 'conversation-1'),
     )
 
-    with pytest.raises(ValueError, match='inside the main Agent workspace'):
+    with pytest.raises(ValueError, match='inside the current main-Agent workspace'):
         chat_artifact.save_chat_artifact(
             'outside.zip', str(outside), content_type='file',
         )
+
+
+def test_workspace_file_tools_share_chat_agent_workspace(tmp_path, monkeypatch):
+    monkeypatch.setitem(chat_artifact._cfg, 'agentic_workspace', str(tmp_path))
+    monkeypatch.setattr(
+        chat_artifact, '_current_artifact_scope', lambda: ('user-1', 'conversation-1'),
+    )
+
+    written = chat_artifact.write_file('bid_output/outline.json', '{"chapters": []}')
+    loaded = chat_artifact.read_file('bid_output/outline.json')
+    listing = chat_artifact.list_dir('bid_output')
+
+    workspace = Path(chat_artifact.chat_agent_workspace('user-1', 'conversation-1'))
+    assert written['status'] == 'ok'
+    assert Path(written['path']) == workspace / 'bid_output' / 'outline.json'
+    assert loaded['content'] == '{"chapters": []}'
+    assert listing['entries'] == ['outline.json']
 
 
 def test_artifact_event_translator_preserves_structured_payload():

--- a/tests/algorithm/chat/test_pipeline_agentic.py
+++ b/tests/algorithm/chat/test_pipeline_agentic.py
@@ -44,7 +44,11 @@ def test_handle_chat_constructs_react_agent_from_runtime_context(monkeypatch):
     async def drive():
         response = await chat_service.handle_chat(ChatRequest(
             message={'query': 'hello', 'history': []},
-            conversation={'session_id': 'sid-1'},
+            conversation={
+                'session_id': 'sid-1',
+                'conversation_id': 'conversation-1',
+                'user_id': 'user-1',
+            },
             retrieval={'filters': {}},
             runtime={'llm_config': {}},
             personalization={'use_memory': True},
@@ -78,6 +82,11 @@ def test_handle_chat_constructs_react_agent_from_runtime_context(monkeypatch):
     assert agent_calls[0]['tools']
     assert agent_calls[0]['kwargs']['skills'] is False
     assert agent_calls[0]['kwargs']['stream'] is True
+    tool_names = {getattr(tool, '__name__', '') for tool in agent_calls[0]['tools']}
+    assert {'read_file', 'write_file', 'list_dir'} <= tool_names
+    workspace = chat_service.chat_agent_workspace('user-1', 'conversation-1')
+    assert agent_calls[0]['kwargs']['workspace'] == workspace
+    assert f'Use `{workspace}` as the single working directory' in agent_calls[0]['kwargs']['prompt']
     assert '## Attached Files' not in agent_calls[0]['kwargs']['prompt']
     assert '### User Instruction\n\nhello\n\nATTENTION — `ask_user`' in agent_queries[0]
     assert 'answer:### Runtime Context' in body


### PR DESCRIPTION
- Add scoped read, write, and list tools for the ChatAgent workspace.
- Use one conversation workspace for file tools, skill outputs, and artifact publishing.
- Prevent direct file access outside the current workspace.
- Add tests for workspace consistency and tool registration.