### PR TITLE
Complete shared Workflow Agent Kit policy

### DIFF
--- a/algorithm/lazymind/chat/workflow/workflow_manager.py
+++ b/algorithm/lazymind/chat/workflow/workflow_manager.py
@@ -2119,7 +2119,9 @@ def resolve_workflow_injection(
                 }
                 observe(shadow_projection, {
                     'profile': 'lazymind',
-                    'advance_tools': ['advance_step', 'advance_step_and_hand_off'],
+                    # The Host adapter still registers the historical hand_off
+                    # alias; shadow policy evaluates the canonical v1 protocol.
+                    'advance_tools': ['advance_step', 'advance_step_and_handoff'],
                     'parallel_ready_steps': True,
                     'handoff': True,
                 }, cfg, source='active_session_prompt')

--- a/algorithm/lazymind/chat/workflow_policy_shadow.py
+++ b/algorithm/lazymind/chat/workflow_policy_shadow.py
@@ -32,7 +32,10 @@ def _legacy_decision(projection: Mapping[str, Any], profile: Mapping[str, Any]) 
     wait = bool({'continuous', 'run_all', 'boundary'} & intents) or all(
         approval.get(item) == 'not_required' for item in targets
     )
-    tool = 'advance_step' if wait or not profile.get('handoff') else 'advance_step_and_hand_off'
+    # The legacy prompt still exposes the historical ``hand_off`` spelling.
+    # Normalize it to the versioned public protocol name before comparison so
+    # shadow equivalence measures decisions, not a temporary Host adapter alias.
+    tool = 'advance_step' if wait or not profile.get('handoff') else 'advance_step_and_handoff'
     return Decision('advance', tool, targets[0], targets, 'legacy_prompt_policy')
 
 

--- a/algorithm/tests/test_workflow_agent_kit.py
+++ b/algorithm/tests/test_workflow_agent_kit.py
@@ -1,0 +1,44 @@
+from pathlib import Path
+
+import yaml
+
+
+KIT = Path(__file__).parents[2] / 'skills/workflow-agent-kit'
+
+
+def test_skill_references_exist_and_cover_required_lifecycle():
+    skill = (KIT / 'SKILL.md').read_text()
+    for reference in (
+        'references/decision-policy.md',
+        'references/artifact-and-authoring.md',
+        'references/source-to-policy-mapping.md',
+    ):
+        assert reference in skill
+        assert (KIT / reference).is_file()
+    for clause in ('Discover and prepare', 'Execute', 'Review and recover', 'authoring'):
+        assert clause in skill
+
+
+def test_host_profiles_cover_contract_capabilities():
+    profiles = {
+        path.stem: yaml.safe_load(path.read_text())
+        for path in (KIT / 'profiles').glob('*.yaml')
+    }
+    assert set(profiles) == {'default', 'lazymind', 'codex'}
+    required = {
+        'version', 'profile', 'advance_tools', 'parallel_ready_steps', 'approval',
+        'handoff', 'driver', 'synthetic_turn', 'shadow_authority', 'write_tools',
+    }
+    for name, profile in profiles.items():
+        assert required <= set(profile), name
+        assert profile['version'] == 'workflow.v1'
+    assert 'advance_step_and_handoff' in profiles['lazymind']['advance_tools']
+    assert profiles['codex']['advance_tools'] == ['advance_step']
+    assert profiles['codex']['handoff'] is False
+
+
+def test_mapping_ledger_points_to_current_workflow_sources():
+    ledger = (KIT / 'references/source-to-policy-mapping.md').read_text()
+    assert 'chat/plugin/' not in ledger
+    assert '_trigger_plugin_step' not in ledger
+    assert 'chat/workflow/workflow_manager.py' in ledger

--- a/algorithm/tests/test_workflow_policy_shadow.py
+++ b/algorithm/tests/test_workflow_policy_shadow.py
@@ -36,7 +36,7 @@ for module_name, previous in saved_modules.items():
 
 LAZYMIND_PROFILE = {
     'profile': 'lazymind',
-    'advance_tools': ['advance_step', 'advance_step_and_hand_off'],
+    'advance_tools': ['advance_step', 'advance_step_and_handoff'],
     'parallel_ready_steps': True,
     'handoff': True,
 }

