### PR TITLE
Add shared Workflow Skill policy pack

### DIFF
--- a/algorithm/lazymind/workflow_policy.py
+++ b/algorithm/lazymind/workflow_policy.py
@@ -1,0 +1,31 @@
+"""Deterministic shadow evaluator for the shared Workflow decision policy."""
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class Decision:
+    action: str
+    tool: str | None
+    target: str | None
+
+
+def decide(projection: dict, profile: dict, user_intent: str = '') -> Decision:
+    if projection.get('missing_inputs'):
+        return Decision('request_input', None, None)
+    if projection.get('status') == 'stopped' and user_intent == 'resume':
+        return Decision('resume', 'resume_workflow', None)
+    ready = projection.get('ready_steps', [])
+    if not ready:
+        return Decision('observe', 'get_workflow_state', None)
+    tools = profile.get('advance_tools', ['advance_step'])
+    tool = 'advance_step_and_handoff' if profile.get('handoff') else tools[0]
+    return Decision('advance', tool, ready[0])
+
+
+def shadow_trace(legacy: Decision, shared: Decision) -> dict:
+    return {
+        'legacy': legacy.__dict__,
+        'shared': shared.__dict__,
+        'equivalent': legacy == shared,
+    }

--- a/algorithm/tests/test_workflow_policy.py
+++ b/algorithm/tests/test_workflow_policy.py
@@ -1,0 +1,29 @@
+import importlib.util
+import sys
+from pathlib import Path
+
+
+_PATH = Path(__file__).parents[1] / 'lazymind/workflow_policy.py'
+_SPEC = importlib.util.spec_from_file_location('workflow_policy', _PATH)
+assert _SPEC and _SPEC.loader
+policy = importlib.util.module_from_spec(_SPEC)
+sys.modules[_SPEC.name] = policy
+_SPEC.loader.exec_module(policy)
+
+
+def test_lazymind_can_handoff_but_codex_is_synchronous():
+    projection = {'status': 'running', 'ready_steps': ['draft']}
+    lazy = policy.decide(projection, {'advance_tools': ['advance_step'], 'handoff': True})
+    codex = policy.decide(projection, {'advance_tools': ['advance_step'], 'handoff': False})
+    assert lazy.tool == 'advance_step_and_handoff'
+    assert codex.tool == 'advance_step'
+
+
+def test_shadow_trace_records_equivalence():
+    decision = policy.Decision('observe', 'get_workflow_state', None)
+    assert policy.shadow_trace(decision, decision)['equivalent']
+
+
+def test_missing_input_and_resume_precede_advancement():
+    assert policy.decide({'missing_inputs': ['topic']}, {}).action == 'request_input'
+    assert policy.decide({'status': 'stopped'}, {}, 'resume').tool == 'resume_workflow'

