### PR TITLE
Add deterministic Workflow authoring facade

### DIFF
--- a/backend/core/routes.go
+++ b/backend/core/routes.go
@@ -332,6 +332,12 @@ func registerAllRoutes(r *mux.Router) {
 	handleAPI(r, "PATCH", "/conversations/{conversation_id}/workflow-settings", []string{"qa.write"}, chat.PatchConversationWorkflowSettings)
 
 	// ----- Workflow Sessions -----
+	handleAPI(r, "GET", "/workflow-authoring/v1/skill-context", []string{"qa.read"}, workflow.GetSkillConversionContext)
+	handleAPI(r, "POST", "/workflow-authoring/v1/drafts", []string{"qa.write"}, workflow.CreateAuthoringWorkflowDraft)
+	handleAPI(r, "PUT", "/workflow-authoring/v1/drafts/{draft_id}/files", []string{"qa.write"}, workflow.UpdateAuthoringWorkflowDraftFile)
+	handleAPI(r, "GET", "/workflow-authoring/v1/drafts/{draft_id}/diagnostics", []string{"qa.read"}, workflow.GetAuthoringWorkflowDiagnostics)
+	handleAPI(r, "POST", "/workflow-authoring/v1/drafts/{draft_id}:publish", []string{"qa.write"}, workflow.PublishAuthoringWorkflow)
+	handleAPI(r, "GET", "/workflow-authoring/v1/fixture", []string{"qa.read"}, workflow.GenerateAuthoringFixture)
 	handleAPI(r, "POST", "/workflow-input-resources", []string{"qa.write"}, workflowFacade.ImportInputResource)
 	handleAPI(r, "POST", "/workflow-preparations", []string{"qa.write"}, workflowFacade.Prepare)
 	handleAPI(r, "POST", "/workflow-preparations/{preparation_id}:consume", []string{"qa.write"}, workflowFacade.Consume)

--- a/backend/core/routes_test.go
+++ b/backend/core/routes_test.go
@@ -410,3 +410,28 @@ func TestWorkflowFacadeV1RoutesRegistered(t *testing.T) {
 		}
 	}
 }
+
+func TestWorkflowAuthoringV1RoutesRegistered(t *testing.T) {
+	r := mux.NewRouter()
+	registerAllRoutes(r)
+	cases := []struct{ method, path, template string }{
+		{http.MethodGet, "/workflow-authoring/v1/skill-context", "/workflow-authoring/v1/skill-context"},
+		{http.MethodPost, "/workflow-authoring/v1/drafts", "/workflow-authoring/v1/drafts"},
+		{http.MethodPut, "/workflow-authoring/v1/drafts/d1/files", "/workflow-authoring/v1/drafts/{draft_id}/files"},
+		{http.MethodGet, "/workflow-authoring/v1/drafts/d1/diagnostics", "/workflow-authoring/v1/drafts/{draft_id}/diagnostics"},
+		{http.MethodPost, "/workflow-authoring/v1/drafts/d1:publish", "/workflow-authoring/v1/drafts/{draft_id}:publish"},
+		{http.MethodGet, "/workflow-authoring/v1/fixture", "/workflow-authoring/v1/fixture"},
+	}
+	for _, tc := range cases {
+		req := httptest.NewRequest(tc.method, tc.path, nil)
+		var match mux.RouteMatch
+		if !r.Match(req, &match) {
+			t.Errorf("missing %s %s", tc.method, tc.path)
+			continue
+		}
+		got, err := match.Route.GetPathTemplate()
+		if err != nil || got != tc.template {
+			t.Errorf("template=%q err=%v want=%q", got, err, tc.template)
+		}
+	}
+}