--- a/docs/plan/plugin/phase-one-gate-audit.md
+++ b/docs/plan/plugin/phase-one-gate-audit.md
@@ -24,12 +24,12 @@ is checked and linked to executable evidence.
 
 ## PR 3 — shared Skill and Host Profiles
 
-- [ ] Existing prompt rules have a source-to-policy mapping ledger.
-- [ ] Skill covers discovery, preflight, readiness, parallelism, review, retry/rewind targeting, resume, Artifact and authoring.
-- [ ] Default, LazyMind and Codex profiles cover every Host capability in the contract.
-- [ ] LazyMind production prompt assembly loads the Skill in shadow mode.
-- [ ] Shadow trace is structured, metered and keeps the legacy decision authoritative.
-- [ ] Recorded golden decisions meet the declared equivalence threshold.
+- [x] Existing prompt rules have a source-to-policy mapping ledger.
+- [x] Skill covers discovery, preflight, readiness, parallelism, review, retry/rewind targeting, resume, Artifact and authoring.
+- [x] Default, LazyMind and Codex profiles cover every Host capability in the contract.
+- [x] LazyMind production prompt assembly loads the Skill in shadow mode.
+- [x] Shadow trace is structured, metered and keeps the legacy decision authoritative.
+- [x] Recorded golden decisions meet the declared equivalence threshold.
 
 ## PR 4 — Core Workflow Tool facade
 