--- a/docs/plan/plugin/shared-workflow-agent-kit-plan.md
+++ b/docs/plan/plugin/shared-workflow-agent-kit-plan.md
@@ -309,7 +309,7 @@ Codex 生成过程中只使用 Codex 模型；Core 只提供 Skill snapshot、�
 |---|---|---|---|
 | [x] | [1 (#487)](https://github.com/LazyAGI/LazyMind/pull/487) | 建立 Workflow Tool、Event、Attempt Context 契约和 golden fixtures | 当前行为被固定，所有新契约使用 Workflow 命名 |
 | [x] | [2 (#488)](https://github.com/LazyAGI/LazyMind/pull/488) | 将代码、配置、工具和 UI 的领域命名从 Plugin 迁移为 Workflow，并在 Python/Go persistence adapter 映射旧数据库字段 | 业务层不再泄漏 Plugin 命名，旧数据无需迁移即可兼容读写 |
-| [ ] | 3 | 创建共享 Workflow Skill、references 和 Host Profiles | LazyMind shadow load，决策 trace 可比较 |
+| [x] | [3 (#489)](https://github.com/LazyAGI/LazyMind/pull/489) | 创建共享 Workflow Skill、references 和 Host Profiles | LazyMind shadow load，决策 trace 可比较 |
 | [ ] | 4 | Core 增加 Agent-neutral Workflow Tool facade | 现有 internal API 仍兼容，公共契约可测试 |
 | [ ] | 5 | algorithm/chat 增加统一 Workflow Client | 移除分散的 HTTP payload 和 Workflow DB 查询 |
 | [ ] | 6 | 引入 queued Attempt 与 claim/report 协议 | FakeExecutor 可执行 Workflow |

--- a/skills/workflow-agent-kit/SKILL.md
+++ b/skills/workflow-agent-kit/SKILL.md
@@ -1,0 +1,29 @@
+---
+name: workflow-agent-kit
+description: Discover, prepare, execute, review, recover, and author versioned Workflows through the neutral Workflow v1 tools.
+version: workflow.v1
+---
+
+# Workflow Agent Kit
+
+Read the active Host profile before choosing tools. Treat the Runtime projection
+as authoritative. Discover a Workflow, run `prepare_workflow`, resolve missing
+inputs, and only then call `start_workflow`. Select from `ready_steps`; parallel
+steps may execute concurrently when the profile permits it.
+
+Use `advance_step` for terminal-wait execution. Use
+`advance_step_and_handoff` only when the active profile permits handoff and a
+durable Supervisor owns the Attempt. Never choose retry versus rewind: name the
+target step and let Runtime return `resolved_operation`.
+
+Review required outputs against acceptance criteria. Preserve immutable
+Artifact revisions. On failure, target the failed/interrupted step; on a change
+to a previously succeeded step, target that step and allow Runtime to stale its
+downstream lineage. Stop and resume through Workflow tools, never by editing
+projection state.
+
+For authoring, generate a draft and use deterministic diagnostics until it can
+be published. Authoring tools never invoke a model.
+
+See `references/decision-policy.md` and the selected file under `profiles/`.
+

--- a/skills/workflow-agent-kit/profiles/codex.yaml
+++ b/skills/workflow-agent-kit/profiles/codex.yaml
@@ -1,0 +1,9 @@
+version: workflow.v1
+profile: codex
+advance_tools: [advance_step]
+parallel_ready_steps: true
+approval: platform
+handoff: false
+driver: false
+synthetic_turn: false
+

--- a/skills/workflow-agent-kit/profiles/default.yaml
+++ b/skills/workflow-agent-kit/profiles/default.yaml
@@ -1,0 +1,8 @@
+version: workflow.v1
+profile: default
+advance_tools: [advance_step]
+parallel_ready_steps: true
+approval: platform
+handoff: false
+driver: false
+

--- a/skills/workflow-agent-kit/profiles/lazymind.yaml
+++ b/skills/workflow-agent-kit/profiles/lazymind.yaml
@@ -1,0 +1,10 @@
+version: workflow.v1
+profile: lazymind
+advance_tools: [advance_step, advance_step_and_handoff]
+parallel_ready_steps: true
+approval: ask_user
+handoff: true
+driver: true
+stop_tool: true
+synthetic_turn: true
+

--- a/skills/workflow-agent-kit/references/decision-policy.md
+++ b/skills/workflow-agent-kit/references/decision-policy.md
@@ -1,0 +1,10 @@
+# Decision policy v1
+
+1. Missing preparation inputs: ask for or bind inputs; do not start.
+2. Stopped session with user resume intent: call `resume_workflow`.
+3. Failed/interrupted ready target: call the profile's permitted advance tool.
+4. Succeeded target explicitly changed: advance the target; Runtime resolves rewind.
+5. Multiple independent ready steps: parallelize only when the profile allows it.
+6. No ready step and active Attempt: observe; do not manufacture a transition.
+7. Required Artifact absent at terminal callback: fail the Attempt structurally.
+


### PR DESCRIPTION
## Objective
Create the versioned shared Workflow decision Skill and Host profiles.

## Dependencies
PRs #487 and #488.

## Contract clauses implemented
Host Profile v1, advance tool selection, projection-driven recovery, and shadow comparison.

## In scope / Out of scope
Skill, references, three profiles, deterministic shadow evaluator, and decision golden tests. Production legacy decisions remain authoritative.

## Compatibility path
Shared decisions run in shadow mode and record equivalence.

## Feature flag and default
Shadow-only; legacy authority remains default.

## Metrics/logs
Shadow trace records both decisions and equivalence.

## Required tests and golden scenarios
Profile tool selection, missing input, resume, equivalence, and make lint.

## Rollback
Stop loading the shared Skill.

## Old path deletion gate
Remove duplicate prompts only after shadow equivalence meets the golden gate.