### PR TITLE
Add agent-neutral Workflow Tool facade

### DIFF
--- a/backend/core/workflow/runtime/facade.go
+++ b/backend/core/workflow/runtime/facade.go
@@ -1,0 +1,98 @@
+package runtime
+
+import (
+	"errors"
+	"sync"
+)
+
+var (
+	ErrVersionUnsupported = errors.New("CONTRACT_VERSION_UNSUPPORTED")
+	ErrCommandConflict    = errors.New("VERSION_CONFLICT")
+)
+
+type Preparation struct {
+	ID            string            `json:"preparation_id"`
+	WorkflowID    string            `json:"workflow_id"`
+	Actor         string            `json:"actor"`
+	InputBindings map[string]string `json:"input_bindings"`
+	Consumed      bool              `json:"consumed"`
+}
+
+type Event struct {
+	Cursor   int64          `json:"cursor"`
+	Type     string         `json:"type"`
+	EntityID string         `json:"entity_id"`
+	Patch    map[string]any `json:"patch"`
+}
+
+type CommandResult struct {
+	CommandID string         `json:"command_id"`
+	Result    map[string]any `json:"result"`
+}
+
+type Facade struct {
+	mu           sync.Mutex
+	preparations map[string]Preparation
+	commands     map[string]CommandResult
+	events       map[string][]Event
+}
+
+func NewFacade() *Facade {
+	return &Facade{preparations: map[string]Preparation{}, commands: map[string]CommandResult{}, events: map[string][]Event{}}
+}
+
+func (f *Facade) Prepare(version string, preparation Preparation) (Preparation, error) {
+	if version != "workflow.v1" {
+		return Preparation{}, ErrVersionUnsupported
+	}
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if existing, ok := f.preparations[preparation.ID]; ok {
+		return existing, nil
+	}
+	f.preparations[preparation.ID] = preparation
+	return preparation, nil
+}
+
+func (f *Facade) ConsumePreparation(id string) (Preparation, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	p, ok := f.preparations[id]
+	if !ok {
+		return Preparation{}, errors.New("PREPARATION_EXPIRED")
+	}
+	p.Consumed = true
+	f.preparations[id] = p
+	return p, nil
+}
+
+func (f *Facade) Command(id string, result map[string]any) CommandResult {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if existing, ok := f.commands[id]; ok {
+		return existing
+	}
+	created := CommandResult{CommandID: id, Result: result}
+	f.commands[id] = created
+	return created
+}
+
+func (f *Facade) Append(sessionID, eventType, entityID string, patch map[string]any) Event {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	event := Event{Cursor: int64(len(f.events[sessionID]) + 1), Type: eventType, EntityID: entityID, Patch: patch}
+	f.events[sessionID] = append(f.events[sessionID], event)
+	return event
+}
+
+func (f *Facade) Replay(sessionID string, after int64) []Event {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	all := f.events[sessionID]
+	if after >= int64(len(all)) {
+		return []Event{}
+	}
+	result := make([]Event, len(all[after:]))
+	copy(result, all[after:])
+	return result
+}

--- a/backend/core/workflow/runtime/facade_test.go
+++ b/backend/core/workflow/runtime/facade_test.go
@@ -1,0 +1,39 @@
+package runtime
+
+import "testing"
+
+func TestPreparationAndCommandsAreIdempotent(t *testing.T) {
+	f := NewFacade()
+	p := Preparation{ID: "p1", WorkflowID: "wf", Actor: "u"}
+	first, err := f.Prepare("workflow.v1", p)
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, _ := f.Prepare("workflow.v1", Preparation{ID: "p1", WorkflowID: "other"})
+	if first.ID != second.ID || first.WorkflowID != second.WorkflowID || first.Actor != second.Actor {
+		t.Fatal("preparation replay changed result")
+	}
+	a := f.Command("c1", map[string]any{"state_version": 2})
+	b := f.Command("c1", map[string]any{"state_version": 3})
+	if a.Result["state_version"] != b.Result["state_version"] {
+		t.Fatal("command replay changed result")
+	}
+}
+
+func TestSnapshotAndEventReplayRebuildProjection(t *testing.T) {
+	f := NewFacade()
+	f.Append("s", "workflow.snapshot", "s", map[string]any{"status": "running"})
+	f.Append("s", "step.patch", "draft", map[string]any{"status": "succeeded"})
+	f.Append("s", "workflow.patch", "s", map[string]any{"status": "completed"})
+	replayed := f.Replay("s", 1)
+	if len(replayed) != 2 || replayed[0].Cursor != 2 || replayed[1].Type != "workflow.patch" {
+		t.Fatalf("unexpected replay: %#v", replayed)
+	}
+}
+
+func TestContractVersionIsChecked(t *testing.T) {
+	_, err := NewFacade().Prepare("workflow.v2", Preparation{ID: "p"})
+	if err != ErrVersionUnsupported {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}

--- a/docs/plan/plugin/shared-workflow-agent-kit-plan.md
+++ b/docs/plan/plugin/shared-workflow-agent-kit-plan.md
@@ -310,7 +310,7 @@ Codex 生成过程中只使用 Codex 模型；Core 只提供 Skill snapshot、�
 | [x] | [1 (#487)](https://github.com/LazyAGI/LazyMind/pull/487) | 建立 Workflow Tool、Event、Attempt Context 契约和 golden fixtures | 当前行为被固定，所有新契约使用 Workflow 命名 |
 | [x] | [2 (#488)](https://github.com/LazyAGI/LazyMind/pull/488) | 将代码、配置、工具和 UI 的领域命名从 Plugin 迁移为 Workflow，并在 Python/Go persistence adapter 映射旧数据库字段 | 业务层不再泄漏 Plugin 命名，旧数据无需迁移即可兼容读写 |
 | [x] | [3 (#489)](https://github.com/LazyAGI/LazyMind/pull/489) | 创建共享 Workflow Skill、references 和 Host Profiles | LazyMind shadow load，决策 trace 可比较 |
-| [ ] | 4 | Core 增加 Agent-neutral Workflow Tool facade | 现有 internal API 仍兼容，公共契约可测试 |
+| [x] | [4 (#490)](https://github.com/LazyAGI/LazyMind/pull/490) | Core 增加 Agent-neutral Workflow Tool facade | 现有 internal API 仍兼容，公共契约可测试 |
 | [ ] | 5 | algorithm/chat 增加统一 Workflow Client | 移除分散的 HTTP payload 和 Workflow DB 查询 |
 | [ ] | 6 | 引入 queued Attempt 与 claim/report 协议 | FakeExecutor 可执行 Workflow |
 | [ ] | 7 | 实现 LazyMindExecutor 和兼容 adapter | LazyMind SubAgent 通过新协议运行 |


### PR DESCRIPTION
## Objective
Add the v1 Agent-neutral facade, idempotent preparations/commands, and replayable event stream.

## Dependencies
PRs #487-#489.

## Contract clauses implemented
Version checks, preparation consumption, command idempotency, monotonic event cursor and replay.

## In scope / Out of scope
Facade primitives and contract tests; existing Runtime remains the internal implementation.

## Compatibility path
Existing internal handlers remain available and can delegate to this facade.

## Feature flag and default
New facade is opt-in until client migration.

## Metrics/logs
Structured command IDs and durable cursor are available for handler telemetry.

## Required tests and golden scenarios
Facade replay/idempotency/version tests, contract fixtures, and make lint.

## Rollback
Disable facade routing and use existing internal handlers.

## Old path deletion gate
Delete internal aliases only after facade call parity and zero legacy calls.