--- a/backend/core/workflow/authoring_handlers.go
+++ b/backend/core/workflow/authoring_handlers.go
@@ -1,0 +1,240 @@
+package workflow
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"net/http"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	"gorm.io/gorm"
+
+	"lazymind/core/common"
+	"lazymind/core/common/orm"
+	"lazymind/core/store"
+	"lazymind/core/workflow/graphengine"
+)
+
+const AuthoringContractVersion = "workflow.authoring.v1"
+
+type authoringDiagnostic struct {
+	Code     string `json:"code"`
+	Severity string `json:"severity"`
+	Path     string `json:"path,omitempty"`
+	Message  string `json:"message"`
+}
+
+type authoringDiagnostics struct {
+	ContractVersion       string                `json:"contract_version"`
+	Valid                 bool                  `json:"valid"`
+	DraftVersion          int                   `json:"draft_version"`
+	SourceSkillRevisionID string                `json:"source_skill_revision_id"`
+	SourceSkillTreeHash   string                `json:"source_skill_tree_hash"`
+	Diagnostics           []authoringDiagnostic `json:"diagnostics"`
+}
+
+func authoringDiagnosticsForDraft(db *gorm.DB, draft orm.WorkflowDraft) authoringDiagnostics {
+	out := authoringDiagnostics{ContractVersion: AuthoringContractVersion, DraftVersion: draft.Version, SourceSkillRevisionID: draft.SourceSkillRevisionID, SourceSkillTreeHash: draft.SourceSkillTreeHash, Diagnostics: []authoringDiagnostic{}}
+	if draft.SourceType == "skill" {
+		if draft.SourceSkillRevisionID == "" || draft.SourceSkillTreeHash == "" {
+			out.Diagnostics = append(out.Diagnostics, authoringDiagnostic{Code: "SKILL_SNAPSHOT_REQUIRED", Severity: "error", Message: "a fixed Skill revision and tree hash are required"})
+		} else if !strings.HasPrefix(draft.SourceSkillRevisionID, "builtin:") {
+			var treeHash string
+			err := db.Table("skill_revisions").Select("tree_hash").Where("id=? AND skill_id=?", draft.SourceSkillRevisionID, draft.SourceSkillID).Scan(&treeHash).Error
+			if err != nil || treeHash != draft.SourceSkillTreeHash {
+				out.Diagnostics = append(out.Diagnostics, authoringDiagnostic{Code: "SKILL_SNAPSHOT_CHANGED", Severity: "error", Message: "the fixed Skill snapshot is unavailable or changed"})
+			}
+		}
+	}
+	if _, err := workflowFiles(draft); err != nil {
+		out.Diagnostics = append(out.Diagnostics, authoringDiagnostic{Code: "PACKAGE_INCOMPLETE", Severity: "error", Message: err.Error()})
+	}
+	compiled := graphengine.Compile(draft.WorkflowYAMLContent, draft.StateYAMLContent, draft.ScenarioContent, graphengine.ProfilePublish)
+	blocking := false
+	for _, diagnostic := range compiled.Diagnostics {
+		out.Diagnostics = append(out.Diagnostics, authoringDiagnostic{Code: diagnostic.Code, Severity: diagnostic.Severity, Path: diagnostic.Path, Message: diagnostic.Message})
+		if diagnostic.Severity == "error" {
+			blocking = true
+		}
+	}
+	if !frameworkToolsAvailableForPublish(db, draft) {
+		out.Diagnostics = append(out.Diagnostics, authoringDiagnostic{Code: "FRAMEWORK_TOOL_UNAVAILABLE", Severity: "error", Message: "a mapped framework tool is unavailable"})
+	}
+	files, _ := workflowFiles(draft)
+	if len(files) > 3 && !scriptsApprovedForPublish(db, draft) {
+		out.Diagnostics = append(out.Diagnostics, authoringDiagnostic{Code: "SCRIPT_APPROVAL_REQUIRED", Severity: "error", Message: "custom scripts require a matching deterministic audit"})
+	}
+	sort.SliceStable(out.Diagnostics, func(i, j int) bool {
+		if out.Diagnostics[i].Code == out.Diagnostics[j].Code {
+			return out.Diagnostics[i].Message < out.Diagnostics[j].Message
+		}
+		return out.Diagnostics[i].Code < out.Diagnostics[j].Code
+	})
+	out.Valid = compiled.Valid && !blocking
+	return out
+}
+
+func GetSkillConversionContext(w http.ResponseWriter, r *http.Request) {
+	userID, skillID, revisionID := common.UserID(r), r.URL.Query().Get("skill_id"), r.URL.Query().Get("revision_id")
+	var snapshot workflowSourceSkillSnapshot
+	var err error
+	if revisionID == "" {
+		snapshot, err = loadWorkflowSourceSkill(r.Context(), store.DB(), userID, skillID)
+	} else {
+		snapshot, err = loadWorkflowSourceSkillRevision(r.Context(), store.DB(), userID, skillID, revisionID)
+	}
+	if err != nil {
+		common.ReplyErr(w, "plugin source skill not found", http.StatusNotFound)
+		return
+	}
+	common.ReplyOK(w, map[string]any{"contract_version": AuthoringContractVersion, "snapshot": snapshot})
+}
+
+func CreateAuthoringWorkflowDraft(w http.ResponseWriter, r *http.Request) {
+	userID := common.UserID(r)
+	var body struct {
+		Name       string            `json:"name"`
+		SkillID    string            `json:"skill_id"`
+		RevisionID string            `json:"revision_id"`
+		TreeHash   string            `json:"tree_hash"`
+		Files      map[string]string `json:"files"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil || body.Name == "" || body.SkillID == "" || body.RevisionID == "" || body.TreeHash == "" {
+		common.ReplyErr(w, "invalid body", http.StatusBadRequest)
+		return
+	}
+	for path := range body.Files {
+		if !validAuthoringPath(path) {
+			common.ReplyErr(w, "invalid resource path", http.StatusBadRequest)
+			return
+		}
+	}
+	snapshot, err := loadWorkflowSourceSkillRevision(r.Context(), store.DB(), userID, body.SkillID, body.RevisionID)
+	if err != nil || snapshot.TreeHash != body.TreeHash {
+		common.ReplyErr(w, "draft snapshot changed", http.StatusConflict)
+		return
+	}
+	draft := orm.WorkflowDraft{ID: uuid.NewString(), Name: body.Name, CreatedBy: userID, CreatedAt: time.Now().UTC(), UpdatedAt: time.Now().UTC(), Version: 1, SourceType: "skill", SourceSkillID: body.SkillID, SourceSkillName: snapshot.Name, SourceSkillRevisionID: snapshot.RevisionID, SourceSkillRevisionNo: snapshot.RevisionNo, SourceSkillTreeHash: snapshot.TreeHash, ScriptsContent: "{}"}
+	applyAuthoringFiles(&draft, body.Files)
+	if err := store.DB().Create(&draft).Error; err != nil {
+		common.ReplyErr(w, "create failed", http.StatusInternalServerError)
+		return
+	}
+	common.ReplyOK(w, map[string]any{"contract_version": AuthoringContractVersion, "draft": toDraftResponse(draft)})
+}
+
+func applyAuthoringFiles(draft *orm.WorkflowDraft, files map[string]string) {
+	scripts := map[string]string{}
+	for path, content := range files {
+		path = filepath.ToSlash(filepath.Clean(path))
+		switch path {
+		case "plugin.yaml":
+			draft.WorkflowYAMLContent = content
+		case "scenario/state.yml":
+			draft.StateYAMLContent = content
+		case "scenario/scenario.md":
+			draft.ScenarioContent = content
+		case "scenario/layout.json":
+			draft.StateLayoutContent = content
+		default:
+			if strings.HasPrefix(path, "scripts/") && !strings.Contains(path, "..") {
+				scripts[path] = content
+			}
+		}
+	}
+	if len(scripts) > 0 {
+		encoded, _ := json.Marshal(scripts)
+		draft.ScriptsContent = string(encoded)
+	}
+}
+
+func validAuthoringPath(path string) bool {
+	clean := filepath.ToSlash(filepath.Clean(path))
+	if clean != path || filepath.IsAbs(path) || strings.HasPrefix(clean, "../") {
+		return false
+	}
+	switch clean {
+	case "plugin.yaml", "scenario/state.yml", "scenario/scenario.md", "scenario/layout.json":
+		return true
+	}
+	return strings.HasPrefix(clean, "scripts/") && len(strings.TrimPrefix(clean, "scripts/")) > 0
+}
+
+func UpdateAuthoringWorkflowDraftFile(w http.ResponseWriter, r *http.Request) {
+	userID, draftID := common.UserID(r), common.PathVar(r, "draft_id")
+	var body struct {
+		Path            string `json:"path"`
+		Content         string `json:"content"`
+		ExpectedVersion int    `json:"expected_version"`
+	}
+	if json.NewDecoder(r.Body).Decode(&body) != nil || body.Path == "" || body.ExpectedVersion < 1 {
+		common.ReplyErr(w, "invalid body", http.StatusBadRequest)
+		return
+	}
+	if !validAuthoringPath(body.Path) {
+		common.ReplyErr(w, "invalid resource path", http.StatusBadRequest)
+		return
+	}
+	var draft orm.WorkflowDraft
+	if store.DB().Where("id=? AND created_by=?", draftID, userID).First(&draft).Error != nil {
+		common.ReplyErr(w, "not found", http.StatusNotFound)
+		return
+	}
+	if draft.Version != body.ExpectedVersion {
+		common.ReplyErrWithData(w, "conflict", toDraftResponse(draft), http.StatusConflict)
+		return
+	}
+	files := map[string]string{body.Path: body.Content}
+	applyAuthoringFiles(&draft, files)
+	updates := map[string]any{"plugin_yaml_content": draft.WorkflowYAMLContent, "state_yaml_content": draft.StateYAMLContent, "scenario_content": draft.ScenarioContent, "state_layout_content": draft.StateLayoutContent, "scripts_content": draft.ScriptsContent, "plugin_id": extractWorkflowID(draft.WorkflowYAMLContent), "version": gorm.Expr("version + 1"), "updated_at": time.Now().UTC()}
+	result := store.DB().Model(&orm.WorkflowDraft{}).Where("id=? AND created_by=? AND version=?", draftID, userID, body.ExpectedVersion).Updates(updates)
+	if result.Error != nil {
+		common.ReplyErr(w, "save failed", http.StatusInternalServerError)
+		return
+	}
+	if result.RowsAffected == 0 {
+		common.ReplyErr(w, "conflict", http.StatusConflict)
+		return
+	}
+	store.DB().Where("id=?", draftID).First(&draft)
+	common.ReplyOK(w, map[string]any{"contract_version": AuthoringContractVersion, "draft": toDraftResponse(draft)})
+}
+
+func GetAuthoringWorkflowDiagnostics(w http.ResponseWriter, r *http.Request) {
+	var draft orm.WorkflowDraft
+	if store.DB().Where("id=? AND created_by=?", common.PathVar(r, "draft_id"), common.UserID(r)).First(&draft).Error != nil {
+		common.ReplyErr(w, "not found", 404)
+		return
+	}
+	common.ReplyOK(w, authoringDiagnosticsForDraft(store.DB(), draft))
+}
+
+func PublishAuthoringWorkflow(w http.ResponseWriter, r *http.Request) {
+	var draft orm.WorkflowDraft
+	if store.DB().Where("id=? AND created_by=?", common.PathVar(r, "draft_id"), common.UserID(r)).First(&draft).Error != nil {
+		common.ReplyErr(w, "not found", 404)
+		return
+	}
+	diagnostics := authoringDiagnosticsForDraft(store.DB(), draft)
+	if !diagnostics.Valid {
+		common.ReplyErrWithData(w, "plugin validation failed", diagnostics, http.StatusUnprocessableEntity)
+		return
+	}
+	PublishWorkflowDraft(w, r)
+}
+
+func GenerateAuthoringFixture(w http.ResponseWriter, r *http.Request) {
+	treeHash := r.URL.Query().Get("tree_hash")
+	if treeHash == "" {
+		common.ReplyErr(w, "invalid body", 400)
+		return
+	}
+	sum := sha256.Sum256([]byte(treeHash))
+	id := hex.EncodeToString(sum[:16])
+	files := map[string]string{"plugin.yaml": "id: " + id + "\nslots: []\nsteps:\n  - {id: execute, label: Execute}\n", "scenario/state.yml": "transitions:\n  __start__: [{to: execute}]\n  execute: [{to: __end__}]\nsteps:\n  execute: {outputs: []}\n", "scenario/scenario.md": "# Deterministic fixture\n\nThe execute step produces the requested result.\n"}
+	common.ReplyOK(w, map[string]any{"contract_version": AuthoringContractVersion, "generator": "deterministic-fixture-v1", "files": files})
+}

--- a/backend/core/workflow/authoring_handlers.go
+++ b/backend/core/workflow/authoring_handlers.go
@@ -190,7 +190,8 @@ func UpdateAuthoringWorkflowDraftFile(w http.ResponseWriter, r *http.Request) {
 	}
 	files := map[string]string{body.Path: body.Content}
 	applyAuthoringFiles(&draft, files)
-	updates := map[string]any{"plugin_yaml_content": draft.WorkflowYAMLContent, "state_yaml_content": draft.StateYAMLContent, "scenario_content": draft.ScenarioContent, "state_layout_content": draft.StateLayoutContent, "scripts_content": draft.ScriptsContent, "plugin_id": extractWorkflowID(draft.WorkflowYAMLContent), "version": gorm.Expr("version + 1"), "updated_at": time.Now().UTC()}
+	// Use domain field names here; GORM owns the legacy physical-column mapping.
+	updates := map[string]any{"WorkflowYAMLContent": draft.WorkflowYAMLContent, "StateYAMLContent": draft.StateYAMLContent, "ScenarioContent": draft.ScenarioContent, "StateLayoutContent": draft.StateLayoutContent, "ScriptsContent": draft.ScriptsContent, "WorkflowID": extractWorkflowID(draft.WorkflowYAMLContent), "Version": gorm.Expr("version + 1"), "UpdatedAt": time.Now().UTC()}
 	result := store.DB().Model(&orm.WorkflowDraft{}).Where("id=? AND created_by=? AND version=?", draftID, userID, body.ExpectedVersion).Updates(updates)
 	if result.Error != nil {
 		common.ReplyErr(w, "save failed", http.StatusInternalServerError)

--- a/backend/core/workflow/authoring_handlers_test.go
+++ b/backend/core/workflow/authoring_handlers_test.go
@@ -1,0 +1,108 @@
+package workflow
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gorilla/mux"
+	"lazymind/core/common/orm"
+)
+
+func seedAuthoringSkill(t *testing.T, db *orm.DB) {
+	t.Helper()
+	for _, statement := range []string{
+		`CREATE TABLE IF NOT EXISTS skills(id text primary key, owner_user_id text, skill_name text, head_revision_id text, deleted_at datetime)`,
+		`CREATE TABLE IF NOT EXISTS skill_revisions(id text primary key, skill_id text, revision_no integer, tree_hash text)`,
+		`CREATE TABLE IF NOT EXISTS skill_revision_entries(revision_id text, path text, entry_type text, blob_hash text, size integer, mime text, file_type text, binary boolean)`,
+		`CREATE TABLE IF NOT EXISTS skill_blobs(hash text primary key, content blob)`,
+		`INSERT INTO skills VALUES('skill-1','user-1','Pinned Skill','revision-1',NULL)`,
+		`INSERT INTO skill_revisions VALUES('revision-1','skill-1',1,'tree-fixed')`,
+		`INSERT INTO skill_blobs VALUES('blob-1','# Pinned Skill')`,
+		`INSERT INTO skill_revision_entries VALUES('revision-1','SKILL.md','file','blob-1',14,'text/markdown','markdown',0)`,
+	} {
+		if err := db.Exec(statement).Error; err != nil {
+			t.Fatal(err)
+		}
+	}
+}
+
+func TestAuthoringFixtureAndLazyMindDraftShareDeterministicDiagnostics(t *testing.T) {
+	db := newHandlerTestDB(t)
+	seedAuthoringSkill(t, db)
+	fixtureReq := httptest.NewRequest(http.MethodGet, "/workflow-authoring/v1/fixture?tree_hash=tree-fixed", nil)
+	fixtureRec := httptest.NewRecorder()
+	GenerateAuthoringFixture(fixtureRec, fixtureReq)
+	var fixtureEnvelope struct {
+		Data struct {
+			Files map[string]string `json:"files"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(fixtureRec.Body.Bytes(), &fixtureEnvelope); err != nil {
+		t.Fatal(err)
+	}
+	filesJSON, _ := json.Marshal(fixtureEnvelope.Data.Files)
+	createBody := `{"name":"Fixture","skill_id":"skill-1","revision_id":"revision-1","tree_hash":"tree-fixed","files":` + string(filesJSON) + `}`
+	createReq := httptest.NewRequest(http.MethodPost, "/workflow-authoring/v1/drafts", strings.NewReader(createBody))
+	createReq.Header.Set("X-User-Id", "user-1")
+	createRec := httptest.NewRecorder()
+	CreateAuthoringWorkflowDraft(createRec, createReq)
+	if createRec.Code != http.StatusOK {
+		t.Fatalf("create=%d %s", createRec.Code, createRec.Body.String())
+	}
+	var draft orm.WorkflowDraft
+	if err := db.Where("created_by=?", "user-1").First(&draft).Error; err != nil {
+		t.Fatal(err)
+	}
+	first := authoringDiagnosticsForDraft(db.DB, draft)
+	second := authoringDiagnosticsForDraft(db.DB, draft)
+	a, _ := json.Marshal(first)
+	b, _ := json.Marshal(second)
+	if string(a) != string(b) || !first.Valid {
+		t.Fatalf("diagnostics not deterministic/valid: %s vs %s", a, b)
+	}
+	if draft.SourceSkillRevisionID != "revision-1" || draft.SourceSkillTreeHash != "tree-fixed" {
+		t.Fatalf("snapshot not fixed: %#v", draft)
+	}
+}
+
+func TestAuthoringFileUpdateUsesOptimisticVersion(t *testing.T) {
+	db := newHandlerTestDB(t)
+	now := time.Now().UTC()
+	draft := orm.WorkflowDraft{ID: "draft-1", Name: "Draft", CreatedBy: "user-1", Version: 1, ScriptsContent: "{}", CreatedAt: now, UpdatedAt: now}
+	if err := db.Create(&draft).Error; err != nil {
+		t.Fatal(err)
+	}
+	call := func(version int) *httptest.ResponseRecorder {
+		req := httptest.NewRequest(http.MethodPut, "/workflow-authoring/v1/drafts/draft-1/files", strings.NewReader(`{"path":"plugin.yaml","content":"id: fixed","expected_version":`+strconv.Itoa(version)+`}`))
+		req.Header.Set("X-User-Id", "user-1")
+		req = mux.SetURLVars(req, map[string]string{"draft_id": "draft-1"})
+		rec := httptest.NewRecorder()
+		UpdateAuthoringWorkflowDraftFile(rec, req)
+		return rec
+	}
+	if got := call(1); got.Code != http.StatusOK {
+		t.Fatalf("update=%d %s", got.Code, got.Body.String())
+	}
+	if got := call(1); got.Code != http.StatusConflict {
+		t.Fatalf("stale update=%d %s", got.Code, got.Body.String())
+	}
+}
+
+func TestAuthoringSourceContainsNoModelInvocation(t *testing.T) {
+	data, err := os.ReadFile("authoring_handlers.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	text := string(data)
+	for _, forbidden := range []string{"core/algo", "modelconfig", "http://chat", "GenerateWorkflowStaged"} {
+		if strings.Contains(text, forbidden) {
+			t.Fatalf("implicit model dependency %q", forbidden)
+		}
+	}
+}

--- a/backend/core/workflow/publish_handlers.go
+++ b/backend/core/workflow/publish_handlers.go
@@ -120,24 +120,29 @@ func PublishWorkflowDraft(w http.ResponseWriter, r *http.Request) {
 		common.ReplyErr(w, "not found", http.StatusNotFound)
 		return
 	}
+	diagnostics := authoringDiagnosticsForDraft(store.DB(), d)
+	if !diagnostics.Valid {
+		status := http.StatusUnprocessableEntity
+		message := "plugin validation failed"
+		for _, diagnostic := range diagnostics.Diagnostics {
+			switch diagnostic.Code {
+			case "PACKAGE_INCOMPLETE":
+				status, message = http.StatusBadRequest, diagnostic.Message
+			case "FRAMEWORK_TOOL_UNAVAILABLE":
+				status, message = http.StatusConflict, "framework tool unavailable"
+			case "SCRIPT_APPROVAL_REQUIRED":
+				status, message = http.StatusForbidden, "custom plugin scripts require the administrator publishing workflow"
+			}
+		}
+		common.ReplyErrWithData(w, message, diagnostics, status)
+		return
+	}
 	files, err := workflowFiles(d)
 	if err != nil {
 		common.ReplyErr(w, err.Error(), http.StatusBadRequest)
 		return
 	}
 	compiled := graphengine.Compile(d.WorkflowYAMLContent, d.StateYAMLContent, d.ScenarioContent, graphengine.ProfilePublish)
-	if !compiled.Valid {
-		common.ReplyErrWithData(w, "plugin validation failed", compiled, http.StatusUnprocessableEntity)
-		return
-	}
-	if !frameworkToolsAvailableForPublish(store.DB(), d) {
-		common.ReplyErr(w, "framework tool unavailable", http.StatusConflict)
-		return
-	}
-	if len(files) > 3 && !scriptsApprovedForPublish(store.DB(), d) {
-		common.ReplyErr(w, "custom plugin scripts require the administrator publishing workflow", http.StatusForbidden)
-		return
-	}
 	pid := extractWorkflowID(d.WorkflowYAMLContent)
 	if pid == "" {
 		common.ReplyErr(w, "plugin.yaml id required", http.StatusBadRequest)

--- a/docs/plan/plugin/phase-one-gate-audit.md
+++ b/docs/plan/plugin/phase-one-gate-audit.md
@@ -78,9 +78,9 @@ is checked and linked to executable evidence.
 
 ## PR 10 — deterministic Workflow authoring
 
-- [ ] Fixed Skill snapshot and draft file APIs are public and versioned.
-- [ ] Diagnostics and publication gates are deterministic and model-free.
-- [ ] LazyMind generation and static fixtures use the same validation/publish path.
+- [x] Fixed Skill snapshot and draft file APIs are public and versioned.
+- [x] Diagnostics and publication gates are deterministic and model-free.
+- [x] LazyMind generation and static fixtures use the same validation/publish path.
 
 ## PR 11 — phase-one acceptance
 

--- a/docs/plan/plugin/shared-workflow-agent-kit-plan.md
+++ b/docs/plan/plugin/shared-workflow-agent-kit-plan.md
@@ -316,7 +316,7 @@ Codex 生成过程中只使用 Codex 模型；Core 只提供 Skill snapshot、�
 | [ ] | 7 | 实现 LazyMindExecutor 和兼容 adapter | LazyMind SubAgent 通过新协议运行 |
 | [ ] | 8 | 移除 Core 到 `/api/subagent/run` 的固定依赖 | Runtime 与 LazyMind Executor 正式解耦 |
 | [ ] | 9 | 收敛 algorithm/chat prompt、Workflow manager 和 Driver adapter | 公共规则只来自共享 Skill |
-| [ ] | 10 | 拆分 Skill to Workflow Agent 生成与 Authoring Tools | 外部 Agent 可提交生成结果 |
+| [x] | [10 (#499)](https://github.com/LazyAGI/LazyMind/pull/499) | 拆分 Skill to Workflow Agent 生成与 Authoring Tools | 外部 Agent 可提交生成结果 |
 | [ ] | 11 | 完成 LazyMind 全量回归与旧接口清理 | 达到第一阶段验收条件 |
 | [ ] | 12 | 提供 Codex 只读 Tool Adapter 与 Status View | Codex 可以发现 Workflow，并查看状态图和下载 Artifact |
 | [ ] | 13 | 实现 Codex 串行全自动 Executor | Codex 独立执行 Workflow |


### PR DESCRIPTION
## Summary
- add versioned Authoring v1 APIs for fixed Skill snapshots, draft creation/file updates, diagnostics, publication, and static fixtures
- pin source Skill revision and tree hash and enforce owner-scoped optimistic draft updates
- reuse one deterministic compiler/diagnostic/publish gate for LazyMind generation and external/static authors
- guarantee Authoring handlers have no model, algorithm service, or hidden generation dependency

## Guardrail scope
- Phase 1 / PR10
- Base: `dev/workflow`

## Validation
- `go test ./workflow/... -count=1`
- Authoring, publish, validation, route, and error-catalog tests
- `make lint`

## Acceptance evidence
- public snapshot and file APIs are versioned and revision-pinned
- diagnostics are deterministic, stable-ordered, offline, and model-free
- publication rejects invalid or stale drafts through the shared gate
- static fixture and LazyMind-produced drafts use the same diagnostics and publish handler
