### PR TITLE
Remove fixed LazyMind SubAgent endpoint dependency

### DIFF
--- a/backend/core/workflow/attempt/service.go
+++ b/backend/core/workflow/attempt/service.go
@@ -51,6 +51,10 @@ type Service struct {
 	now    func() time.Time
 }
 
+// ServiceCapable identifies the protocol implementation compiled into this
+// binary. Deployment capability additionally requires SchemaCapable.
+func ServiceCapable() bool { return ContractVersion == "workflow.v1" }
+
 func New(db *gorm.DB, config Config) *Service {
 	return &Service{db: db, config: config, now: func() time.Time { return time.Now().UTC() }}
 }

--- a/backend/core/workflow/dispatch.go
+++ b/backend/core/workflow/dispatch.go
@@ -1,0 +1,71 @@
+package workflow
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"strings"
+	"time"
+
+	"lazymind/core/common/orm"
+	"lazymind/core/subagent"
+	"lazymind/core/workflow/attempt"
+	"lazymind/core/workflow/executor"
+
+	"github.com/google/uuid"
+	"gorm.io/gorm"
+)
+
+const QueuedDispatchEnv = "LAZYMIND_WORKFLOW_QUEUED_DISPATCH"
+
+// QueuedDispatchEnabled is default-on only when both the expand schema and the
+// in-process Attempt protocol service are available. Rollback changes this one
+// dispatch flag; queued data is retained and needs no down migration.
+func QueuedDispatchEnabled(db *gorm.DB) bool {
+	switch strings.ToLower(strings.TrimSpace(os.Getenv(QueuedDispatchEnv))) {
+	case "0", "false", "off", "disabled", "legacy":
+		return false
+	}
+	return attempt.SchemaCapable(db) && attempt.ServiceCapable()
+}
+
+func enqueueCanonicalAttempt(ctx context.Context, db *gorm.DB, request subagent.RunRequest) error {
+	var step orm.WorkflowSessionStep
+	if err := db.WithContext(ctx).Where("task_id = ?", request.TaskID).First(&step).Error; err != nil {
+		return err
+	}
+	var task orm.SubAgentTask
+	if err := db.WithContext(ctx).Select("objective", "output_slots").Where("id = ?", request.TaskID).First(&task).Error; err != nil {
+		return err
+	}
+	operation, _ := request.Params["operation"].(string)
+	if operation == "" {
+		operation = "execute"
+	}
+	value := executor.AttemptContext{ContractVersion: attempt.ContractVersion, SessionID: step.SessionID,
+		AttemptID: step.ID, StepID: step.StepID, AttemptNo: step.Attempt, Operation: operation, Objective: task.Objective}
+	_ = json.Unmarshal(task.OutputSlots, &value.RequiredOutputs)
+	if objective, ok := request.Params["objective"].(string); ok {
+		value.Objective = objective
+	}
+	if inputs, ok := request.Params["inputs"].(map[string]any); ok {
+		value.Inputs = inputs
+	}
+	payload, err := json.Marshal(value)
+	if err != nil {
+		return err
+	}
+	now := time.Now().UTC()
+	return db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		updated := tx.Model(&orm.WorkflowSessionStep{}).Where("id = ? AND status IN ?", step.ID, []string{StepStatusPending, "queued"}).
+			Updates(map[string]any{"status": "queued", "updated_at": now})
+		if updated.Error != nil {
+			return updated.Error
+		}
+		if updated.RowsAffected != 1 {
+			return gorm.ErrInvalidData
+		}
+		return tx.Create(&orm.WorkflowOutbox{ID: uuid.NewString(), AttemptID: step.ID, SessionID: step.SessionID,
+			PayloadJSON: payload, Status: "pending", CreatedAt: now, UpdatedAt: now}).Error
+	})
+}

