### PR TITLE
feat(writer): 完善 Markdown 草稿与 .lmd 写作工作流

### DIFF
--- a/algorithm/lazymind/chat/engine/subagent/runner.py
+++ b/algorithm/lazymind/chat/engine/subagent/runner.py
@@ -629,7 +629,10 @@ async def run_subagent_stream(
         lazyllm.set_trace_context({
             'trace_id': params.get('trace_id') or None,
             'parent_span_id': params.get('parent_span_id') or None,
-            'session_id': params.get('session_id') or params.get('chat_session_id') or None,
+            'session_id': (
+                params.get('session_id') or params.get('chat_session_id')
+                or lazyllm.get_trace_context().session_id
+            ),
             'sampled': True, 'request_tags': ['subagent'],
             'module_trace': {
                 'by_class': {

--- a/algorithm/lazymind/chat/engine/subagent/runner.py
+++ b/algorithm/lazymind/chat/engine/subagent/runner.py
@@ -627,10 +627,19 @@ async def run_subagent_stream(
         lazyllm.globals._init_sid(sid=sid)
         lazyllm.locals._init_sid(sid=sid)
         lazyllm.set_trace_context({
+            'trace_id': params.get('trace_id') or None,
+            'parent_span_id': params.get('parent_span_id') or None,
             'session_id': params.get('session_id') or params.get('chat_session_id') or None,
-            'sampled': True,
-            'module_trace': {'default': True},
-            'request_tags': ['subagent'],
+            'sampled': True, 'request_tags': ['subagent'],
+            'module_trace': {
+                'by_class': {
+                    'FunctionCall': False, 'ToolManager': False,
+                    'Pipeline': False, 'Diverter': False,
+                },
+                'by_name': {
+                    '_build_history': False, '_post_action': False, '_safe_call': False,
+                },
+            }
         })
         inject_model_config(model_config)
         inject_tool_config(tool_config)

--- a/algorithm/lazymind/chat/engine/subagent/tools.py
+++ b/algorithm/lazymind/chat/engine/subagent/tools.py
@@ -30,18 +30,6 @@ _CONTENT_TYPES = {'text', 'json', 'image', 'file', 'file_list'}
 UPLOAD_MARKER = '/var/lib/lazymind/uploads/'
 SUBAGENT_MARKER = '/data/subagent/'
 
-_WRITER_DOCUMENT_SLOT_STAGES = {
-    'outline_ir': 'outline',
-    'draft_document': 'draft',
-    'final_document': 'final',
-}
-_WRITER_MARKDOWN_SLOTS = {
-    'draft_blocks',
-    'draft_document_md',
-    'final_document_md',
-    'delivered_markdown',
-}
-
 
 def _materialize_local_path(path: str) -> str:
     """Resolve Docker-canonical upload paths onto the real LAZYMIND_UPLOAD_ROOT.
@@ -198,13 +186,12 @@ def _build_artifact_value(value: Any, content_type: str):
     return {'text': str(value)}, 'text'
 
 
-def _validate_declared_artifact(
+def _validate_declared_artifact_type(
     ctx: Any,
     key: str,
-    value: Any,
     content_type: str,
 ) -> Optional[str]:
-    """Validate a plugin artifact against its declared slot contract."""
+    """Validate only the framework-level content type declared by a plugin slot."""
     plugin_id = str((ctx.params or {}).get('plugin_id') or '').strip()
     if not plugin_id:
         return None
@@ -224,42 +211,6 @@ def _validate_declared_artifact(
             'by the producing tool instead of copying its contents.'
         )
 
-    if plugin_id != 'writer-plugin' or content_type != 'file':
-        return None
-
-    path = str(value or '').strip()
-    if key in _WRITER_MARKDOWN_SLOTS:
-        if not path.lower().endswith(('.md', '.markdown')):
-            return f'Writer Markdown artifact {key!r} must be a real .md file path.'
-        return None
-
-    expected_stage = _WRITER_DOCUMENT_SLOT_STAGES.get(key)
-    if expected_stage is None:
-        return None
-    if not path.lower().endswith('.lmd'):
-        return f'Writer IR artifact {key!r} must use the .lmd file suffix.'
-    try:
-        with open(path, 'r', encoding='utf-8') as fh:
-            payload = json.load(fh)
-    except Exception as exc:
-        return f'Writer IR artifact {key!r} is not a readable JSON envelope: {exc}'
-    document = payload.get('data') if isinstance(payload, dict) and 'data' in payload else payload
-    if not isinstance(document, dict):
-        return f'Writer IR artifact {key!r} does not contain a WriterDocument object.'
-    if document.get('stage') != expected_stage:
-        return (
-            f'Writer IR artifact {key!r} must have stage={expected_stage!r}; '
-            f'got {document.get("stage")!r}.'
-        )
-    if document.get('ui_editable') is not True:
-        return f'Writer IR artifact {key!r} must have ui_editable=true.'
-    metadata = document.get('metadata')
-    if isinstance(metadata, dict) and metadata.get('kind') == 'step_status':
-        return f'Writer status placeholder cannot be saved as {key!r}.'
-    if key == 'outline_ir':
-        blocks = document.get('blocks')
-        if not isinstance(blocks, list) or len(blocks) < 3:
-            return 'Writer outline_ir must contain at least three top-level outline blocks.'
     return None
 
 
@@ -323,7 +274,7 @@ def _save_artifact(key: str, value: Any, content_type: str = 'text',
             f'Allowed keys: {", ".join(ctx.output_slots)}',
         )
     ct = content_type if content_type in _CONTENT_TYPES else 'text'
-    contract_error = _validate_declared_artifact(ctx, key, value, ct)
+    contract_error = _validate_declared_artifact_type(ctx, key, ct)
     if contract_error:
         return tool_error('save_artifacts', contract_error)
     built, actual_ct = _build_artifact_value(value, ct)
@@ -339,16 +290,6 @@ def _save_artifact(key: str, value: Any, content_type: str = 'text',
             out_of_range_warning = resolve_err
     if caption is not None:
         built['caption'] = str(caption)
-    for existing in reversed(ctx.local_artifacts([key])):
-        if (
-            existing.get('content_type') == actual_ct
-            and existing.get('value') == built
-        ):
-            return tool_success('save_artifacts', {
-                'status': 'ok',
-                'message': f"Artifact '{key}' was already saved with the same value.",
-                'deduplicated': True,
-            })
     seq = ctx.next_artifact_seq(key)
     ctx.record_local_artifact(key, actual_ct, built, seq)
     ctx.emit({
@@ -380,9 +321,7 @@ def save_artifacts(artifacts: List[Dict[str, Any]]) -> Dict[str, Any]:
     if len(artifacts) > 50:
         return tool_error('save_artifacts', 'At most 50 artifacts may be saved at once.')
 
-    # Preflight the complete batch before emitting anything. Otherwise, one bad
-    # item late in the list leaves earlier items partially saved and a model retry
-    # creates duplicate revisions for those slots.
+    results: List[Dict[str, Any]] = []
     for index, item in enumerate(artifacts):
         if not isinstance(item, dict):
             return tool_error('save_artifacts', f'artifacts[{index}] must be an object.')
@@ -390,32 +329,6 @@ def save_artifacts(artifacts: List[Dict[str, Any]]) -> Dict[str, Any]:
             return tool_error(
                 'save_artifacts', f'artifacts[{index}] requires key and value.',
             )
-        ctx = require_context()
-        key = str(item['key'])
-        if ctx.output_slots and key not in ctx.output_slots:
-            return tool_error(
-                'save_artifacts',
-                f'Artifact key {key!r} is not declared for this step. '
-                f'Allowed keys: {", ".join(ctx.output_slots)}',
-            )
-        content_type = str(item.get('content_type') or 'text')
-        if content_type not in _CONTENT_TYPES:
-            content_type = 'text'
-        contract_error = _validate_declared_artifact(
-            ctx, key, item['value'], content_type,
-        )
-        if contract_error:
-            return tool_error('save_artifacts', contract_error)
-        try:
-            _build_artifact_value(item['value'], content_type)
-        except Exception as exc:
-            return tool_error(
-                'save_artifacts',
-                f'artifacts[{index}] could not be prepared: {exc}',
-            )
-
-    results: List[Dict[str, Any]] = []
-    for item in artifacts:
         saved = _save_artifact(
             key=str(item['key']),
             value=item['value'],

--- a/algorithm/lazymind/chat/engine/subagent/tools.py
+++ b/algorithm/lazymind/chat/engine/subagent/tools.py
@@ -30,6 +30,18 @@ _CONTENT_TYPES = {'text', 'json', 'image', 'file', 'file_list'}
 UPLOAD_MARKER = '/var/lib/lazymind/uploads/'
 SUBAGENT_MARKER = '/data/subagent/'
 
+_WRITER_DOCUMENT_SLOT_STAGES = {
+    'outline_ir': 'outline',
+    'draft_document': 'draft',
+    'final_document': 'final',
+}
+_WRITER_MARKDOWN_SLOTS = {
+    'draft_blocks',
+    'draft_document_md',
+    'final_document_md',
+    'delivered_markdown',
+}
+
 
 def _materialize_local_path(path: str) -> str:
     """Resolve Docker-canonical upload paths onto the real LAZYMIND_UPLOAD_ROOT.
@@ -186,6 +198,71 @@ def _build_artifact_value(value: Any, content_type: str):
     return {'text': str(value)}, 'text'
 
 
+def _validate_declared_artifact(
+    ctx: Any,
+    key: str,
+    value: Any,
+    content_type: str,
+) -> Optional[str]:
+    """Validate a plugin artifact against its declared slot contract."""
+    plugin_id = str((ctx.params or {}).get('plugin_id') or '').strip()
+    if not plugin_id:
+        return None
+
+    try:
+        from lazymind.chat.plugin import plugin_loader
+        spec = plugin_loader.get_plugin(plugin_id)
+        slot_def = spec.get_slot_def(key) if spec else None
+    except Exception:
+        slot_def = None
+
+    declared_type = str((slot_def or {}).get('type') or '').strip()
+    if declared_type == 'file' and content_type not in {'file', 'file_list'}:
+        return (
+            f'Artifact {key!r} is declared as a file slot and must be saved with '
+            f'content_type="file"; got {content_type!r}. Save the exact path returned '
+            'by the producing tool instead of copying its contents.'
+        )
+
+    if plugin_id != 'writer-plugin' or content_type != 'file':
+        return None
+
+    path = str(value or '').strip()
+    if key in _WRITER_MARKDOWN_SLOTS:
+        if not path.lower().endswith(('.md', '.markdown')):
+            return f'Writer Markdown artifact {key!r} must be a real .md file path.'
+        return None
+
+    expected_stage = _WRITER_DOCUMENT_SLOT_STAGES.get(key)
+    if expected_stage is None:
+        return None
+    if not path.lower().endswith('.lmd'):
+        return f'Writer IR artifact {key!r} must use the .lmd file suffix.'
+    try:
+        with open(path, 'r', encoding='utf-8') as fh:
+            payload = json.load(fh)
+    except Exception as exc:
+        return f'Writer IR artifact {key!r} is not a readable JSON envelope: {exc}'
+    document = payload.get('data') if isinstance(payload, dict) and 'data' in payload else payload
+    if not isinstance(document, dict):
+        return f'Writer IR artifact {key!r} does not contain a WriterDocument object.'
+    if document.get('stage') != expected_stage:
+        return (
+            f'Writer IR artifact {key!r} must have stage={expected_stage!r}; '
+            f'got {document.get("stage")!r}.'
+        )
+    if document.get('ui_editable') is not True:
+        return f'Writer IR artifact {key!r} must have ui_editable=true.'
+    metadata = document.get('metadata')
+    if isinstance(metadata, dict) and metadata.get('kind') == 'step_status':
+        return f'Writer status placeholder cannot be saved as {key!r}.'
+    if key == 'outline_ir':
+        blocks = document.get('blocks')
+        if not isinstance(blocks, list) or len(blocks) < 3:
+            return 'Writer outline_ir must contain at least three top-level outline blocks.'
+    return None
+
+
 def _save_artifact(key: str, value: Any, content_type: str = 'text',
                    source_tool: Optional[str] = None,
                    sort_order: Optional[int] = None,
@@ -246,6 +323,9 @@ def _save_artifact(key: str, value: Any, content_type: str = 'text',
             f'Allowed keys: {", ".join(ctx.output_slots)}',
         )
     ct = content_type if content_type in _CONTENT_TYPES else 'text'
+    contract_error = _validate_declared_artifact(ctx, key, value, ct)
+    if contract_error:
+        return tool_error('save_artifacts', contract_error)
     built, actual_ct = _build_artifact_value(value, ct)
     if source_tool:
         built['_source_tool'] = str(source_tool)
@@ -259,6 +339,16 @@ def _save_artifact(key: str, value: Any, content_type: str = 'text',
             out_of_range_warning = resolve_err
     if caption is not None:
         built['caption'] = str(caption)
+    for existing in reversed(ctx.local_artifacts([key])):
+        if (
+            existing.get('content_type') == actual_ct
+            and existing.get('value') == built
+        ):
+            return tool_success('save_artifacts', {
+                'status': 'ok',
+                'message': f"Artifact '{key}' was already saved with the same value.",
+                'deduplicated': True,
+            })
     seq = ctx.next_artifact_seq(key)
     ctx.record_local_artifact(key, actual_ct, built, seq)
     ctx.emit({
@@ -290,7 +380,9 @@ def save_artifacts(artifacts: List[Dict[str, Any]]) -> Dict[str, Any]:
     if len(artifacts) > 50:
         return tool_error('save_artifacts', 'At most 50 artifacts may be saved at once.')
 
-    results: List[Dict[str, Any]] = []
+    # Preflight the complete batch before emitting anything. Otherwise, one bad
+    # item late in the list leaves earlier items partially saved and a model retry
+    # creates duplicate revisions for those slots.
     for index, item in enumerate(artifacts):
         if not isinstance(item, dict):
             return tool_error('save_artifacts', f'artifacts[{index}] must be an object.')
@@ -298,14 +390,43 @@ def save_artifacts(artifacts: List[Dict[str, Any]]) -> Dict[str, Any]:
             return tool_error(
                 'save_artifacts', f'artifacts[{index}] requires key and value.',
             )
-        results.append(_save_artifact(
+        ctx = require_context()
+        key = str(item['key'])
+        if ctx.output_slots and key not in ctx.output_slots:
+            return tool_error(
+                'save_artifacts',
+                f'Artifact key {key!r} is not declared for this step. '
+                f'Allowed keys: {", ".join(ctx.output_slots)}',
+            )
+        content_type = str(item.get('content_type') or 'text')
+        if content_type not in _CONTENT_TYPES:
+            content_type = 'text'
+        contract_error = _validate_declared_artifact(
+            ctx, key, item['value'], content_type,
+        )
+        if contract_error:
+            return tool_error('save_artifacts', contract_error)
+        try:
+            _build_artifact_value(item['value'], content_type)
+        except Exception as exc:
+            return tool_error(
+                'save_artifacts',
+                f'artifacts[{index}] could not be prepared: {exc}',
+            )
+
+    results: List[Dict[str, Any]] = []
+    for item in artifacts:
+        saved = _save_artifact(
             key=str(item['key']),
             value=item['value'],
             content_type=str(item.get('content_type') or 'text'),
             source_tool=item.get('source_tool'),
             sort_order=item.get('sort_order'),
             caption=item.get('caption'),
-        ))
+        )
+        if not saved.get('success'):
+            return saved
+        results.append(saved)
     return tool_success('save_artifacts', {
         'status': 'ok',
         'saved_count': len(results),

--- a/algorithm/lazymind/chat/engine/tools/writer.py
+++ b/algorithm/lazymind/chat/engine/tools/writer.py
@@ -32,7 +32,7 @@ from lazyllm.tools.writer.utils import render_document_markdown, save_artifact_j
 WRITER_DATA_MODEL_SCHEMA_PREFIX = 'lazyllm.tools.writer.data_models'
 _FEISHU_URL_RE = re.compile(
     r"https?://[^\s<>\"']*(?:feishu\.(?:cn|com)|larksuite\.com)/"
-    r"[^\s<>\"'，。；！？、）】》」』]+",
+    r"[^\s<>\"'，。；！？、（）【】《》「」『』]+",
     re.IGNORECASE,
 )
 

--- a/algorithm/lazymind/chat/engine/tools/writer.py
+++ b/algorithm/lazymind/chat/engine/tools/writer.py
@@ -409,23 +409,24 @@ class WriterToolkitBase:
         document = WriterDocument.model_validate(
             _json_loads(source_document_json, {}),
         )
-        for block in document.blocks:
-            if block.type != 'paragraph':
-                continue
-            lines = [line.strip() for line in block.content.splitlines() if line.strip()]
-            if not lines:
-                continue
-            block.type = 'heading'
-            block.content = lines[0]
-            block.spans = []
-            block.numbering['level'] = 1
-            if len(lines) > 1:
-                block.children.insert(0, WriterBlock(
-                    node_id=f'{block.node_id}-description',
-                    type='paragraph',
-                    content='\n'.join(lines[1:]),
-                    stage='outline',
-                ))
+        if not any(block.type == 'heading' for block in document.blocks):
+            for block in document.blocks:
+                if block.type != 'paragraph':
+                    continue
+                lines = [line.strip() for line in block.content.splitlines() if line.strip()]
+                if not lines:
+                    continue
+                block.type = 'heading'
+                block.content = lines[0]
+                block.spans = []
+                block.numbering['level'] = 1
+                if len(lines) > 1:
+                    block.children.insert(0, WriterBlock(
+                        node_id=f'{block.node_id}-description',
+                        type='paragraph',
+                        content='\n'.join(lines[1:]),
+                        stage='outline',
+                    ))
         return _set_document_editable(
             document, stage='outline',
         ).model_dump_json(exclude_defaults=True)

--- a/algorithm/lazymind/chat/engine/tools/writer.py
+++ b/algorithm/lazymind/chat/engine/tools/writer.py
@@ -481,6 +481,34 @@ class WriterToolkitBase:
         )
         return _json_dumps(_primary_data(result))
 
+    def generate_draft_section_markdown(
+        self,
+        writing_task_json: str,
+        section_instruction_json: str,
+        writing_context_json: str,
+        previous_markdown: str = '',
+    ) -> str:
+        """Generate one draft section as Markdown while preserving the IR API."""
+        root = _temp_root()
+        task_path = _write_input_artifact(
+            root, 'writing_task.json', _json_loads(writing_task_json, {}), writer_schema('task.WritingTask'),
+        )
+        context_path = _write_input_artifact(
+            root, 'writing_context.json', _json_loads(writing_context_json, {}),
+            writer_schema('context.WritingContext'),
+        )
+        instruction = SectionInstruction.model_validate(_json_loads(section_instruction_json, {}))
+        result = WriterDraftingTools(
+            llm=AutoModel(model='llm'), artifact_store=str(root),
+        ).generate_draft_section_markdown(
+            task=task_path,
+            section_instruction=instruction,
+            context=context_path,
+            previous_markdown=previous_markdown,
+        )
+        with open(result['artifact_path'], 'r', encoding='utf-8') as fh:
+            return fh.read()
+
     def generate_draft_blocks(
         self,
         writing_task_json: str,
@@ -506,6 +534,31 @@ class WriterToolkitBase:
             ), {})
             blocks.append(block)
         return _json_dumps(blocks)
+
+    def generate_draft_blocks_markdown(
+        self,
+        writing_task_json: str,
+        section_instructions_json: str,
+        writing_context_json: str,
+    ) -> str:
+        """Generate every planned draft section in Markdown, in order."""
+        instructions_data = _json_loads(section_instructions_json, {})
+        instructions = (
+            instructions_data.get('instructions')
+            if isinstance(instructions_data, dict) else None
+        )
+        if not isinstance(instructions, list):
+            raise TypeError('section_instructions_json must contain instructions.')
+
+        sections: list[str] = []
+        for instruction in instructions:
+            sections.append(self.generate_draft_section_markdown(
+                writing_task_json=writing_task_json,
+                section_instruction_json=_json_dumps(instruction),
+                writing_context_json=writing_context_json,
+                previous_markdown='\n\n'.join(sections),
+            ))
+        return _json_dumps(sections)
 
     def generate_draft_document(
         self,
@@ -541,6 +594,40 @@ class WriterToolkitBase:
             outline=outline_path,
         )
         return _json_dumps(_primary_data(result))
+
+    def generate_draft_document_markdown(
+        self,
+        draft_sections_json: str,
+        writing_context_json: str,
+        outline_json: str = '',
+    ) -> str:
+        """Combine Markdown sections and convert the completed draft once to IR."""
+        root = _temp_root()
+        sections = _json_loads(draft_sections_json, [])
+        if not isinstance(sections, list) or not sections:
+            raise ValueError('draft_sections_json must be a non-empty JSON array.')
+        context_path = _write_input_artifact(
+            root, 'writing_context.json', _json_loads(writing_context_json, {}),
+            writer_schema('context.WritingContext'),
+        )
+        outline_path = None
+        if outline_json:
+            outline_path = _write_input_artifact(
+                root, 'outline.lmd', _json_loads(outline_json, {}), self.WRITER_IR_SCHEMA,
+            )
+        result = WriterDraftingTools(
+            llm=None, artifact_store=str(root),
+        ).generate_draft_document_markdown(
+            draft_sections=sections,
+            context=context_path,
+            outline=outline_path,
+        )
+        with open(result['draft_document_md'], 'r', encoding='utf-8') as fh:
+            markdown = fh.read()
+        return _json_dumps({
+            'draft_document': _primary_data(result),
+            'draft_document_md': markdown,
+        })
 
     def update_writing_context(self, content_artifact_json: str, writing_context_json: str) -> str:
         """Update context from a WriterDocument or WriterBlock."""
@@ -943,7 +1030,9 @@ class WriterCreateToolkit(WriterToolkitBase):
         'build_writing_task', 'build_resources', 'profile_resources',
         'create_writing_context', 'prepare_outline', 'generate_outline',
         'generate_section_instructions', 'generate_draft_section',
-        'generate_draft_blocks', 'generate_draft_document',
+        'generate_draft_section_markdown',
+        'generate_draft_blocks', 'generate_draft_blocks_markdown',
+        'generate_draft_document', 'generate_draft_document_markdown',
         'update_writing_context', 'check_consistency',
         'generate_final_document', 'render_markdown',
     ]

--- a/algorithm/lazymind/chat/plugin/driver_agent.py
+++ b/algorithm/lazymind/chat/plugin/driver_agent.py
@@ -240,10 +240,16 @@ def evaluate_step(
         _init_driver_sid(session_id, plugin_id, step_id)
         driver_db = _init_driver_artifact_context(session_id, plugin_id, step_id)
         lazyllm.set_trace_context({
-            'session_id': session_id or '',
-            'sampled': True,
-            'module_trace': {'default': True},
-            'request_tags': ['plugin_driver'],
+            'session_id': session_id or '', 'sampled': True, 'request_tags': ['plugin_driver'],
+            'module_trace': {
+                'by_class': {
+                    'FunctionCall': False, 'ToolManager': False,
+                    'Pipeline': False, 'Diverter': False,
+                },
+                'by_name': {
+                    '_build_history': False, '_post_action': False, '_safe_call': False,
+                },
+            }
         })
         llm = _build_llm(llm_config)
         tools: List[Any] = []

--- a/algorithm/lazymind/chat/plugin/plugin_manager.py
+++ b/algorithm/lazymind/chat/plugin/plugin_manager.py
@@ -167,6 +167,10 @@ def _submit_transition_to_core(
         'preflight_id': preflight_id,
         'external_materials': cfg.get('plugin_external_materials') or {},
     }
+    trace_context = lazyllm.get_trace_context()
+    if trace_context.trace_id and trace_context.parent_span_id:
+        payload['trace_id'] = trace_context.trace_id
+        payload['parent_span_id'] = trace_context.parent_span_id
     if targets:
         payload['targets'] = targets
     endpoint = (

--- a/algorithm/lazymind/chat/plugin/plugin_manager.py
+++ b/algorithm/lazymind/chat/plugin/plugin_manager.py
@@ -330,7 +330,10 @@ _COLD_START_PLUGIN_PROMPT = (
     "internally decided is part of a larger multi-step plan. If the user's "
     'request involves multiple steps and only one of those steps would use a '
     'workflow, do NOT trigger the workflow. Never infer workflow intent from '
-    'indirect or implicit cues.\n'
+    'indirect or implicit cues. A user request that directly matches a workflow\'s '
+    '`when_to_use` description is itself a PRIMARY and DIRECT intent; the user does '
+    'not need to know or name the workflow. In that case, use the workflow instead '
+    'of producing the workflow\'s final deliverable directly in chat.\n'
     'When a workflow matches, call its `trigger_<workflow>` preflight tool. Trigger does NOT '
     'start a task. It loads the full workflow and returns ready, need_information, '
     'not_applicable, or preflight_failed.\n'
@@ -1522,8 +1525,19 @@ def build_advance_step_and_hand_off_tool(
         include_default_approval=include_approval_guidance,
     )
 
-    def advance_step_and_hand_off(steps: List[Dict[str, Any]]) -> str:
+    def advance_step_and_hand_off(
+        steps: Optional[List[Dict[str, Any]]] = None,
+        step_id: str = '',
+        user_input: str = '',
+        runtime_instruction: str = '',
+    ) -> str:
         """Start one or more Ready steps and end the current ReAct turn."""
+        if not steps and step_id:
+            steps = [{
+                'step_id': step_id,
+                'user_input': user_input,
+                'runtime_instruction': runtime_instruction,
+            }]
         if not isinstance(steps, list) or not steps:
             raise ValueError('steps must contain at least one step command.')
         if len(steps) > 1:
@@ -1586,10 +1600,32 @@ def build_advance_step_tool(
         current_step=current_step if current_step in snapshot.retry_steps else '',
     )
 
-    def advance_step(steps: List[Dict[str, Any]]) -> str:
+    def advance_step(
+        steps: Optional[List[Dict[str, Any]]] = None,
+        step_id: str = '',
+        user_input: str = '',
+        runtime_instruction: str = '',
+    ) -> str:
         """Start one or more Ready steps and wait for their results."""
+        if not steps and step_id:
+            steps = [{
+                'step_id': step_id,
+                'user_input': user_input,
+                'runtime_instruction': runtime_instruction,
+            }]
         if not isinstance(steps, list) or not steps:
             raise ValueError('steps must contain at least one step command.')
+        if any(
+            isinstance(command, dict)
+            and plugin_loader.get_step_mode(
+                plugin_id, str(command.get('step_id') or '')
+            ) == 'human'
+            for command in steps
+        ):
+            raise ValueError(
+                'Steps with default approval required must use '
+                'advance_step_and_hand_off.'
+            )
         if len(steps) > 1:
             submission = _trigger_plugin_steps(plugin_id, steps, hand_off=False)
             if not submission.accepted:
@@ -2347,7 +2383,7 @@ def _build_mode_guidance(
         '    than what the current artifacts reflect.\n'
         'If intent has changed, identify the EARLIEST step whose output is now\n'
         'invalidated and select that step again using `advance_step_and_hand_off` with\n'
-        '`step_id=<affected_step>`. The backend clears affected artifacts and determines\n'
+        '`steps=[{"step_id": "<affected_step>"}]`. The backend clears affected artifacts and determines\n'
         'the lifecycle operation automatically. Do NOT continue to the next forward step.\n\n'
         '### Rule 2 — DAG frontier and atomic batching\n'
         'The authoritative Ready list is the only forward execution frontier. Never infer\n'

--- a/algorithm/lazymind/chat/plugin/plugin_manager.py
+++ b/algorithm/lazymind/chat/plugin/plugin_manager.py
@@ -1525,19 +1525,8 @@ def build_advance_step_and_hand_off_tool(
         include_default_approval=include_approval_guidance,
     )
 
-    def advance_step_and_hand_off(
-        steps: Optional[List[Dict[str, Any]]] = None,
-        step_id: str = '',
-        user_input: str = '',
-        runtime_instruction: str = '',
-    ) -> str:
+    def advance_step_and_hand_off(steps: List[Dict[str, Any]]) -> str:
         """Start one or more Ready steps and end the current ReAct turn."""
-        if not steps and step_id:
-            steps = [{
-                'step_id': step_id,
-                'user_input': user_input,
-                'runtime_instruction': runtime_instruction,
-            }]
         if not isinstance(steps, list) or not steps:
             raise ValueError('steps must contain at least one step command.')
         if len(steps) > 1:
@@ -1600,19 +1589,8 @@ def build_advance_step_tool(
         current_step=current_step if current_step in snapshot.retry_steps else '',
     )
 
-    def advance_step(
-        steps: Optional[List[Dict[str, Any]]] = None,
-        step_id: str = '',
-        user_input: str = '',
-        runtime_instruction: str = '',
-    ) -> str:
+    def advance_step(steps: List[Dict[str, Any]]) -> str:
         """Start one or more Ready steps and wait for their results."""
-        if not steps and step_id:
-            steps = [{
-                'step_id': step_id,
-                'user_input': user_input,
-                'runtime_instruction': runtime_instruction,
-            }]
         if not isinstance(steps, list) or not steps:
             raise ValueError('steps must contain at least one step command.')
         if any(

--- a/algorithm/lazymind/chat/service/chat_service.py
+++ b/algorithm/lazymind/chat/service/chat_service.py
@@ -681,17 +681,25 @@ async def _handle_chat_impl(
         ]))
         skill_config = selected_skills or False
     set_trace_context({
-        'trace_id': conversation.session_id,
-        'session_id': conversation.session_id,
-        'sampled': True,
-        'module_trace': {'default': True},
+        'trace_id': conversation.session_id, 'session_id': conversation.session_id, 'sampled': True,
+        'module_trace': {
+            'by_class': {
+                'FunctionCall': False, 'ToolManager': False,
+                'Pipeline': False, 'Diverter': False,
+            },
+            'by_name': {
+                '_build_history': False, '_post_action': False, '_safe_call': False,
+            },
+        },
         'request_tags': ['handle_chat'],
-        'task_profile_source': task_profile.source if task_profile else 'disabled',
-        'task_profile': task_profile.to_trace_dict() if task_profile else {},
-        'router_latency_ms': task_profile.router_latency_ms if task_profile else 0,
-        'router_error': task_profile.router_error if task_profile else '',
-        'prompt_modules': selected_prompt_modules(task_profile) if task_profile else [],
-        'skills_exposed': list(selected_skills or []),
+        'trace_metadata': {
+            'task_profile_source': task_profile.source if task_profile else 'disabled',
+            'task_profile': task_profile.to_trace_dict() if task_profile else {},
+            'router_latency_ms': task_profile.router_latency_ms if task_profile else 0,
+            'router_error': task_profile.router_error if task_profile else '',
+            'prompt_modules': selected_prompt_modules(task_profile) if task_profile else [],
+            'skills_exposed': list(selected_skills or []),
+        },
     })
     prompt_builder = PromptBuilder.for_role(AgentRole.CHAT)
     active_tool_configs = active_configs + attachment_configs + ask_user_configs

--- a/algorithm/lazymind/chat/service/component/history.py
+++ b/algorithm/lazymind/chat/service/component/history.py
@@ -155,6 +155,60 @@ def _append_pending_assistant(
     pending_tool_calls.clear()
 
 
+def _drop_incomplete_tool_exchanges(
+    messages: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    """Keep only provider-valid assistant tool-call/result groups."""
+    cleaned: list[dict[str, Any]] = []
+    index = 0
+    while index < len(messages):
+        message = messages[index]
+        if message.get('role') == 'tool':
+            index += 1
+            continue
+
+        tool_calls = message.get('tool_calls') if message.get('role') == 'assistant' else None
+        if not isinstance(tool_calls, list) or not tool_calls:
+            cleaned.append(message)
+            index += 1
+            continue
+
+        call_ids = [
+            str(tool_call.get('id') or '')
+            for tool_call in tool_calls
+            if isinstance(tool_call, dict)
+        ]
+        expected_ids = set(call_ids)
+        cursor = index + 1
+        results_by_id: dict[str, dict[str, Any]] = {}
+        while cursor < len(messages) and messages[cursor].get('role') == 'tool':
+            result = messages[cursor]
+            result_id = str(result.get('tool_call_id') or '')
+            if result_id in expected_ids and result_id not in results_by_id:
+                results_by_id[result_id] = result
+            cursor += 1
+
+        complete = (
+            bool(expected_ids)
+            and len(call_ids) == len(expected_ids)
+            and set(results_by_id) == expected_ids
+        )
+        if complete:
+            cleaned.append(message)
+            cleaned.extend(results_by_id[call_id] for call_id in call_ids)
+        else:
+            assistant_without_calls = {
+                key: value for key, value in message.items() if key != 'tool_calls'
+            }
+            if (
+                str(assistant_without_calls.get('content') or '').strip()
+                or str(assistant_without_calls.get('reasoning_content') or '').strip()
+            ):
+                cleaned.append(assistant_without_calls)
+        index = cursor
+    return cleaned
+
+
 def normalize_history_for_agent(
     history: list[dict[str, Any]],
 ) -> list[dict[str, Any]]:
@@ -237,4 +291,4 @@ def normalize_history_for_agent(
         content = _history_message_content(message)
         if content:
             normalized.append({'role': role or 'assistant', 'content': content})
-    return normalized
+    return _drop_incomplete_tool_exchanges(normalized)

--- a/backend/core/plugin/eventloop.go
+++ b/backend/core/plugin/eventloop.go
@@ -47,6 +47,9 @@ type PluginStepParams struct {
 
 	// ChatSessionID identifies the ChatAgent turn for task lifecycle context.
 	ChatSessionID string `json:"chat_session_id,omitempty"`
+	// TraceID and ParentSpanID continue the ChatAgent trace in dispatched SubAgent.
+	TraceID      string `json:"trace_id,omitempty"`
+	ParentSpanID string `json:"parent_span_id,omitempty"`
 
 	// PluginMode is "auto" | "dynamic" — resolved from the conversation request and
 	// persisted into params so that OnSubAgentDone can branch correctly even when
@@ -101,6 +104,10 @@ func (p PluginStepParams) asMap() map[string]any {
 	}
 	if p.ChatSessionID != "" {
 		m["chat_session_id"] = p.ChatSessionID
+	}
+	if p.TraceID != "" && p.ParentSpanID != "" {
+		m["trace_id"] = p.TraceID
+		m["parent_span_id"] = p.ParentSpanID
 	}
 	if p.RetryHint != "" {
 		m["retry_hint"] = p.RetryHint
@@ -516,6 +523,10 @@ func launchPluginAttempt(
 	if params.ChatSessionID != "" {
 		rawParamsMap["chat_session_id"] = params.ChatSessionID
 	}
+	if params.TraceID != "" && params.ParentSpanID != "" {
+		rawParamsMap["trace_id"] = params.TraceID
+		rawParamsMap["parent_span_id"] = params.ParentSpanID
+	}
 	if params.RetryHint != "" {
 		rawParamsMap["retry_hint"] = params.RetryHint
 	}
@@ -585,6 +596,10 @@ func launchPluginAttempt(
 		"plugin_id":  pluginID,
 		"step_id":    stepID,
 		"session_id": sessionID,
+	}
+	if params.TraceID != "" && params.ParentSpanID != "" {
+		runParams["trace_id"] = params.TraceID
+		runParams["parent_span_id"] = params.ParentSpanID
 	}
 	if len(params.HistoryFilesPerTurn) > 0 {
 		runParams["history_files_per_turn"] = params.HistoryFilesPerTurn

--- a/backend/core/plugin/transition_handlers.go
+++ b/backend/core/plugin/transition_handlers.go
@@ -33,6 +33,8 @@ type transitionCommandRequest struct {
 	HandOff              bool                `json:"hand_off"`
 	PluginMode           string              `json:"plugin_mode"`
 	ChatSessionID        string              `json:"chat_session_id"`
+	TraceID              string              `json:"trace_id"`
+	ParentSpanID         string              `json:"parent_span_id"`
 	HistoryFilesPerTurn  map[string][]string `json:"history_files_per_turn"`
 	Filters              map[string]any      `json:"filters"`
 	LLMConfig            map[string]any      `json:"llm_config"`
@@ -296,7 +298,7 @@ func StartPluginSession(w http.ResponseWriter, r *http.Request) {
 		req.TaskID = uuid.NewString()
 	}
 	handOff := req.HandOff
-	params := PluginStepParams{PluginID: req.PluginID, PluginRef: req.PluginRef, RevisionID: req.PluginRevisionID, RevisionNo: req.PluginRevisionNo, TreeHash: req.PluginTreeHash, RemoteRoot: req.PluginRemoteRoot, StepID: req.TargetStepID, UserInput: req.UserInput, IsColdStart: true, HandOff: &handOff, PreflightID: req.PreflightID, ChatSessionID: req.ChatSessionID, PluginMode: req.PluginMode, UserID: req.UserID, HistoryFilesPerTurn: req.HistoryFilesPerTurn, Filters: req.Filters, ParentAgenticConfig: req.ParentAgenticConfig, RequiredOutputs: graph.Nodes[req.TargetStepID].RequiredOutputs}
+	params := PluginStepParams{PluginID: req.PluginID, PluginRef: req.PluginRef, RevisionID: req.PluginRevisionID, RevisionNo: req.PluginRevisionNo, TreeHash: req.PluginTreeHash, RemoteRoot: req.PluginRemoteRoot, StepID: req.TargetStepID, UserInput: req.UserInput, IsColdStart: true, HandOff: &handOff, PreflightID: req.PreflightID, ChatSessionID: req.ChatSessionID, TraceID: req.TraceID, ParentSpanID: req.ParentSpanID, PluginMode: req.PluginMode, UserID: req.UserID, HistoryFilesPerTurn: req.HistoryFilesPerTurn, Filters: req.Filters, ParentAgenticConfig: req.ParentAgenticConfig, RequiredOutputs: graph.Nodes[req.TargetStepID].RequiredOutputs}
 	nodeDef := graph.Nodes[req.TargetStepID]
 	inputKeys := graphengine.Materials(nodeDef.Input)
 	for _, optional := range nodeDef.OptionalInputs {
@@ -610,7 +612,7 @@ func TransitionPluginSession(w http.ResponseWriter, r *http.Request) {
 			for _, optional := range nodeDef.OptionalInputs {
 				inputKeys = append(inputKeys, optional.Material)
 			}
-			params := PluginStepParams{PluginID: session.PluginID, PluginRef: session.PluginRef, RevisionID: session.PluginRevisionID, RevisionNo: session.PluginRevisionNo, TreeHash: session.PluginTreeHash, RemoteRoot: session.PluginRemoteRoot, StepID: target.TargetStepID, SessionID: session.ID, UserInput: target.UserInput, HandOff: &handOff, ChatSessionID: req.ChatSessionID, PluginMode: req.PluginMode, RetryHint: target.RuntimeInstruction, PartialIndices: target.PartialIndices, HistoryFilesPerTurn: req.HistoryFilesPerTurn, Filters: req.Filters, ParentAgenticConfig: req.ParentAgenticConfig, UserID: session.CreateUserID, RequiredOutputs: nodeDef.RequiredOutputs}
+			params := PluginStepParams{PluginID: session.PluginID, PluginRef: session.PluginRef, RevisionID: session.PluginRevisionID, RevisionNo: session.PluginRevisionNo, TreeHash: session.PluginTreeHash, RemoteRoot: session.PluginRemoteRoot, StepID: target.TargetStepID, SessionID: session.ID, UserInput: target.UserInput, HandOff: &handOff, ChatSessionID: req.ChatSessionID, TraceID: req.TraceID, ParentSpanID: req.ParentSpanID, PluginMode: req.PluginMode, RetryHint: target.RuntimeInstruction, PartialIndices: target.PartialIndices, HistoryFilesPerTurn: req.HistoryFilesPerTurn, Filters: req.Filters, ParentAgenticConfig: req.ParentAgenticConfig, UserID: session.CreateUserID, RequiredOutputs: nodeDef.RequiredOutputs}
 			_, taskID, _, launchErr := launchPluginAttempt(r.Context(), tx, store.State(), session.ConversationID, session.TriggerHistoryID, session.CreateUserID, target.TaskID, session.PluginID+":"+target.TargetStepID, target.Objective, params, inputKeys, nodeDef.Outputs, req.LLMConfig, req.ToolConfig, false, false)
 			if launchErr != nil {
 				return launchErr

--- a/frontend/src/modules/chat/components/PluginPanel/SlotComponents.tsx
+++ b/frontend/src/modules/chat/components/PluginPanel/SlotComponents.tsx
@@ -203,6 +203,13 @@ function isSpaFallbackHtml(content: string): boolean {
     && (normalized.includes('/@vite/client') || normalized.includes('id="root"'));
 }
 
+export function isWriterIrSource(source: unknown): boolean {
+  const normalized = String(source ?? '')
+    .split(/[?#]/, 1)[0]
+    .toLowerCase();
+  return normalized.endsWith('.lmd') || normalized.endsWith('_ir.json');
+}
+
 /** Shown when the slot has no artifact yet (backend returned no artifact_value). */
 function SlotPending({ type, cardMode }: { type: 'image' | 'file' | 'text'; cardMode?: boolean }) {
   if (type === 'image') {
@@ -342,7 +349,11 @@ async function resolveSnapshotDiffText(snapshot: unknown): Promise<string> {
     const response = await fetch(fetchUrl);
     if (!response.ok) throw new Error(localizeErrorCode('2000509'));
     const contentType = response.headers.get('content-type') || '';
-    if (contentType.includes('json') || trimmed.toLowerCase().includes('.json')) {
+    if (
+      contentType.includes('json')
+      || isWriterIrSource(trimmed)
+      || trimmed.toLowerCase().includes('.json')
+    ) {
       return formatPayloadForDiff(await response.json());
     }
     const text = await response.text();
@@ -375,6 +386,8 @@ async function resolveSnapshotDiffText(snapshot: unknown): Promise<string> {
   if (!response.ok) throw new Error(localizeErrorCode('2000509'));
   const contentType = response.headers.get('content-type') || '';
   const looksJson = contentType.includes('json')
+    || isWriterIrSource(pathForSign)
+    || isWriterIrSource(record.filename)
     || pathForSign.toLowerCase().includes('.json')
     || String(record.type ?? '').toLowerCase() === 'json'
     || String(record.filename ?? '').toLowerCase().endsWith('.json');
@@ -1742,7 +1755,7 @@ function getFileIcon(filename: string): string {
   if (ext === 'xls' || ext === 'xlsx') return '📊';
   if (ext === 'ppt' || ext === 'pptx') return '📑';
   if (ext === 'txt' || ext === 'md') return '📄';
-  if (ext === 'json' || ext === 'csv') return '📋';
+  if (ext === 'json' || ext === 'lmd' || ext === 'csv') return '📋';
   if (ext === 'zip' || ext === 'tar' || ext === 'gz' || ext === 'rar') return '🗜️';
   if (ext === 'jpg' || ext === 'jpeg' || ext === 'png' || ext === 'gif' || ext === 'webp') return '🖼️';
   return '📎';
@@ -1773,8 +1786,12 @@ function isJsonArtifactFile(slot: SlotRevision): boolean {
 
 function isWriterIrArtifactFile(slot: SlotRevision): boolean {
   const raw = slot.artifact_value;
-  const name = String(raw?.filename ?? raw?.name ?? '').toLowerCase();
-  return name.endsWith('_ir.json');
+  return [
+    raw?.filename,
+    raw?.name,
+    raw?.path,
+    raw?.url,
+  ].some(isWriterIrSource);
 }
 
 function isMarkdownArtifactFile(slot: SlotRevision): boolean {
@@ -1856,9 +1873,13 @@ function hasProviderTarget(document?: WriterDocument | null): boolean {
   );
 }
 
-function ensureJsonFilename(name: string): string {
-  const trimmed = name.trim() || 'writer-document.json';
-  return trimmed.toLowerCase().endsWith('.json') ? trimmed : `${trimmed}.json`;
+function ensureWriterIrFilename(name: string): string {
+  const trimmed = name.trim() || 'writer-document.lmd';
+  if (trimmed.toLowerCase().endsWith('.lmd')) return trimmed;
+  if (trimmed.toLowerCase().endsWith('_ir.json')) {
+    return `${trimmed.slice(0, -5)}.lmd`;
+  }
+  return `${trimmed.replace(/\.json$/i, '')}.lmd`;
 }
 
 async function syncWriterDocumentSlot(
@@ -1942,8 +1963,9 @@ function writerDocumentToMarkdown(document: WriterDocument): string {
 
 function writerMarkdownFilename(name: string): string {
   const trimmed = name.trim() || 'document';
+  if (trimmed.toLowerCase().endsWith('_ir.lmd')) return `${trimmed.slice(0, -7)}.md`;
   if (trimmed.toLowerCase().endsWith('_ir.json')) return `${trimmed.slice(0, -8)}.md`;
-  return `${trimmed.replace(/\.json$/i, '')}.md`;
+  return `${trimmed.replace(/\.(?:lmd|json)$/i, '')}.md`;
 }
 
 function shouldRenderInlineStructuredContent(
@@ -2149,7 +2171,7 @@ function SlotJsonFile({
     }
 
     const serialized = replaceStructuredArtifactPayload(sourceJson, document);
-    const filename = ensureJsonFilename(name);
+    const filename = ensureWriterIrFilename(name);
     const file = new File(
       [JSON.stringify(serialized, null, 2)],
       filename,
@@ -2158,7 +2180,6 @@ function SlotJsonFile({
     const storedPath = await uploadFileInChunks(file);
     const nextValue: Record<string, unknown> = {
       ...(raw && typeof raw === 'object' ? raw : {}),
-      type: 'json',
       path: storedPath,
       filename,
       size: file.size,
@@ -2512,6 +2533,7 @@ function SlotInlineStructured({
 
 interface SlotMarkdownFileProps {
   slot: SlotRevision;
+  originalFileSlot?: SlotRevision;
   sessionId?: string;
   slotId?: string;
   revisionCount?: number;
@@ -2520,6 +2542,7 @@ interface SlotMarkdownFileProps {
 
 function SlotMarkdownFile({
   slot,
+  originalFileSlot,
   sessionId,
   slotId,
   revisionCount,
@@ -2529,6 +2552,9 @@ function SlotMarkdownFile({
   const raw = slot.artifact_value;
   const name: string = raw?.filename ?? raw?.name ?? slotId ?? slot.slot;
   const { url, resolving, hasSource } = useArtifactFileUrl(raw);
+  const originalRaw = originalFileSlot?.artifact_value;
+  const originalName: string = originalRaw?.filename ?? originalRaw?.name ?? 'final_document.lmd';
+  const { url: originalUrl } = useArtifactFileUrl(originalRaw);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [content, setContent] = useState('');
@@ -2622,10 +2648,10 @@ function SlotMarkdownFile({
         >
           {tr('chat.writer.downloadMarkdown')}
         </button>
-        {url ? (
+        {originalUrl ? (
           <a
-            href={url}
-            download={name}
+            href={originalUrl}
+            download={originalName}
             className='plugin-slot__file-action-btn'
             onClick={(e) => e.stopPropagation()}
           >
@@ -2834,6 +2860,7 @@ export function SlotFile({ slot, sessionId, slotId, revisionCount, onRefresh, re
  */
 export function SlotRenderer({
   slot,
+  originalFileSlot,
   cardMode = false,
   expectedType,
   sessionId,
@@ -2846,6 +2873,7 @@ export function SlotRenderer({
   hideImageMutationActions,
 }: {
   slot: SlotRevision;
+  originalFileSlot?: SlotRevision;
   cardMode?: boolean;
   expectedType?: 'image' | 'file' | 'text';
   sessionId?: string;
@@ -2883,6 +2911,7 @@ export function SlotRenderer({
     return (
       <SlotMarkdownFile
         slot={slot}
+        originalFileSlot={originalFileSlot}
         sessionId={sessionId}
         slotId={slotId}
         revisionCount={revisionCount}

--- a/frontend/src/modules/chat/components/PluginPanel/index.tsx
+++ b/frontend/src/modules/chat/components/PluginPanel/index.tsx
@@ -22,7 +22,12 @@ import type {
   CompositeColumnNode,
   InnerTabsNode,
 } from '@/modules/chat/store/pluginPanel';
-import { SlotRenderer, SlotDownloadContext, SlotEditingContext } from './SlotComponents';
+import {
+  isWriterIrSource,
+  SlotRenderer,
+  SlotDownloadContext,
+  SlotEditingContext,
+} from './SlotComponents';
 import './PluginPanel.scss';
 
 /** Parse a JSON intent context string and return the text field, or '' if empty/invalid. */
@@ -404,13 +409,14 @@ function getTabSlotRevisions(
   return slots.filter((s) => s.slot === artifactKey && s.selected);
 }
 
-function isJsonArtifactRevision(slot: SlotRevision): boolean {
+function isStructuredWriterArtifactRevision(slot: SlotRevision): boolean {
   if (slot.content_type === 'json') return true;
   const raw = slot.artifact_value;
   if (!raw || typeof raw !== 'object') return false;
   if (raw.type === 'json') return true;
   const source = String(raw.filename ?? raw.name ?? raw.path ?? raw.url ?? '');
-  return source.split(/[?#]/, 1)[0].toLowerCase().endsWith('.json');
+  const normalized = source.split(/[?#]/, 1)[0].toLowerCase();
+  return isWriterIrSource(normalized) || normalized.endsWith('.json');
 }
 
 /** Prefer the structured WriterDocument over its Markdown export when both exist. */
@@ -422,7 +428,7 @@ function resolveWriterFinalSlotDefs(tab: TabDef, session: PluginSession): SlotDe
     if (!slotDef.id.endsWith('_md')) return [slotDef];
     const irSlotId = slotDef.id.slice(0, -3);
     const hasIRArtifact = getTabSlotRevisions(session, tab, irSlotId)
-      .some(isJsonArtifactRevision);
+      .some(isStructuredWriterArtifactRevision);
     if (!hasIRArtifact) return [slotDef];
     if (declaredSlotIds.has(irSlotId)) return [];
 
@@ -935,6 +941,11 @@ function NamedTabSlot({
           >
             <SlotRenderer
               slot={rev}
+              originalFileSlot={
+                slotDef.id === 'delivered_markdown'
+                  ? session.slots?.find((item) => item.slot === 'final_document' && item.selected)
+                  : undefined
+              }
               expectedType={slotDef.type}
               sessionId={session.session_id}
               slotId={slotDef.id}

--- a/plugins/writer-plugin/plugin.yaml
+++ b/plugins/writer-plugin/plugin.yaml
@@ -6,10 +6,13 @@ description: >
   as Markdown or publish it to Feishu through one WriterDocument-based workflow.
 
 when_to_use: >
-  Use this plugin for compound writing work that benefits from persisted
-  artifacts: creating long-form content, continuing from a supplied outline,
-  revising an existing Feishu document, combining knowledge-base evidence with
-  writing, or publishing a generated document to Feishu. Do not require the
+  Always use this plugin when the user's primary request is to create a complete
+  article, report, or other long-form document, including writing from supplied
+  materials or knowledge-base evidence. Such a direct writing request matches
+  this workflow even when the user does not know or name AI Writer; do not
+  generate the requested full document directly in chat. Also use it for
+  continuing from a supplied outline, revising an existing Feishu document, or
+  publishing a generated document to Feishu. Do not require the
   user to choose between creation and revision workflows; select the applicable
   reachable step from the user's request and the available artifacts. When
   triggering after clarification or a cloud-file read, request_context must
@@ -28,7 +31,9 @@ tool_scripts:
       - writer_generate_outline
       - writer_generate_section_instructions
       - writer_generate_draft_blocks
+      - writer_generate_draft_blocks_markdown
       - writer_generate_draft_document
+      - writer_generate_draft_document_markdown
       - writer_update_writing_context
       - writer_generate_final_document
       - writer_export_markdown
@@ -59,10 +64,6 @@ slots:
     cardinality: single
   - id: writing_context
     label: Writing Context
-    type: file
-    cardinality: single
-  - id: context_ir
-    label: Context Result
     type: file
     cardinality: single
   - id: source_ir
@@ -123,6 +124,10 @@ slots:
     ordered: true
   - id: draft_document
     label: Full Draft
+    type: file
+    cardinality: single
+  - id: draft_document_md
+    label: Full Draft Markdown
     type: file
     cardinality: single
   - id: writing_context_after_draft
@@ -228,7 +233,6 @@ i18n:
       writing_task: {label: 写作任务}
       resource_profiles: {label: 资源画像}
       writing_context: {label: 写作上下文}
-      context_ir: {label: 上下文构造结果}
       source_ir: {label: 资源文档}
       target_document: {label: 云文档目标}
       outline_ir: {label: 大纲}
@@ -236,6 +240,7 @@ i18n:
       section_plan_ir: {label: 章节规划结果}
       draft_blocks: {label: 章节草稿}
       draft_document: {label: 完整初稿}
+      draft_document_md: {label: 完整初稿 Markdown}
       final_document: {label: 最终正文}
       final_document_md: {label: 最终正文 Markdown}
       delivered_markdown: {label: Markdown 文稿}

--- a/plugins/writer-plugin/scenario/driver.md
+++ b/plugins/writer-plugin/scenario/driver.md
@@ -7,7 +7,7 @@ value is merely a local path string does not satisfy an output and must be RETRY
 
 ## prepare
 
-- PASS when writing_task, resource_profiles, writing_context, and context_ir exist.
+- PASS when writing_task, resource_profiles, and writing_context exist.
 - If the request required a Feishu/Lark source, source_ir and target_document must exist.
 - References to "this/my/original Feishu document" require source_ir and target_document;
   a prose summary of its content is not a source artifact.
@@ -28,8 +28,8 @@ value is merely a local path string does not satisfy an output and must be RETRY
 - PASS when final_document and writing_context_after_draft exist.
 - final_document must have stage="final" and ui_editable=true.
 - An outline-stage artifact saved under final_document is invalid and must be RETRY.
-- For generation/rewrite mode, section_instructions, draft_blocks, draft_document, and
-  final_document_md must exist.
+- For generation/rewrite mode, section_instructions, Markdown draft_blocks,
+  draft_document_md, draft_document, and final_document_md must exist.
 - For targeted revision mode, document_revision_task, document_locate_result,
   document_modify_plan, document_patch_set, and document_patch_result must exist.
 - A cloud-bound body revision must remain local in this step; provider confirmation is

--- a/plugins/writer-plugin/scenario/scenario.md
+++ b/plugins/writer-plugin/scenario/scenario.md
@@ -51,8 +51,9 @@ Generation/rewrite mode:
 
 1. read the latest selected `outline_ir`;
 2. regenerate section instructions;
-3. draft all sections;
-4. assemble and save `final_document`.
+3. draft all sections as Markdown;
+4. assemble the complete Markdown draft and convert it once to WriterDocument IR;
+5. save `final_document`.
 
 Targeted revision mode:
 
@@ -113,7 +114,8 @@ a hidden current-document pointer.
 
 ## Artifact contract
 
-- All structured outline and body results use the same WriterDocument schema.
+- All structured outline and body results use the same WriterDocument schema and
+  `.lmd` file suffix. Markdown draft sections remain internal `.md` artifacts.
 - `outline_ir`, `final_document`, and `published_document` have ui_editable=true.
 - `delivered_markdown` is the Markdown file regenerated from the latest selected
   WriterDocument for local delivery.

--- a/plugins/writer-plugin/scenario/state.yml
+++ b/plugins/writer-plugin/scenario/state.yml
@@ -70,8 +70,8 @@ steps:
          user_input, source_ir_path when present, and knowledge_text when KB evidence was
          retrieved. Save resource_profiles.
       5. Call writer_create_writing_context with writing_task_path,
-         resource_profiles_path, and source_ir_path when present. Save writing_context
-         and context_ir.
+         resource_profiles_path, and source_ir_path when present. Save its returned path
+         as writing_context.
 
       source_ir and target_document are optional because a from-scratch request has no
       cloud source. Do not invent either artifact. If a required tool fails, stop without
@@ -95,13 +95,12 @@ steps:
       - material: writing_task
       - material: resource_profiles
       - material: writing_context
-      - material: context_ir
       - material: source_ir
         required: false
       - material: target_document
         required: false
     acceptance_criteria: |
-      writing_task, resource_profiles, writing_context, and context_ir are present.
+      writing_task, resource_profiles, and writing_context are present.
       When a Feishu/Lark source was required, source_ir and target_document are also present.
 
   outline:
@@ -220,12 +219,14 @@ steps:
 
          1. Call writer_generate_section_instructions using the latest outline_ir and
             writing_context_after_outline. Save section_instructions and section_plan_ir.
-         2. Call writer_generate_draft_blocks once with writing_task,
+         2. Call writer_generate_draft_blocks_markdown once with writing_task,
             section_instructions, and writing_context_after_outline. It returns every
-            generated block path in order. Save all returned paths as the ordered
-            draft_blocks list, preferably in one save_artifacts call.
-         3. Call writer_generate_draft_document using the last block path, current
-            context, and outline. Save draft_document.
+            generated Markdown section path in order. Save each returned path as a separate
+            draft_blocks entry with content_type="file", preserving order in one
+            save_artifacts call. Never stringify the path list or save the whole list as one
+            content_type="file" entry.
+         3. Call writer_generate_draft_document_markdown using the last section path,
+            current context, and outline. Save draft_document and draft_document_md.
          4. Call writer_update_writing_context using draft_document and save
             writing_context_after_draft.
          5. Call writer_generate_final_document using draft_document and
@@ -262,8 +263,8 @@ steps:
       retried within that same mode.
     tools:
       - writer_generate_section_instructions
-      - writer_generate_draft_blocks
-      - writer_generate_draft_document
+      - writer_generate_draft_blocks_markdown
+      - writer_generate_draft_document_markdown
       - writer_update_writing_context
       - writer_generate_final_document
       - writer_build_revision_task
@@ -292,6 +293,8 @@ steps:
       - material: draft_blocks
         required: false
       - material: draft_document
+        required: false
+      - material: draft_document_md
         required: false
       - material: final_document_md
         required: false

--- a/plugins/writer-plugin/scenario/state.yml
+++ b/plugins/writer-plugin/scenario/state.yml
@@ -255,10 +255,11 @@ steps:
          the bound source only by the publish step. Human frontend edits remain revisions
          of this same slot.
 
-      Do not execute both modes in one run. Do not synthesize missing artifacts when a
-      tool fails. If any generation-mode tool fails, stop the step immediately. Never
-      switch to revision mode, never retry section planning with a different artifact,
-      and never pass source_ir or outline_ir to writer_generate_final_document.
+      Complete exactly one mode in each run. Generation mode is complete when its draft
+      lineage produces final_document. Revision mode is complete when its revision task,
+      locate result, modify plan, patch set, and successful patch result produce
+      final_document. A tool failure leaves the selected mode incomplete and should be
+      retried within that same mode.
     tools:
       - writer_generate_section_instructions
       - writer_generate_draft_blocks
@@ -307,8 +308,9 @@ steps:
     acceptance_criteria: |
       final_document and writing_context_after_draft are present, with
       final_document.stage="final" and ui_editable=true. Drafting artifacts are required
-      only for generation/rewrite mode. Revision artifacts are required only for targeted
-      revision mode. This step must not mutate a cloud document.
+      for generation/rewrite mode. A targeted revision requires document_revision_task,
+      document_locate_result, document_modify_plan, document_patch_set, and a successful
+      document_patch_result. This step must not mutate a cloud document.
 
   publish:
     label: 交付文稿
@@ -327,8 +329,8 @@ steps:
          or write-back action. A Feishu/Lark URL used only as a source or reference does
          not authorize publishing to it.
          1. Call writer_export_markdown with the latest selected WriterDocument path.
-         2. Save the exact returned .md path as delivered_markdown with
-            content_type="file".
+         2. writer_export_markdown returns the .md path as a plain string. Save that
+            string directly as delivered_markdown with content_type="file".
          3. Do not call any Feishu publishing tool and do not ask for a destination.
 
       B. Feishu delivery:
@@ -339,17 +341,15 @@ steps:
 
       1. If publish_target_document already exists from an earlier attempt of this step,
          reuse it as target_document_path. Do not create another document.
-      2. If document_patch_set exists and the destination is the original bound source,
-         retrieve source_ir and document_patch_set, then call writer_publish_revision.
-         This is mandatory for a targeted body revision. Do not call
-         writer_append_document afterward: appending content to an existing Feishu
-         document would undo deletions or duplicate retained blocks.
-      3. If final_document was generated or rewritten from source_ir/outline_ir and the
-         user requests writing it back to that same bound source, retrieve both
-         final_document and source_ir, then call writer_replace_document. This replaces
-         the source outline/body; never append the generated document after its source.
-         Never call writer_replace_document unless source_ir is bound to that provider
-         document.
+      2. A targeted revision of the original bound source uses patch delivery. Retrieve
+         source_ir and document_patch_set, then call writer_publish_revision. The revision
+         is publishable when document_revision_task, document_patch_set, and a successful
+         document_patch_result are present.
+      3. A document generated through the draft lineage uses replacement delivery when
+         the user requests writing it back to the same bound source. Retrieve
+         final_document and source_ir, then call writer_replace_document. This route
+         applies to generated or explicitly rewritten content rather than a targeted
+         revision.
       4. Call writer_append_document only when the user explicitly requests append,
          continue-at-end, or preservation of all existing target content.
       5. If the selected WriterDocument is unbound and the user explicitly asks to
@@ -364,8 +364,9 @@ steps:
          clear from the user request and artifact lineage, ask the user. Never default
          to append for an existing document.
 
-      Before passing an existing artifact to a writer tool, call get_artifact and use
-      the absolute path in value.path. Never pass only an artifact filename.
+      Before passing an existing artifact to a writer tool, call get_artifact, extract
+      the absolute path string from value.path, and pass that string to the tool. Never
+      pass the value object or only an artifact filename.
 
       writer_create_document only needs the intended title and optional parent_uri. Save
       its exact returned file path as publish_target_document. Then call
@@ -398,7 +399,11 @@ steps:
         required: false
       - material: source_ir
         required: false
+      - material: document_revision_task
+        required: false
       - material: document_patch_set
+        required: false
+      - material: document_patch_result
         required: false
     outputs:
       - material: delivered_markdown
@@ -417,3 +422,5 @@ steps:
       no Feishu artifacts. Feishu mode requires publish_result to report success,
       published_document to be the provider-confirmed editable WriterDocument, and
       published_link to be the provider URL returned by the same successful tool call.
+      A targeted revision succeeds through writer_publish_revision with its prepared
+      document_patch_set.

--- a/plugins/writer-plugin/scripts/tools.py
+++ b/plugins/writer-plugin/scripts/tools.py
@@ -60,6 +60,13 @@ def _json_loads(value: str, default: Any = None) -> Any:
     return parsed
 
 
+def _editable_writer_json(value: str | dict) -> str:
+    """Mark a public WriterDocument editable at the plugin boundary."""
+    payload = _json_loads(value, {}) if isinstance(value, str) else dict(value or {})
+    payload['ui_editable'] = True
+    return json.dumps(payload, ensure_ascii=False)
+
+
 def _save_json_artifact(
     name: str,
     content_json: str,
@@ -69,9 +76,17 @@ def _save_json_artifact(
 ) -> str:
     root = directory or _workspace_root()
     root.mkdir(parents=True, exist_ok=True)
+    extension = (
+        '.lmd'
+        if schema_name in {
+            WriterToolkitBase.WRITER_IR_SCHEMA,
+            WriterToolkitBase.WRITER_BLOCK_SCHEMA,
+        }
+        else '.json'
+    )
     return save_artifact_json(
         _json_loads(content_json, {}),
-        str(root / f'{name}.json'),
+        str(root / f'{name}{extension}'),
         schema_name=schema_name,
         created_by='writer-plugin-wrapper',
     )
@@ -92,7 +107,7 @@ def _save_publish_payload(payload: dict, root: Path) -> dict:
         ),
         'published_document': _save_json_artifact(
             'published_document',
-            json.dumps(payload.get('published_document') or {}, ensure_ascii=False),
+            _editable_writer_json(payload.get('published_document') or {}),
             WriterToolkitBase.WRITER_IR_SCHEMA,
             directory=root,
         ),
@@ -160,25 +175,16 @@ def writer_create_writing_context(
     writing_task_path: str,
     resource_profiles_path: str,
     source_ir_path: str = '',
-) -> dict:
+) -> str:
     """Create WritingContext, optionally incorporating an existing WriterDocument."""
     content = WriterCreateToolkit().create_writing_context(
         writing_task_json=_read_json_string(writing_task_path),
         resource_profiles_json=_read_json_string(resource_profiles_path),
         writer_document_json=_read_json_string(source_ir_path) if source_ir_path else '',
     )
-    return {
-        'writing_context': _save_json_artifact(
-            'writing_context', content, writer_schema('context.WritingContext'),
-        ),
-        'context_ir': _save_json_artifact(
-            'context_ir',
-            build_writer_status_ir(
-                'context_ready', '已成功构造写作上下文', source='writer-plugin',
-            ),
-            WriterToolkitBase.WRITER_IR_SCHEMA,
-        ),
-    }
+    return _save_json_artifact(
+        'writing_context', content, writer_schema('context.WritingContext'),
+    )
 
 
 def writer_prepare_outline(source_ir_path: str) -> str:
@@ -186,7 +192,9 @@ def writer_prepare_outline(source_ir_path: str) -> str:
     content = WriterCreateToolkit().prepare_outline(
         source_document_json=_read_json_string(source_ir_path),
     )
-    return _save_json_artifact('outline_ir', content, WriterToolkitBase.WRITER_IR_SCHEMA)
+    return _save_json_artifact(
+        'outline_ir', _editable_writer_json(content), WriterToolkitBase.WRITER_IR_SCHEMA,
+    )
 
 
 def writer_generate_outline(writing_task_path: str, writing_context_path: str) -> str:
@@ -196,7 +204,7 @@ def writer_generate_outline(writing_task_path: str, writing_context_path: str) -
         writing_context_json=_read_json_string(writing_context_path),
     )
     return _save_json_artifact(
-        'outline_ir', generated, WriterToolkitBase.WRITER_IR_SCHEMA,
+        'outline_ir', _editable_writer_json(generated), WriterToolkitBase.WRITER_IR_SCHEMA,
     )
 
 
@@ -248,6 +256,26 @@ def writer_generate_draft_blocks(
     ]
 
 
+def writer_generate_draft_blocks_markdown(
+    writing_task_path: str,
+    section_instructions_path: str,
+    writing_context_path: str,
+) -> list[str]:
+    """Generate and persist all planned draft sections as Markdown."""
+    sections = _json_loads(WriterCreateToolkit().generate_draft_blocks_markdown(
+        writing_task_json=_read_json_string(writing_task_path),
+        section_instructions_json=_read_json_string(section_instructions_path),
+        writing_context_json=_read_json_string(writing_context_path),
+    ), [])
+    root = _run_root('draft-sections-markdown')
+    paths = []
+    for index, section in enumerate(sections, start=1):
+        path = root / f'draft_section_{index:04d}.md'
+        path.write_text(str(section), encoding='utf-8')
+        paths.append(str(path))
+    return paths
+
+
 def writer_generate_draft_document(
     draft_blocks_anchor_path: str,
     writing_context_path: str,
@@ -260,7 +288,7 @@ def writer_generate_draft_document(
     )
     draft_blocks_dir = anchor if anchor.is_dir() else anchor.parent
     draft_block_paths = sorted(
-        (str(path) for path in draft_blocks_dir.glob('draft_block_*.json')),
+        (str(path) for path in draft_blocks_dir.glob('draft_block_*.lmd')),
         key=lambda path: int(Path(path).stem.rsplit('_', 1)[-1]),
     )
     if not draft_block_paths:
@@ -275,6 +303,45 @@ def writer_generate_draft_document(
         outline_json=_read_json_string(outline_path) if outline_path else '',
     )
     return _save_json_artifact('draft_document', content, WriterToolkitBase.WRITER_IR_SCHEMA)
+
+
+def writer_generate_draft_document_markdown(
+    draft_sections_anchor_path: str,
+    writing_context_path: str,
+    outline_path: str = '',
+) -> dict:
+    """Assemble Markdown sections, then convert the complete draft once to IR."""
+    anchor = (
+        Path(draft_sections_anchor_path)
+        if draft_sections_anchor_path else _workspace_root() / 'draft_sections'
+    )
+    sections_dir = anchor if anchor.is_dir() else anchor.parent
+    section_paths = sorted(
+        sections_dir.glob('draft_section_*.md'),
+        key=lambda path: int(path.stem.rsplit('_', 1)[-1]),
+    )
+    if not section_paths:
+        raise ValueError(
+            'draft_sections_anchor_path must point to a generated Markdown section or directory.',
+        )
+    sections = [path.read_text(encoding='utf-8') for path in section_paths]
+    payload = _json_loads(WriterCreateToolkit().generate_draft_document_markdown(
+        draft_sections_json=json.dumps(sections, ensure_ascii=False),
+        writing_context_json=_read_json_string(writing_context_path),
+        outline_json=_read_json_string(outline_path) if outline_path else '',
+    ), {})
+    root = _run_root('draft-document-markdown')
+    markdown_path = root / 'draft_document.md'
+    markdown_path.write_text(str(payload.get('draft_document_md') or ''), encoding='utf-8')
+    return {
+        'draft_document': _save_json_artifact(
+            'draft_document_ir',
+            _editable_writer_json(payload.get('draft_document') or {}),
+            WriterToolkitBase.WRITER_IR_SCHEMA,
+            directory=root,
+        ),
+        'draft_document_md': str(markdown_path),
+    }
 
 
 def writer_update_writing_context(
@@ -295,7 +362,7 @@ def writer_generate_final_document(
     draft_path: str,
     writing_context_path: str,
 ) -> dict:
-    """Generate an editable final WriterDocument and its Markdown artifact."""
+    """Generate final artifacts from a draft WriterDocument IR (.lmd), not Markdown."""
     content = WriterCreateToolkit().generate_final_document(
         draft_document_json=_read_json_string(draft_path),
         writing_context_json=_read_json_string(writing_context_path),
@@ -303,7 +370,7 @@ def writer_generate_final_document(
     payload = _json_loads(content, {})
     final_document_path = _save_json_artifact(
         'final_document_ir',
-        json.dumps(payload.get('final_document') or {}, ensure_ascii=False),
+        _editable_writer_json(payload.get('final_document') or {}),
         WriterToolkitBase.WRITER_IR_SCHEMA,
     )
     markdown_path = _workspace_root() / 'final_document.md'
@@ -416,7 +483,7 @@ def writer_apply_revision(
         ),
         'revised_ir': _save_json_artifact(
             'revised_ir',
-            json.dumps(payload.get('revised_document') or {}, ensure_ascii=False),
+            _editable_writer_json(payload.get('revised_document') or {}),
             WriterToolkitBase.WRITER_IR_SCHEMA,
             directory=root,
         ),

--- a/plugins/writer-plugin/scripts/tools.py
+++ b/plugins/writer-plugin/scripts/tools.py
@@ -12,6 +12,7 @@ import uuid
 from pathlib import Path
 from typing import Any
 
+from lazyllm.tools.writer.data_models import WriterDocument
 from lazyllm.tools.writer.utils import save_artifact_json
 
 from lazymind.chat.engine.subagent.context import require_context
@@ -60,11 +61,26 @@ def _json_loads(value: str, default: Any = None) -> Any:
     return parsed
 
 
-def _editable_writer_json(value: str | dict) -> str:
-    """Mark a public WriterDocument editable at the plugin boundary."""
+def _writer_document_json(
+    value: str | dict,
+    *,
+    expected_stage: str | None = None,
+    editable: bool = False,
+) -> str:
+    """Validate and normalize a WriterDocument before it leaves the writer plugin."""
     payload = _json_loads(value, {}) if isinstance(value, str) else dict(value or {})
-    payload['ui_editable'] = True
-    return json.dumps(payload, ensure_ascii=False)
+    document = WriterDocument.model_validate(payload)
+    if expected_stage is not None and document.stage != expected_stage:
+        raise ValueError(
+            f'WriterDocument must have stage={expected_stage!r}; got {document.stage!r}.',
+        )
+    if document.metadata.get('kind') == 'step_status':
+        raise ValueError('A writer status placeholder cannot be used as a document artifact.')
+    if expected_stage == 'outline' and len(document.blocks) < 3:
+        raise ValueError('An outline WriterDocument must contain at least three top-level blocks.')
+    if editable:
+        document.ui_editable = True
+    return document.model_dump_json(exclude_defaults=True)
 
 
 def _save_json_artifact(
@@ -92,6 +108,27 @@ def _save_json_artifact(
     )
 
 
+def _save_writer_document(
+    name: str,
+    value: str | dict,
+    *,
+    expected_stage: str | None = None,
+    editable: bool = False,
+    directory: Path | None = None,
+) -> str:
+    """Persist a schema-valid WriterDocument as a .lmd artifact."""
+    return _save_json_artifact(
+        name,
+        _writer_document_json(
+            value,
+            expected_stage=expected_stage,
+            editable=editable,
+        ),
+        WriterToolkitBase.WRITER_IR_SCHEMA,
+        directory=directory,
+    )
+
+
 def _markdown_filename(title: str) -> str:
     filename = re.sub(r'[\\/:*?"<>|\x00-\x1f]+', '_', title).strip(' ._')
     return f'{filename[:80] or "文稿"}.md'
@@ -105,10 +142,10 @@ def _save_publish_payload(payload: dict, root: Path) -> dict:
             writer_schema('revision.PatchResult'),
             directory=root,
         ),
-        'published_document': _save_json_artifact(
+        'published_document': _save_writer_document(
             'published_document',
-            _editable_writer_json(payload.get('published_document') or {}),
-            WriterToolkitBase.WRITER_IR_SCHEMA,
+            payload.get('published_document') or {},
+            editable=True,
             directory=root,
         ),
         'published_link': str(payload.get('published_link') or ''),
@@ -129,10 +166,10 @@ def writer_load_document(user_input: str, stage: str = 'final') -> dict:
         {},
     )
     return {
-        'source_ir': _save_json_artifact(
+        'source_ir': _save_writer_document(
             'source_ir',
-            json.dumps(payload.get('source_document') or {}, ensure_ascii=False),
-            WriterToolkitBase.WRITER_IR_SCHEMA,
+            payload.get('source_document') or {},
+            expected_stage=stage,
             directory=root,
         ),
         'target_document': _save_json_artifact(
@@ -192,8 +229,8 @@ def writer_prepare_outline(source_ir_path: str) -> str:
     content = WriterCreateToolkit().prepare_outline(
         source_document_json=_read_json_string(source_ir_path),
     )
-    return _save_json_artifact(
-        'outline_ir', _editable_writer_json(content), WriterToolkitBase.WRITER_IR_SCHEMA,
+    return _save_writer_document(
+        'outline_ir', content, expected_stage='outline', editable=True,
     )
 
 
@@ -203,8 +240,8 @@ def writer_generate_outline(writing_task_path: str, writing_context_path: str) -
         writing_task_json=_read_json_string(writing_task_path),
         writing_context_json=_read_json_string(writing_context_path),
     )
-    return _save_json_artifact(
-        'outline_ir', _editable_writer_json(generated), WriterToolkitBase.WRITER_IR_SCHEMA,
+    return _save_writer_document(
+        'outline_ir', generated, expected_stage='outline', editable=True,
     )
 
 
@@ -302,7 +339,9 @@ def writer_generate_draft_document(
         writing_context_json=_read_json_string(writing_context_path),
         outline_json=_read_json_string(outline_path) if outline_path else '',
     )
-    return _save_json_artifact('draft_document', content, WriterToolkitBase.WRITER_IR_SCHEMA)
+    return _save_writer_document(
+        'draft_document', content, expected_stage='draft', editable=True,
+    )
 
 
 def writer_generate_draft_document_markdown(
@@ -334,10 +373,11 @@ def writer_generate_draft_document_markdown(
     markdown_path = root / 'draft_document.md'
     markdown_path.write_text(str(payload.get('draft_document_md') or ''), encoding='utf-8')
     return {
-        'draft_document': _save_json_artifact(
+        'draft_document': _save_writer_document(
             'draft_document_ir',
-            _editable_writer_json(payload.get('draft_document') or {}),
-            WriterToolkitBase.WRITER_IR_SCHEMA,
+            payload.get('draft_document') or {},
+            expected_stage='draft',
+            editable=True,
             directory=root,
         ),
         'draft_document_md': str(markdown_path),
@@ -368,10 +408,11 @@ def writer_generate_final_document(
         writing_context_json=_read_json_string(writing_context_path),
     )
     payload = _json_loads(content, {})
-    final_document_path = _save_json_artifact(
+    final_document_path = _save_writer_document(
         'final_document_ir',
-        _editable_writer_json(payload.get('final_document') or {}),
-        WriterToolkitBase.WRITER_IR_SCHEMA,
+        payload.get('final_document') or {},
+        expected_stage='final',
+        editable=True,
     )
     markdown_path = _workspace_root() / 'final_document.md'
     markdown_path.write_text(str(payload.get('final_document_md') or ''), encoding='utf-8')
@@ -481,10 +522,11 @@ def writer_apply_revision(
             writer_schema('revision.PatchResult'),
             directory=root,
         ),
-        'revised_ir': _save_json_artifact(
+        'revised_ir': _save_writer_document(
             'revised_ir',
-            _editable_writer_json(payload.get('revised_document') or {}),
-            WriterToolkitBase.WRITER_IR_SCHEMA,
+            payload.get('revised_document') or {},
+            expected_stage='final' if is_body_step else 'outline',
+            editable=True,
             directory=root,
         ),
         'write_result': '',

--- a/tests/algorithm/chat/test_agentic_history.py
+++ b/tests/algorithm/chat/test_agentic_history.py
@@ -92,3 +92,21 @@ def test_normalize_history_drops_ephemeral_intentwrite_trace():
     assert normalize_history_for_agent(history) == [
         {'role': 'assistant', 'content': '继续回答当前问题。', 'reasoning_content': ''},
     ]
+
+
+def test_normalize_history_drops_incomplete_tool_exchange_after_cancel():
+    history = [{
+        'role': 'assistant',
+        'content': (
+            '正在处理。'
+            '<tool_call>{"id":"call-1","name":"trigger_writer_plugin","arguments":{}}</tool_call>'
+        ),
+    }, {
+        'role': 'user',
+        'content': '重新执行',
+    }]
+
+    assert normalize_history_for_agent(history) == [
+        {'role': 'assistant', 'content': '正在处理。', 'reasoning_content': ''},
+        {'role': 'user', 'content': '重新执行'},
+    ]


### PR DESCRIPTION
## Writer 工作流与产物

- 写作流程调整为“分节生成 Markdown → 汇总全文 → 一次性转换 WriterDocument”，减少重复转换和格式漂移。
- 新增章节及全文 Markdown 工具，统一使用 `.md` 保存草稿、`.lmd` 保存结构化文档。
- 调整 writer plugin 的触发规则、步骤依赖及修订流程，并修复飞书链接包含中文尾随标点的问题。

## 校验与框架边界

- WriterDocument 的解析、阶段检查、占位内容过滤、提纲完整性校验及 `.lmd` 保存均移至 writer plugin 内部。
- 通用 subagent 工具只保留基础声明类型校验，移除 Writer 专属预检和全局值去重，避免业务逻辑侵入框架层。

## 前端适配

- 支持识别、编辑和下载 `.lmd`，同时兼容历史 `_ir.json` 产物。
- 展示时优先使用结构化 IR，并规范编辑保存及 Markdown 下载文件名。

## 插件执行与链路追踪

- 在 ChatAgent、Core、Plugin/SubAgent 间透传 trace 上下文，过滤高噪声内部 span，并规范 trace metadata。
- 优化工作流冷启动判断及步骤推进参数；需人工确认的步骤强制使用 hand-off。

## 历史消息容错

- 清理取消或重试后不完整的 tool call/result，保留有效文本和 reasoning，避免向模型发送非法消息序列。
- 增加对应的历史清理回归测试。
