### PR TITLE
Converge LazyMind on shared Workflow policy

### DIFF
--- a/algorithm/lazymind/chat/engine/agent_runtime/executor.py
+++ b/algorithm/lazymind/chat/engine/agent_runtime/executor.py
@@ -14,6 +14,7 @@ from .tool_limit_control import tool_limit_decision_coordinator
 
 _EXPANDED_BUDGET_TOOLS = {
     'advance_step',
+    'advance_step_and_handoff',
     'advance_step_and_hand_off',
     'create_workflow_draft',
     'create_subagent',

--- a/algorithm/lazymind/chat/service/component/tool_rendering.py
+++ b/algorithm/lazymind/chat/service/component/tool_rendering.py
@@ -828,6 +828,24 @@ _TOOL_EXECUTION_ERROR_RE = re.compile(
 )
 
 
+# Canonical Workflow v1 spelling. Keep the historical key only as an input
+# compatibility alias while every emitted/registered tool uses ``handoff``.
+for _workflow_template_map in (
+    _REPRESENTATIVE_TOOL_ARGUMENTS,
+    _REPRESENTATIVE_TOOL_RESULTS,
+    _TOOL_CALL_PREVIEW_TEMPLATES,
+    _ZH_TOOL_CALL_PREVIEW_TEMPLATES,
+    _TOOL_RESULT_PREVIEW_TEMPLATES,
+    _ZH_TOOL_RESULT_PREVIEW_TEMPLATES,
+    _TOOL_RESULT_FAILURE_TEMPLATES,
+    _ZH_TOOL_RESULT_FAILURE_TEMPLATES,
+):
+    if 'advance_step_and_hand_off' in _workflow_template_map:
+        _workflow_template_map['advance_step_and_handoff'] = (
+            _workflow_template_map['advance_step_and_hand_off']
+        )
+
+
 def _tool_name_suffixes(tool_name: str) -> list[str]:
     if not tool_name:
         return []

--- a/algorithm/lazymind/chat/workflow/client.py
+++ b/algorithm/lazymind/chat/workflow/client.py
@@ -131,6 +131,11 @@ class WorkflowClient:
         return self._read(f'/workflow-sessions/{session_id}/projection').result
 
     def advance(self, request: AdvanceRequest) -> WorkflowResponse:
+        # Core's pre-v1 wire spelling remains a metered transport alias. Agent
+        # surfaces and policy use the canonical ``..._handoff`` name.
+        if request.handoff:
+            from lazymind.chat.workflow.decision_policy import record_handoff_alias_call
+            record_handoff_alias_call()
         tool = 'advance_step_and_hand_off' if request.handoff else 'advance_step'
         payload = {
             'contract_version': CONTRACT_VERSION,

--- a/algorithm/lazymind/chat/workflow/decision_policy.py
+++ b/algorithm/lazymind/chat/workflow/decision_policy.py
@@ -1,0 +1,58 @@
+"""LazyMind Host binding for the authoritative shared Workflow policy."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Mapping
+
+
+POLICY_FLAG = 'LAZYMIND_WORKFLOW_POLICY_V1'
+POLICY_VERSION = 'workflow.policy.v1'
+legacy_policy_hits = 0
+compat_handoff_alias_hits = 0
+
+
+def shared_policy_enabled(environ: Mapping[str, str] | None = None) -> bool:
+    """Default-on policy switch; false is the bounded rollback path."""
+    value = (environ or os.environ).get(POLICY_FLAG, '1')
+    return value.strip().lower() not in {'0', 'false', 'no', 'off'}
+
+
+def record_legacy_policy_call() -> None:
+    global legacy_policy_hits
+    legacy_policy_hits += 1
+
+
+def record_handoff_alias_call() -> None:
+    global compat_handoff_alias_hits
+    compat_handoff_alias_hits += 1
+
+
+def _skill_root() -> Path:
+    return Path(__file__).resolve().parents[4] / 'skills' / 'workflow-agent-kit'
+
+
+def shared_decision_prompt() -> str:
+    """Load the canonical lifecycle policy directly from the shared Skill pack."""
+    root = _skill_root()
+    policy = (root / 'references' / 'decision-policy.md').read_text(encoding='utf-8')
+    return (
+        '## Shared Workflow Decision Policy [AUTHORITATIVE]\n\n'
+        f'Policy version: {POLICY_VERSION}. Runtime projection is authoritative.\n\n'
+        + policy
+    )
+
+
+def lazymind_host_prompt(workflow_mode: str) -> str:
+    """Describe Host capabilities without restating shared lifecycle decisions."""
+    driver = workflow_mode == 'auto'
+    return (
+        '\n\n## LazyMind Host Profile\n\n'
+        '- This Host supports synchronous waiting and durable handoff.\n'
+        '- `advance_step_and_handoff` is the canonical handoff tool name.\n'
+        f'- Driver is {"enabled" if driver else "disabled"}; this changes only turn orchestration.\n'
+        '- A handoff ends the ChatAgent turn only after durable Supervisor ownership.\n'
+        '- Driver, approval, stop-tool, and synthetic-turn behavior never change Runtime projection, '
+        'Attempt operation, or Artifact lineage.\n'
+    )

--- a/algorithm/lazymind/chat/workflow/workflow_manager.py
+++ b/algorithm/lazymind/chat/workflow/workflow_manager.py
@@ -3,7 +3,7 @@
 Tool types registered dynamically per-conversation:
 
 - trigger_<workflow_id>       : Cold-start tool. Injected when no active workflow session exists.
-- advance_step_and_hand_off : Asynchronous stop-tool accepting one or more step commands.
+- advance_step_and_handoff : Asynchronous stop-tool accepting one or more step commands.
 - advance_step              : Synchronous tool accepting one or more step commands; dynamic mode only.
 - ask_user                  : Ask the user a question (stop-tool). ChatAgent only; absent in auto mode.
 - intentwrite               : Extended with workflow-session and workflow-step scopes when active.
@@ -1201,7 +1201,7 @@ def build_cold_start_tools(
                 if static_advancement:
                     launch_plan.update({
                         'hand_off': True,
-                        'advance_tool': 'advance_step_and_hand_off',
+                        'advance_tool': 'advance_step_and_handoff',
                     })
                 elif inline_auto_step:
                     launch_plan.update({
@@ -1234,7 +1234,7 @@ def build_cold_start_tools(
                     instruction = (
                         'Infer whether the user explicitly requested multiple workflow steps. '
                         'If yes, choose `advance_step`; otherwise choose the default '
-                        '`advance_step_and_hand_off`. Do not answer with prose first.'
+                        '`advance_step_and_handoff`. Do not answer with prose first.'
                     )
                 return json.dumps({
                     'status': 'ready',
@@ -1292,7 +1292,7 @@ def _commit_prepared_workflow(
         raise ValueError(f'First step must be {expected_step!r}, got {step_id!r}.')
     expected_hand_off = bool(plan.get('hand_off', True))
     if isinstance(plan.get('hand_off'), bool) and hand_off != expected_hand_off:
-        expected_tool = 'advance_step_and_hand_off' if expected_hand_off else 'advance_step'
+        expected_tool = 'advance_step_and_handoff' if expected_hand_off else 'advance_step'
         raise ValueError(f'Launch plan requires {expected_tool}.')
     workflow_id = str(prepared.get('workflow_id') or '')
     normalised_request = str(plan.get('normalized_request') or '').strip()
@@ -1371,7 +1371,7 @@ def build_cold_advance_tools(workflow_mode: str = 'dynamic') -> List[Any]:
             )
         return _commit_prepared_workflow(step_id, hand_off=False)
 
-    def advance_step_and_hand_off(step_id: str) -> str:
+    def advance_step_and_handoff(step_id: str) -> str:
         """Start the prepared workflow and hand control off immediately.
 
         Use after a ready trigger when current request policy calls for an asynchronous boundary.
@@ -1386,7 +1386,7 @@ def build_cold_advance_tools(workflow_mode: str = 'dynamic') -> List[Any]:
         if cfg.get('workflow_session_id') and cfg.get('workflow_id'):
             prepared = cfg.get('prepared_workflow') or {}
             plan = prepared.get('launch_plan') or {}
-            return build_advance_step_and_hand_off_tool(
+            return build_advance_step_and_handoff_tool(
                 str(cfg['workflow_id']), str(cfg.get('workflow_step') or '')
             )(
                 steps=[{
@@ -1397,8 +1397,8 @@ def build_cold_advance_tools(workflow_mode: str = 'dynamic') -> List[Any]:
         return _commit_prepared_workflow(step_id, hand_off=True)
 
     if workflow_mode == 'auto':
-        return [advance_step_and_hand_off]
-    return [advance_step_and_hand_off, advance_step]
+        return [advance_step_and_handoff]
+    return [advance_step_and_handoff, advance_step]
 
 
 def commit_prepared_workflow_fallback() -> str:
@@ -1483,7 +1483,7 @@ async def _enforce_prepared_workflow_advance(
             'The workflow trigger already returned ready. Do not answer, explain, confirm, '
             'or ask another question. Immediately start first_step_id. Infer whether the user '
             'explicitly requested multiple workflow steps. Use `advance_step` only if they did; '
-            'otherwise use the default `advance_step_and_hand_off`. Launch plan:\n'
+            'otherwise use the default `advance_step_and_handoff`. Launch plan:\n'
             + json.dumps(visible_launch_plan, ensure_ascii=False)
             + '\n'
             + str(prepared.get('step_name_index') or '')
@@ -1614,7 +1614,7 @@ def _live_reachability_snapshot(
     )
 
 
-def build_advance_step_and_hand_off_tool(
+def build_advance_step_and_handoff_tool(
     workflow_id: str,
     current_step: str,
     rewind_steps: Optional[List[str]] = None,
@@ -1636,7 +1636,7 @@ def build_advance_step_and_hand_off_tool(
         include_default_approval=include_approval_guidance,
     )
 
-    def advance_step_and_hand_off(steps: List[Dict[str, Any]]) -> str:
+    def advance_step_and_handoff(steps: List[Dict[str, Any]]) -> str:
         """Start one or more Ready steps and end the current ReAct turn."""
         if not isinstance(steps, list) or not steps:
             raise ValueError('steps must contain at least one step command.')
@@ -1670,7 +1670,7 @@ def build_advance_step_and_hand_off_tool(
         if include_approval_guidance
         else 'Use this tool to start the selected next step.\n'
     )
-    advance_step_and_hand_off.__doc__ = (
+    advance_step_and_handoff.__doc__ = (
         'Start one or more Ready workflow steps asynchronously and end the current turn.\n\n'
         + selection_guidance
         + 'Pass one command for one step. Pass multiple commands only for independent Ready\n'
@@ -1681,7 +1681,14 @@ def build_advance_step_and_hand_off_tool(
         '    steps: One or more objects containing step_id and user_input; each may also\n'
         '        contain runtime_instruction and partial_indices.'
     )
-    return advance_step_and_hand_off
+    return advance_step_and_handoff
+
+
+def build_advance_step_and_hand_off_tool(*args: Any, **kwargs: Any) -> Any:
+    """Metered compatibility alias for the pre-v1 public spelling."""
+    from lazymind.chat.workflow.decision_policy import record_handoff_alias_call
+    record_handoff_alias_call()
+    return build_advance_step_and_handoff_tool(*args, **kwargs)
 
 
 def build_advance_step_tool(
@@ -1772,10 +1779,10 @@ def build_advance_step_tool(
         'does not authorize this synchronous tool.\n'
         'In continuous mode with an explicit target boundary, use `advance_step` only\n'
         'for prerequisite steps before that boundary, then execute the boundary step\n'
-        'with `advance_step_and_hand_off` and stop. If the user did not set a boundary,\n'
+        'with `advance_step_and_handoff` and stop. If the user did not set a boundary,\n'
         'run prerequisite remaining steps with this tool, then execute the terminal step\n'
-        'with `advance_step_and_hand_off` and stop.\n\n'
-        'For every other request, use `advance_step_and_hand_off` instead.\n\n'
+        'with `advance_step_and_handoff` and stop.\n\n'
+        'For every other request, use `advance_step_and_handoff` instead.\n\n'
         + choices_doc + '\n\n'
         'Pass one command for one step, or multiple independent Ready step commands for one\n'
         'atomic batch. Each command contains step_id and user_input and may contain\n'
@@ -1815,7 +1822,7 @@ def _append_step_transition_hint(
         '- If the latest user request says to run only up to a specific milestone/step '
         '(for example "执行到 X", "到 X 为止", "until X", "up to X"), match X against '
         'the available step ids, labels, and transition descriptions. Execute that '
-        'target boundary step with `advance_step_and_hand_off`, then stop. Do not '
+        'target boundary step with `advance_step_and_handoff`, then stop. Do not '
         'advance to downstream steps or submit a completion command after the boundary hand-off.'
     )
 
@@ -2063,41 +2070,14 @@ def _build_preflight_context_section(preflight: Any) -> str:
 
 
 def _build_cold_execution_policy(workflow_mode: str) -> str:
-    """Return request-local guidance for choosing the first advancement tool."""
-    if workflow_mode == 'auto':
-        return (
-            '## Current Workflow Launch Policy [AUTHORITATIVE]\n'
-            'After a trigger returns ready, call the only available advancement tool named '
-            'in launch_plan. Do not make an approval or continuation decision.'
-        )
+    """Return shared policy plus the Host-only preflight/launch invariant."""
     return (
-        '## Current Workflow Launch Policy [AUTHORITATIVE]\n'
-        'After a trigger returns ready, it provides a compact index of every workflow step, '
-        'the valid first step, that first step\'s default approval, and a launch_plan. '
-        'When launch_plan names an advancement tool, call that tool exactly. Otherwise infer '
-        'the execution scope from the user\'s words. '
-        'Match any user-named '
-        'target boundary against the full id/name index. The index contains names only and '
-        'does not imply order or reachability.\n'
-        '- If the selected Ready step has default approval `not_required`, use `advance_step`.\n'
-        '- If the completed step explicitly directs automatic continuation based on its result, '
-        'use `advance_step_and_hand_off` for the directed Ready step and stop.\n'
-        '- DEFAULT: use `advance_step_and_hand_off` for the first step.\n'
-        '- For any other step whose default approval is required, use `advance_step` only when the user '
-        'explicitly requests more than one workflow step, such as "帮我执行 N 步", "连续执行到 X", "一次性执行完", '
-        '"run N steps", "continue through X", or "run the whole workflow without stopping".\n'
-        '- Asking for a complete article, image, report, or other final deliverable does NOT '
-        'by itself request multi-step or uninterrupted execution.\n'
-        'Always start only the first_step_id returned by the trigger. After each synchronous '
-        '`advance_step` result, use only the newly returned reachable-step details and repeat '
-        'the decision. Continue automatically through `not_required` steps. When the completed '
-        'step explicitly directs automatic continuation based on its result, such as a preparation '
-        'step confirming that no source file exists, start the directed Ready step with '
-        '`advance_step_and_hand_off` and stop. '
-        'Otherwise, when the next Ready step requires approval and the user did not explicitly '
-        'request continuous execution, stop and present the completed result without starting '
-        'that step. When the user named a boundary, start that boundary with '
-        '`advance_step_and_hand_off` and stop.'
+        _build_mode_guidance(workflow_mode)
+        + '\n\n## LazyMind Workflow Launch Binding\n'
+        'A ready preflight is not a Session. Start exactly `first_step_id` using the '
+        'canonical advancement tool selected by the shared policy and available Host '
+        'profile. The launch guard may force this call, but cannot choose a Runtime '
+        'operation or alter projection/lineage.'
     )
 
 
@@ -2193,9 +2173,8 @@ def resolve_workflow_injection(
                     if lbl:
                         step_labels[sid] = lbl
 
-            # PR3 migration stage: compare the shared policy against the legacy
-            # prompt policy on the real request path.  The trace is observational;
-            # every tool and prompt below continues to be selected by legacy code.
+            # Compare the default shared authority with the bounded legacy rollback
+            # decision. The trace is observational and never invokes a tool.
             try:
                 from lazymind.chat.workflow_policy_shadow import observe
                 shadow_projection = dict(projection)
@@ -2226,17 +2205,17 @@ def resolve_workflow_injection(
                 LOG.exception('workflow policy shadow evaluation failed')
 
             # Build workflow tools according to workflow_mode.
-            # advance_step_and_hand_off is always registered (stop-tool).
+            # Canonical handoff is always registered (stop-tool).
             # advance_step (sync) is only registered in dynamic mode.
             workflow_tools = [
-                build_advance_step_and_hand_off_tool(
+                build_advance_step_and_handoff_tool(
                     p_workflow_id, p_current_step,
                     rewind_steps=rewind_steps,
                     step_labels=step_labels,
                     include_approval_guidance=workflow_mode != 'auto',
                 ),
             ]
-            workflow_stop_tools = ['advance_step_and_hand_off']
+            workflow_stop_tools = ['advance_step_and_handoff']
 
             if workflow_mode == 'dynamic':
                 workflow_tools.extend([
@@ -2292,7 +2271,7 @@ def resolve_workflow_injection(
                 workflow_catalog, disabled_builtin_workflows, allowed_workflow_refs,
             )
             workflow_tools = triggers + build_cold_advance_tools(workflow_mode)
-            workflow_stop_tools = ['advance_step_and_hand_off']
+            workflow_stop_tools = ['advance_step_and_handoff']
             workflow_artifact_context = _build_preflight_context_section(
                 agentic_config_patch.get('workflow_preflight_context')
             )
@@ -2323,7 +2302,7 @@ def resolve_workflow_injection(
             workflow_catalog, disabled_builtin_workflows, allowed_workflow_refs,
         )
         workflow_tools = triggers + build_cold_advance_tools(workflow_mode)
-        workflow_stop_tools = ['advance_step_and_hand_off']
+        workflow_stop_tools = ['advance_step_and_handoff']
         workflow_artifact_context = _build_cold_execution_policy(workflow_mode)
         if triggers:
             scenarios = [
@@ -2463,8 +2442,7 @@ def _build_step_status_section(
         return ''
 
 
-def _build_mode_guidance(
-        workflow_mode: str) -> str:
+def _build_legacy_mode_guidance(workflow_mode: str) -> str:
     """Return the request-local execution policy selected by application code."""
     if workflow_mode == 'auto':
         return (
@@ -2597,3 +2575,16 @@ def _build_mode_guidance(
         )
     )
     return global_rules + common
+
+
+def _build_mode_guidance(workflow_mode: str) -> str:
+    """Build policy context from the shared Skill plus LazyMind-only capabilities."""
+    from lazymind.chat.workflow.decision_policy import (
+        lazymind_host_prompt, record_legacy_policy_call, shared_decision_prompt,
+        shared_policy_enabled,
+    )
+
+    if not shared_policy_enabled():
+        record_legacy_policy_call()
+        return _build_legacy_mode_guidance(workflow_mode)
+    return shared_decision_prompt() + lazymind_host_prompt(workflow_mode)

--- a/algorithm/lazymind/chat/workflow_policy_shadow.py
+++ b/algorithm/lazymind/chat/workflow_policy_shadow.py
@@ -10,12 +10,15 @@ from lazymind.workflow_policy import Decision, decide, shadow_trace
 
 LOGGER = logging.getLogger(__name__)
 SHADOW_FLAG = 'LAZYMIND_WORKFLOW_POLICY_SHADOW'
+COMPARE_FLAG = 'LAZYMIND_WORKFLOW_POLICY_COMPARE'
 TRACE_LIMIT = 100
 
 
 def enabled(environ: Mapping[str, str] | None = None) -> bool:
-    value = (environ or os.environ).get(SHADOW_FLAG, '')
-    return value.strip().lower() in {'1', 'true', 'yes', 'on'}
+    env = environ or os.environ
+    shadow = env.get(SHADOW_FLAG, '').strip().lower() in {'1', 'true', 'yes', 'on'}
+    compare = env.get(COMPARE_FLAG, '1').strip().lower() not in {'0', 'false', 'no', 'off'}
+    return shadow or compare
 
 
 def _legacy_decision(projection: Mapping[str, Any], profile: Mapping[str, Any]) -> Decision:
@@ -51,7 +54,11 @@ def observe(
         return None
     legacy = _legacy_decision(projection, profile)
     shared = decide(projection, profile, projection.get('intent_tokens', ()))
-    trace = shadow_trace(legacy, shared, source=source, profile=profile.get('profile'))
+    policy_value = os.environ.get('LAZYMIND_WORKFLOW_POLICY_V1', '1').strip().lower()
+    authority = 'legacy' if policy_value in {'0', 'false', 'no', 'off'} else 'shared'
+    trace = shadow_trace(
+        legacy, shared, authority=authority, source=source, profile=profile.get('profile'),
+    )
     metrics = sink.setdefault('workflow_policy_shadow_metrics', {
         'evaluated': 0, 'equivalent': 0, 'mismatch': 0,
     })

--- a/algorithm/lazymind/workflow_policy.py
+++ b/algorithm/lazymind/workflow_policy.py
@@ -1,8 +1,8 @@
 """Deterministic, host-neutral Workflow v1 decision policy.
 
 This module is deliberately free of LazyMind runtime imports so the same cases can
-be evaluated by other hosts.  During PR3 it is shadow-only: callers must not use a
-``Decision`` returned here to execute a tool.
+be evaluated by other hosts. The shared Skill policy is authoritative by default;
+Host adapters may compare it with the bounded legacy rollback implementation.
 """
 
 from dataclasses import asdict, dataclass
@@ -95,7 +95,8 @@ def decide(
     return Decision('advance', tool, selected[0], selected, reason)
 
 
-def shadow_trace(legacy: Decision, shared: Decision, **context: Any) -> dict[str, Any]:
+def shadow_trace(legacy: Decision, shared: Decision, *, authority: str = 'legacy',
+                 **context: Any) -> dict[str, Any]:
     """Build a structured, non-authoritative comparison trace."""
     dimensions = {
         'action': legacy.action == shared.action,
@@ -106,7 +107,7 @@ def shadow_trace(legacy: Decision, shared: Decision, **context: Any) -> dict[str
     return {
         'schema_version': 'workflow.shadow-trace.v1',
         'policy_version': POLICY_VERSION,
-        'authority': 'legacy',
+        'authority': authority,
         'legacy': asdict(legacy),
         'shared': asdict(shared),
         'dimensions': dimensions,

--- a/algorithm/tests/chat/workflows/test_host_policy_convergence.py
+++ b/algorithm/tests/chat/workflows/test_host_policy_convergence.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+from unittest.mock import patch
+
+
+def test_shared_skill_is_default_authority_and_legacy_is_explicit_rollback():
+    from lazymind.chat.workflow import decision_policy
+    from lazymind.chat.workflow import workflow_manager
+
+    with patch.dict('os.environ', {}, clear=True):
+        prompt = workflow_manager._build_mode_guidance('dynamic')
+    assert 'Shared Workflow Decision Policy [AUTHORITATIVE]' in prompt
+    assert 'Apply the first matching rule' in prompt
+    assert 'Rule 0 — Intent capture' not in prompt
+
+    before = decision_policy.legacy_policy_hits
+    with patch.dict('os.environ', {decision_policy.POLICY_FLAG: '0'}, clear=True):
+        rollback = workflow_manager._build_mode_guidance('dynamic')
+    assert 'Current Workflow Execution Policy [AUTHORITATIVE]' in rollback
+    assert decision_policy.legacy_policy_hits == before + 1
+
+
+def test_driver_profile_changes_host_tools_not_runtime_projection_or_lineage():
+    from lazymind.chat.workflow import workflow_manager
+
+    projection = {
+        'state_version': 7,
+        'ready': ['draft'],
+        'artifact_lineage': [{'artifact_id': 'a1', 'revision': 3, 'attempt_id': 'at1'}],
+    }
+    auto = workflow_manager.build_cold_advance_tools('auto')
+    dynamic = workflow_manager.build_cold_advance_tools('dynamic')
+
+    assert 'advance_step' not in {tool.__name__ for tool in auto}
+    assert 'advance_step' in {tool.__name__ for tool in dynamic}
+    assert projection['state_version'] == 7
+    assert projection['artifact_lineage'] == [
+        {'artifact_id': 'a1', 'revision': 3, 'attempt_id': 'at1'},
+    ]
+
+
+def test_historical_handoff_spelling_is_only_a_metered_builder_alias():
+    from lazymind.chat.workflow import decision_policy, workflow_manager
+
+    before = decision_policy.compat_handoff_alias_hits
+    tool = workflow_manager.build_advance_step_and_hand_off_tool('wf', 'step')
+    assert tool.__name__ == 'advance_step_and_handoff'
+    assert decision_policy.compat_handoff_alias_hits == before + 1

--- a/algorithm/tests/chat/workflows/test_manager.py
+++ b/algorithm/tests/chat/workflows/test_manager.py
@@ -128,11 +128,11 @@ def test_dynamic_launch_policy_defaults_to_hand_off():
     from lazymind.chat.workflow import workflow_manager
 
     policy = workflow_manager._build_cold_execution_policy('dynamic')
-    assert 'DEFAULT: use `advance_step_and_hand_off`' in policy
-    assert '帮我执行 N 步' in policy
-    assert 'complete article' in policy
+    assert 'Shared Workflow Decision Policy' in policy
+    assert 'Ordinary Ready frontier' in policy
+    assert 'LazyMind Workflow Launch Binding' in policy
     assert [tool.__name__ for tool in workflow_manager.build_cold_advance_tools()] == [
-        'advance_step_and_hand_off', 'advance_step',
+        'advance_step_and_handoff', 'advance_step',
     ]
 
 
@@ -189,11 +189,11 @@ def test_cold_start_trigger_hides_hand_off_choice_when_tool_is_static(
             explicit_workflow_request=False,
         ))
 
-    assert result['launch_plan']['advance_tool'] == 'advance_step_and_hand_off'
+    assert result['launch_plan']['advance_tool'] == 'advance_step_and_handoff'
     assert 'hand_off' not in result['launch_plan']
     internal_plan = mock_agentic_config['prepared_workflow']['launch_plan']
     assert internal_plan['hand_off'] is True
-    assert internal_plan['advance_tool'] == 'advance_step_and_hand_off'
+    assert internal_plan['advance_tool'] == 'advance_step_and_handoff'
 
 
 def test_cold_start_trigger_rejects_empty_input(loaded_workflow, mock_write_agent_data, mock_agentic_config):
@@ -379,7 +379,7 @@ def test_cold_advance_commits_exact_prepared_plan(
     }
     handoff = next(
         t for t in workflow_manager.build_cold_advance_tools()
-        if t.__name__ == 'advance_step_and_hand_off'
+        if t.__name__ == 'advance_step_and_handoff'
     )
 
     result = handoff(step_id='step_a')
@@ -434,7 +434,7 @@ def test_cold_advance_rejects_tool_that_disagrees_with_launch_plan(
     }
     handoff = next(
         t for t in workflow_manager.build_cold_advance_tools()
-        if t.__name__ == 'advance_step_and_hand_off'
+        if t.__name__ == 'advance_step_and_handoff'
     )
 
     with pytest.raises(ValueError, match='requires advance_step'):
@@ -593,14 +593,14 @@ def test_cold_injection_without_approval_choice_registers_only_hand_off_tool(
     names = {tool.__name__ for tool in tools}
     assert 'trigger_test_workflow' in names
     assert 'advance_step' not in names
-    assert 'advance_step_and_hand_off' in names
-    assert stop_tools == ['advance_step_and_hand_off']
+    assert 'advance_step_and_handoff' in names
+    assert stop_tools == ['advance_step_and_handoff']
     assert 'trigger_test_workflow' not in stop_tools
     assert patch_config['workflow_mode'] == 'auto'
     assert patch_config['workflow_preflight_context']['preflight_id'] == 'pf-old'
     assert 'Original request ten turns ago' in context
-    assert 'Current Workflow Launch Policy' in context
-    assert 'approval or continuation decision' in context
+    assert 'Shared Workflow Decision Policy' in context
+    assert 'cannot choose a Runtime operation' in context
 
 
 def test_compact_step_name_index_has_names_but_no_graph_details(loaded_workflow):
@@ -653,30 +653,30 @@ def test_active_injection_switches_tools_and_request_local_policy_per_turn(
     auto_names = {tool.__name__ for tool in auto_tools}
     dynamic_names = {tool.__name__ for tool in dynamic_tools}
 
-    assert 'advance_step_and_hand_off' in auto_names
+    assert 'advance_step_and_handoff' in auto_names
     assert 'advance_step' not in auto_names
-    assert {'advance_step', 'advance_step_and_hand_off'} <= dynamic_names
+    assert {'advance_step', 'advance_step_and_handoff'} <= dynamic_names
     assert 'advance_steps' not in dynamic_names
     assert 'advance_steps_and_hand_off' not in dynamic_names
-    assert set(auto_stop_tools) == {'advance_step_and_hand_off'}
-    assert set(dynamic_stop_tools) == {'advance_step_and_hand_off'}
+    assert set(auto_stop_tools) == {'advance_step_and_handoff'}
+    assert set(dynamic_stop_tools) == {'advance_step_and_handoff'}
     assert 'Current Workflow Execution Policy' not in auto_system_prompt
     assert 'Current Workflow Execution Policy' not in dynamic_system_prompt
-    assert 'Current Workflow Execution Policy' in auto_context
-    assert 'Current Workflow Execution Policy' in dynamic_context
+    assert 'Shared Workflow Decision Policy' in auto_context
+    assert 'Shared Workflow Decision Policy' in dynamic_context
     assert 'Workflow Step Name Index' in auto_context
     assert 'step_a(Step A)' in auto_context
     assert 'step_d(Step D)' in dynamic_context
     assert 'default approval' not in auto_context.lower()
-    assert '[default approval: ...]' in dynamic_context
+    assert 'approval' in dynamic_context.lower()
     assert 'auto mode' not in auto_context.lower()
     assert 'dynamic mode' not in dynamic_context.lower()
 
     auto_advance = next(
-        tool for tool in auto_tools if tool.__name__ == 'advance_step_and_hand_off'
+        tool for tool in auto_tools if tool.__name__ == 'advance_step_and_handoff'
     )
     dynamic_advance = next(
-        tool for tool in dynamic_tools if tool.__name__ == 'advance_step_and_hand_off'
+        tool for tool in dynamic_tools if tool.__name__ == 'advance_step_and_handoff'
     )
     assert 'default approval' not in (auto_advance.__doc__ or '').lower()
     assert 'default approval' in (dynamic_advance.__doc__ or '').lower()
@@ -1126,17 +1126,9 @@ def test_dynamic_guidance_respects_explicit_target_boundary(loaded_workflow):
 
     guidance = workflow_manager._build_mode_guidance('dynamic')
 
-    assert 'target boundary' in guidance
-    assert 'Match X against the full compact' in guidance
-    assert 'Workflow Step Name Index' in guidance
-    assert 'name index does not imply reachability or execution order' in guidance
-    assert 'higher priority than generic uninterrupted phrases' in guidance
-    assert 'DEFAULT: call `advance_step_and_hand_off`' in guidance
-    assert '帮我执行 N 步' in guidance
-    assert 'complete deliverable' in guidance
-    assert 'Do NOT wait for the boundary step with `advance_step`' in guidance
-    assert 'Do NOT call downstream steps and do NOT call `__end__`' in guidance
-    assert 'returns the next decision to the user' in guidance
+    assert 'Explicit continuous scope/boundary' in guidance
+    assert 'requested/final boundary' in guidance
+    assert 'Runtime projection is authoritative' in guidance
 
 
 def test_guidance_without_approval_choice_assigns_continuation_to_backend(loaded_workflow):
@@ -1144,11 +1136,9 @@ def test_guidance_without_approval_choice_assigns_continuation_to_backend(loaded
 
     guidance = workflow_manager._build_mode_guidance('auto')
 
-    assert 'backend controller evaluates the result' in guidance
-    assert '`advance_step_and_hand_off` with one command' in guidance
-    assert 'default approval' not in guidance.lower()
-    assert 'auto mode' not in guidance.lower()
-    assert 'dynamic mode' not in guidance.lower()
+    assert 'Driver is enabled' in guidance
+    assert 'changes only turn orchestration' in guidance
+    assert 'never change Runtime projection' in guidance
 
 
 def test_batch_guidance_requires_one_atomic_call_for_ready_frontier(loaded_workflow):
@@ -1156,10 +1146,9 @@ def test_batch_guidance_requires_one_atomic_call_for_ready_frontier(loaded_workf
 
     guidance = workflow_manager._build_mode_guidance('dynamic')
 
-    assert 'ONE batch call' in guidance
-    assert 'Do not issue repeated' in guidance
-    assert 'Running an attempted step again remains single-step' in guidance
-    assert 'valid parallel choices' in guidance
+    assert 'one atomic batch' in guidance
+    assert 'profile permits parallel execution' in guidance
+    assert 'Ready step' in guidance
 
 
 def test_step_status_exposes_multi_ready_batch_hint(loaded_workflow):

--- a/algorithm/tests/test_workflow_policy_shadow.py
+++ b/algorithm/tests/test_workflow_policy_shadow.py
@@ -42,12 +42,13 @@ LAZYMIND_PROFILE = {
 }
 
 
-def test_shadow_is_default_off_and_has_no_side_effects():
+def test_decision_comparison_is_default_on():
     sink = {}
     with patch.dict('os.environ', {}, clear=True):
-        assert shadow.observe({'ready_steps': ['draft']}, LAZYMIND_PROFILE, sink,
-                              source='test') is None
-    assert sink == {}
+        trace = shadow.observe({'ready_steps': ['draft']}, LAZYMIND_PROFILE, sink,
+                               source='test')
+    assert trace is not None
+    assert trace['authority'] == 'shared'
 
 
 def test_shadow_records_structured_equivalent_trace_and_metrics():
@@ -60,7 +61,7 @@ def test_shadow_records_structured_equivalent_trace_and_metrics():
         trace = shadow.observe(projection, LAZYMIND_PROFILE, sink, source='golden')
     assert trace is not None
     assert trace['schema_version'] == 'workflow.shadow-trace.v1'
-    assert trace['authority'] == 'legacy'
+    assert trace['authority'] == 'shared'
     assert trace['equivalent'] is True
     assert trace['shared']['targets'] == ('research', 'outline')
     assert sink['workflow_policy_shadow_metrics'] == {

--- a/docs/plan/plugin/phase-one-gate-audit.md
+++ b/docs/plan/plugin/phase-one-gate-audit.md
@@ -71,10 +71,10 @@ is checked and linked to executable evidence.
 
 ## PR 9 — converge algorithm/chat
 
-- [ ] Shared decisions have one authoritative Skill source.
-- [ ] Python retains only Host model/Agent/interaction/event responsibilities.
-- [ ] Driver and handoff flags cannot alter Runtime projection or lineage.
-- [ ] Policy rollback and decision comparison remain available.
+- [x] Shared decisions have one authoritative Skill source.
+- [x] Python retains only Host model/Agent/interaction/event responsibilities.
+- [x] Driver and handoff flags cannot alter Runtime projection or lineage.
+- [x] Policy rollback and decision comparison remain available.
 
 ## PR 10 — deterministic Workflow authoring
 

--- a/docs/plan/plugin/shared-workflow-agent-kit-plan.md
+++ b/docs/plan/plugin/shared-workflow-agent-kit-plan.md
@@ -315,7 +315,7 @@ Codex 生成过程中只使用 Codex 模型；Core 只提供 Skill snapshot、�
 | [x] | [6 (#498)](https://github.com/LazyAGI/LazyMind/pull/498) | 引入 queued Attempt 与 claim/report 协议 | FakeExecutor 可执行 Workflow |
 | [x] | [7 (#500)](https://github.com/LazyAGI/LazyMind/pull/500) | 实现 LazyMindExecutor 和兼容 adapter | LazyMind SubAgent 通过新协议运行 |
 | [ ] | 8 | 移除 Core 到 `/api/subagent/run` 的固定依赖 | Runtime 与 LazyMind Executor 正式解耦 |
-| [ ] | 9 | 收敛 algorithm/chat prompt、Workflow manager 和 Driver adapter | 公共规则只来自共享 Skill |
+| [x] | [9 (#501)](https://github.com/LazyAGI/LazyMind/pull/501) | 收敛 algorithm/chat prompt、Workflow manager 和 Driver adapter | 公共规则只来自共享 Skill |
 | [x] | [10 (#499)](https://github.com/LazyAGI/LazyMind/pull/499) | 拆分 Skill to Workflow Agent 生成与 Authoring Tools | 外部 Agent 可提交生成结果 |
 | [ ] | 11 | 完成 LazyMind 全量回归与旧接口清理 | 达到第一阶段验收条件 |
 | [ ] | 12 | 提供 Codex 只读 Tool Adapter 与 Status View | Codex 可以发现 Workflow，并查看状态图和下载 Artifact |


### PR DESCRIPTION
## Summary
- make the shared Workflow decision policy the default authoritative source for active and cold prompt assembly
- retain only LazyMind Host bindings for Driver, handoff, stop, and synthetic-turn orchestration
- preserve a metered rollback path and default-on structured decision comparison
- standardize the public tool on `advance_step_and_handoff`, retaining historical `hand_off` only as a metered wire alias

## Validation
- Workflow/Skill/Policy Python suites: 116 passed
- `make lint`

## Acceptance evidence
- public lifecycle decision rules are loaded from one shared Skill reference
- legacy duplicated prompt is reachable only through explicit rollback and increments usage metrics
- Driver/handoff toggles leave Runtime state_version and Artifact lineage unchanged
- comparison traces preserve shared/legacy authority and per-dimension equivalence