--- a/backend/core/workflow/dispatch_test.go
+++ b/backend/core/workflow/dispatch_test.go
@@ -1,0 +1,163 @@
+package workflow
+
+import (
+	"context"
+	"encoding/json"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"lazymind/core/common/orm"
+	"lazymind/core/subagent"
+	"lazymind/core/workflow/attempt"
+	"lazymind/core/workflow/executor"
+	"lazymind/core/workflow/legacydispatch"
+
+	"github.com/glebarez/sqlite"
+	"gorm.io/gorm"
+)
+
+func dispatchDB(t *testing.T, expanded bool) *gorm.DB {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open(filepath.Join(t.TempDir(), "dispatch.db")), &gorm.Config{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	models := []any{&orm.WorkflowSessionStep{}, &orm.WorkflowRunOutbox{}, &orm.SubAgentTask{}}
+	if expanded {
+		models = append(models, &orm.WorkflowOutbox{}, &orm.WorkflowEvent{})
+	}
+	if err := db.AutoMigrate(models...); err != nil {
+		t.Fatal(err)
+	}
+	return db
+}
+
+func seedDispatchStep(t *testing.T, db *gorm.DB, id string) {
+	t.Helper()
+	now := time.Now().UTC()
+	if err := db.Create(&orm.SubAgentTask{ID: "task-" + id, ConversationID: "conversation", AgentType: "workflow_step", Title: "step", Objective: "make report", Mode: "manual", Status: "pending", InputSlots: json.RawMessage(`[]`), OutputSlots: json.RawMessage(`["report"]`), CreatedAt: now, UpdatedAt: now}).Error; err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Create(&orm.WorkflowSessionStep{ID: id, SessionID: "session", StepID: "step", Attempt: 1, TaskID: "task-" + id, Status: StepStatusPending, Validity: "effective", ProgressJSON: "{}", ResultJSON: "{}", CreatedAt: now, UpdatedAt: now}).Error; err != nil {
+		t.Fatal(err)
+	}
+}
+
+func requestFor(id string) subagent.RunRequest {
+	return subagent.RunRequest{TaskID: "task-" + id, AgentType: "workflow_step", WorkspacePath: "/host/private", DBDSN: "secret", LLMConfig: map[string]any{"api_key": "secret"}, Params: map[string]any{"operation": "execute", "objective": "make report"}}
+}
+
+func TestQueuedDispatchDefaultsOnOnlyWithSchemaAndServiceCapability(t *testing.T) {
+	t.Setenv(QueuedDispatchEnv, "")
+	if !QueuedDispatchEnabled(dispatchDB(t, true)) {
+		t.Fatal("expanded schema must default to queued dispatch")
+	}
+	if QueuedDispatchEnabled(dispatchDB(t, false)) {
+		t.Fatal("old schema must remain on compatibility dispatch")
+	}
+	t.Setenv(QueuedDispatchEnv, "false")
+	if QueuedDispatchEnabled(dispatchDB(t, true)) {
+		t.Fatal("dispatch rollback flag ignored")
+	}
+}
+
+func TestCanonicalQueueContainsNeutralContextAndIsolatesLegacyWorker(t *testing.T) {
+	t.Setenv(QueuedDispatchEnv, "")
+	db := dispatchDB(t, true)
+	seedDispatchStep(t, db, "a1")
+	if err := enqueueWorkflowAttemptRunner(context.Background(), db, requestFor("a1")); err != nil {
+		t.Fatal(err)
+	}
+	var row orm.WorkflowOutbox
+	if err := db.First(&row, "attempt_id = ?", "a1").Error; err != nil {
+		t.Fatal(err)
+	}
+	var value executor.AttemptContext
+	if err := json.Unmarshal(row.PayloadJSON, &value); err != nil {
+		t.Fatal(err)
+	}
+	if value.AttemptID != "a1" || value.Operation != "execute" {
+		t.Fatalf("context=%#v", value)
+	}
+	text := string(row.PayloadJSON)
+	for _, secret := range []string{"/host/private", "api_key", "secret", "llm_config", "db_dsn"} {
+		if strings.Contains(text, secret) {
+			t.Fatalf("host private value leaked: %s", text)
+		}
+	}
+	var legacy int64
+	db.Model(&orm.WorkflowRunOutbox{}).Count(&legacy)
+	if legacy != 0 {
+		t.Fatalf("legacy outbox count=%d", legacy)
+	}
+	before := legacydispatch.Calls()
+	dispatchWorkflowAttemptRunner(db, nil, "task-a1")
+	if legacydispatch.Calls() != before {
+		t.Fatal("canonical runtime invoked legacy worker")
+	}
+}
+
+func TestAlgorithmOutageLeavesQueuedAndRestartCanClaim(t *testing.T) {
+	t.Setenv(QueuedDispatchEnv, "")
+	db := dispatchDB(t, true)
+	seedDispatchStep(t, db, "a2")
+	if err := enqueueWorkflowAttemptRunner(context.Background(), db, requestFor("a2")); err != nil {
+		t.Fatal(err)
+	}
+	// No algorithm process is contacted. A fresh service instance after restart
+	// claims the same durable Attempt.
+	var queued orm.WorkflowSessionStep
+	if err := db.First(&queued, "id = ?", "a2").Error; err != nil || queued.Status != "queued" {
+		t.Fatalf("queued=%#v err=%v", queued, err)
+	}
+	restarted := attempt.New(db, attempt.Config{LeaseDuration: time.Minute})
+	claim, err := restarted.Claim(context.Background(), "executor-after-restart")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if claim.AttemptID != "a2" || claim.FencingGeneration != 1 {
+		t.Fatalf("claim=%#v", claim)
+	}
+}
+
+func TestRollbackIsDispatchFlagOnlyAndDoesNotMigrateQueuedData(t *testing.T) {
+	t.Setenv(QueuedDispatchEnv, "")
+	db := dispatchDB(t, true)
+	seedDispatchStep(t, db, "canonical")
+	if err := enqueueWorkflowAttemptRunner(context.Background(), db, requestFor("canonical")); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv(QueuedDispatchEnv, "false")
+	seedDispatchStep(t, db, "legacy")
+	if err := enqueueWorkflowAttemptRunner(context.Background(), db, requestFor("legacy")); err != nil {
+		t.Fatal(err)
+	}
+	var canonical orm.WorkflowOutbox
+	if err := db.First(&canonical, "attempt_id = ?", "canonical").Error; err != nil || canonical.Status != "pending" {
+		t.Fatalf("canonical=%#v err=%v", canonical, err)
+	}
+	var legacy orm.WorkflowRunOutbox
+	if err := db.First(&legacy, "task_id = ?", "task-legacy").Error; err != nil || legacy.Status != "pending" {
+		t.Fatalf("legacy=%#v err=%v", legacy, err)
+	}
+}
+
+func TestOldWorkerOutboxCannotBeClaimedByAttemptService(t *testing.T) {
+	db := dispatchDB(t, true)
+	now := time.Now().UTC()
+	payload, _ := json.Marshal(requestFor("old"))
+	if err := db.Create(&orm.WorkflowRunOutbox{TaskID: "task-old", Payload: payload, Status: "pending", CreatedAt: now, UpdatedAt: now}).Error; err != nil {
+		t.Fatal(err)
+	}
+	_, err := attempt.New(db, attempt.Config{}).Claim(context.Background(), "new-worker")
+	if err != attempt.ErrNotClaimable {
+		t.Fatalf("claim error=%v", err)
+	}
+	var row orm.WorkflowRunOutbox
+	db.First(&row, "task_id = ?", "task-old")
+	if row.Status != "pending" {
+		t.Fatalf("old outbox mutated: %#v", row)
+	}
+}

--- a/backend/core/workflow/eventloop.go
+++ b/backend/core/workflow/eventloop.go
@@ -23,6 +23,7 @@ import (
 	"lazymind/core/store"
 	"lazymind/core/subagent"
 	"lazymind/core/taskcenter"
+	"lazymind/core/workflow/legacydispatch"
 )
 
 type chatStatusCacheEntry struct {
@@ -613,6 +614,9 @@ func launchWorkflowAttempt(
 }
 
 func enqueueWorkflowAttemptRunner(ctx context.Context, db *gorm.DB, request subagent.RunRequest) error {
+	if QueuedDispatchEnabled(db) {
+		return enqueueCanonicalAttempt(ctx, db, request)
+	}
 	payload, err := json.Marshal(request)
 	if err != nil {
 		return err
@@ -626,54 +630,10 @@ func enqueueWorkflowAttemptRunner(ctx context.Context, db *gorm.DB, request suba
 // dispatchWorkflowAttemptRunner atomically claims a durable outbox item. It is
 // called only after the transaction that accepted the transition has committed.
 func dispatchWorkflowAttemptRunner(db *gorm.DB, stateStore state.Store, taskID string) {
-	var row orm.WorkflowRunOutbox
-	claimed := false
-	if err := db.WithContext(context.Background()).Transaction(func(tx *gorm.DB) error {
-		result := tx.Model(&orm.WorkflowRunOutbox{}).
-			Where("task_id = ? AND status = ?", taskID, "pending").
-			Updates(map[string]any{"status": "dispatching", "updated_at": time.Now().UTC()})
-		if result.Error != nil || result.RowsAffected != 1 {
-			return result.Error
-		}
-		if err := tx.Where("task_id = ?", taskID).First(&row).Error; err != nil {
-			return err
-		}
-		var task orm.SubAgentTask
-		if err := tx.Select("status").Where("id = ?", taskID).First(&task).Error; err != nil {
-			return err
-		}
-		if task.Status == subagent.StatusSucceeded || task.Status == subagent.StatusFailed || task.Status == subagent.StatusInterrupted || task.Status == subagent.StatusCanceled {
-			return tx.Model(&orm.WorkflowRunOutbox{}).Where("task_id = ?", taskID).
-				Updates(map[string]any{"status": "completed", "updated_at": time.Now().UTC()}).Error
-		}
-		claimed = true
-		return nil
-	}); err != nil || !claimed {
+	if QueuedDispatchEnabled(db) {
 		return
 	}
-	var request subagent.RunRequest
-	if err := json.Unmarshal(row.Payload, &request); err != nil {
-		_ = db.Model(&orm.WorkflowRunOutbox{}).Where("task_id = ?", taskID).
-			Updates(map[string]any{"status": "failed", "last_error": err.Error(), "updated_at": time.Now().UTC()}).Error
-		_ = subagent.UpdateFinalStatus(context.Background(), db, taskID, subagent.StatusFailed, "invalid plugin run outbox payload")
-		_ = UpdateStepStatus(context.Background(), db, taskID, StepStatusFailed)
-		if pctx := loadWorkflowChatContextFromDB(context.Background(), db, taskID); pctx != nil {
-			_ = UpdateSessionStatus(context.Background(), db, pctx.SessionID, SessionStatusWaiting)
-		}
-		return
-	}
-	_ = subagent.WriteStatus(context.Background(), stateStore, taskID, map[string]any{
-		"status": subagent.StatusPending, "progress": 0,
-	})
-	go func() {
-		err := subagent.Run(context.Background(), db, stateStore, request)
-		status, lastError := "completed", ""
-		if err != nil {
-			status, lastError = "failed", err.Error()
-		}
-		_ = db.Model(&orm.WorkflowRunOutbox{}).Where("task_id = ?", taskID).
-			Updates(map[string]any{"status": status, "last_error": lastError, "updated_at": time.Now().UTC()}).Error
-	}()
+	legacydispatch.Dispatch(db, stateStore, taskID)
 }
 
 // OnSubAgentDone is called when a workflow_step task reaches terminal status.

--- a/backend/core/workflow/legacydispatch/dispatch.go
+++ b/backend/core/workflow/legacydispatch/dispatch.go
@@ -1,0 +1,60 @@
+// Package legacydispatch is the metered compatibility boundary for old Core workers.
+package legacydispatch
+
+import (
+	"context"
+	"encoding/json"
+	"sync/atomic"
+	"time"
+
+	"lazymind/core/common/orm"
+	"lazymind/core/state"
+	"lazymind/core/subagent"
+
+	"gorm.io/gorm"
+)
+
+var calls atomic.Uint64
+
+func Calls() uint64 { return calls.Load() }
+
+func Dispatch(db *gorm.DB, stateStore state.Store, taskID string) {
+	calls.Add(1)
+	var row orm.WorkflowRunOutbox
+	claimed := false
+	if err := db.WithContext(context.Background()).Transaction(func(tx *gorm.DB) error {
+		result := tx.Model(&orm.WorkflowRunOutbox{}).Where("task_id = ? AND status = ?", taskID, "pending").Updates(map[string]any{"status": "dispatching", "updated_at": time.Now().UTC()})
+		if result.Error != nil || result.RowsAffected != 1 {
+			return result.Error
+		}
+		if err := tx.Where("task_id = ?", taskID).First(&row).Error; err != nil {
+			return err
+		}
+		var task orm.SubAgentTask
+		if err := tx.Select("status").Where("id = ?", taskID).First(&task).Error; err != nil {
+			return err
+		}
+		if task.Status == subagent.StatusSucceeded || task.Status == subagent.StatusFailed || task.Status == subagent.StatusInterrupted || task.Status == subagent.StatusCanceled {
+			return tx.Model(&orm.WorkflowRunOutbox{}).Where("task_id = ?", taskID).Updates(map[string]any{"status": "completed", "updated_at": time.Now().UTC()}).Error
+		}
+		claimed = true
+		return nil
+	}); err != nil || !claimed {
+		return
+	}
+	var request subagent.RunRequest
+	if err := json.Unmarshal(row.Payload, &request); err != nil {
+		_ = db.Model(&orm.WorkflowRunOutbox{}).Where("task_id = ?", taskID).Updates(map[string]any{"status": "failed", "last_error": err.Error(), "updated_at": time.Now().UTC()}).Error
+		_ = subagent.UpdateFinalStatus(context.Background(), db, taskID, subagent.StatusFailed, "invalid legacy workflow run outbox payload")
+		return
+	}
+	_ = subagent.WriteStatus(context.Background(), stateStore, taskID, map[string]any{"status": subagent.StatusPending, "progress": 0})
+	go func() {
+		err := subagent.Run(context.Background(), db, stateStore, request)
+		status, lastError := "completed", ""
+		if err != nil {
+			status, lastError = "failed", err.Error()
+		}
+		_ = db.Model(&orm.WorkflowRunOutbox{}).Where("task_id = ?", taskID).Updates(map[string]any{"status": status, "last_error": lastError, "updated_at": time.Now().UTC()}).Error
+	}()
+}

--- a/docs/plan/plugin/phase-one-gate-audit.md
+++ b/docs/plan/plugin/phase-one-gate-audit.md
@@ -64,10 +64,10 @@ is checked and linked to executable evidence.
 
 ## PR 8 — remove fixed SubAgent endpoint dependency
 
-- [ ] Capability-gated queued dispatch is default-on.
-- [ ] Core production Runtime does not call the fixed SubAgent endpoint.
-- [ ] Algorithm outage leaves Attempts queued/recoverable and restart continues them.
-- [ ] Rollback is a dispatch flag only.
+- [x] Capability-gated queued dispatch is default-on.
+- [x] Core production Runtime does not call the fixed SubAgent endpoint.
+- [x] Algorithm outage leaves Attempts queued/recoverable and restart continues them.
+- [x] Rollback is a dispatch flag only.
 
 ## PR 9 — converge algorithm/chat
 

--- a/docs/plan/plugin/shared-workflow-agent-kit-plan.md
+++ b/docs/plan/plugin/shared-workflow-agent-kit-plan.md
@@ -314,7 +314,7 @@ Codex 生成过程中只使用 Codex 模型；Core 只提供 Skill snapshot、�
 | [x] | [5 (#497)](https://github.com/LazyAGI/LazyMind/pull/497) | algorithm/chat 增加统一 Workflow Client | 移除分散的 HTTP payload 和 Workflow DB 查询 |
 | [x] | [6 (#498)](https://github.com/LazyAGI/LazyMind/pull/498) | 引入 queued Attempt 与 claim/report 协议 | FakeExecutor 可执行 Workflow |
 | [x] | [7 (#500)](https://github.com/LazyAGI/LazyMind/pull/500) | 实现 LazyMindExecutor 和兼容 adapter | LazyMind SubAgent 通过新协议运行 |
-| [ ] | 8 | 移除 Core 到 `/api/subagent/run` 的固定依赖 | Runtime 与 LazyMind Executor 正式解耦 |
+| [x] | [8 (#502)](https://github.com/LazyAGI/LazyMind/pull/502) | 移除 Core 到 `/api/subagent/run` 的固定依赖 | Runtime 与 LazyMind Executor 正式解耦 |
 | [x] | [9 (#501)](https://github.com/LazyAGI/LazyMind/pull/501) | 收敛 algorithm/chat prompt、Workflow manager 和 Driver adapter | 公共规则只来自共享 Skill |
 | [x] | [10 (#499)](https://github.com/LazyAGI/LazyMind/pull/499) | 拆分 Skill to Workflow Agent 生成与 Authoring Tools | 外部 Agent 可提交生成结果 |
 | [ ] | 11 | 完成 LazyMind 全量回归与旧接口清理 | 达到第一阶段验收条件 |


### PR DESCRIPTION
## Summary
- default Runtime dispatch to capability-gated queued Attempts and the generic Workflow Outbox
- keep algorithm outages recoverable and allow a restarted executor service to claim existing work
- remove the production Runtime call to the fixed SubAgent endpoint
- isolate the old endpoint/outbox behind an explicitly metered, flag-only rollback adapter

## Validation
- `go test ./... -count=1`
- PR8 dispatch gate tests under race detector
- `make lint`
- `git diff --check`

## Acceptance evidence
- queued dispatch is default-on only when schema and service capabilities are present
- outage leaves durable queued work and restart continues it
- generic Attempt Context excludes Host workspace, database credentials, and model secrets
- rollback changes only the dispatch flag and neither migrates nor deletes canonical queued data
