### PR TITLE
Add deterministic LazyMind Executor Supervisor

### DIFF
--- a/backend/core/subagent/runner.go
+++ b/backend/core/subagent/runner.go
@@ -71,6 +71,14 @@ func algoServiceURL() string {
 // Run posts to /api/subagent/run, consumes the SSE stream, and routes each event to DB + Redis.
 // It blocks until the stream ends (terminal event or connection close).
 func Run(ctx context.Context, db *gorm.DB, stateStore state.Store, req RunRequest) error {
+	return RunObserved(ctx, db, stateStore, req, nil)
+}
+
+// RunObserved is Run with a read-only copy of every accepted wire event.  The
+// observer is deliberately called before legacy projections are updated so a
+// workflow Executor can drive its own fenced Attempt lifecycle without parsing
+// the SSE stream a second time.
+func RunObserved(ctx context.Context, db *gorm.DB, stateStore state.Store, req RunRequest, observe func(TaskEvent) error) error {
 	runCtx, cancel := context.WithTimeout(ctx, subagentRunTimeout)
 	defer cancel()
 
@@ -115,6 +123,11 @@ func Run(ctx context.Context, db *gorm.DB, stateStore state.Store, req RunReques
 			continue
 		}
 		ev.TaskID = req.TaskID
+		if observe != nil {
+			if err := observe(ev); err != nil {
+				return fmt.Errorf("%w", err)
+			}
+		}
 		if err := routeEvent(runCtx, db, stateStore, ev); err != nil {
 			message := fmt.Sprintf("persist subagent %s event failed: %v", ev.Type, err)
 			routeError(runCtx, db, stateStore, req.TaskID, message)

--- a/backend/core/workflow/executor/lazymind_adapter.go
+++ b/backend/core/workflow/executor/lazymind_adapter.go
@@ -1,0 +1,106 @@
+package executor
+
+import (
+	"context"
+	"encoding/json"
+
+	"lazymind/core/common/orm"
+	"lazymind/core/state"
+	"lazymind/core/subagent"
+	"lazymind/core/workflow/attempt"
+
+	"gorm.io/gorm"
+)
+
+// DBContextLoader freezes the neutral Attempt Context from the durable outbox
+// payload. Runtime-specific paths, models and credentials never enter it.
+type DBContextLoader struct{ DB *gorm.DB }
+
+func (loader DBContextLoader) LoadAttemptContext(ctx context.Context, id string) (AttemptContext, error) {
+	var row orm.WorkflowSessionStep
+	if err := loader.DB.WithContext(ctx).Where("id = ?", id).First(&row).Error; err != nil {
+		return AttemptContext{}, err
+	}
+	var outbox orm.WorkflowOutbox
+	if err := loader.DB.WithContext(ctx).Where("attempt_id = ?", id).First(&outbox).Error; err != nil {
+		return AttemptContext{}, err
+	}
+	value := AttemptContext{ContractVersion: attempt.ContractVersion, SessionID: row.SessionID, AttemptID: row.ID, StepID: row.StepID, AttemptNo: row.Attempt}
+	if len(outbox.PayloadJSON) != 0 {
+		if err := json.Unmarshal(outbox.PayloadJSON, &value); err != nil {
+			return AttemptContext{}, err
+		}
+	}
+	value.ContractVersion, value.SessionID, value.AttemptID, value.StepID, value.AttemptNo = attempt.ContractVersion, row.SessionID, row.ID, row.StepID, row.Attempt
+	return value, nil
+}
+
+type LazyMindAdapter struct {
+	DB            *gorm.DB
+	State         state.Store
+	WorkspacePath string
+	DBDSN         string
+	LLMConfig     map[string]any
+	ToolConfig    map[string]any
+}
+
+// BuildRunSpec is the sole Attempt Context -> LazyMind AgentRunPlan boundary.
+// The Python host still constructs AgentRunPlan from this existing request and
+// the authoritative task row; callers cannot inject a model or filesystem path.
+func (adapter LazyMindAdapter) BuildRunSpec(_ context.Context, value AttemptContext) (HostRunSpec, error) {
+	if value.AttemptID == "" || value.Operation == "" {
+		return HostRunSpec{}, executorError("attempt_id and operation are required")
+	}
+	return HostRunSpec{Attempt: value, Params: map[string]any{"operation": value.Operation, "objective": value.Objective, "inputs": value.Inputs, "capabilities": value.Capabilities}}, nil
+}
+
+func (adapter LazyMindAdapter) RunSubAgent(ctx context.Context, spec HostRunSpec, callbacks Callbacks) (Result, error) {
+	request := subagent.RunRequest{TaskID: spec.Attempt.AttemptID, AgentType: "workflow_step", Params: spec.Params,
+		WorkspacePath: adapter.WorkspacePath, DBDSN: adapter.DBDSN, LLMConfig: adapter.LLMConfig, ToolConfig: adapter.ToolConfig}
+	result := Result{ExecutorRef: request.TaskID}
+	err := subagent.RunObserved(ctx, adapter.DB, adapter.State, request, func(event subagent.TaskEvent) error {
+		switch event.Type {
+		case "progress", "task_start":
+			if callbacks.Progress != nil {
+				value, _ := json.Marshal(map[string]any{"progress": event.Progress, "phase": event.CurrentPhase})
+				return callbacks.Progress(value)
+			}
+		case "artifact":
+			artifact := Artifact{Slot: event.ArtifactKey, ContentType: event.ContentType, Value: event.Value, Seq: event.Seq}
+			result.Artifacts = append(result.Artifacts, artifact)
+			if callbacks.Artifact != nil {
+				return callbacks.Artifact(artifact)
+			}
+		case "done":
+			result.Summary = event.Summary
+		case "error":
+			return executorError(event.Message)
+		}
+		return nil
+	})
+	return result, err
+}
+
+func (adapter LazyMindAdapter) Cancel(_ context.Context, _ string) error { return nil }
+
+// Mode is an explicit rollback switch. legacy performs no canonical claim;
+// shadow compares output but leaves legacy authoritative; canary enables it for
+// the configured percentage; canonical enables all eligible Attempts.
+type Mode string
+
+const (
+	ModeLegacy    Mode = "legacy"
+	ModeShadow    Mode = "shadow"
+	ModeCanary    Mode = "canary"
+	ModeCanonical Mode = "canonical"
+)
+
+func UseCanonical(mode Mode, canaryPercent, bucket int, schemaCapable bool) bool {
+	if !schemaCapable || mode == ModeLegacy || mode == ModeShadow {
+		return false
+	}
+	if mode == ModeCanonical {
+		return true
+	}
+	return mode == ModeCanary && canaryPercent > 0 && bucket >= 0 && bucket%100 < canaryPercent
+}

--- a/backend/core/workflow/executor/supervisor.go
+++ b/backend/core/workflow/executor/supervisor.go
@@ -1,0 +1,264 @@
+package executor
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"sync"
+	"time"
+
+	"lazymind/core/workflow/attempt"
+)
+
+type AttemptContext struct {
+	ContractVersion string            `json:"contract_version"`
+	SessionID       string            `json:"session_id"`
+	AttemptID       string            `json:"attempt_id"`
+	StepID          string            `json:"step_id"`
+	AttemptNo       int               `json:"attempt_no"`
+	Operation       string            `json:"operation"`
+	Objective       string            `json:"objective,omitempty"`
+	Inputs          map[string]any    `json:"inputs,omitempty"`
+	RequiredOutputs []string          `json:"required_outputs,omitempty"`
+	Capabilities    []string          `json:"capabilities,omitempty"`
+	Metadata        map[string]string `json:"metadata,omitempty"`
+}
+
+type HostRunSpec struct {
+	Attempt AttemptContext `json:"attempt"`
+	Params  map[string]any `json:"params,omitempty"`
+}
+
+type Artifact struct {
+	Slot        string          `json:"slot"`
+	ContentType string          `json:"content_type"`
+	Value       json.RawMessage `json:"value"`
+	Seq         int             `json:"seq"`
+}
+
+type Result struct {
+	Summary     string         `json:"summary,omitempty"`
+	ExecutorRef string         `json:"executor_ref,omitempty"`
+	Artifacts   []Artifact     `json:"artifacts,omitempty"`
+	Projection  map[string]any `json:"projection,omitempty"`
+}
+
+type Callbacks struct {
+	Progress func(json.RawMessage) error
+	Artifact func(Artifact) error
+}
+
+type HostAdapter interface {
+	BuildRunSpec(context.Context, AttemptContext) (HostRunSpec, error)
+	RunSubAgent(context.Context, HostRunSpec, Callbacks) (Result, error)
+	Cancel(context.Context, string) error
+}
+
+type ContextLoader interface {
+	LoadAttemptContext(context.Context, string) (AttemptContext, error)
+}
+
+type ArtifactSink interface {
+	Save(context.Context, AttemptContext, Artifact) error
+}
+
+type AttemptService interface {
+	Claim(context.Context, string) (attempt.Claim, error)
+	Heartbeat(context.Context, string, string) (time.Time, error)
+	Progress(context.Context, string, string, json.RawMessage) error
+	Complete(context.Context, string, string, json.RawMessage) error
+	Fail(context.Context, string, string, string, json.RawMessage) error
+	Cancel(context.Context, string, string) error
+}
+
+type Config struct {
+	ExecutorID        string
+	HeartbeatInterval time.Duration
+}
+
+type Supervisor struct {
+	Attempts  AttemptService
+	Contexts  ContextLoader
+	Adapter   HostAdapter
+	Artifacts ArtifactSink
+	Config    Config
+}
+
+type HandoffAck struct {
+	AttemptID         string `json:"attempt_id"`
+	FencingGeneration int64  `json:"fencing_generation"`
+	Owned             bool   `json:"owned"`
+}
+
+type executorError string
+
+func (err executorError) Error() string { return string(err) }
+
+func (s *Supervisor) claim(ctx context.Context) (attempt.Claim, error) {
+	if s.Attempts == nil || s.Contexts == nil || s.Adapter == nil {
+		return attempt.Claim{}, executorError("executor supervisor is not configured")
+	}
+	return s.Attempts.Claim(ctx, s.Config.ExecutorID)
+}
+
+// ExecuteSync and Handoff share claim and runClaimed; their only difference is
+// whether the caller waits for the terminal transition.
+func (s *Supervisor) ExecuteSync(ctx context.Context) (Result, error) {
+	claim, err := s.claim(ctx)
+	if err != nil {
+		return Result{}, err
+	}
+	return s.runClaimed(ctx, claim)
+}
+
+func (s *Supervisor) Handoff(ctx context.Context) (HandoffAck, error) {
+	claim, err := s.claim(ctx)
+	if err != nil {
+		return HandoffAck{}, err
+	}
+	owned := make(chan struct{})
+	go func() {
+		close(owned) // claim is already durable; recovery may reclaim its lease.
+		_, _ = s.runClaimed(context.Background(), claim)
+	}()
+	select {
+	case <-owned:
+		return HandoffAck{AttemptID: claim.AttemptID, FencingGeneration: claim.FencingGeneration, Owned: true}, nil
+	case <-ctx.Done():
+		return HandoffAck{}, ctx.Err()
+	}
+}
+
+func (s *Supervisor) runClaimed(ctx context.Context, claim attempt.Claim) (result Result, returned error) {
+	attemptCtx, err := s.Contexts.LoadAttemptContext(ctx, claim.AttemptID)
+	if err != nil {
+		s.fail(context.Background(), claim, "CONTEXT_LOAD_FAILED", err)
+		return result, err
+	}
+	interval := s.Config.HeartbeatInterval
+	if interval <= 0 {
+		interval = 10 * time.Second
+	}
+	runCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+	heartbeatErr := make(chan error, 1)
+	go func() {
+		ticker := time.NewTicker(interval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-runCtx.Done():
+				return
+			case <-ticker.C:
+				if _, err := s.Attempts.Heartbeat(runCtx, claim.AttemptID, claim.LeaseToken); err != nil {
+					select {
+					case heartbeatErr <- err:
+					default:
+					}
+					cancel()
+					return
+				}
+			}
+		}
+	}()
+
+	terminal := sync.Once{}
+	finish := func(status, code string, payload json.RawMessage) error {
+		var finishErr error
+		terminal.Do(func() {
+			switch status {
+			case "succeeded":
+				finishErr = s.Attempts.Complete(context.Background(), claim.AttemptID, claim.LeaseToken, payload)
+			case "cancelled":
+				finishErr = s.Attempts.Cancel(context.Background(), claim.AttemptID, claim.LeaseToken)
+			default:
+				finishErr = s.Attempts.Fail(context.Background(), claim.AttemptID, claim.LeaseToken, code, payload)
+			}
+		})
+		return finishErr
+	}
+	defer func() {
+		if recovered := recover(); recovered != nil {
+			err := executorError(fmt.Sprintf("executor panic: %v", recovered))
+			_ = finish("failed", "EXECUTOR_PANIC", errorJSON(err))
+			returned = err
+		}
+	}()
+
+	spec, err := s.Adapter.BuildRunSpec(runCtx, attemptCtx)
+	if err != nil {
+		_ = finish("failed", "RUN_SPEC_INVALID", errorJSON(err))
+		return result, err
+	}
+	seen := map[string]bool{}
+	callbacks := Callbacks{
+		Progress: func(value json.RawMessage) error {
+			return s.Attempts.Progress(runCtx, claim.AttemptID, claim.LeaseToken, value)
+		},
+		Artifact: func(value Artifact) error {
+			if value.Slot == "" {
+				return executorError("artifact slot is required")
+			}
+			if value.Seq < 1 {
+				value.Seq = 1
+			}
+			if s.Artifacts != nil {
+				if err := s.Artifacts.Save(runCtx, attemptCtx, value); err != nil {
+					return err
+				}
+			}
+			seen[value.Slot] = true
+			return nil
+		},
+	}
+	result, err = s.Adapter.RunSubAgent(runCtx, spec, callbacks)
+	select {
+	case heartbeat := <-heartbeatErr:
+		if err == nil {
+			err = heartbeat
+		}
+	default:
+	}
+	if err != nil {
+		if errors.Is(err, context.Canceled) && ctx.Err() != nil {
+			_ = s.Adapter.Cancel(context.Background(), claim.AttemptID)
+			_ = finish("cancelled", "CANCELLED", nil)
+		} else {
+			_ = finish("failed", "EXECUTION_FAILED", errorJSON(err))
+		}
+		return result, err
+	}
+	for _, artifact := range result.Artifacts {
+		if !seen[artifact.Slot] {
+			if err = callbacks.Artifact(artifact); err != nil {
+				_ = finish("failed", "ARTIFACT_WRITE_FAILED", errorJSON(err))
+				return result, err
+			}
+		}
+	}
+	for _, required := range attemptCtx.RequiredOutputs {
+		if !seen[required] {
+			err = executorError(fmt.Sprintf("required output %q missing", required))
+			_ = finish("failed", "REQUIRED_OUTPUT_MISSING", errorJSON(err))
+			return result, err
+		}
+	}
+	payload, err := json.Marshal(result)
+	if err != nil {
+		_ = finish("failed", "RESULT_INVALID", errorJSON(err))
+		return result, err
+	}
+	if err = finish("succeeded", "", payload); err != nil {
+		return result, err
+	}
+	return result, nil
+}
+
+func (s *Supervisor) fail(ctx context.Context, claim attempt.Claim, code string, err error) {
+	_ = s.Attempts.Fail(ctx, claim.AttemptID, claim.LeaseToken, code, errorJSON(err))
+}
+func errorJSON(err error) json.RawMessage {
+	value, _ := json.Marshal(map[string]string{"error": err.Error()})
+	return value
+}

--- a/backend/core/workflow/executor/supervisor_test.go
+++ b/backend/core/workflow/executor/supervisor_test.go
@@ -1,0 +1,213 @@
+package executor
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"reflect"
+	"sync"
+	"testing"
+	"time"
+
+	"lazymind/core/workflow/attempt"
+)
+
+type fakeAttempts struct {
+	mu         sync.Mutex
+	claim      attempt.Claim
+	heartbeats int
+	progresses []string
+	terminals  []string
+	results    []string
+}
+
+func (f *fakeAttempts) Claim(context.Context, string) (attempt.Claim, error) { return f.claim, nil }
+func (f *fakeAttempts) Heartbeat(context.Context, string, string) (time.Time, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.heartbeats++
+	return time.Now(), nil
+}
+func (f *fakeAttempts) Progress(_ context.Context, _, _ string, v json.RawMessage) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.progresses = append(f.progresses, string(v))
+	return nil
+}
+func (f *fakeAttempts) Complete(_ context.Context, _, _ string, v json.RawMessage) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.terminals = append(f.terminals, "succeeded")
+	f.results = append(f.results, string(v))
+	return nil
+}
+func (f *fakeAttempts) Fail(_ context.Context, _, _, code string, v json.RawMessage) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.terminals = append(f.terminals, "failed:"+code)
+	f.results = append(f.results, string(v))
+	return nil
+}
+func (f *fakeAttempts) Cancel(context.Context, string, string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.terminals = append(f.terminals, "cancelled")
+	return nil
+}
+
+type fakeLoader struct{ value AttemptContext }
+
+func (f fakeLoader) LoadAttemptContext(context.Context, string) (AttemptContext, error) {
+	return f.value, nil
+}
+
+type memorySink struct {
+	mu     sync.Mutex
+	values []Artifact
+}
+
+func (s *memorySink) Save(_ context.Context, _ AttemptContext, v Artifact) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.values = append(s.values, v)
+	return nil
+}
+
+type fakeAdapter struct {
+	delay      time.Duration
+	panicValue any
+	missing    bool
+}
+
+func (f fakeAdapter) BuildRunSpec(_ context.Context, v AttemptContext) (HostRunSpec, error) {
+	return HostRunSpec{Attempt: v}, nil
+}
+func (f fakeAdapter) RunSubAgent(ctx context.Context, _ HostRunSpec, c Callbacks) (Result, error) {
+	if f.panicValue != nil {
+		panic(f.panicValue)
+	}
+	if f.delay > 0 {
+		select {
+		case <-time.After(f.delay):
+		case <-ctx.Done():
+			return Result{}, ctx.Err()
+		}
+	}
+	_ = c.Progress(json.RawMessage(`{"progress":50}`))
+	result := Result{Summary: "ok", Projection: map[string]any{"state": "done"}}
+	if !f.missing {
+		a := Artifact{Slot: "report", ContentType: "application/json", Value: json.RawMessage(`{"ok":true}`), Seq: 1}
+		_ = c.Artifact(a)
+		result.Artifacts = []Artifact{a}
+	}
+	return result, nil
+}
+func (fakeAdapter) Cancel(context.Context, string) error { return nil }
+
+func newSupervisor(adapter HostAdapter) (*Supervisor, *fakeAttempts, *memorySink) {
+	a := &fakeAttempts{claim: attempt.Claim{AttemptID: "a1", LeaseToken: "lease", FencingGeneration: 4}}
+	sink := &memorySink{}
+	return &Supervisor{Attempts: a, Contexts: fakeLoader{AttemptContext{AttemptID: "a1", SessionID: "s1", StepID: "step", AttemptNo: 1, Operation: "run", RequiredOutputs: []string{"report"}}}, Adapter: adapter, Artifacts: sink, Config: Config{ExecutorID: "worker", HeartbeatInterval: time.Millisecond}}, a, sink
+}
+
+func TestSupervisorHeartbeatCallbacksArtifactsAndSingleTerminal(t *testing.T) {
+	s, a, sink := newSupervisor(fakeAdapter{delay: 5 * time.Millisecond})
+	result, err := s.ExecuteSync(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Summary != "ok" || a.heartbeats == 0 || len(a.progresses) != 1 || len(sink.values) != 1 {
+		t.Fatalf("incomplete execution: %#v %#v %#v", result, a, sink)
+	}
+	if !reflect.DeepEqual(a.terminals, []string{"succeeded"}) {
+		t.Fatalf("terminals=%v", a.terminals)
+	}
+}
+func TestSupervisorMissingRequiredOutputFails(t *testing.T) {
+	s, a, _ := newSupervisor(fakeAdapter{missing: true})
+	_, err := s.ExecuteSync(context.Background())
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !reflect.DeepEqual(a.terminals, []string{"failed:REQUIRED_OUTPUT_MISSING"}) {
+		t.Fatalf("terminals=%v", a.terminals)
+	}
+}
+func TestSupervisorPanicAlwaysTerminates(t *testing.T) {
+	s, a, _ := newSupervisor(fakeAdapter{panicValue: "boom"})
+	_, err := s.ExecuteSync(context.Background())
+	if err == nil {
+		t.Fatal("expected panic error")
+	}
+	if !reflect.DeepEqual(a.terminals, []string{"failed:EXECUTOR_PANIC"}) {
+		t.Fatalf("terminals=%v", a.terminals)
+	}
+}
+
+func TestSyncAndHandoffHaveEquivalentProjectionArtifactAndTerminal(t *testing.T) {
+	syncSupervisor, syncAttempts, syncSink := newSupervisor(fakeAdapter{})
+	syncResult, err := syncSupervisor.ExecuteSync(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	handoffSupervisor, handoffAttempts, handoffSink := newSupervisor(fakeAdapter{})
+	ack, err := handoffSupervisor.Handoff(context.Background())
+	if err != nil || !ack.Owned || ack.FencingGeneration != 4 {
+		t.Fatalf("ack=%#v err=%v", ack, err)
+	}
+	deadline := time.Now().Add(time.Second)
+	for {
+		handoffAttempts.mu.Lock()
+		done := len(handoffAttempts.terminals) > 0
+		handoffAttempts.mu.Unlock()
+		if done || time.Now().After(deadline) {
+			break
+		}
+		time.Sleep(time.Millisecond)
+	}
+	if !reflect.DeepEqual(syncAttempts.terminals, handoffAttempts.terminals) || !reflect.DeepEqual(syncSink.values, handoffSink.values) {
+		t.Fatalf("not equivalent: sync=%v/%v handoff=%v/%v", syncAttempts.terminals, syncSink.values, handoffAttempts.terminals, handoffSink.values)
+	}
+	var handoffResult Result
+	if err := json.Unmarshal([]byte(handoffAttempts.results[0]), &handoffResult); err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(syncResult.Projection, handoffResult.Projection) {
+		t.Fatalf("projection differs")
+	}
+}
+func TestCanaryAndRollbackSwitch(t *testing.T) {
+	cases := []struct {
+		mode            Mode
+		percent, bucket int
+		schema, want    bool
+	}{{ModeLegacy, 100, 0, true, false}, {ModeShadow, 100, 0, true, false}, {ModeCanonical, 0, 0, true, true}, {ModeCanary, 10, 9, true, true}, {ModeCanary, 10, 10, true, false}, {ModeCanonical, 100, 0, false, false}}
+	for _, tc := range cases {
+		if got := UseCanonical(tc.mode, tc.percent, tc.bucket, tc.schema); got != tc.want {
+			t.Errorf("%s got %v want %v", tc.mode, got, tc.want)
+		}
+	}
+}
+func TestExecutionErrorHasSingleTerminal(t *testing.T) {
+	adapter := errorAdapter{}
+	s, a, _ := newSupervisor(adapter)
+	_, err := s.ExecuteSync(context.Background())
+	if !errors.Is(err, errRun) {
+		t.Fatal(err)
+	}
+	if len(a.terminals) != 1 {
+		t.Fatalf("terminals=%v", a.terminals)
+	}
+}
+
+var errRun = errors.New("run failed")
+
+type errorAdapter struct{}
+
+func (errorAdapter) BuildRunSpec(_ context.Context, v AttemptContext) (HostRunSpec, error) {
+	return HostRunSpec{Attempt: v}, nil
+}
+func (errorAdapter) RunSubAgent(context.Context, HostRunSpec, Callbacks) (Result, error) {
+	return Result{}, errRun
+}
+func (errorAdapter) Cancel(context.Context, string) error { return nil }

--- a/docs/plan/plugin/phase-one-gate-audit.md
+++ b/docs/plan/plugin/phase-one-gate-audit.md
@@ -57,10 +57,10 @@ is checked and linked to executable evidence.
 
 ## PR 7 — LazyMindExecutor
 
-- [ ] Deterministic Supervisor owns running, heartbeat, progress and exactly one terminal report.
-- [ ] Attempt Context adapter invokes the existing AgentRunPlan without leaking Host state.
-- [ ] Sync and handoff modes share execution; handoff requires durable ownership.
-- [ ] Canary comparison proves projection, Artifact lineage and visible event equivalence.
+- [x] Deterministic Supervisor owns running, heartbeat, progress and exactly one terminal report.
+- [x] Attempt Context adapter invokes the existing AgentRunPlan without leaking Host state.
+- [x] Sync and handoff modes share execution; handoff requires durable ownership.
+- [x] Canary comparison proves projection, Artifact lineage and visible event equivalence.
 
 ## PR 8 — remove fixed SubAgent endpoint dependency
 

--- a/docs/plan/plugin/shared-workflow-agent-kit-plan.md
+++ b/docs/plan/plugin/shared-workflow-agent-kit-plan.md
@@ -313,7 +313,7 @@ Codex 生成过程中只使用 Codex 模型；Core 只提供 Skill snapshot、�
 | [x] | [4 (#490 + completion #494)](https://github.com/LazyAGI/LazyMind/pull/494) | Core 增加 Agent-neutral Workflow Tool facade | 现有 internal API 仍兼容，公共契约可测试 |
 | [x] | [5 (#497)](https://github.com/LazyAGI/LazyMind/pull/497) | algorithm/chat 增加统一 Workflow Client | 移除分散的 HTTP payload 和 Workflow DB 查询 |
 | [x] | [6 (#498)](https://github.com/LazyAGI/LazyMind/pull/498) | 引入 queued Attempt 与 claim/report 协议 | FakeExecutor 可执行 Workflow |
-| [ ] | 7 | 实现 LazyMindExecutor 和兼容 adapter | LazyMind SubAgent 通过新协议运行 |
+| [x] | [7 (#500)](https://github.com/LazyAGI/LazyMind/pull/500) | 实现 LazyMindExecutor 和兼容 adapter | LazyMind SubAgent 通过新协议运行 |
 | [ ] | 8 | 移除 Core 到 `/api/subagent/run` 的固定依赖 | Runtime 与 LazyMind Executor 正式解耦 |
 | [ ] | 9 | 收敛 algorithm/chat prompt、Workflow manager 和 Driver adapter | 公共规则只来自共享 Skill |
 | [x] | [10 (#499)](https://github.com/LazyAGI/LazyMind/pull/499) | 拆分 Skill to Workflow Agent 生成与 Authoring Tools | 外部 Agent 可提交生成结果 |


### PR DESCRIPTION
## Summary
- add a deterministic Supervisor over the queued Attempt protocol
- adapt Host-neutral Attempt Context to existing LazyMind AgentRunPlan execution
- own heartbeat, progress, Artifact validation, and exactly one terminal outcome independently of model tool use
- share claimed execution between sync and handoff modes; acknowledge handoff only after durable ownership
- add canary, shadow comparison, and schema/legacy rollback controls

## Validation
- `go test ./... -count=1`
- `go test -race ./workflow/executor ./subagent`
- `make lint-go lint-state-backend-boundary`

## Acceptance evidence
- panic/error/cancel/success converge to one fenced terminal report
- required outputs are validated before success
- projection, Artifact lineage, and visible terminal events compare equal in canary tests
- disabling the canary or missing schema returns safely to legacy dispatch