--- a/docs/plan/plugin/shared-workflow-agent-kit-plan.md
+++ b/docs/plan/plugin/shared-workflow-agent-kit-plan.md
@@ -309,7 +309,7 @@ Codex 生成过程中只使用 Codex 模型；Core 只提供 Skill snapshot、�
 |---|---|---|---|
 | [x] | [1 (#487 + completion #492)](https://github.com/LazyAGI/LazyMind/pull/492) | 建立 Workflow Tool、Event、Attempt Context 契约和 golden fixtures | 当前行为被固定，所有新契约使用 Workflow 命名 |
 | [x] | [2 (#488 + Go #493 + completion #495)](https://github.com/LazyAGI/LazyMind/pull/495) | 将代码、配置、工具和 UI 的领域命名从 Plugin 迁移为 Workflow，并在 Python/Go persistence adapter 映射旧数据库字段 | 业务层不再泄漏 Plugin 命名，旧数据无需迁移即可兼容读写 |
-| [ ] | [3 (#489，退出条件未满足)](https://github.com/LazyAGI/LazyMind/pull/489) | 创建共享 Workflow Skill、references 和 Host Profiles | LazyMind shadow load，决策 trace 可比较 |
+| [x] | [3 (#489 + completion #496)](https://github.com/LazyAGI/LazyMind/pull/496) | 创建共享 Workflow Skill、references 和 Host Profiles | LazyMind shadow load，决策 trace 可比较 |
 | [x] | [4 (#490 + completion #494)](https://github.com/LazyAGI/LazyMind/pull/494) | Core 增加 Agent-neutral Workflow Tool facade | 现有 internal API 仍兼容，公共契约可测试 |
 | [ ] | 5 | algorithm/chat 增加统一 Workflow Client | 移除分散的 HTTP payload 和 Workflow DB 查询 |
 | [ ] | 6 | 引入 queued Attempt 与 claim/report 协议 | FakeExecutor 可执行 Workflow |

--- a/skills/workflow-agent-kit/SKILL.md
+++ b/skills/workflow-agent-kit/SKILL.md
@@ -6,24 +6,55 @@ version: workflow.v1
 
 # Workflow Agent Kit
 
-Read the active Host profile before choosing tools. Treat the Runtime projection
-as authoritative. Discover a Workflow, run `prepare_workflow`, resolve missing
-inputs, and only then call `start_workflow`. Select from `ready_steps`; parallel
-steps may execute concurrently when the profile permits it.
+## Required reading
 
-Use `advance_step` for terminal-wait execution. Use
+1. Load exactly one file from `profiles/`; absent Host metadata means `default`.
+2. Read `references/decision-policy.md` before making a lifecycle decision.
+3. Read `references/artifact-and-authoring.md` before reviewing output or authoring.
+4. Treat the latest Runtime projection and its `state_version` as authoritative.
+
+## Discover and prepare
+
+Discover a Workflow, run `prepare_workflow`, bind durable Input Resources, resolve
+all missing inputs, and only then call `start_workflow`. A preparation is not a
+running Session. Never infer a start from discovery or preparation success.
+
+## Execute
+
+Select targets only from `ready_steps`. A Ready list is a frontier, not display
+order. Independent applicable steps may be submitted atomically when the profile
+permits parallel execution; alternatives must be narrowed from Runtime conditions
+and user intent. Never submit a blocked or downstream step speculatively.
+
+Use `advance_step` when the Host must wait for the Attempt result. Use
 `advance_step_and_handoff` only when the active profile permits handoff and a
-durable Supervisor owns the Attempt. Never choose retry versus rewind: name the
-target step and let Runtime return `resolved_operation`.
+durable Supervisor has accepted ownership. Handoff is a turn boundary, not a
+different transition. Never choose retry versus rewind: name a Ready or previously
+attempted target and let Runtime return `resolved_operation`. On a version conflict,
+refresh state and decide again; do not blindly replay with a new command id.
 
-Review required outputs against acceptance criteria. Preserve immutable
-Artifact revisions. On failure, target the failed/interrupted step; on a change
-to a previously succeeded step, target that step and allow Runtime to stale its
-downstream lineage. Stop and resume through Workflow tools, never by editing
-projection state.
+## Review and recover
 
-For authoring, generate a draft and use deterministic diagnostics until it can
-be published. Authoring tools never invoke a model.
+Review required outputs against acceptance criteria before reporting completion.
+Preserve immutable Artifact revisions and lineage. On failure or interruption,
+target only that attempted step. When the user changes a succeeded result, target
+the earliest invalidated step and allow Runtime to resolve rewind and stale its
+downstream lineage. Never batch a retry with fresh frontier work. Stop, resume,
+cancel, and retry through Workflow tools; never edit projection state.
 
-See `references/decision-policy.md` and the selected file under `profiles/`.
+If a required Artifact is absent when an Executor reports success, report a
+structured failure. Do not manufacture output or mark the Attempt complete.
 
+## Authority during migration
+
+The shared policy may run in shadow mode. A shadow trace is observational and must
+record both decisions, comparison dimensions, policy/profile versions, and
+`authority: legacy`. It must never invoke a tool or mutate Runtime state.
+
+For authoring, follow `references/artifact-and-authoring.md`: analyze a pinned
+Skill revision, generate a draft outside Runtime, submit it to deterministic
+diagnostics, repair reported diagnostics, and publish only a validated revision.
+Authoring tools never invoke a model.
+
+The source audit for migrated LazyMind rules is in
+`references/source-to-policy-mapping.md`.

--- a/skills/workflow-agent-kit/profiles/codex.yaml
+++ b/skills/workflow-agent-kit/profiles/codex.yaml
@@ -6,4 +6,7 @@ approval: platform
 handoff: false
 driver: false
 synthetic_turn: false
-
+shadow_authority: legacy
+write_tools: true
+executor: codex
+advance_mode: synchronous

--- a/skills/workflow-agent-kit/profiles/default.yaml
+++ b/skills/workflow-agent-kit/profiles/default.yaml
@@ -5,4 +5,6 @@ parallel_ready_steps: true
 approval: platform
 handoff: false
 driver: false
-
+synthetic_turn: false
+shadow_authority: legacy
+write_tools: false

--- a/skills/workflow-agent-kit/profiles/lazymind.yaml
+++ b/skills/workflow-agent-kit/profiles/lazymind.yaml
@@ -4,7 +4,11 @@ advance_tools: [advance_step, advance_step_and_handoff]
 parallel_ready_steps: true
 approval: ask_user
 handoff: true
+handoff_requires_durable_supervisor: true
 driver: true
 stop_tool: true
 synthetic_turn: true
-
+shadow_authority: legacy
+write_tools: true
+executor: lazymind
+advance_mode: profile_policy

--- a/skills/workflow-agent-kit/references/artifact-and-authoring.md
+++ b/skills/workflow-agent-kit/references/artifact-and-authoring.md
@@ -1,0 +1,25 @@
+# Artifact and authoring policy v1
+
+## Artifact review
+
+Treat Artifact revisions as immutable execution facts. Read the latest revision
+through Workflow tools, verify every required output against the step acceptance
+criteria, and preserve its Attempt, Input Resource, and predecessor lineage. A
+missing required Artifact is a structured execution failure. A user-requested
+change creates a new revision; it never overwrites history. If that change makes
+downstream output stale, target the earliest invalidated step and let Runtime
+resolve rewind and stale propagation.
+
+## Deterministic authoring
+
+1. Pin the source Skill package and revision before analysis.
+2. Decide whether its procedure is representable as a deterministic Workflow.
+3. Generate the draft in the Host; Authoring Tools do not call a model.
+4. Submit files with `create_workflow_draft` or `update_workflow_draft`.
+5. Run deterministic diagnostics and repair every error against the same draft
+   revision. Do not silently weaken graph, tool, safety, or Artifact constraints.
+6. Publish only a validated draft using an idempotent command and expected draft
+   revision. A conflict requires reread and deliberate reconciliation.
+
+Published Workflow revisions and source Skill revisions remain linked so a later
+regeneration is auditable and cannot silently replace an active Session contract.

--- a/skills/workflow-agent-kit/references/decision-policy.md
+++ b/skills/workflow-agent-kit/references/decision-policy.md
@@ -1,10 +1,23 @@
 # Decision policy v1
 
-1. Missing preparation inputs: ask for or bind inputs; do not start.
-2. Stopped session with user resume intent: call `resume_workflow`.
-3. Failed/interrupted ready target: call the profile's permitted advance tool.
-4. Succeeded target explicitly changed: advance the target; Runtime resolves rewind.
-5. Multiple independent ready steps: parallelize only when the profile allows it.
-6. No ready step and active Attempt: observe; do not manufacture a transition.
-7. Required Artifact absent at terminal callback: fail the Attempt structurally.
+Apply the first matching rule. Runtime state wins over conversation recollection.
 
+| Priority | Condition | Decision |
+|---|---|---|
+| 1 | Preparation has missing inputs | Bind durable resources or request input; do not start. |
+| 2 | Session is stopped and resume is explicit | `resume_workflow`; otherwise only observe. |
+| 3 | No Ready step | Observe active Attempts/events; do not manufacture a transition. |
+| 4 | User changes a succeeded result | Target the earliest invalidated step; Runtime resolves rewind/staleness. |
+| 5 | Failed/interrupted step is targeted | Advance that step alone; Runtime resolves retry/resume. |
+| 6 | Multiple independent applicable Ready steps | Submit one atomic batch only if the profile permits parallel execution. |
+| 7 | Ready step needs no approval | Use the profile's waiting tool and continue from the returned projection. |
+| 8 | Explicit continuous scope/boundary | Wait through prerequisites; hand off only at the requested/final boundary if permitted. |
+| 9 | Ordinary Ready frontier | Use handoff if permitted; otherwise use the waiting tool. |
+
+`advance_step` and `advance_step_and_handoff` request the same Runtime transition.
+Only waiting/ownership semantics differ. Codex never selects handoff. LazyMind may
+select it only after durable ownership acceptance.
+
+Terminal success requires every contract-required Artifact. Version conflict,
+permission denial, invalid target, and missing Artifact are structured outcomes;
+none may be converted into success or repaired by directly editing projection.

--- a/skills/workflow-agent-kit/references/source-to-policy-mapping.md
+++ b/skills/workflow-agent-kit/references/source-to-policy-mapping.md
@@ -1,0 +1,30 @@
+# LazyMind legacy source → shared policy ledger
+
+This ledger is the audit boundary for PR3. It maps existing behavior; it does not
+make the shared evaluator authoritative.
+
+| Legacy source | Existing rule | Shared policy clause | Shadow input/evidence |
+|---|---|---|---|
+| `chat/workflow/workflow_manager.py::_COLD_START_PLUGIN_PROMPT` | Trigger only for direct intent; explicit named Workflow must trigger | Discover/prepare before start | Cold-start prompt tests remain authoritative; the constant name is a tracked legacy prompt alias |
+| `build_cold_start_tools` preflight | `need_information` blocks start; `ready` produces one valid first step | Missing-input and preparation gates | Existing preflight tests |
+| `_build_cold_execution_policy` | Auto hands off; dynamic waits only for explicit multi-step/no-approval cases | Rules 7–9 | Golden launch cases |
+| `_build_step_status_section` | Go Ready projection is the execution frontier; conditions disambiguate choices | Rules 3 and 6 | `ready_steps`, active edges |
+| `_build_mode_guidance` Rule 0 | Persist explicit user constraints before advancement | Host intent capture before shared decision | Intent-writer tests; policy receives normalized intent tokens only |
+| `_build_mode_guidance` Rule 1 | Changed succeeded output targets earliest invalid step | Rule 4 | `changed_succeeded_step` |
+| `_build_mode_guidance` Rule 2 | Atomic batch of independent Ready steps; retry is singular | Rules 5–6 | Ready/attempted sets |
+| `_build_mode_guidance` Rules 3–4 | Approval and explicit uninterrupted boundary choose wait vs handoff | Rules 7–9 | approval map + normalized intent tokens |
+| `build_advance_step_tool` | Wait for submitted task result and continue current turn | Waiting-tool semantics | Existing manager tests |
+| `build_advance_step_and_hand_off_tool` | Submit atomically then stop after durable acceptance | Handoff semantics | Existing manager/stream-guard tests |
+| `_trigger_workflow_step(s)` | Runtime resolves transition and accepts/rejects command | Runtime authority/idempotency | Transition submission tests |
+| `engine/driver_agent.py` | Synthetic next turn after asynchronous completion | LazyMind Host profile (`driver`, `synthetic_turn`) | Driver tests; not a Runtime policy rule |
+| `engine/subagent/runner.py::_build_subagent_plan` | Attempt objective, inputs, artifacts and output contract are isolated | Execute/review contract | SubAgent prompt-plan tests |
+| `engine/subagent/runner.py` terminal handling | Artifacts and terminal outcome are reported after execution | Required-Artifact terminal rule | SubAgent artifact tests |
+
+## Migration gate
+
+The production flag is `LAZYMIND_WORKFLOW_POLICY_SHADOW` (default off). When on,
+the active-session prompt path records `workflow.shadow-trace.v1` entries and
+counters (`evaluated`, `equivalent`, `mismatch`) in request agentic configuration
+and structured logs. Legacy remains authoritative. The PR3 golden suite requires
+100% equivalence; default-on/canary and deletion of legacy prompt rules belong to
+later migration PRs.


### PR DESCRIPTION
## Summary
- complete the shared Workflow Agent Kit lifecycle policy and deterministic Artifact/authoring reference
- define complete default, LazyMind, and Codex Host capability profiles using canonical v1 tool names
- map every retained LazyMind prompt rule to shared policy and current production sources
- load the shared decision evaluator in the real LazyMind active-session prompt path as a side-effect-free, default-off shadow
- emit structured bounded traces and equivalence metrics while legacy decisions remain authoritative

## Guardrail scope
- Phase 1 / PR3 completion
- Base: `dev/workflow`
- Completes the insufficient initial scaffold in #489

## Validation
- `PYTHONPATH=algorithm:algorithm/lazyllm python3 -m pytest algorithm/tests/test_workflow_policy.py algorithm/tests/test_workflow_policy_shadow.py algorithm/tests/test_workflow_agent_kit.py -q` (10 passed)
- `PYTHONPATH=algorithm:algorithm/lazyllm python3 -m pytest algorithm/tests/chat/workflows/test_manager.py -q` (59 passed)
- `make lint`

## Acceptance evidence
- source-to-policy ledger points to current Workflow sources
- shared Skill covers discovery, preparation, readiness, parallelism, review, retry/rewind, resume, Artifact lineage, and deterministic authoring
- all Host profiles are contract-checked and Codex cannot choose handoff
- shadow is default-off, bounded, structured, metered, side-effect-free, and legacy-authoritative
- recorded golden decisions meet the declared 100% equivalence threshold
