### PR TITLE
Keep established Workflow hand-off tool name

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,14 +1,8 @@
-# CI: run lint, documentation checks, and tests for pushes and pull requests.
+# CI: run lint, documentation checks, and tests for pull requests.
 name: CI
 
 on:
   workflow_dispatch:
-  push:
-    branches: [main, master, 'dev/*']
-    paths-ignore:
-      - "**.md"
-      - ".git*"
-      - "docs/**"
   pull_request:
     branches: [main, master, 'dev/*']
     paths-ignore:
@@ -17,7 +11,7 @@ on:
       - "docs/**"
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-pr-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/algorithm/lazymind/chat/engine/agent_runtime/executor.py
+++ b/algorithm/lazymind/chat/engine/agent_runtime/executor.py
@@ -14,7 +14,6 @@ from .tool_limit_control import tool_limit_decision_coordinator
 
 _EXPANDED_BUDGET_TOOLS = {
     'advance_step',
-    'advance_step_and_handoff',
     'advance_step_and_hand_off',
     'create_workflow_draft',
     'create_subagent',

--- a/algorithm/lazymind/chat/service/chat_service.py
+++ b/algorithm/lazymind/chat/service/chat_service.py
@@ -160,8 +160,10 @@ def check_sensitive_content(query: str) -> Optional[SensitiveMatch]:
     return sensitive_filter.evaluate(query)
 
 
-def _should_skip_sensitive_filter(query: str, workflow_context: Dict[str, Any]) -> bool:
+def _should_skip_sensitive_filter(query: str, workflow_context: Optional[Dict[str, Any]]) -> bool:
     """Bypass user-input filtering only for trusted Workflow synthetic turns."""
+    if not isinstance(workflow_context, dict):
+        return False
     if not workflow_context.get('workflow_id') or not workflow_context.get('session_id'):
         return False
     if workflow_context.get('synthetic_source') == 'driver':

--- a/algorithm/lazymind/chat/service/chat_service.py
+++ b/algorithm/lazymind/chat/service/chat_service.py
@@ -331,12 +331,11 @@ async def handle_chat(request: ChatRequest) -> Union[Dict[str, Any], StreamingRe
     if not provisional.routing_review_required:
         return await _handle_chat_impl(request, task_profile_override=provisional)
 
-    from lazymind.chat.workflow.workflow_manager import is_workflow_driver_turn
     raw_query = str(request.message.query or '')
     filter_query, _ = _normalize_cite_message_query_for_agent(raw_query)
     skip_sensitive_filter = (
         request.runtime.skip_sensitive_filter
-        or is_workflow_driver_turn(request.workflow.workflow_context)
+        or _should_skip_sensitive_filter(filter_query, request.workflow.workflow_context)
         or request.runtime.context_usage_preview
         or request.runtime.context_prompt_export
     )
@@ -409,7 +408,6 @@ async def _handle_chat_impl(
     from lazymind.chat.workflow.workflow_manager import (
         _build_chat_agent_task_context,
         guard_workflow_agent_stream,
-        is_workflow_driver_turn,
         resolve_workflow_injection,
         update_intentwriter,
     )
@@ -437,10 +435,9 @@ async def _handle_chat_impl(
     if user_cited_context:
         cited_message_context = user_cited_context
     language_query = user_input.strip()
-    is_driver_turn = is_workflow_driver_turn(workflow.workflow_context)
     skip_sensitive_filter = (
         runtime.skip_sensitive_filter
-        or is_driver_turn
+        or _should_skip_sensitive_filter(query, workflow.workflow_context)
         or runtime.context_usage_preview
         or runtime.context_prompt_export
     )

--- a/algorithm/lazymind/chat/service/component/tool_rendering.py
+++ b/algorithm/lazymind/chat/service/component/tool_rendering.py
@@ -828,24 +828,6 @@ _TOOL_EXECUTION_ERROR_RE = re.compile(
 )
 
 
-# Canonical Workflow v1 spelling. Keep the historical key only as an input
-# compatibility alias while every emitted/registered tool uses ``handoff``.
-for _workflow_template_map in (
-    _REPRESENTATIVE_TOOL_ARGUMENTS,
-    _REPRESENTATIVE_TOOL_RESULTS,
-    _TOOL_CALL_PREVIEW_TEMPLATES,
-    _ZH_TOOL_CALL_PREVIEW_TEMPLATES,
-    _TOOL_RESULT_PREVIEW_TEMPLATES,
-    _ZH_TOOL_RESULT_PREVIEW_TEMPLATES,
-    _TOOL_RESULT_FAILURE_TEMPLATES,
-    _ZH_TOOL_RESULT_FAILURE_TEMPLATES,
-):
-    if 'advance_step_and_hand_off' in _workflow_template_map:
-        _workflow_template_map['advance_step_and_handoff'] = (
-            _workflow_template_map['advance_step_and_hand_off']
-        )
-
-
 def _tool_name_suffixes(tool_name: str) -> list[str]:
     if not tool_name:
         return []

--- a/algorithm/lazymind/chat/workflow/client.py
+++ b/algorithm/lazymind/chat/workflow/client.py
@@ -7,14 +7,18 @@ from __future__ import annotations
 
 import logging
 import os
-import time
-import uuid
-from dataclasses import asdict, dataclass, field
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict
 
 import httpx
+from lazymind.workflow_sdk import client as _sdk
 
-CONTRACT_VERSION = 'workflow.v1'
+CONTRACT_VERSION = _sdk.CONTRACT_VERSION
+AdvanceRequest = _sdk.AdvanceRequest
+StepCommand = _sdk.StepCommand
+WorkflowClient = _sdk.WorkflowClient
+WorkflowClientError = _sdk.WorkflowClientError
+WorkflowResponse = _sdk.WorkflowResponse
+
 LOG = logging.getLogger(__name__)
 workflow_legacy_client_hits = 0
 WorkflowTransportTimeout = httpx.TimeoutException
@@ -32,143 +36,6 @@ def workflow_http_post(url: str, **kwargs: Any) -> Any:
     record_legacy_client_call('POST ' + url.rsplit('/', 1)[-1])
     transport = kwargs.pop('transport', httpx)
     return transport.post(url, **kwargs)
-
-
-@dataclass(frozen=True)
-class StepCommand:
-    step_id: str
-    task_id: str = ''
-    objective: str = ''
-    user_input: str = ''
-    runtime_instruction: str = ''
-    partial_indices: Dict[str, List[int]] = field(default_factory=dict)
-
-
-@dataclass(frozen=True)
-class AdvanceRequest:
-    session_id: str
-    expected_state_version: int
-    steps: List[StepCommand]
-    handoff: bool = False
-    command_id: str = field(default_factory=lambda: str(uuid.uuid4()))
-
-
-@dataclass(frozen=True)
-class WorkflowResponse:
-    result: Dict[str, Any]
-    request_id: str = ''
-
-
-class WorkflowClientError(RuntimeError):
-    def __init__(self, code: str, message: str, retryable: bool = False,
-                 status_code: int = 0, details: Optional[Dict[str, Any]] = None):
-        super().__init__(code, message, retryable, status_code, details)
-        self.code = code
-        self.message = message
-        self.retryable = retryable
-        self.status_code = status_code
-        self.details = details or {}
-
-    def __str__(self) -> str:
-        return self.message
-
-
-class WorkflowClient:
-    """Small synchronous facade client with bounded safe retries."""
-
-    def __init__(self, base_url: str, user_id: str = '', *, timeout: float = 15.0,
-                 read_retries: int = 2, transport: Any = httpx):
-        self.base_url = base_url.rstrip('/')
-        self.user_id = user_id
-        self.timeout = timeout
-        self.read_retries = read_retries
-        self.transport = transport
-
-    def _headers(self, command_id: str = '') -> Dict[str, str]:
-        headers = {'Workflow-Contract-Version': CONTRACT_VERSION}
-        if self.user_id:
-            headers['X-User-Id'] = self.user_id
-        if command_id:
-            headers['Idempotency-Key'] = command_id
-        return headers
-
-    @staticmethod
-    def _decode(response: Any) -> WorkflowResponse:
-        try:
-            body = response.json()
-        except Exception as exc:
-            raise WorkflowClientError('INVALID_RESPONSE', str(exc),
-                                      status_code=response.status_code) from exc
-        if response.status_code >= 400 or (isinstance(body, dict) and body.get('ok') is False):
-            error = body.get('error', {}) if isinstance(body, dict) else {}
-            raise WorkflowClientError(
-                str(error.get('code') or 'WORKFLOW_REQUEST_FAILED'),
-                str(error.get('message') or f'Workflow request failed ({response.status_code})'),
-                retryable=bool(error.get('retryable')),
-                status_code=response.status_code,
-                details=error.get('details') if isinstance(error.get('details'), dict) else {},
-            )
-        result = body.get('result', body.get('data', body)) if isinstance(body, dict) else {}
-        return WorkflowResponse(result=result if isinstance(result, dict) else {'value': result},
-                                request_id=str(body.get('request_id') or '') if isinstance(body, dict) else '')
-
-    def _read(self, path: str) -> WorkflowResponse:
-        for attempt in range(self.read_retries + 1):
-            try:
-                return self._decode(self.transport.get(
-                    self.base_url + path, headers=self._headers(), timeout=self.timeout,
-                ))
-            except WorkflowClientError as exc:
-                if not exc.retryable or attempt >= self.read_retries:
-                    raise
-            except (httpx.TimeoutException, httpx.TransportError) as exc:
-                if attempt >= self.read_retries:
-                    raise WorkflowClientError('WORKFLOW_TIMEOUT', str(exc), retryable=True) from exc
-            time.sleep(0.05 * (2 ** attempt))
-        raise AssertionError('unreachable')
-
-    def get_state(self, session_id: str) -> Dict[str, Any]:
-        return self._read(f'/workflow-sessions/{session_id}/projection').result
-
-    def advance(self, request: AdvanceRequest) -> WorkflowResponse:
-        # Keep the established public tool spelling across Host and Runtime.
-        tool = 'advance_step_and_hand_off' if request.handoff else 'advance_step'
-        payload = {
-            'contract_version': CONTRACT_VERSION,
-            'command_id': request.command_id,
-            'tool': tool,
-            'session_id': request.session_id,
-            'expected_state_version': request.expected_state_version,
-            'steps': [asdict(step) for step in request.steps],
-        }
-        path = f'/workflow-sessions/{request.session_id}:' + (
-            'advance-step-and-hand-off' if request.handoff else 'advance-step'
-        )
-        try:
-            response = self.transport.post(
-                self.base_url + path, json=payload,
-                headers=self._headers(request.command_id), timeout=self.timeout,
-            )
-        except (httpx.TimeoutException, httpx.TransportError) as exc:
-            # Commands are never blindly retried. The command id is safe for explicit reconciliation.
-            raise WorkflowClientError('TRANSITION_RESULT_UNKNOWN', str(exc), retryable=True) from exc
-        return self._decode(response)
-
-    def prepare_start(self, workflow_id: str, session_id: str, command_id: str,
-                      start_fields: Dict[str, Any]) -> WorkflowResponse:
-        payload = {
-            **start_fields, 'workflow_id': workflow_id,
-            'preparation_id': command_id, 'idempotency_key': command_id,
-        }
-        prepared = self._decode(self.transport.post(
-            self.base_url + '/workflow-preparations', json=payload,
-            headers=self._headers(command_id), timeout=self.timeout,
-        )).result
-        preparation_id = str(prepared.get('id') or prepared.get('preparation_id') or command_id)
-        return self._decode(self.transport.post(
-            f'{self.base_url}/workflow-preparations/{preparation_id}:consume',
-            json={'session_id': session_id}, headers=self._headers(command_id), timeout=self.timeout,
-        ))
 
 
 def use_legacy_client() -> bool:

--- a/algorithm/lazymind/chat/workflow/client.py
+++ b/algorithm/lazymind/chat/workflow/client.py
@@ -131,11 +131,7 @@ class WorkflowClient:
         return self._read(f'/workflow-sessions/{session_id}/projection').result
 
     def advance(self, request: AdvanceRequest) -> WorkflowResponse:
-        # Core's pre-v1 wire spelling remains a metered transport alias. Agent
-        # surfaces and policy use the canonical ``..._handoff`` name.
-        if request.handoff:
-            from lazymind.chat.workflow.decision_policy import record_handoff_alias_call
-            record_handoff_alias_call()
+        # Keep the established public tool spelling across Host and Runtime.
         tool = 'advance_step_and_hand_off' if request.handoff else 'advance_step'
         payload = {
             'contract_version': CONTRACT_VERSION,

--- a/algorithm/lazymind/chat/workflow/decision_policy.py
+++ b/algorithm/lazymind/chat/workflow/decision_policy.py
@@ -10,7 +10,6 @@ from typing import Mapping
 POLICY_FLAG = 'LAZYMIND_WORKFLOW_POLICY_V1'
 POLICY_VERSION = 'workflow.policy.v1'
 legacy_policy_hits = 0
-compat_handoff_alias_hits = 0
 
 
 def shared_policy_enabled(environ: Mapping[str, str] | None = None) -> bool:
@@ -22,11 +21,6 @@ def shared_policy_enabled(environ: Mapping[str, str] | None = None) -> bool:
 def record_legacy_policy_call() -> None:
     global legacy_policy_hits
     legacy_policy_hits += 1
-
-
-def record_handoff_alias_call() -> None:
-    global compat_handoff_alias_hits
-    compat_handoff_alias_hits += 1
 
 
 def _skill_root() -> Path:
@@ -50,7 +44,7 @@ def lazymind_host_prompt(workflow_mode: str) -> str:
     return (
         '\n\n## LazyMind Host Profile\n\n'
         '- This Host supports synchronous waiting and durable handoff.\n'
-        '- `advance_step_and_handoff` is the canonical handoff tool name.\n'
+        '- `advance_step_and_hand_off` is the canonical handoff tool name.\n'
         f'- Driver is {"enabled" if driver else "disabled"}; this changes only turn orchestration.\n'
         '- A handoff ends the ChatAgent turn only after durable Supervisor ownership.\n'
         '- Driver, approval, stop-tool, and synthetic-turn behavior never change Runtime projection, '

--- a/algorithm/lazymind/chat/workflow/workflow_manager.py
+++ b/algorithm/lazymind/chat/workflow/workflow_manager.py
@@ -3,7 +3,7 @@
 Tool types registered dynamically per-conversation:
 
 - trigger_<workflow_id>       : Cold-start tool. Injected when no active workflow session exists.
-- advance_step_and_handoff : Asynchronous stop-tool accepting one or more step commands.
+- advance_step_and_hand_off : Asynchronous stop-tool accepting one or more step commands.
 - advance_step              : Synchronous tool accepting one or more step commands; dynamic mode only.
 - ask_user                  : Ask the user a question (stop-tool). ChatAgent only; absent in auto mode.
 - intentwrite               : Extended with workflow-session and workflow-step scopes when active.
@@ -1201,7 +1201,7 @@ def build_cold_start_tools(
                 if static_advancement:
                     launch_plan.update({
                         'hand_off': True,
-                        'advance_tool': 'advance_step_and_handoff',
+                        'advance_tool': 'advance_step_and_hand_off',
                     })
                 elif inline_auto_step:
                     launch_plan.update({
@@ -1234,7 +1234,7 @@ def build_cold_start_tools(
                     instruction = (
                         'Infer whether the user explicitly requested multiple workflow steps. '
                         'If yes, choose `advance_step`; otherwise choose the default '
-                        '`advance_step_and_handoff`. Do not answer with prose first.'
+                        '`advance_step_and_hand_off`. Do not answer with prose first.'
                     )
                 return json.dumps({
                     'status': 'ready',
@@ -1292,7 +1292,7 @@ def _commit_prepared_workflow(
         raise ValueError(f'First step must be {expected_step!r}, got {step_id!r}.')
     expected_hand_off = bool(plan.get('hand_off', True))
     if isinstance(plan.get('hand_off'), bool) and hand_off != expected_hand_off:
-        expected_tool = 'advance_step_and_handoff' if expected_hand_off else 'advance_step'
+        expected_tool = 'advance_step_and_hand_off' if expected_hand_off else 'advance_step'
         raise ValueError(f'Launch plan requires {expected_tool}.')
     workflow_id = str(prepared.get('workflow_id') or '')
     normalised_request = str(plan.get('normalized_request') or '').strip()
@@ -1371,7 +1371,7 @@ def build_cold_advance_tools(workflow_mode: str = 'dynamic') -> List[Any]:
             )
         return _commit_prepared_workflow(step_id, hand_off=False)
 
-    def advance_step_and_handoff(step_id: str) -> str:
+    def advance_step_and_hand_off(step_id: str) -> str:
         """Start the prepared workflow and hand control off immediately.
 
         Use after a ready trigger when current request policy calls for an asynchronous boundary.
@@ -1386,7 +1386,7 @@ def build_cold_advance_tools(workflow_mode: str = 'dynamic') -> List[Any]:
         if cfg.get('workflow_session_id') and cfg.get('workflow_id'):
             prepared = cfg.get('prepared_workflow') or {}
             plan = prepared.get('launch_plan') or {}
-            return build_advance_step_and_handoff_tool(
+            return build_advance_step_and_hand_off_tool(
                 str(cfg['workflow_id']), str(cfg.get('workflow_step') or '')
             )(
                 steps=[{
@@ -1397,8 +1397,8 @@ def build_cold_advance_tools(workflow_mode: str = 'dynamic') -> List[Any]:
         return _commit_prepared_workflow(step_id, hand_off=True)
 
     if workflow_mode == 'auto':
-        return [advance_step_and_handoff]
-    return [advance_step_and_handoff, advance_step]
+        return [advance_step_and_hand_off]
+    return [advance_step_and_hand_off, advance_step]
 
 
 def commit_prepared_workflow_fallback() -> str:
@@ -1483,7 +1483,7 @@ async def _enforce_prepared_workflow_advance(
             'The workflow trigger already returned ready. Do not answer, explain, confirm, '
             'or ask another question. Immediately start first_step_id. Infer whether the user '
             'explicitly requested multiple workflow steps. Use `advance_step` only if they did; '
-            'otherwise use the default `advance_step_and_handoff`. Launch plan:\n'
+            'otherwise use the default `advance_step_and_hand_off`. Launch plan:\n'
             + json.dumps(visible_launch_plan, ensure_ascii=False)
             + '\n'
             + str(prepared.get('step_name_index') or '')
@@ -1614,7 +1614,7 @@ def _live_reachability_snapshot(
     )
 
 
-def build_advance_step_and_handoff_tool(
+def build_advance_step_and_hand_off_tool(
     workflow_id: str,
     current_step: str,
     rewind_steps: Optional[List[str]] = None,
@@ -1636,7 +1636,7 @@ def build_advance_step_and_handoff_tool(
         include_default_approval=include_approval_guidance,
     )
 
-    def advance_step_and_handoff(steps: List[Dict[str, Any]]) -> str:
+    def advance_step_and_hand_off(steps: List[Dict[str, Any]]) -> str:
         """Start one or more Ready steps and end the current ReAct turn."""
         if not isinstance(steps, list) or not steps:
             raise ValueError('steps must contain at least one step command.')
@@ -1670,7 +1670,7 @@ def build_advance_step_and_handoff_tool(
         if include_approval_guidance
         else 'Use this tool to start the selected next step.\n'
     )
-    advance_step_and_handoff.__doc__ = (
+    advance_step_and_hand_off.__doc__ = (
         'Start one or more Ready workflow steps asynchronously and end the current turn.\n\n'
         + selection_guidance
         + 'Pass one command for one step. Pass multiple commands only for independent Ready\n'
@@ -1681,14 +1681,7 @@ def build_advance_step_and_handoff_tool(
         '    steps: One or more objects containing step_id and user_input; each may also\n'
         '        contain runtime_instruction and partial_indices.'
     )
-    return advance_step_and_handoff
-
-
-def build_advance_step_and_hand_off_tool(*args: Any, **kwargs: Any) -> Any:
-    """Metered compatibility alias for the pre-v1 public spelling."""
-    from lazymind.chat.workflow.decision_policy import record_handoff_alias_call
-    record_handoff_alias_call()
-    return build_advance_step_and_handoff_tool(*args, **kwargs)
+    return advance_step_and_hand_off
 
 
 def build_advance_step_tool(
@@ -1779,10 +1772,10 @@ def build_advance_step_tool(
         'does not authorize this synchronous tool.\n'
         'In continuous mode with an explicit target boundary, use `advance_step` only\n'
         'for prerequisite steps before that boundary, then execute the boundary step\n'
-        'with `advance_step_and_handoff` and stop. If the user did not set a boundary,\n'
+        'with `advance_step_and_hand_off` and stop. If the user did not set a boundary,\n'
         'run prerequisite remaining steps with this tool, then execute the terminal step\n'
-        'with `advance_step_and_handoff` and stop.\n\n'
-        'For every other request, use `advance_step_and_handoff` instead.\n\n'
+        'with `advance_step_and_hand_off` and stop.\n\n'
+        'For every other request, use `advance_step_and_hand_off` instead.\n\n'
         + choices_doc + '\n\n'
         'Pass one command for one step, or multiple independent Ready step commands for one\n'
         'atomic batch. Each command contains step_id and user_input and may contain\n'
@@ -1822,7 +1815,7 @@ def _append_step_transition_hint(
         '- If the latest user request says to run only up to a specific milestone/step '
         '(for example "执行到 X", "到 X 为止", "until X", "up to X"), match X against '
         'the available step ids, labels, and transition descriptions. Execute that '
-        'target boundary step with `advance_step_and_handoff`, then stop. Do not '
+        'target boundary step with `advance_step_and_hand_off`, then stop. Do not '
         'advance to downstream steps or submit a completion command after the boundary hand-off.'
     )
 
@@ -2195,9 +2188,9 @@ def resolve_workflow_injection(
                 }
                 observe(shadow_projection, {
                     'profile': 'lazymind',
-                    # The Host adapter still registers the historical hand_off
-                    # alias; shadow policy evaluates the canonical v1 protocol.
-                    'advance_tools': ['advance_step', 'advance_step_and_handoff'],
+                    # The Host adapter and shared policy use the established
+                    # public hand_off spelling.
+                    'advance_tools': ['advance_step', 'advance_step_and_hand_off'],
                     'parallel_ready_steps': True,
                     'handoff': True,
                 }, cfg, source='active_session_prompt')
@@ -2208,14 +2201,14 @@ def resolve_workflow_injection(
             # Canonical handoff is always registered (stop-tool).
             # advance_step (sync) is only registered in dynamic mode.
             workflow_tools = [
-                build_advance_step_and_handoff_tool(
+                build_advance_step_and_hand_off_tool(
                     p_workflow_id, p_current_step,
                     rewind_steps=rewind_steps,
                     step_labels=step_labels,
                     include_approval_guidance=workflow_mode != 'auto',
                 ),
             ]
-            workflow_stop_tools = ['advance_step_and_handoff']
+            workflow_stop_tools = ['advance_step_and_hand_off']
 
             if workflow_mode == 'dynamic':
                 workflow_tools.extend([
@@ -2271,7 +2264,7 @@ def resolve_workflow_injection(
                 workflow_catalog, disabled_builtin_workflows, allowed_workflow_refs,
             )
             workflow_tools = triggers + build_cold_advance_tools(workflow_mode)
-            workflow_stop_tools = ['advance_step_and_handoff']
+            workflow_stop_tools = ['advance_step_and_hand_off']
             workflow_artifact_context = _build_preflight_context_section(
                 agentic_config_patch.get('workflow_preflight_context')
             )
@@ -2302,7 +2295,7 @@ def resolve_workflow_injection(
             workflow_catalog, disabled_builtin_workflows, allowed_workflow_refs,
         )
         workflow_tools = triggers + build_cold_advance_tools(workflow_mode)
-        workflow_stop_tools = ['advance_step_and_handoff']
+        workflow_stop_tools = ['advance_step_and_hand_off']
         workflow_artifact_context = _build_cold_execution_policy(workflow_mode)
         if triggers:
             scenarios = [

--- a/algorithm/lazymind/chat/workflow_policy_shadow.py
+++ b/algorithm/lazymind/chat/workflow_policy_shadow.py
@@ -38,7 +38,7 @@ def _legacy_decision(projection: Mapping[str, Any], profile: Mapping[str, Any]) 
     # The legacy prompt still exposes the historical ``hand_off`` spelling.
     # Normalize it to the versioned public protocol name before comparison so
     # shadow equivalence measures decisions, not a temporary Host adapter alias.
-    tool = 'advance_step' if wait or not profile.get('handoff') else 'advance_step_and_handoff'
+    tool = 'advance_step' if wait or not profile.get('handoff') else 'advance_step_and_hand_off'
     return Decision('advance', tool, targets[0], targets, 'legacy_prompt_policy')
 
 

--- a/algorithm/lazymind/workflow_mcp/__init__.py
+++ b/algorithm/lazymind/workflow_mcp/__init__.py
@@ -1,0 +1,1 @@
+"""LazyMind Workflow MCP adapter."""

--- a/algorithm/lazymind/workflow_mcp/__main__.py
+++ b/algorithm/lazymind/workflow_mcp/__main__.py
@@ -1,0 +1,3 @@
+from .server import main
+
+main()

--- a/algorithm/lazymind/workflow_mcp/server.py
+++ b/algorithm/lazymind/workflow_mcp/server.py
@@ -41,6 +41,21 @@ TOOL_SCHEMAS = {
         }, ['step_id'])},
         'command_id': {'type': 'string'},
     }, ['session_id', 'expected_state_version', 'steps']),
+    'get_skill_conversion_context': _object({
+        'skill_id': {'type': 'string'}, 'revision_id': {'type': 'string'},
+    }, ['skill_id']),
+    'create_workflow_draft': _object({
+        'name': {'type': 'string'}, 'skill_id': {'type': 'string'},
+        'revision_id': {'type': 'string'}, 'tree_hash': {'type': 'string'},
+        'files': {'type': 'object', 'additionalProperties': {'type': 'string'}},
+    }, ['name', 'skill_id', 'revision_id', 'tree_hash', 'files']),
+    'update_workflow_draft_file': _object({
+        'draft_id': {'type': 'string'}, 'path': {'type': 'string'},
+        'content': {'type': 'string'}, 'expected_version': {'type': 'integer', 'minimum': 1},
+    }, ['draft_id', 'path', 'content', 'expected_version']),
+    'validate_workflow_draft': _object({'draft_id': {'type': 'string'}}, ['draft_id']),
+    'get_workflow_diagnostics': _object({'draft_id': {'type': 'string'}}, ['draft_id']),
+    'publish_workflow': _object({'draft_id': {'type': 'string'}}, ['draft_id']),
 }
 
 TOOL_DESCRIPTIONS = {
@@ -52,6 +67,12 @@ TOOL_DESCRIPTIONS = {
     'get_workflow_state': 'Read the authoritative Workflow projection and state_version.',
     'get_ready_steps': 'Read only the current Ready frontier from the authoritative projection.',
     'advance_step': 'Synchronously request one or more Ready targets; Runtime resolves execute/retry/rewind.',
+    'get_skill_conversion_context': 'Read a complete, immutable Skill revision snapshot; never invokes a model.',
+    'create_workflow_draft': 'Store Agent-authored Workflow package files against a pinned Skill snapshot.',
+    'update_workflow_draft_file': 'Deterministically update one draft file with optimistic version checking.',
+    'validate_workflow_draft': 'Compile the draft with the deterministic Workflow graph validator.',
+    'get_workflow_diagnostics': 'Read deterministic package, graph, tool, and script diagnostics.',
+    'publish_workflow': 'Publish only a draft that passes deterministic publish diagnostics.',
 }
 
 
@@ -87,13 +108,30 @@ class WorkflowMCPServer:
             result = client.get_state(arguments['session_id'])
         elif name == 'get_ready_steps':
             result = client.get_ready_steps(arguments['session_id'])
-        else:
+        elif name == 'advance_step':
             steps = [StepCommand(**step) for step in arguments['steps']]
             result = client.advance(AdvanceRequest(
                 session_id=arguments['session_id'],
                 expected_state_version=arguments['expected_state_version'], steps=steps,
                 command_id=arguments.get('command_id') or str(uuid.uuid4()),
             )).result
+        elif name == 'get_skill_conversion_context':
+            result = client.get_skill_conversion_context(
+                arguments['skill_id'], arguments.get('revision_id', '')).result
+        elif name == 'create_workflow_draft':
+            result = client.create_workflow_draft(
+                arguments['name'], arguments['skill_id'], arguments['revision_id'],
+                arguments['tree_hash'], arguments['files']).result
+        elif name == 'update_workflow_draft_file':
+            result = client.update_workflow_draft_file(
+                arguments['draft_id'], arguments['path'], arguments['content'],
+                arguments['expected_version']).result
+        elif name == 'validate_workflow_draft':
+            result = client.validate_workflow_draft(arguments['draft_id']).result
+        elif name == 'get_workflow_diagnostics':
+            result = client.get_workflow_diagnostics(arguments['draft_id']).result
+        else:
+            result = client.publish_workflow(arguments['draft_id']).result
         return {'content': [{'type': 'text', 'text': json.dumps(result, ensure_ascii=False)}],
                 'structuredContent': result, 'isError': False}
 

--- a/algorithm/lazymind/workflow_mcp/server.py
+++ b/algorithm/lazymind/workflow_mcp/server.py
@@ -1,0 +1,151 @@
+"""Dependency-light stdio MCP server backed by the shared Workflow SDK."""
+from __future__ import annotations
+
+import json
+import sys
+import uuid
+from typing import Any, Callable, Dict
+
+from lazymind.workflow_sdk import AdvanceRequest, StepCommand, WorkflowClient, WorkflowClientError
+
+PROTOCOL_VERSION = '2025-06-18'
+
+
+def _object(properties: Dict[str, Any], required: list[str] | None = None) -> Dict[str, Any]:
+    return {'type': 'object', 'properties': properties, 'required': required or [],
+            'additionalProperties': False}
+
+
+TOOL_SCHEMAS = {
+    'workflow_connection_status': _object({}),
+    'list_workflows': _object({}),
+    'get_workflow': _object({'workflow_id': {'type': 'string'}}, ['workflow_id']),
+    'prepare_workflow': _object({
+        'workflow_id': {'type': 'string'},
+        'input_bindings': {'type': 'object'},
+        'command_id': {'type': 'string'},
+    }, ['workflow_id']),
+    'start_workflow': _object({
+        'preparation_id': {'type': 'string'}, 'session_id': {'type': 'string'},
+        'command_id': {'type': 'string'},
+    }, ['preparation_id', 'session_id']),
+    'get_workflow_state': _object({'session_id': {'type': 'string'}}, ['session_id']),
+    'get_ready_steps': _object({'session_id': {'type': 'string'}}, ['session_id']),
+    'advance_step': _object({
+        'session_id': {'type': 'string'},
+        'expected_state_version': {'type': 'integer', 'minimum': 0},
+        'steps': {'type': 'array', 'minItems': 1, 'items': _object({
+            'step_id': {'type': 'string'}, 'task_id': {'type': 'string'},
+            'objective': {'type': 'string'}, 'user_input': {'type': 'string'},
+            'runtime_instruction': {'type': 'string'}, 'partial_indices': {'type': 'object'},
+        }, ['step_id'])},
+        'command_id': {'type': 'string'},
+    }, ['session_id', 'expected_state_version', 'steps']),
+}
+
+TOOL_DESCRIPTIONS = {
+    'workflow_connection_status': 'Discover LazyMind Core and verify Workflow API connectivity.',
+    'list_workflows': 'List enabled Workflows visible to the current LazyMind user.',
+    'get_workflow': 'Read one Workflow definition and pinned revision metadata.',
+    'prepare_workflow': 'Validate a Workflow and inputs without creating a Session.',
+    'start_workflow': 'Consume a ready preparation and create a Workflow Session.',
+    'get_workflow_state': 'Read the authoritative Workflow projection and state_version.',
+    'get_ready_steps': 'Read only the current Ready frontier from the authoritative projection.',
+    'advance_step': 'Synchronously request one or more Ready targets; Runtime resolves execute/retry/rewind.',
+}
+
+
+class WorkflowMCPServer:
+    def __init__(self, client_factory: Callable[[], WorkflowClient] = WorkflowClient):
+        self.client_factory = client_factory
+
+    def list_tools(self) -> list[Dict[str, Any]]:
+        return [{'name': name, 'description': TOOL_DESCRIPTIONS[name], 'inputSchema': schema}
+                for name, schema in TOOL_SCHEMAS.items()]
+
+    def call_tool(self, name: str, arguments: Dict[str, Any]) -> Dict[str, Any]:
+        if name not in TOOL_SCHEMAS:
+            raise WorkflowClientError('UNKNOWN_TOOL', f'Unknown Workflow tool: {name}')
+        client = self.client_factory()
+        if name == 'workflow_connection_status':
+            result = client.connection_status()
+        elif name == 'list_workflows':
+            result = client.list_workflows().result
+        elif name == 'get_workflow':
+            result = client.get_workflow(arguments['workflow_id']).result
+        elif name == 'prepare_workflow':
+            result = client.prepare_workflow(
+                arguments['workflow_id'], input_bindings=arguments.get('input_bindings'),
+                command_id=arguments.get('command_id', ''),
+            ).result
+        elif name == 'start_workflow':
+            result = client.start_workflow(
+                arguments['preparation_id'], arguments['session_id'],
+                command_id=arguments.get('command_id', ''),
+            ).result
+        elif name == 'get_workflow_state':
+            result = client.get_state(arguments['session_id'])
+        elif name == 'get_ready_steps':
+            result = client.get_ready_steps(arguments['session_id'])
+        else:
+            steps = [StepCommand(**step) for step in arguments['steps']]
+            result = client.advance(AdvanceRequest(
+                session_id=arguments['session_id'],
+                expected_state_version=arguments['expected_state_version'], steps=steps,
+                command_id=arguments.get('command_id') or str(uuid.uuid4()),
+            )).result
+        return {'content': [{'type': 'text', 'text': json.dumps(result, ensure_ascii=False)}],
+                'structuredContent': result, 'isError': False}
+
+    def handle(self, request: Dict[str, Any]) -> Dict[str, Any] | None:
+        method = request.get('method')
+        request_id = request.get('id')
+        if request_id is None:
+            return None
+        try:
+            if method == 'initialize':
+                result = {'protocolVersion': PROTOCOL_VERSION,
+                          'capabilities': {'tools': {'listChanged': False}},
+                          'serverInfo': {'name': 'lazymind-workflow', 'version': 'workflow.v1'}}
+            elif method == 'ping':
+                result = {}
+            elif method == 'tools/list':
+                result = {'tools': self.list_tools()}
+            elif method == 'tools/call':
+                params = request.get('params') or {}
+                result = self.call_tool(str(params.get('name') or ''), params.get('arguments') or {})
+            else:
+                return {'jsonrpc': '2.0', 'id': request_id,
+                        'error': {'code': -32601, 'message': f'Method not found: {method}'}}
+            return {'jsonrpc': '2.0', 'id': request_id, 'result': result}
+        except WorkflowClientError as exc:
+            result = {'code': exc.code, 'message': exc.message, 'retryable': exc.retryable,
+                      'status_code': exc.status_code, 'details': exc.details}
+            return {'jsonrpc': '2.0', 'id': request_id, 'result': {
+                'content': [{'type': 'text', 'text': json.dumps(result, ensure_ascii=False)}],
+                'structuredContent': {'error': result}, 'isError': True,
+            }}
+        except (KeyError, TypeError, ValueError) as exc:
+            return {'jsonrpc': '2.0', 'id': request_id,
+                    'error': {'code': -32602, 'message': f'Invalid tool arguments: {exc}'}}
+
+
+def main() -> None:
+    server = WorkflowMCPServer()
+    for line in sys.stdin:
+        try:
+            request = json.loads(line)
+            response = server.handle(request)
+            if response is not None:
+                sys.stdout.write(json.dumps(response, ensure_ascii=False) + '\n')
+                sys.stdout.flush()
+        except (ValueError, TypeError) as exc:
+            sys.stdout.write(json.dumps({
+                'jsonrpc': '2.0', 'id': None,
+                'error': {'code': -32700, 'message': f'Parse error: {exc}'},
+            }) + '\n')
+            sys.stdout.flush()
+
+
+if __name__ == '__main__':
+    main()

--- a/algorithm/lazymind/workflow_policy.py
+++ b/algorithm/lazymind/workflow_policy.py
@@ -47,12 +47,9 @@ def _advance_tool(profile: Mapping[str, Any], *, wait: bool) -> str:
     tools = tuple(profile.get('advance_tools') or ('advance_step',))
     if wait or not profile.get('handoff'):
         return 'advance_step' if 'advance_step' in tools else str(tools[0])
-    if 'advance_step_and_handoff' in tools:
-        return 'advance_step_and_handoff'
-    # LazyMind's current public spelling is retained as a host capability alias.
     if 'advance_step_and_hand_off' in tools:
         return 'advance_step_and_hand_off'
-    return 'advance_step_and_handoff'
+    return 'advance_step_and_hand_off'
 
 
 def decide(

--- a/algorithm/lazymind/workflow_sdk/__init__.py
+++ b/algorithm/lazymind/workflow_sdk/__init__.py
@@ -1,0 +1,16 @@
+"""Host-neutral Workflow v1 SDK."""
+
+from .client import (
+    AdvanceRequest,
+    ConnectionInfo,
+    StepCommand,
+    WorkflowClient,
+    WorkflowClientError,
+    WorkflowResponse,
+    discover_connection,
+)
+
+__all__ = [
+    'AdvanceRequest', 'ConnectionInfo', 'StepCommand', 'WorkflowClient',
+    'WorkflowClientError', 'WorkflowResponse', 'discover_connection',
+]

--- a/algorithm/lazymind/workflow_sdk/client.py
+++ b/algorithm/lazymind/workflow_sdk/client.py
@@ -9,7 +9,7 @@ import uuid
 from dataclasses import asdict, dataclass, field
 from pathlib import Path
 from typing import Any, Dict, List, Optional
-from urllib.parse import urlsplit
+from urllib.parse import quote, urlencode, urlsplit
 
 import httpx
 
@@ -235,3 +235,43 @@ class WorkflowClient:
         ).result
         preparation_id = str(prepared.get('id') or prepared.get('preparation_id') or command_id)
         return self.start_workflow(preparation_id, session_id, command_id=command_id)
+
+    def get_skill_conversion_context(self, skill_id: str,
+                                     revision_id: str = '') -> WorkflowResponse:
+        query = {'skill_id': skill_id}
+        if revision_id:
+            query['revision_id'] = revision_id
+        return self._read('/workflow-authoring/v1/skill-context?' + urlencode(query))
+
+    def create_workflow_draft(self, name: str, skill_id: str, revision_id: str,
+                              tree_hash: str, files: Dict[str, str]) -> WorkflowResponse:
+        return self._decode(self.transport.post(
+            self.base_url + '/workflow-authoring/v1/drafts',
+            json={'name': name, 'skill_id': skill_id, 'revision_id': revision_id,
+                  'tree_hash': tree_hash, 'files': files},
+            headers=self._headers(), timeout=self.timeout,
+        ))
+
+    def update_workflow_draft_file(self, draft_id: str, path: str, content: str,
+                                   expected_version: int) -> WorkflowResponse:
+        return self._decode(self.transport.put(
+            f'{self.base_url}/workflow-authoring/v1/drafts/{quote(draft_id, safe="")}/files',
+            json={'path': path, 'content': content, 'expected_version': expected_version},
+            headers=self._headers(), timeout=self.timeout,
+        ))
+
+    def validate_workflow_draft(self, draft_id: str) -> WorkflowResponse:
+        return self._decode(self.transport.post(
+            f'{self.base_url}/workflow-drafts/{quote(draft_id, safe="")}:validate',
+            json={}, headers=self._headers(), timeout=self.timeout,
+        ))
+
+    def get_workflow_diagnostics(self, draft_id: str) -> WorkflowResponse:
+        return self._read(
+            f'/workflow-authoring/v1/drafts/{quote(draft_id, safe="")}/diagnostics')
+
+    def publish_workflow(self, draft_id: str) -> WorkflowResponse:
+        return self._decode(self.transport.post(
+            f'{self.base_url}/workflow-authoring/v1/drafts/{quote(draft_id, safe="")}:publish',
+            json={}, headers=self._headers(), timeout=self.timeout,
+        ))

--- a/algorithm/lazymind/workflow_sdk/client.py
+++ b/algorithm/lazymind/workflow_sdk/client.py
@@ -1,0 +1,237 @@
+"""Host-neutral client and local LazyMind endpoint discovery for Workflow v1."""
+from __future__ import annotations
+
+import json
+import os
+import platform
+import time
+import uuid
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+from urllib.parse import urlsplit
+
+import httpx
+
+CONTRACT_VERSION = 'workflow.v1'
+
+
+class WorkflowClientError(RuntimeError):
+    def __init__(self, code: str, message: str, retryable: bool = False,
+                 status_code: int = 0, details: Optional[Dict[str, Any]] = None):
+        super().__init__(code, message, retryable, status_code, details)
+        self.code = code
+        self.message = message
+        self.retryable = retryable
+        self.status_code = status_code
+        self.details = details or {}
+
+    def __str__(self) -> str:
+        return self.message
+
+
+@dataclass(frozen=True)
+class ConnectionInfo:
+    base_url: str
+    source: str
+    runtime_root: str = ''
+
+
+@dataclass(frozen=True)
+class StepCommand:
+    step_id: str
+    task_id: str = ''
+    objective: str = ''
+    user_input: str = ''
+    runtime_instruction: str = ''
+    partial_indices: Dict[str, List[int]] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class AdvanceRequest:
+    session_id: str
+    expected_state_version: int
+    steps: List[StepCommand]
+    handoff: bool = False
+    command_id: str = field(default_factory=lambda: str(uuid.uuid4()))
+
+
+@dataclass(frozen=True)
+class WorkflowResponse:
+    result: Dict[str, Any]
+    request_id: str = ''
+
+
+def _default_runtime_roots() -> list[Path]:
+    explicit = os.getenv('LAZYMIND_RUNTIME_ROOT', '').strip()
+    roots = [Path(explicit)] if explicit else []
+    system = platform.system().lower()
+    if system == 'darwin':
+        roots.append(Path.home() / 'Library' / 'Application Support' / 'LazyMind')
+    elif system == 'windows':
+        local = os.getenv('LOCALAPPDATA', '').strip()
+        if local:
+            roots.append(Path(local) / 'LazyMind')
+    else:
+        data = os.getenv('XDG_DATA_HOME', '').strip()
+        roots.append(Path(data) / 'LazyMind' if data else Path.home() / '.local/share/LazyMind')
+    return list(dict.fromkeys(roots))
+
+
+def _endpoint_from_file(path: Path) -> str:
+    try:
+        body = json.loads(path.read_text(encoding='utf-8'))
+    except (OSError, ValueError):
+        return ''
+    host = body.get('host') or body.get('Host') or {}
+    endpoint = str(
+        host.get('coreBaseUrl') or host.get('coreBaseURL') or host.get('core_base_url')
+        or host.get('CoreBaseURL') or ''
+    ).rstrip('/')
+    if endpoint and urlsplit(endpoint).path in {'', '/'}:
+        endpoint += '/api/core'
+    return endpoint
+
+
+def discover_connection() -> ConnectionInfo:
+    """Resolve Core without assuming a fixed local port."""
+    for name in ('LAZYMIND_WORKFLOW_BASE_URL', 'LAZYMIND_ENDPOINT_HOST_CORE_BASE_URL',
+                 'LAZYMIND_CORE_API_URL', 'LAZYMIND_CORE_SERVICE_URL'):
+        value = os.getenv(name, '').strip().rstrip('/')
+        if value:
+            return ConnectionInfo(value, f'env:{name}')
+    for root in _default_runtime_roots():
+        endpoint = _endpoint_from_file(root / 'generated' / 'service-endpoints.json')
+        if endpoint:
+            return ConnectionInfo(endpoint, 'runtime-service-endpoints', str(root))
+    raise WorkflowClientError(
+        'LAZYMIND_NOT_FOUND',
+        'LazyMind Core was not discovered; start LazyMind or set LAZYMIND_WORKFLOW_BASE_URL.',
+    )
+
+
+class WorkflowClient:
+    """Shared HTTP implementation used by LazyMind and MCP adapters."""
+
+    def __init__(self, base_url: str = '', user_id: str = '', *, token: str = '',
+                 timeout: float = 15.0, read_retries: int = 2, transport: Any = httpx):
+        connection = ConnectionInfo(base_url.rstrip('/'), 'argument') if base_url else discover_connection()
+        self.connection = connection
+        self.base_url = connection.base_url
+        self.user_id = user_id or os.getenv('LAZYMIND_WORKFLOW_USER_ID', '').strip()
+        self.token = token or os.getenv('LAZYMIND_WORKFLOW_TOKEN', '').strip()
+        self.timeout = timeout
+        self.read_retries = read_retries
+        self.transport = transport
+
+    def _headers(self, command_id: str = '') -> Dict[str, str]:
+        headers = {'Workflow-Contract-Version': CONTRACT_VERSION}
+        if self.user_id:
+            headers['X-User-Id'] = self.user_id
+        if self.token:
+            headers['Authorization'] = f'Bearer {self.token}'
+        if command_id:
+            headers['Idempotency-Key'] = command_id
+        return headers
+
+    @staticmethod
+    def _decode(response: Any) -> WorkflowResponse:
+        try:
+            body = response.json()
+        except Exception as exc:
+            raise WorkflowClientError('INVALID_RESPONSE', str(exc),
+                                      status_code=response.status_code) from exc
+        if response.status_code >= 400 or (isinstance(body, dict) and body.get('ok') is False):
+            error = body.get('error', {}) if isinstance(body, dict) else {}
+            raise WorkflowClientError(
+                str(error.get('code') or 'WORKFLOW_REQUEST_FAILED'),
+                str(error.get('message') or f'Workflow request failed ({response.status_code})'),
+                retryable=bool(error.get('retryable')), status_code=response.status_code,
+                details=error.get('details') if isinstance(error.get('details'), dict) else {},
+            )
+        result = body.get('result', body.get('data', body)) if isinstance(body, dict) else {}
+        return WorkflowResponse(
+            result=result if isinstance(result, dict) else {'value': result},
+            request_id=str(body.get('request_id') or '') if isinstance(body, dict) else '',
+        )
+
+    def _read(self, path: str) -> WorkflowResponse:
+        for attempt in range(self.read_retries + 1):
+            try:
+                response = self.transport.get(
+                    self.base_url + path, headers=self._headers(), timeout=self.timeout,
+                )
+                return self._decode(response)
+            except WorkflowClientError as exc:
+                if not exc.retryable or attempt >= self.read_retries:
+                    raise
+            except (httpx.TimeoutException, httpx.TransportError) as exc:
+                if attempt >= self.read_retries:
+                    raise WorkflowClientError('WORKFLOW_TIMEOUT', str(exc), retryable=True) from exc
+            time.sleep(0.05 * (2 ** attempt))
+        raise AssertionError('unreachable')
+
+    def connection_status(self) -> Dict[str, Any]:
+        workflows = self.list_workflows().result
+        return {'connected': True, 'base_url': self.base_url,
+                'source': self.connection.source, 'contract_version': CONTRACT_VERSION,
+                'discovery_response': workflows}
+
+    def list_workflows(self) -> WorkflowResponse:
+        return self._read('/workflows')
+
+    def get_workflow(self, workflow_id: str) -> WorkflowResponse:
+        return self._read(f'/workflows/{workflow_id}')
+
+    def get_state(self, session_id: str) -> Dict[str, Any]:
+        return self._read(f'/workflow-sessions/{session_id}/projection').result
+
+    def get_ready_steps(self, session_id: str) -> Dict[str, Any]:
+        state = self.get_state(session_id)
+        ready = state.get('ready_steps', state.get('ready', []))
+        return {'session_id': session_id, 'state_version': state.get('state_version'),
+                'ready_steps': ready, 'projection': state}
+
+    def prepare_workflow(self, workflow_id: str, *, input_bindings: Optional[Dict[str, Any]] = None,
+                         command_id: str = '', fields: Optional[Dict[str, Any]] = None) -> WorkflowResponse:
+        command_id = command_id or str(uuid.uuid4())
+        payload = {**(fields or {}), 'workflow_id': workflow_id, 'preparation_id': command_id,
+                   'idempotency_key': command_id, 'input_bindings': input_bindings or {}}
+        return self._decode(self.transport.post(
+            self.base_url + '/workflow-preparations', json=payload,
+            headers=self._headers(command_id), timeout=self.timeout,
+        ))
+
+    def start_workflow(self, preparation_id: str, session_id: str,
+                       *, command_id: str = '') -> WorkflowResponse:
+        command_id = command_id or preparation_id
+        return self._decode(self.transport.post(
+            f'{self.base_url}/workflow-preparations/{preparation_id}:consume',
+            json={'session_id': session_id}, headers=self._headers(command_id), timeout=self.timeout,
+        ))
+
+    def advance(self, request: AdvanceRequest) -> WorkflowResponse:
+        tool = 'advance_step_and_hand_off' if request.handoff else 'advance_step'
+        payload = {'contract_version': CONTRACT_VERSION, 'command_id': request.command_id,
+                   'tool': tool, 'session_id': request.session_id,
+                   'expected_state_version': request.expected_state_version,
+                   'steps': [asdict(step) for step in request.steps]}
+        path = f'/workflow-sessions/{request.session_id}:' + (
+            'advance-step-and-hand-off' if request.handoff else 'advance-step')
+        try:
+            response = self.transport.post(
+                self.base_url + path, json=payload, headers=self._headers(request.command_id),
+                timeout=self.timeout,
+            )
+        except (httpx.TimeoutException, httpx.TransportError) as exc:
+            raise WorkflowClientError('TRANSITION_RESULT_UNKNOWN', str(exc), retryable=True) from exc
+        return self._decode(response)
+
+    def prepare_start(self, workflow_id: str, session_id: str, command_id: str,
+                      start_fields: Dict[str, Any]) -> WorkflowResponse:
+        prepared = self.prepare_workflow(
+            workflow_id, input_bindings=start_fields.get('input_bindings'), command_id=command_id,
+            fields=start_fields,
+        ).result
+        preparation_id = str(prepared.get('id') or prepared.get('preparation_id') or command_id)
+        return self.start_workflow(preparation_id, session_id, command_id=command_id)

--- a/algorithm/tests/chat/test_sensitive_filter_skip.py
+++ b/algorithm/tests/chat/test_sensitive_filter_skip.py
@@ -35,3 +35,7 @@ def test_no_skip_synthetic_marker_without_workflow_identity():
         'Step analyze_subject completed. Please proceed.',
         {'synthetic_source': 'driver'},
     )
+
+
+def test_no_skip_without_workflow_context():
+    assert not _should_skip_sensitive_filter('普通用户消息', None)

--- a/algorithm/tests/chat/test_sensitive_filter_skip.py
+++ b/algorithm/tests/chat/test_sensitive_filter_skip.py
@@ -28,3 +28,10 @@ def test_no_skip_normal_workflow_user_message():
         'session_id': 'ps-1',
     }
     assert not _should_skip_sensitive_filter('继续', ctx)
+
+
+def test_no_skip_synthetic_marker_without_workflow_identity():
+    assert not _should_skip_sensitive_filter(
+        'Step analyze_subject completed. Please proceed.',
+        {'synthetic_source': 'driver'},
+    )

--- a/algorithm/tests/chat/workflows/test_host_policy_convergence.py
+++ b/algorithm/tests/chat/workflows/test_host_policy_convergence.py
@@ -39,10 +39,8 @@ def test_driver_profile_changes_host_tools_not_runtime_projection_or_lineage():
     ]
 
 
-def test_historical_handoff_spelling_is_only_a_metered_builder_alias():
-    from lazymind.chat.workflow import decision_policy, workflow_manager
+def test_handoff_builder_keeps_established_public_spelling():
+    from lazymind.chat.workflow import workflow_manager
 
-    before = decision_policy.compat_handoff_alias_hits
     tool = workflow_manager.build_advance_step_and_hand_off_tool('wf', 'step')
-    assert tool.__name__ == 'advance_step_and_handoff'
-    assert decision_policy.compat_handoff_alias_hits == before + 1
+    assert tool.__name__ == 'advance_step_and_hand_off'

--- a/algorithm/tests/chat/workflows/test_manager.py
+++ b/algorithm/tests/chat/workflows/test_manager.py
@@ -132,7 +132,7 @@ def test_dynamic_launch_policy_defaults_to_hand_off():
     assert 'Ordinary Ready frontier' in policy
     assert 'LazyMind Workflow Launch Binding' in policy
     assert [tool.__name__ for tool in workflow_manager.build_cold_advance_tools()] == [
-        'advance_step_and_handoff', 'advance_step',
+        'advance_step_and_hand_off', 'advance_step',
     ]
 
 
@@ -189,11 +189,11 @@ def test_cold_start_trigger_hides_hand_off_choice_when_tool_is_static(
             explicit_workflow_request=False,
         ))
 
-    assert result['launch_plan']['advance_tool'] == 'advance_step_and_handoff'
+    assert result['launch_plan']['advance_tool'] == 'advance_step_and_hand_off'
     assert 'hand_off' not in result['launch_plan']
     internal_plan = mock_agentic_config['prepared_workflow']['launch_plan']
     assert internal_plan['hand_off'] is True
-    assert internal_plan['advance_tool'] == 'advance_step_and_handoff'
+    assert internal_plan['advance_tool'] == 'advance_step_and_hand_off'
 
 
 def test_cold_start_trigger_rejects_empty_input(loaded_workflow, mock_write_agent_data, mock_agentic_config):
@@ -379,7 +379,7 @@ def test_cold_advance_commits_exact_prepared_plan(
     }
     handoff = next(
         t for t in workflow_manager.build_cold_advance_tools()
-        if t.__name__ == 'advance_step_and_handoff'
+        if t.__name__ == 'advance_step_and_hand_off'
     )
 
     result = handoff(step_id='step_a')
@@ -434,7 +434,7 @@ def test_cold_advance_rejects_tool_that_disagrees_with_launch_plan(
     }
     handoff = next(
         t for t in workflow_manager.build_cold_advance_tools()
-        if t.__name__ == 'advance_step_and_handoff'
+        if t.__name__ == 'advance_step_and_hand_off'
     )
 
     with pytest.raises(ValueError, match='requires advance_step'):
@@ -593,8 +593,8 @@ def test_cold_injection_without_approval_choice_registers_only_hand_off_tool(
     names = {tool.__name__ for tool in tools}
     assert 'trigger_test_workflow' in names
     assert 'advance_step' not in names
-    assert 'advance_step_and_handoff' in names
-    assert stop_tools == ['advance_step_and_handoff']
+    assert 'advance_step_and_hand_off' in names
+    assert stop_tools == ['advance_step_and_hand_off']
     assert 'trigger_test_workflow' not in stop_tools
     assert patch_config['workflow_mode'] == 'auto'
     assert patch_config['workflow_preflight_context']['preflight_id'] == 'pf-old'
@@ -653,13 +653,13 @@ def test_active_injection_switches_tools_and_request_local_policy_per_turn(
     auto_names = {tool.__name__ for tool in auto_tools}
     dynamic_names = {tool.__name__ for tool in dynamic_tools}
 
-    assert 'advance_step_and_handoff' in auto_names
+    assert 'advance_step_and_hand_off' in auto_names
     assert 'advance_step' not in auto_names
-    assert {'advance_step', 'advance_step_and_handoff'} <= dynamic_names
+    assert {'advance_step', 'advance_step_and_hand_off'} <= dynamic_names
     assert 'advance_steps' not in dynamic_names
     assert 'advance_steps_and_hand_off' not in dynamic_names
-    assert set(auto_stop_tools) == {'advance_step_and_handoff'}
-    assert set(dynamic_stop_tools) == {'advance_step_and_handoff'}
+    assert set(auto_stop_tools) == {'advance_step_and_hand_off'}
+    assert set(dynamic_stop_tools) == {'advance_step_and_hand_off'}
     assert 'Current Workflow Execution Policy' not in auto_system_prompt
     assert 'Current Workflow Execution Policy' not in dynamic_system_prompt
     assert 'Shared Workflow Decision Policy' in auto_context
@@ -673,10 +673,10 @@ def test_active_injection_switches_tools_and_request_local_policy_per_turn(
     assert 'dynamic mode' not in dynamic_context.lower()
 
     auto_advance = next(
-        tool for tool in auto_tools if tool.__name__ == 'advance_step_and_handoff'
+        tool for tool in auto_tools if tool.__name__ == 'advance_step_and_hand_off'
     )
     dynamic_advance = next(
-        tool for tool in dynamic_tools if tool.__name__ == 'advance_step_and_handoff'
+        tool for tool in dynamic_tools if tool.__name__ == 'advance_step_and_hand_off'
     )
     assert 'default approval' not in (auto_advance.__doc__ or '').lower()
     assert 'default approval' in (dynamic_advance.__doc__ or '').lower()

--- a/algorithm/tests/test_workflow_agent_kit.py
+++ b/algorithm/tests/test_workflow_agent_kit.py
@@ -32,7 +32,7 @@ def test_host_profiles_cover_contract_capabilities():
     for name, profile in profiles.items():
         assert required <= set(profile), name
         assert profile['version'] == 'workflow.v1'
-    assert 'advance_step_and_handoff' in profiles['lazymind']['advance_tools']
+    assert 'advance_step_and_hand_off' in profiles['lazymind']['advance_tools']
     assert profiles['codex']['advance_tools'] == ['advance_step']
     assert profiles['codex']['handoff'] is False
 

--- a/algorithm/tests/test_workflow_agent_kit.py
+++ b/algorithm/tests/test_workflow_agent_kit.py
@@ -9,8 +9,13 @@ KIT = Path(__file__).parents[2] / 'skills/workflow-agent-kit'
 def test_skill_references_exist_and_cover_required_lifecycle():
     skill = (KIT / 'SKILL.md').read_text()
     for reference in (
+        'references/lifecycle.md',
         'references/decision-policy.md',
-        'references/artifact-and-authoring.md',
+        'references/execution-policy.md',
+        'references/artifact-policy.md',
+        'references/recovery-policy.md',
+        'references/skill-to-workflow.md',
+        'references/tool-contracts.md',
         'references/source-to-policy-mapping.md',
     ):
         assert reference in skill
@@ -35,6 +40,28 @@ def test_host_profiles_cover_contract_capabilities():
     assert 'advance_step_and_hand_off' in profiles['lazymind']['advance_tools']
     assert profiles['codex']['advance_tools'] == ['advance_step']
     assert profiles['codex']['handoff'] is False
+    assert all(profile['shadow_authority'] == 'shared' for profile in profiles.values())
+
+
+def test_skill_to_workflow_covers_complete_authoring_tool_chain():
+    policy = (KIT / 'references' / 'skill-to-workflow.md').read_text()
+    for tool in (
+        'get_skill_conversion_context',
+        'create_workflow_draft',
+        'update_workflow_draft_file',
+        'validate_workflow_draft',
+        'get_workflow_diagnostics',
+        'publish_workflow',
+    ):
+        assert f'`{tool}`' in policy
+
+
+def test_host_adapters_keep_runtime_rules_out_of_host_capabilities():
+    for host in ('lazymind', 'codex'):
+        adapter = KIT / 'adapters' / f'{host}.md'
+        assert adapter.is_file()
+        content = adapter.read_text()
+        assert 'Supervisor' in content
 
 
 def test_mapping_ledger_points_to_current_workflow_sources():

--- a/algorithm/tests/test_workflow_agent_kit.py
+++ b/algorithm/tests/test_workflow_agent_kit.py
@@ -9,6 +9,7 @@ KIT = Path(__file__).parents[2] / 'skills/workflow-agent-kit'
 def test_skill_references_exist_and_cover_required_lifecycle():
     skill = (KIT / 'SKILL.md').read_text()
     for reference in (
+        'references/installation-and-connection.md',
         'references/lifecycle.md',
         'references/decision-policy.md',
         'references/execution-policy.md',
@@ -33,6 +34,7 @@ def test_host_profiles_cover_contract_capabilities():
     required = {
         'version', 'profile', 'advance_tools', 'parallel_ready_steps', 'approval',
         'handoff', 'driver', 'synthetic_turn', 'shadow_authority', 'write_tools',
+        'workflow_tools',
     }
     for name, profile in profiles.items():
         assert required <= set(profile), name
@@ -40,6 +42,8 @@ def test_host_profiles_cover_contract_capabilities():
     assert 'advance_step_and_hand_off' in profiles['lazymind']['advance_tools']
     assert profiles['codex']['advance_tools'] == ['advance_step']
     assert profiles['codex']['handoff'] is False
+    assert 'workflow_connection_status' in profiles['codex']['workflow_tools']
+    assert 'advance_step_and_hand_off' not in profiles['codex']['workflow_tools']
     assert all(profile['shadow_authority'] == 'shared' for profile in profiles.values())
 
 

--- a/algorithm/tests/test_workflow_agent_kit.py
+++ b/algorithm/tests/test_workflow_agent_kit.py
@@ -10,12 +10,14 @@ def test_skill_references_exist_and_cover_required_lifecycle():
     skill = (KIT / 'SKILL.md').read_text()
     for reference in (
         'references/installation-and-connection.md',
+        'references/model-execution-boundary.md',
         'references/lifecycle.md',
         'references/decision-policy.md',
         'references/execution-policy.md',
         'references/artifact-policy.md',
         'references/recovery-policy.md',
         'references/skill-to-workflow.md',
+        'references/workflow-format.md',
         'references/tool-contracts.md',
         'references/source-to-policy-mapping.md',
     ):
@@ -57,7 +59,13 @@ def test_skill_to_workflow_covers_complete_authoring_tool_chain():
         'get_workflow_diagnostics',
         'publish_workflow',
     ):
-        assert f'`{tool}`' in policy
+        assert tool in policy
+    boundary = (KIT / 'references' / 'model-execution-boundary.md').read_text()
+    assert 'Only execution of a Workflow step may invoke another model' in boundary
+    assert 'No other tool may hide' in boundary
+    format_policy = (KIT / 'references' / 'workflow-format.md').read_text()
+    for path in ('plugin.yaml', 'scenario/state.yml', 'scenario/scenario.md'):
+        assert path in format_policy
 
 
 def test_host_adapters_keep_runtime_rules_out_of_host_capabilities():

--- a/algorithm/tests/test_workflow_policy.py
+++ b/algorithm/tests/test_workflow_policy.py
@@ -15,7 +15,7 @@ def test_lazymind_can_handoff_but_codex_is_synchronous():
     projection = {'status': 'running', 'ready_steps': ['draft']}
     lazy = policy.decide(projection, {'advance_tools': ['advance_step'], 'handoff': True})
     codex = policy.decide(projection, {'advance_tools': ['advance_step'], 'handoff': False})
-    assert lazy.tool == 'advance_step_and_handoff'
+    assert lazy.tool == 'advance_step_and_hand_off'
     assert codex.tool == 'advance_step'
 
 

--- a/algorithm/tests/test_workflow_policy_shadow.py
+++ b/algorithm/tests/test_workflow_policy_shadow.py
@@ -36,7 +36,7 @@ for module_name, previous in saved_modules.items():
 
 LAZYMIND_PROFILE = {
     'profile': 'lazymind',
-    'advance_tools': ['advance_step', 'advance_step_and_handoff'],
+    'advance_tools': ['advance_step', 'advance_step_and_hand_off'],
     'parallel_ready_steps': True,
     'handoff': True,
 }

--- a/algorithm/tests/test_workflow_sdk.py
+++ b/algorithm/tests/test_workflow_sdk.py
@@ -34,6 +34,11 @@ def test_mcp_lists_only_real_public_tools():
             'get_workflow_state', 'get_ready_steps', 'advance_step'} <= names
     assert 'stop_workflow' not in names
     assert 'patch_artifact' not in names
+    assert {
+        'get_skill_conversion_context', 'create_workflow_draft',
+        'update_workflow_draft_file', 'validate_workflow_draft',
+        'get_workflow_diagnostics', 'publish_workflow',
+    } <= names
 
 
 def test_mcp_uses_shared_sdk_client():
@@ -53,3 +58,38 @@ def test_mcp_initialize_and_tools_list_protocol():
     assert initialized['result']['capabilities']['tools'] == {'listChanged': False}
     listed = server.handle({'jsonrpc': '2.0', 'id': 2, 'method': 'tools/list'})
     assert {tool['name'] for tool in listed['result']['tools']} == set(TOOL_SCHEMAS)
+
+
+def test_mcp_authoring_submits_agent_text_to_deterministic_sdk():
+    client = MagicMock()
+    client.create_workflow_draft.return_value = MagicMock(result={
+        'draft': {'id': 'd1', 'version': 1},
+    })
+    server = WorkflowMCPServer(lambda: client)
+    files = {
+        'plugin.yaml': 'id: report\n',
+        'scenario/state.yml': 'initial: __start__\n',
+        'scenario/scenario.md': '# Report\n',
+    }
+    result = server.call_tool('create_workflow_draft', {
+        'name': 'Report', 'skill_id': 's1', 'revision_id': 'r1',
+        'tree_hash': 'sha256:tree', 'files': files,
+    })
+    assert result['structuredContent']['draft']['id'] == 'd1'
+    client.create_workflow_draft.assert_called_once_with(
+        'Report', 's1', 'r1', 'sha256:tree', files,
+    )
+
+
+def test_sdk_authoring_routes_do_not_use_generation_endpoints():
+    transport = MagicMock()
+    transport.get.return_value = MagicMock(
+        status_code=200, json=lambda: {'ok': True, 'data': {'valid': True}},
+    )
+    from lazymind.workflow_sdk import WorkflowClient
+
+    client = WorkflowClient('http://core/api/core', 'u1', transport=transport)
+    client.get_workflow_diagnostics('d1')
+    path = transport.get.call_args.args[0]
+    assert path.endswith('/workflow-authoring/v1/drafts/d1/diagnostics')
+    assert 'ai-' not in path

--- a/algorithm/tests/test_workflow_sdk.py
+++ b/algorithm/tests/test_workflow_sdk.py
@@ -1,0 +1,55 @@
+import json
+from unittest.mock import MagicMock
+
+from lazymind.workflow_mcp.server import TOOL_SCHEMAS, WorkflowMCPServer
+from lazymind.workflow_sdk import ConnectionInfo, discover_connection
+
+
+def test_discovery_prefers_explicit_workflow_url(monkeypatch):
+    monkeypatch.setenv('LAZYMIND_WORKFLOW_BASE_URL', 'http://127.0.0.1:54321/api/core/')
+    found = discover_connection()
+    assert found == ConnectionInfo('http://127.0.0.1:54321/api/core',
+                                   'env:LAZYMIND_WORKFLOW_BASE_URL')
+
+
+def test_discovery_reads_dynamic_runtime_endpoint(tmp_path, monkeypatch):
+    monkeypatch.delenv('LAZYMIND_WORKFLOW_BASE_URL', raising=False)
+    monkeypatch.delenv('LAZYMIND_ENDPOINT_HOST_CORE_BASE_URL', raising=False)
+    monkeypatch.delenv('LAZYMIND_CORE_API_URL', raising=False)
+    monkeypatch.delenv('LAZYMIND_CORE_SERVICE_URL', raising=False)
+    monkeypatch.setenv('LAZYMIND_RUNTIME_ROOT', str(tmp_path))
+    generated = tmp_path / 'generated'
+    generated.mkdir()
+    (generated / 'service-endpoints.json').write_text(json.dumps({
+        'host': {'coreBaseUrl': 'http://127.0.0.1:49152'},
+    }))
+    found = discover_connection()
+    assert found.base_url == 'http://127.0.0.1:49152/api/core'
+    assert found.source == 'runtime-service-endpoints'
+
+
+def test_mcp_lists_only_real_public_tools():
+    names = set(TOOL_SCHEMAS)
+    assert {'list_workflows', 'prepare_workflow', 'start_workflow',
+            'get_workflow_state', 'get_ready_steps', 'advance_step'} <= names
+    assert 'stop_workflow' not in names
+    assert 'patch_artifact' not in names
+
+
+def test_mcp_uses_shared_sdk_client():
+    client = MagicMock()
+    client.get_ready_steps.return_value = {
+        'session_id': 's1', 'state_version': 3, 'ready_steps': ['draft'],
+    }
+    server = WorkflowMCPServer(lambda: client)
+    result = server.call_tool('get_ready_steps', {'session_id': 's1'})
+    assert result['structuredContent']['ready_steps'] == ['draft']
+    client.get_ready_steps.assert_called_once_with('s1')
+
+
+def test_mcp_initialize_and_tools_list_protocol():
+    server = WorkflowMCPServer()
+    initialized = server.handle({'jsonrpc': '2.0', 'id': 1, 'method': 'initialize'})
+    assert initialized['result']['capabilities']['tools'] == {'listChanged': False}
+    listed = server.handle({'jsonrpc': '2.0', 'id': 2, 'method': 'tools/list'})
+    assert {tool['name'] for tool in listed['result']['tools']} == set(TOOL_SCHEMAS)

--- a/backend/core/migrations/dev_mode/v0_2/20260803220000_workflow_input_resources.up.sql
+++ b/backend/core/migrations/dev_mode/v0_2/20260803220000_workflow_input_resources.up.sql
@@ -1,3 +1,4 @@
+-- +migrate Dialect postgres
 CREATE TABLE IF NOT EXISTS workflow_input_resources (
     id varchar(36) PRIMARY KEY,
     owner_user_id varchar(255) NOT NULL,
@@ -6,8 +7,8 @@ CREATE TABLE IF NOT EXISTS workflow_input_resources (
     size bigint NOT NULL,
     content_hash varchar(80) NOT NULL,
     revision bigint NOT NULL DEFAULT 1,
-    content blob NOT NULL,
-    created_at datetime NOT NULL
+    content bytea NOT NULL,
+    created_at timestamp NOT NULL
 );
 CREATE INDEX IF NOT EXISTS idx_workflow_input_resources_owner_hash
     ON workflow_input_resources(owner_user_id, content_hash);
@@ -22,7 +23,7 @@ CREATE TABLE IF NOT EXISTS workflow_input_bindings (
     content_hash varchar(80) NOT NULL,
     validity varchar(16) NOT NULL DEFAULT 'effective',
     created_by_command_id varchar(64) NOT NULL,
-    created_at datetime NOT NULL
+    created_at timestamp NOT NULL
 );
 CREATE INDEX IF NOT EXISTS idx_workflow_input_bindings_session
     ON workflow_input_bindings(workflow_session_id);
@@ -33,3 +34,40 @@ ALTER TABLE plugin_attempt_input_bindings ADD COLUMN source_type varchar(32) NOT
 ALTER TABLE plugin_attempt_input_bindings ADD COLUMN source_id varchar(128) NOT NULL DEFAULT '';
 ALTER TABLE plugin_attempt_input_bindings ADD COLUMN source_revision varchar(64) NOT NULL DEFAULT '';
 ALTER TABLE plugin_attempt_input_bindings ADD COLUMN content_hash varchar(80) NOT NULL DEFAULT '';
+
+-- +migrate Dialect sqlite
+CREATE TABLE IF NOT EXISTS workflow_input_resources (
+    id TEXT PRIMARY KEY,
+    owner_user_id TEXT NOT NULL,
+    name TEXT NOT NULL,
+    mime_type TEXT NOT NULL,
+    size INTEGER NOT NULL,
+    content_hash TEXT NOT NULL,
+    revision INTEGER NOT NULL DEFAULT 1,
+    content BLOB NOT NULL,
+    created_at DATETIME NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_workflow_input_resources_owner_hash
+    ON workflow_input_resources(owner_user_id, content_hash);
+
+CREATE TABLE IF NOT EXISTS workflow_input_bindings (
+    id TEXT PRIMARY KEY,
+    workflow_session_id TEXT NOT NULL,
+    material_id TEXT NOT NULL,
+    resource_type TEXT NOT NULL,
+    resource_id TEXT NOT NULL,
+    resource_revision INTEGER NOT NULL,
+    content_hash TEXT NOT NULL,
+    validity TEXT NOT NULL DEFAULT 'effective',
+    created_by_command_id TEXT NOT NULL,
+    created_at DATETIME NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_workflow_input_bindings_session
+    ON workflow_input_bindings(workflow_session_id);
+CREATE INDEX IF NOT EXISTS idx_workflow_input_bindings_resource
+    ON workflow_input_bindings(resource_id);
+
+ALTER TABLE plugin_attempt_input_bindings ADD COLUMN source_type TEXT NOT NULL DEFAULT 'artifact';
+ALTER TABLE plugin_attempt_input_bindings ADD COLUMN source_id TEXT NOT NULL DEFAULT '';
+ALTER TABLE plugin_attempt_input_bindings ADD COLUMN source_revision TEXT NOT NULL DEFAULT '';
+ALTER TABLE plugin_attempt_input_bindings ADD COLUMN content_hash TEXT NOT NULL DEFAULT '';

--- a/backend/core/migrations/version_mode/v0_2/20260723183515_squash_post_init.down.sql
+++ b/backend/core/migrations/version_mode/v0_2/20260723183515_squash_post_init.down.sql
@@ -4,6 +4,24 @@
 DROP TABLE IF EXISTS public.workflow_events CASCADE;
 DROP TABLE IF EXISTS public.workflow_commands CASCADE;
 DROP TABLE IF EXISTS public.workflow_preparations CASCADE;
+DROP TABLE IF EXISTS public.workflow_input_bindings CASCADE;
+DROP TABLE IF EXISTS public.workflow_input_resources CASCADE;
+DROP TABLE IF EXISTS public.workflow_outbox CASCADE;
+ALTER TABLE public.plugin_attempt_input_bindings DROP COLUMN IF EXISTS content_hash;
+ALTER TABLE public.plugin_attempt_input_bindings DROP COLUMN IF EXISTS source_revision;
+ALTER TABLE public.plugin_attempt_input_bindings DROP COLUMN IF EXISTS source_id;
+ALTER TABLE public.plugin_attempt_input_bindings DROP COLUMN IF EXISTS source_type;
+ALTER TABLE public.plugin_session_steps DROP COLUMN IF EXISTS result_json;
+ALTER TABLE public.plugin_session_steps DROP COLUMN IF EXISTS terminal_code;
+ALTER TABLE public.plugin_session_steps DROP COLUMN IF EXISTS progress_json;
+ALTER TABLE public.plugin_session_steps DROP COLUMN IF EXISTS heartbeat_at;
+ALTER TABLE public.plugin_session_steps DROP COLUMN IF EXISTS lease_expires_at;
+ALTER TABLE public.plugin_session_steps DROP COLUMN IF EXISTS fencing_generation;
+ALTER TABLE public.plugin_session_steps DROP COLUMN IF EXISTS lease_token;
+ALTER TABLE public.plugin_session_steps DROP COLUMN IF EXISTS lease_owner;
+ALTER TABLE public.plugin_sessions DROP COLUMN IF EXISTS controller_host;
+ALTER TABLE public.plugin_sessions DROP COLUMN IF EXISTS origin_ref;
+ALTER TABLE public.plugin_sessions DROP COLUMN IF EXISTS origin_host;
 
 -- Reverse the flattened net migration back to the unchanged init schema.
 -- Data from tables intentionally dropped by the historical migrations cannot be restored.

--- a/backend/core/migrations/version_mode/v0_2/20260723183515_squash_post_init.up.sql
+++ b/backend/core/migrations/version_mode/v0_2/20260723183515_squash_post_init.up.sql
@@ -3245,7 +3245,7 @@ INSERT INTO public.eval_set_shards (
     5368709120, 0, 0, now(), now()
 ) ON CONFLICT (id) DO NOTHING;
 
-CREATE TABLE public.workflow_preparations (id varchar(36) PRIMARY KEY, idempotency_key varchar(255) NOT NULL, owner_user_id varchar(255) NOT NULL, workflow_id varchar(255) NOT NULL, contract_version varchar(32) NOT NULL, request_json jsonb NOT NULL, response_json jsonb NOT NULL, consumed_at timestamp NULL, session_id varchar(36) NOT NULL DEFAULT '', created_at timestamp NOT NULL, updated_at timestamp NOT NULL, UNIQUE(owner_user_id, idempotency_key));
+CREATE TABLE public.workflow_preparations (id varchar(36) PRIMARY KEY, idempotency_key varchar(255) NOT NULL, owner_user_id varchar(255) NOT NULL, workflow_id varchar(255) NOT NULL, contract_version varchar(32) NOT NULL, request_json jsonb NOT NULL, response_json jsonb NOT NULL, consumed_at timestamp NULL, session_id varchar(36) NOT NULL DEFAULT '', created_at timestamp NOT NULL, updated_at timestamp NOT NULL, CONSTRAINT uk_workflow_preparation_owner_key UNIQUE(owner_user_id, idempotency_key));
 CREATE INDEX idx_workflow_preparations_owner ON public.workflow_preparations(owner_user_id);
 CREATE TABLE public.workflow_commands (command_id varchar(255) PRIMARY KEY, owner_user_id varchar(255) NOT NULL, session_id varchar(36) NOT NULL, contract_version varchar(32) NOT NULL, request_hash varchar(64) NOT NULL, http_status integer NOT NULL, response_json jsonb NOT NULL, created_at timestamp NOT NULL);
 CREATE INDEX idx_workflow_commands_owner ON public.workflow_commands(owner_user_id);
@@ -3254,6 +3254,56 @@ CREATE TABLE public.workflow_events (id bigserial PRIMARY KEY, session_id varcha
 CREATE INDEX idx_workflow_events_session_cursor ON public.workflow_events(session_id, id);
 CREATE INDEX idx_workflow_events_owner ON public.workflow_events(owner_user_id);
 CREATE INDEX idx_workflow_events_command ON public.workflow_events(command_id);
+
+ALTER TABLE public.plugin_sessions ADD COLUMN origin_host varchar(32) NOT NULL DEFAULT 'lazymind';
+ALTER TABLE public.plugin_sessions ADD COLUMN origin_ref varchar(255) NOT NULL DEFAULT '';
+ALTER TABLE public.plugin_sessions ADD COLUMN controller_host varchar(32) NOT NULL DEFAULT 'lazymind';
+CREATE INDEX idx_plugin_sessions_origin ON public.plugin_sessions(origin_host, origin_ref);
+
+ALTER TABLE public.plugin_session_steps ADD COLUMN lease_owner varchar(255) NOT NULL DEFAULT '';
+ALTER TABLE public.plugin_session_steps ADD COLUMN lease_token varchar(255) NOT NULL DEFAULT '';
+ALTER TABLE public.plugin_session_steps ADD COLUMN fencing_generation bigint NOT NULL DEFAULT 0;
+ALTER TABLE public.plugin_session_steps ADD COLUMN lease_expires_at timestamp NULL;
+ALTER TABLE public.plugin_session_steps ADD COLUMN heartbeat_at timestamp NULL;
+ALTER TABLE public.plugin_session_steps ADD COLUMN progress_json jsonb NOT NULL DEFAULT '{}';
+ALTER TABLE public.plugin_session_steps ADD COLUMN terminal_code varchar(64) NOT NULL DEFAULT '';
+ALTER TABLE public.plugin_session_steps ADD COLUMN result_json jsonb NOT NULL DEFAULT '{}';
+CREATE INDEX idx_plugin_session_steps_claim ON public.plugin_session_steps(status, lease_expires_at, id);
+
+CREATE TABLE public.workflow_outbox (
+    id varchar(36) PRIMARY KEY,
+    attempt_id varchar(36) NOT NULL UNIQUE,
+    session_id varchar(36) NOT NULL,
+    payload_json jsonb NOT NULL,
+    status varchar(16) NOT NULL DEFAULT 'pending',
+    created_at timestamp NOT NULL,
+    updated_at timestamp NOT NULL
+);
+CREATE INDEX idx_workflow_outbox_status ON public.workflow_outbox(status, created_at);
+CREATE INDEX idx_workflow_outbox_session ON public.workflow_outbox(session_id);
+
+CREATE TABLE public.workflow_input_resources (
+    id varchar(36) PRIMARY KEY, owner_user_id varchar(255) NOT NULL,
+    name varchar(255) NOT NULL, mime_type varchar(255) NOT NULL,
+    size bigint NOT NULL, content_hash varchar(80) NOT NULL,
+    revision bigint NOT NULL DEFAULT 1, content bytea NOT NULL,
+    created_at timestamp NOT NULL
+);
+CREATE INDEX idx_workflow_input_resources_owner_hash ON public.workflow_input_resources(owner_user_id, content_hash);
+CREATE TABLE public.workflow_input_bindings (
+    id varchar(36) PRIMARY KEY, workflow_session_id varchar(36) NOT NULL,
+    material_id varchar(64) NOT NULL, resource_type varchar(32) NOT NULL,
+    resource_id varchar(36) NOT NULL, resource_revision bigint NOT NULL,
+    content_hash varchar(80) NOT NULL, validity varchar(16) NOT NULL DEFAULT 'effective',
+    created_by_command_id varchar(64) NOT NULL, created_at timestamp NOT NULL
+);
+CREATE INDEX idx_workflow_input_bindings_session ON public.workflow_input_bindings(workflow_session_id);
+CREATE INDEX idx_workflow_input_bindings_resource ON public.workflow_input_bindings(resource_id);
+
+ALTER TABLE public.plugin_attempt_input_bindings ADD COLUMN source_type varchar(32) NOT NULL DEFAULT 'artifact';
+ALTER TABLE public.plugin_attempt_input_bindings ADD COLUMN source_id varchar(128) NOT NULL DEFAULT '';
+ALTER TABLE public.plugin_attempt_input_bindings ADD COLUMN source_revision varchar(64) NOT NULL DEFAULT '';
+ALTER TABLE public.plugin_attempt_input_bindings ADD COLUMN content_hash varchar(80) NOT NULL DEFAULT '';
 
 -- +migrate Dialect sqlite
 PRAGMA defer_foreign_keys = ON;

--- a/docs/plan/plugin/contracts/host-adapter-contract.md
+++ b/docs/plan/plugin/contracts/host-adapter-contract.md
@@ -25,7 +25,7 @@ Agent-facing Transition Tools：
 ```text
 get_ready_steps
 advance_step
-advance_step_and_handoff
+advance_step_and_hand_off
 ```
 
 Executor-only Tools：
@@ -44,7 +44,7 @@ Executor-only Tools 只注册给受认证的 Executor Supervisor，不注册给�
 
 ## 3. 两种 advance 等待语义
 
-`advance_step` 与 `advance_step_and_handoff` 必须复用同一个 Runtime transition handler 和 Executor Supervisor。
+`advance_step` 与 `advance_step_and_hand_off` 必须复用同一个 Runtime transition handler 和 Executor Supervisor。
 
 ### `advance_step`
 
@@ -58,7 +58,7 @@ transition commit
 → return terminal result
 ```
 
-### `advance_step_and_handoff`
+### `advance_step_and_hand_off`
 
 ```text
 transition commit
@@ -142,14 +142,14 @@ workflow_tools:
     - resume_workflow
 
   disabled:
-    - advance_step_and_handoff
+    - advance_step_and_hand_off
 
 execution:
   executor: codex
   advance_mode: synchronous
 ```
 
-Codex v1 不选择 `advance_step_and_handoff`。
+Codex v1 不选择 `advance_step_and_hand_off`。
 Codex v1 注册 `patch_artifact` 供模型自主修订 Artifact，但不在 Status View 中提供用户手工编辑；Codex 不接入 LazyMind Chat，只使用只读 Workflow Status View 和 Artifact 下载。
 
 ### LazyMind v1
@@ -166,7 +166,7 @@ workflow_tools:
     - get_workflow_state
     - get_ready_steps
     - advance_step
-    - advance_step_and_handoff
+    - advance_step_and_hand_off
     - list_artifacts
     - read_artifact
     - patch_artifact
@@ -272,7 +272,7 @@ Host 只有同时满足以下条件才能启用执行：
 - 同一 transition fixture 在同步和 handoff 模式产生相同 Attempt/Artifact 领域结果。
 - 模型不调用任何 lifecycle tool 时，Supervisor 仍产生 heartbeat 和唯一合法终态。
 - handoff 在 durable ownership 之前失败，不结束 turn。
-- Codex tool selection trace 不出现 `advance_step_and_handoff`。
+- Codex tool selection trace 不出现 `advance_step_and_hand_off`。
 - LazyMind approval/Driver handoff 后可由事件恢复并继续。
 - capability allowlist 不向 SubAgent 泄漏未授权 Host 工具。
 - required output 缺失时 Attempt 失败，不错误完成。

--- a/docs/plan/plugin/contracts/runtime-contract.md
+++ b/docs/plan/plugin/contracts/runtime-contract.md
@@ -108,7 +108,7 @@ queued → claimed → running → succeeded
 
 Attempt 生命周期调用属于 Executor Supervisor，不属于模型决策。Supervisor 必须以系统 timer 发送 heartbeat，以执行器 callback/事件桥报告 progress，并用 `defer/finally` 保证正常返回、错误、取消和 panic 均尝试写入一个合法终态。进程硬崩溃时由独立 lease reaper 使 Attempt 进入 interrupted/recoverable；不得依赖模型在下一轮对话中修复 running 状态。
 
-公共 Tool Protocol 提供两种等待策略，但不得改变上述事实：`advance_step` 同步等待终态；`advance_step_and_handoff` 在 durable dispatch/Supervisor ownership 成功后返回 acknowledgement。两者必须复用同一 Runtime transition，不得形成两套状态机。LazyMind Profile 可选择 handoff，Codex v1 Profile 只选择同步执行。
+公共 Tool Protocol 提供两种等待策略，但不得改变上述事实：`advance_step` 同步等待终态；`advance_step_and_hand_off` 在 durable dispatch/Supervisor ownership 成功后返回 acknowledgement。两者必须复用同一 Runtime transition，不得形成两套状态机。LazyMind Profile 可选择 handoff，Codex v1 Profile 只选择同步执行。
 
 ## 7. Artifact、lineage 与 stale
 

--- a/docs/plan/plugin/contracts/tool-event-contract.md
+++ b/docs/plan/plugin/contracts/tool-event-contract.md
@@ -26,12 +26,12 @@ resume_workflow
 ```text
 get_ready_steps
 advance_step
-advance_step_and_handoff
+advance_step_and_hand_off
 ```
 
 不得公开 `retry_step` 或 `rewind_step`；其内部语义见 Runtime Contract。
 
-`advance_step_and_handoff` 属于共享 Workflow Tool Protocol，但是否选择由 Host Profile 决定。它必须复用 `advance_step` 的 Runtime command handler、状态校验和 Executor Supervisor，不得形成第二套 transition。LazyMind Profile 在审批、Driver 和异步推进场景选择它；Codex Profile 明确只选择 `advance_step`。Adapter 可以按 Profile 缩减实际注册给模型的工具集合，但不能改变协议语义。
+`advance_step_and_hand_off` 属于共享 Workflow Tool Protocol，但是否选择由 Host Profile 决定。它必须复用 `advance_step` 的 Runtime command handler、状态校验和 Executor Supervisor，不得形成第二套 transition。LazyMind Profile 在审批、Driver 和异步推进场景选择它；Codex Profile 明确只选择 `advance_step`。Adapter 可以按 Profile 缩减实际注册给模型的工具集合，但不能改变协议语义。
 
 ### Attempt execution（Executor-only）
 
@@ -161,7 +161,7 @@ Runtime transition handler 的内部成功结果必须包含：
 
 ### Handoff 语义
 
-`advance_step_and_handoff` 接收与 `advance_step` 相同的业务目标，但 `execution_mode` 固定为 `handoff`。它只有在以下事实均成立后才能返回 handoff acknowledgement：
+`advance_step_and_hand_off` 接收与 `advance_step` 相同的业务目标，但 `execution_mode` 固定为 `handoff`。它只有在以下事实均成立后才能返回 handoff acknowledgement：
 
 1. transition 已持久化并产生 Outbox；
 2. Attempt 已创建；

--- a/docs/plan/plugin/contracts/v1/golden/handoff.json
+++ b/docs/plan/plugin/contracts/v1/golden/handoff.json
@@ -2,7 +2,7 @@
   "contract_version": "workflow.v1",
   "scenario": "handoff",
   "input": {
-    "tool": "advance_step_and_handoff"
+    "tool": "advance_step_and_hand_off"
   },
   "projection": {
     "session_id": "s-handoff",

--- a/docs/plan/plugin/contracts/v1/legacy-behavior-inventory.md
+++ b/docs/plan/plugin/contracts/v1/legacy-behavior-inventory.md
@@ -27,6 +27,6 @@ must not add new business rules.
 - Stop interrupts active execution without deleting saved partial artifacts;
   resume derives new readiness from persisted state.
 - `advance_step` waits for a terminal Attempt while
-  `advance_step_and_handoff` acknowledges only after durable ownership.
+  `advance_step_and_hand_off` acknowledges only after durable ownership.
 - Artifact revisions are immutable, ordered, and linked to their producer
   Attempt.

--- a/docs/plan/plugin/execution-guardrails.md
+++ b/docs/plan/plugin/execution-guardrails.md
@@ -58,7 +58,7 @@ Old path deletion gate
 
 入口：当前生产行为可运行。
 
-必须交付：版本化 Tool/Event/Attempt Context schema fixture、`advance_step` 与 `advance_step_and_handoff` 的共同 transition/不同等待语义、错误码表、串行/并行/choice/retry/rewind/partial retry/stop/resume golden fixtures，以及旧行为清单。
+必须交付：版本化 Tool/Event/Attempt Context schema fixture、`advance_step` 与 `advance_step_and_hand_off` 的共同 transition/不同等待语义、错误码表、串行/并行/choice/retry/rewind/partial retry/stop/resume golden fixtures，以及旧行为清单。
 
 退出：Go、Python 可读取同一 fixture；fixture 能描述当前 projection、Attempt、Artifact revision 和事件序列。不得改生产链路。
 
@@ -106,7 +106,7 @@ Old path deletion gate
 
 入口：Attempt 协议稳定。
 
-必须交付：确定性 Executor Supervisor、claim loop、系统 heartbeat、执行器 progress callback、Attempt Context 到现有 AgentRunPlan 的 adapter、结构化 Artifact/终态提交、同步 `advance_step` 与可靠 `advance_step_and_handoff`、canary flag。
+必须交付：确定性 Executor Supervisor、claim loop、系统 heartbeat、执行器 progress callback、Attempt Context 到现有 AgentRunPlan 的 adapter、结构化 Artifact/终态提交、同步 `advance_step` 与可靠 `advance_step_and_hand_off`、canary flag。
 
 退出：即使模型不调用任何 lifecycle/progress 工具，Supervisor 仍能产生 running、heartbeat 和唯一合法终态；handoff 只有在 durable ownership 成功后发生；canary Workflow 与旧执行器的 golden projection、Artifact lineage 和用户可见事件等价；失败可安全退回旧执行路径。
 
@@ -156,7 +156,7 @@ Old path deletion gate
 
 必须交付：Codex 身份与既有 origin/controller/executor refs 的绑定、prepare/start、只选择同步 `advance_step` 的阶段性 Codex Profile、Codex Executor Supervisor、程序化 SubAgent claim/execute/cancel、系统 heartbeat/progress callback、Input Resource 读取、结构化 Artifact save、终态处理和 Status View 实时状态更新；本 PR 暂不启用 `patch_artifact`，所有新写入受 schema capability 与 canary flag 控制。
 
-退出：关闭 LazyMind 算法服务仍可完成串行 golden Workflow；测试 Agent 即使遗漏所有进度/终态调用，Supervisor 仍可靠完成或失败 Attempt；Codex 工具选择 trace 中不出现 `advance_step_and_handoff`；Codex Session 使用兼容 `conversation_id=''` 且不被旧对话查询误关联；关闭 Codex feature 后旧 LazyMind 路径继续运行且不回滚 schema；Runtime 不出现 Codex 模型私有配置。
+退出：关闭 LazyMind 算法服务仍可完成串行 golden Workflow；测试 Agent 即使遗漏所有进度/终态调用，Supervisor 仍可靠完成或失败 Attempt；Codex 工具选择 trace 中不出现 `advance_step_and_hand_off`；Codex Session 使用兼容 `conversation_id=''` 且不被旧对话查询误关联；关闭 Codex feature 后旧 LazyMind 路径继续运行且不回滚 schema；Runtime 不出现 Codex 模型私有配置。
 
 ### PR 14：Codex 并行、恢复与模型 Artifact 修订
 

--- a/docs/plan/plugin/phase-one-acceptance-report.md
+++ b/docs/plan/plugin/phase-one-acceptance-report.md
@@ -37,7 +37,7 @@ make lint
 Compatibility paths remain observable and rollback-safe; none is deleted without a
 zero-use observation window. The counters are `workflow_legacy_client_hits`,
 `workflow_legacy_db_hits`, `workflow_legacy_route_hits`,
-`compat_handoff_alias_hits`, `legacy_policy_hits`, and legacy dispatch hits.
+`legacy_policy_hits` and legacy dispatch hits.
 The test baseline is zero for every default-on path; rollback tests deliberately
 increment the associated counter.
 
@@ -45,7 +45,6 @@ increment the associated counter.
 |---|---|---|
 | Python legacy Workflow client/DB adapter | off | production counters remain zero for the declared observation window |
 | legacy API route aliases | off/flagged | route counter zero and all clients advertise `workflow.v1` |
-| `advance_step_and_hand_off` wire alias | compatibility only | alias counter zero after client rollout |
 | legacy duplicated policy prompt | off | policy comparison stable and `legacy_policy_hits` zero |
 | fixed SubAgent endpoint and `plugin_run_outbox` | rollback only | queued dispatch healthy and legacy dispatch hits zero |
 

--- a/docs/plan/plugin/shared-workflow-agent-kit-plan.md
+++ b/docs/plan/plugin/shared-workflow-agent-kit-plan.md
@@ -75,7 +75,7 @@ Core 中现有 `plugin/graphengine`、Plugin Session、transition、projection�
 
 共享 Skill 应定义一条完整而稳定的 Agent 工作流：Agent 先搜索适用 Workflow，读取轻量元数据并完成启动前检查；Runtime 创建 Session 后，Agent 每次都以最新权威 projection 为依据选择 Ready step；步骤由当前 Host 的执行器完成，Executor Supervisor 负责持久化并校验 required Artifact；步骤结束后，Agent 根据 acceptance criteria、用户要求和当前产物决定继续、重新执行目标步骤、等待或完成。Host 可以通过 `get_workflow_state` 或可恢复的 Workflow Event Stream 获得最新 projection，发现 state version 缺口时必须重新同步快照，不在 Agent 内部维护另一套状态机，也不得在每个事件后无条件重复查询。
 
-共享 Skill 不直接写死 `ask_user`、`stop_tool`、`create_subagent` 或 Codex 协作工具等 Host 专属名称，而是读取 Host Profile 中声明的能力和策略。公共规则相同，具体交互方式允许不同。`advance_step` 与 `advance_step_and_handoff` 都属于公共 Workflow Tool Protocol，因此共享 Skill 可以定义两者的选择准则；Host Profile 决定当前 Host 是否选择 handoff。LazyMind Profile 在审批、Driver、auto/dynamic 异步推进场景选择 `advance_step_and_handoff`，Codex Profile 明确始终选择 `advance_step`。
+共享 Skill 不直接写死 `ask_user`、`stop_tool`、`create_subagent` 或 Codex 协作工具等 Host 专属名称，而是读取 Host Profile 中声明的能力和策略。公共规则相同，具体交互方式允许不同。`advance_step` 与 `advance_step_and_hand_off` 都属于公共 Workflow Tool Protocol，因此共享 Skill 可以定义两者的选择准则；Host Profile 决定当前 Host 是否选择 handoff。LazyMind Profile 在审批、Driver、auto/dynamic 异步推进场景选择 `advance_step_and_hand_off`，Codex Profile 明确始终选择 `advance_step`。
 
 建议采用以下目录结构：
 
@@ -112,7 +112,7 @@ Codex 第一阶段不强求复刻 LazyMind 的每一种交互。为了降低接�
 | 策略 | LazyMind 默认 | Codex 初期默认 |
 |---|---|---|
 | 启动前审批 | 可按 Workflow 或用户设置开启 | 关闭，满足条件后自动启动 |
-| 步骤推进 | 同步 `advance_step`；审批、Driver 和异步模式选择标准 handoff 工具 `advance_step_and_handoff` | Profile 明确只选择同步 `advance_step`，自动执行全部 Ready step |
+| 步骤推进 | 同步 `advance_step`；审批、Driver 和异步模式选择标准 handoff 工具 `advance_step_and_hand_off` | Profile 明确只选择同步 `advance_step`，自动执行全部 Ready step |
 | 步骤执行器 | LazyMind SubAgent | Codex 原生 SubAgent |
 | 结果验收 | 可启用 DriverAgent | 主 Agent 验收或 Codex review SubAgent |
 | Handoff | 支持结束当前 turn 并由事件重新唤醒 | 默认在当前任务中持续推进 |
@@ -130,7 +130,7 @@ Host Profile 可以覆盖执行器选择、最大并行数、是否启用 Review
 |---|---|---|
 | Workflow Discovery | `list_workflows`、`get_workflow` | 返回有权访问且已启用的 Workflow 及其固定 revision 元数据 |
 | Session Lifecycle | `prepare_workflow`、`start_workflow`、`get_workflow_state`、`stop_workflow`、`resume_workflow` | `prepare_workflow` 完成 revision 固定、权限与必要输入检查并返回短期 preparation，但不创建 Session；`start_workflow` 使用有效 preparation 正式创建并启动 Workflow Session |
-| Transition | `get_ready_steps`、`advance_step`、`advance_step_and_handoff` | 两个 advance 工具共享同一 transition；Agent 只选择目标步骤，Runtime 自动解析内部 `execute`、`retry` 或 `rewind`。`advance_step` 同步等待终态，`advance_step_and_handoff` 在可靠接管后返回 handoff acknowledgement |
+| Transition | `get_ready_steps`、`advance_step`、`advance_step_and_hand_off` | 两个 advance 工具共享同一 transition；Agent 只选择目标步骤，Runtime 自动解析内部 `execute`、`retry` 或 `rewind`。`advance_step` 同步等待终态，`advance_step_and_hand_off` 在可靠接管后返回 handoff acknowledgement |
 | Attempt Execution（Executor-only） | `claim_attempt`、`get_attempt_context`、`report_attempt_progress`、`save_artifact`、`complete_attempt`、`fail_attempt`、`cancel_attempt` | 由 Host Adapter 的确定性 Executor Supervisor 调用，不暴露给模型自行决定是否调用；解耦 Workflow Attempt 与具体 Agent Executor |
 | Artifact | `list_artifacts`、`read_artifact`、`patch_artifact` | Agent 使用 `patch_artifact` 自主修订既有 Artifact；步骤输出由 Supervisor 使用 Executor-only `save_artifact` 提交；用户在 LazyMind Panel 的手工编辑走产品侧 human revision 接口，不调用模型工具 |
 | Workflow Authoring | `get_skill_conversion_context`、`create_workflow_draft`、`update_workflow_draft_file`、`validate_workflow_draft`、`get_workflow_diagnostics`、`publish_workflow` | 支持 LazyMind 或 Codex 使用自己的模型完成 Skill to Workflow |
@@ -139,7 +139,7 @@ Host Profile 可以覆盖执行器选择、最大并行数、是否启用 Review
 
 `advance_step` 是唯一面向 Agent 的步骤执行工具，不再公开 `retry_step` 或 `rewind_step`。当目标步骤没有有效 Attempt 时，Runtime 将其解析为首次 `execute`；当有效 Attempt 为 failed 或 interrupted 时解析为 `retry`；当有效 Attempt 为 succeeded 时解析为 `rewind`。工具响应必须返回 `resolved_operation`，使 Host 能解释实际动作。三个内部动作仍保留各自的不变量、权限与审计语义：特别是 `rewind` 必须传播下游 Attempt 和 Artifact stale，`retry` 只能使失败或中断的 Attempt 失效。工具合并不得弱化这些 Runtime 校验。
 
-模型调用步骤推进工具后，后续 Attempt 生命周期不得依赖模型继续记得调用工具。Host Adapter 必须用确定性 Executor Supervisor 包裹完整执行：事务性创建 Attempt、claim、启动系统 heartbeat、运行 SubAgent、从执行器 callback 转发进度、持久化结构化输出、校验 required Artifact，并在 `defer/finally` 中写入 complete/fail/cancel。`advance_step` 与 `advance_step_and_handoff` 都是公共 Tool Protocol 的标准工具并调用同一个 Runtime command 和 Supervisor；差异只在等待策略。同步工具在步骤终态后返回，handoff 工具在 Attempt 已持久化且 Supervisor 已可靠接管后返回 acknowledgement。LazyMind Profile 可选择两者，Codex Profile 明确只选择同步 `advance_step`。
+模型调用步骤推进工具后，后续 Attempt 生命周期不得依赖模型继续记得调用工具。Host Adapter 必须用确定性 Executor Supervisor 包裹完整执行：事务性创建 Attempt、claim、启动系统 heartbeat、运行 SubAgent、从执行器 callback 转发进度、持久化结构化输出、校验 required Artifact，并在 `defer/finally` 中写入 complete/fail/cancel。`advance_step` 与 `advance_step_and_hand_off` 都是公共 Tool Protocol 的标准工具并调用同一个 Runtime command 和 Supervisor；差异只在等待策略。同步工具在步骤终态后返回，handoff 工具在 Attempt 已持久化且 Supervisor 已可靠接管后返回 acknowledgement。LazyMind Profile 可选择两者，Codex Profile 明确只选择同步 `advance_step`。
 
 ### 2.7 Attempt 与 Executor 解耦
 
@@ -172,7 +172,7 @@ Codex 的 `advance_step` 是一个同步的 Agent-facing 工具调用，但内�
 
 停止需要区分 Agent turn、Attempt 和 Workflow 三个层次。LazyMind stop-tool 可以立即结束当前 Agent turn，但实际执行中的任务还必须调用 `cancel_attempt`，整个 Workflow 停止则必须调用 `stop_workflow`；Runtime 应保留已经保存的部分 Artifact，将 Session 置为可恢复状态，并阻止新 Attempt 继续派发。Codex 没有相同 stop-tool 时，可以在收到用户中止要求后直接调用 `stop_workflow`，并等待运行中的 Codex SubAgent结束或被取消。
 
-Handoff 是公共工具支持、由 Host Profile 选择的调度策略，不是状态机 transition。LazyMind 可通过 `advance_step_and_handoff` 在 Runtime 已接受 transition、Attempt 已持久化且 Executor Supervisor 已取得可靠执行责任后结束当前 turn，并在任务终态时通过 synthetic turn 或事件重新唤醒 ChatAgent；如果可靠接管失败，该工具必须返回失败且不得 handoff。Codex Profile 不选择该工具，在同步 `advance_step` 中等待 SubAgent 终态并自动推进。Runtime 只记录 Attempt 状态和结果，不把 handoff 写入 graph 或领域状态。
+Handoff 是公共工具支持、由 Host Profile 选择的调度策略，不是状态机 transition。LazyMind 可通过 `advance_step_and_hand_off` 在 Runtime 已接受 transition、Attempt 已持久化且 Executor Supervisor 已取得可靠执行责任后结束当前 turn，并在任务终态时通过 synthetic turn 或事件重新唤醒 ChatAgent；如果可靠接管失败，该工具必须返回失败且不得 handoff。Codex Profile 不选择该工具，在同步 `advance_step` 中等待 SubAgent 终态并自动推进。Runtime 只记录 Attempt 状态和结果，不把 handoff 写入 graph 或领域状态。
 
 审批同样属于 Host Policy。Workflow 可以声明风险或建议审批点，但 LazyMind 可以在这些位置调用 `ask_user` 或 stop-tool 暂停，Codex 初期则可以仅对高风险外部操作保留平台级审批，其余 Workflow 自动执行。无论 Host 是否展示审批，Runtime 的权限和安全检查都必须强制执行。
 
@@ -277,7 +277,7 @@ Core 将 transition accepted 后直接调用 `/api/subagent/run` 的模式改为
 
 ### 4.2 阶段二：串行全自动执行
 
-开放 Agent-facing `prepare_workflow`、`start_workflow`、`get_ready_steps` 和同步 `advance_step`，并向 CodexExecutor Supervisor 开放 Executor-only `claim_attempt`、`get_attempt_context`、`report_attempt_progress`、`save_artifact`、`complete_attempt`、`fail_attempt` 和 `cancel_attempt`。Codex 先调用 `prepare_workflow` 完成不创建 Session、不启动执行的准备，在返回 ready 后以 `preparation_id` 调用 `start_workflow`；全自动 Profile 在信息充分时自动完成串行 Workflow，不选择 `advance_step_and_handoff`，也不实现 LazyMind 的逐步审批和 synthetic turn。
+开放 Agent-facing `prepare_workflow`、`start_workflow`、`get_ready_steps` 和同步 `advance_step`，并向 CodexExecutor Supervisor 开放 Executor-only `claim_attempt`、`get_attempt_context`、`report_attempt_progress`、`save_artifact`、`complete_attempt`、`fail_attempt` 和 `cancel_attempt`。Codex 先调用 `prepare_workflow` 完成不创建 Session、不启动执行的准备，在返回 ready 后以 `preparation_id` 调用 `start_workflow`；全自动 Profile 在信息充分时自动完成串行 Workflow，不选择 `advance_step_and_hand_off`，也不实现 LazyMind 的逐步审批和 synthetic turn。
 
 Codex 主 Agent 负责读取 projection、选择目标步骤、验收终态结果并推进下一步；CodexExecutor Adapter 程序化创建 SubAgent，Executor Supervisor 保存并校验 required outputs；Runtime 继续负责 Ready 校验、Attempt 状态和 Artifact revision。需要外部高风险操作时，仍由 Codex 平台现有审批能力控制，而不是复制 LazyMind approval UI。
 
@@ -289,7 +289,7 @@ Codex 执行状态由 CodexExecutor Supervisor 的确定性代码回报，不依
 
 在串行链路稳定后，增加多个 Ready step 的并行执行、Codex review SubAgent、retry、rewind、partial retry、stop/resume 和模型自主 Artifact patch。Codex 主 Agent 根据共享 Skill 决定并行边界、恢复策略、需要重新执行的目标步骤以及是否调用 `patch_artifact` 直接修订既有 Artifact；Runtime 根据权威 Attempt 状态解析 retry 或 rewind，并对 patch 产生新 revision、更新 lineage 和传播 stale。Status View 仍为只读，不提供用户手工编辑入口。
 
-Codex 不使用 `advance_step_and_handoff`，也不依赖主 Agent在长任务中反复调用进度工具；它只使用同步 `advance_step`，由 Supervisor 在当前 Codex task 内执行 SubAgent 并可靠维护状态。若后续 Codex 提供后台唤醒机制，只需增加新的 Host execution disposition，不改变 Agent-facing 工具名、共享 Skill 主流程或 Runtime invariant。
+Codex 不使用 `advance_step_and_hand_off`，也不依赖主 Agent在长任务中反复调用进度工具；它只使用同步 `advance_step`，由 Supervisor 在当前 Codex task 内执行 SubAgent 并可靠维护状态。若后续 Codex 提供后台唤醒机制，只需增加新的 Host execution disposition，不改变 Agent-facing 工具名、共享 Skill 主流程或 Runtime invariant。
 
 完成标准是 Codex 通过第一阶段的完整 golden scenarios，除明确标记为 LazyMind UI 或交互差异的项目外，Workflow projection、Attempt 和 Artifact 结果与 LazyMind 一致。
 

--- a/scripts/lazymind_workflow_mcp.py
+++ b/scripts/lazymind_workflow_mcp.py
@@ -1,0 +1,16 @@
+#!/usr/bin/env python3
+"""Repository entry point for the LazyMind Workflow stdio MCP server."""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPOSITORY_ROOT / 'algorithm'))
+sys.path.insert(0, str(REPOSITORY_ROOT / 'algorithm' / 'lazyllm'))
+
+from lazymind.workflow_mcp.server import main  # noqa: E402
+
+
+if __name__ == '__main__':
+    main()

--- a/skills/workflow-agent-kit/SKILL.md
+++ b/skills/workflow-agent-kit/SKILL.md
@@ -8,14 +8,39 @@ version: workflow.v1
 
 ## Required reading
 
-1. Load exactly one file from `profiles/`; absent Host metadata means `default`.
-2. Read `references/lifecycle.md`, `references/decision-policy.md`, and
+1. If Workflow tools are absent, read `references/installation-and-connection.md`
+   and help the user connect LazyMind before promising execution.
+2. Call `workflow_connection_status` when available. Never guess a port.
+3. Load exactly one file from `profiles/`; absent Host metadata means `default`.
+4. Read `references/lifecycle.md`, `references/decision-policy.md`, and
    `references/execution-policy.md` before changing Workflow state.
-3. Read `references/artifact-policy.md` and `references/recovery-policy.md`
+5. Read `references/artifact-policy.md` and `references/recovery-policy.md`
    before reviewing output or recovering an Attempt.
-4. Read `references/skill-to-workflow.md` before converting a Skill package.
-5. Use `references/tool-contracts.md` as the public tool boundary.
-6. Treat the latest Runtime projection and its `state_version` as authoritative.
+6. Read `references/skill-to-workflow.md` before converting a Skill package.
+7. Use `references/tool-contracts.md` for exact arguments and responses.
+8. Treat the latest Runtime projection and its `state_version` as authoritative.
+
+## ChatAgent operating procedure
+
+For a new request, call `list_workflows`, choose by capability rather than name
+similarity alone, then call `get_workflow`. Explain the chosen Workflow when the
+match is ambiguous or the run has material external effects. Do not start merely
+because discovery returned one result.
+
+Call `prepare_workflow` with explicit durable input bindings. If it reports
+missing inputs, obtain or import those inputs and prepare again. When status is
+ready, create a stable Session id and call `start_workflow` with the returned
+preparation id. Preparation and start are separate operations.
+
+After start and after every transition, read the latest projection. Select only
+from `ready_steps`; obey conditions, approval requirements, user scope, and the
+active Host profile. Call `advance_step` with the exact `state_version`. Review
+the returned Attempt and required Artifacts before advancing again. Continue until
+the projection is terminal, waiting when Attempts are active and asking the user
+only when required information or authority cannot be obtained safely.
+
+If a tool returns an error, follow `references/recovery-policy.md`. Never convert
+an error into success, invent state, or write Runtime persistence directly.
 
 ## Discover and prepare
 
@@ -60,6 +85,14 @@ For authoring, follow `references/skill-to-workflow.md`: analyze a pinned
 Skill revision, generate a draft outside Runtime, submit it to deterministic
 diagnostics, repair reported diagnostics, and publish only a validated revision.
 Authoring tools never invoke a model.
+
+## Capability honesty
+
+Tool availability is authoritative. The bundled MCP adapter currently exposes the
+implemented discovery, prepare/start, projection/Ready, and synchronous advance
+facades. Do not claim stop/resume or Artifact patch support unless those tools are
+actually present in the Host tool list. Explain the unavailable capability and
+preserve the Session state instead of substituting an internal or product API.
 
 The source audit for migrated LazyMind rules is in
 `references/source-to-policy-mapping.md`.

--- a/skills/workflow-agent-kit/SKILL.md
+++ b/skills/workflow-agent-kit/SKILL.md
@@ -14,11 +14,13 @@ version: workflow.v1
 3. Load exactly one file from `profiles/`; absent Host metadata means `default`.
 4. Read `references/lifecycle.md`, `references/decision-policy.md`, and
    `references/execution-policy.md` before changing Workflow state.
-5. Read `references/artifact-policy.md` and `references/recovery-policy.md`
+5. Read and enforce `references/model-execution-boundary.md` for every tool call.
+6. Read `references/artifact-policy.md` and `references/recovery-policy.md`
    before reviewing output or recovering an Attempt.
-6. Read `references/skill-to-workflow.md` before converting a Skill package.
-7. Use `references/tool-contracts.md` for exact arguments and responses.
-8. Treat the latest Runtime projection and its `state_version` as authoritative.
+7. Read `references/skill-to-workflow.md` and `references/workflow-format.md`
+   completely before converting a Skill package.
+8. Use `references/tool-contracts.md` for exact arguments and responses.
+9. Treat the latest Runtime projection and its `state_version` as authoritative.
 
 ## ChatAgent operating procedure
 

--- a/skills/workflow-agent-kit/SKILL.md
+++ b/skills/workflow-agent-kit/SKILL.md
@@ -9,9 +9,13 @@ version: workflow.v1
 ## Required reading
 
 1. Load exactly one file from `profiles/`; absent Host metadata means `default`.
-2. Read `references/decision-policy.md` before making a lifecycle decision.
-3. Read `references/artifact-and-authoring.md` before reviewing output or authoring.
-4. Treat the latest Runtime projection and its `state_version` as authoritative.
+2. Read `references/lifecycle.md`, `references/decision-policy.md`, and
+   `references/execution-policy.md` before changing Workflow state.
+3. Read `references/artifact-policy.md` and `references/recovery-policy.md`
+   before reviewing output or recovering an Attempt.
+4. Read `references/skill-to-workflow.md` before converting a Skill package.
+5. Use `references/tool-contracts.md` as the public tool boundary.
+6. Treat the latest Runtime projection and its `state_version` as authoritative.
 
 ## Discover and prepare
 
@@ -45,13 +49,14 @@ cancel, and retry through Workflow tools; never edit projection state.
 If a required Artifact is absent when an Executor reports success, report a
 structured failure. Do not manufacture output or mark the Attempt complete.
 
-## Authority during migration
+## Authority and rollback
 
-The shared policy may run in shadow mode. A shadow trace is observational and must
-record both decisions, comparison dimensions, policy/profile versions, and
-`authority: legacy`. It must never invoke a tool or mutate Runtime state.
+The shared policy is authoritative by default. A Host may expose an explicit,
+bounded rollback flag for the former Host policy. Shadow traces are observational:
+they must record both decisions, comparison dimensions, policy/profile versions,
+and the actual authority, and must never invoke a tool or mutate Runtime state.
 
-For authoring, follow `references/artifact-and-authoring.md`: analyze a pinned
+For authoring, follow `references/skill-to-workflow.md`: analyze a pinned
 Skill revision, generate a draft outside Runtime, submit it to deterministic
 diagnostics, repair reported diagnostics, and publish only a validated revision.
 Authoring tools never invoke a model.

--- a/skills/workflow-agent-kit/SKILL.md
+++ b/skills/workflow-agent-kit/SKILL.md
@@ -27,7 +27,7 @@ permits parallel execution; alternatives must be narrowed from Runtime condition
 and user intent. Never submit a blocked or downstream step speculatively.
 
 Use `advance_step` when the Host must wait for the Attempt result. Use
-`advance_step_and_handoff` only when the active profile permits handoff and a
+`advance_step_and_hand_off` only when the active profile permits handoff and a
 durable Supervisor has accepted ownership. Handoff is a turn boundary, not a
 different transition. Never choose retry versus rewind: name a Ready or previously
 attempted target and let Runtime return `resolved_operation`. On a version conflict,

--- a/skills/workflow-agent-kit/adapters/codex.md
+++ b/skills/workflow-agent-kit/adapters/codex.md
@@ -1,0 +1,7 @@
+# Codex Host adapter
+
+Codex uses synchronous `advance_step`, platform approvals, native SubAgents, and
+ordinary task progress. It does not select handoff or depend on LazyMind Driver,
+synthetic turns, SSE, or editable Workflow Panel behavior. The deterministic
+Codex Executor Supervisor owns Attempt claim, heartbeat, Artifact persistence,
+and terminal reporting.

--- a/skills/workflow-agent-kit/adapters/lazymind.md
+++ b/skills/workflow-agent-kit/adapters/lazymind.md
@@ -1,0 +1,10 @@
+# LazyMind Host adapter
+
+LazyMind may use approval UI, DriverAgent, SubAgent execution, stop-tool, SSE,
+synthetic turns, and durable handoff. These capabilities affect orchestration and
+presentation only. They do not change Runtime readiness, Attempt operations,
+Artifact lineage, permissions, or state-version checks.
+
+Use `advance_step_and_hand_off` only after durable Supervisor acceptance; trusted
+Driver synthetic turns may bypass user-input filtering, while ordinary Workflow
+user messages must still be filtered.

--- a/skills/workflow-agent-kit/profiles/codex.yaml
+++ b/skills/workflow-agent-kit/profiles/codex.yaml
@@ -1,5 +1,6 @@
 version: workflow.v1
 profile: codex
+workflow_tools: [workflow_connection_status, list_workflows, get_workflow, prepare_workflow, start_workflow, get_workflow_state, get_ready_steps, advance_step]
 advance_tools: [advance_step]
 parallel_ready_steps: true
 approval: platform

--- a/skills/workflow-agent-kit/profiles/codex.yaml
+++ b/skills/workflow-agent-kit/profiles/codex.yaml
@@ -6,7 +6,7 @@ approval: platform
 handoff: false
 driver: false
 synthetic_turn: false
-shadow_authority: legacy
+shadow_authority: shared
 write_tools: true
 executor: codex
 advance_mode: synchronous

--- a/skills/workflow-agent-kit/profiles/codex.yaml
+++ b/skills/workflow-agent-kit/profiles/codex.yaml
@@ -1,6 +1,6 @@
 version: workflow.v1
 profile: codex
-workflow_tools: [workflow_connection_status, list_workflows, get_workflow, prepare_workflow, start_workflow, get_workflow_state, get_ready_steps, advance_step]
+workflow_tools: [workflow_connection_status, list_workflows, get_workflow, prepare_workflow, start_workflow, get_workflow_state, get_ready_steps, advance_step, get_skill_conversion_context, create_workflow_draft, update_workflow_draft_file, validate_workflow_draft, get_workflow_diagnostics, publish_workflow]
 advance_tools: [advance_step]
 parallel_ready_steps: true
 approval: platform

--- a/skills/workflow-agent-kit/profiles/default.yaml
+++ b/skills/workflow-agent-kit/profiles/default.yaml
@@ -1,5 +1,6 @@
 version: workflow.v1
 profile: default
+workflow_tools: [workflow_connection_status, list_workflows, get_workflow, prepare_workflow, start_workflow, get_workflow_state, get_ready_steps, advance_step]
 advance_tools: [advance_step]
 parallel_ready_steps: true
 approval: platform

--- a/skills/workflow-agent-kit/profiles/default.yaml
+++ b/skills/workflow-agent-kit/profiles/default.yaml
@@ -6,5 +6,5 @@ approval: platform
 handoff: false
 driver: false
 synthetic_turn: false
-shadow_authority: legacy
+shadow_authority: shared
 write_tools: false

--- a/skills/workflow-agent-kit/profiles/lazymind.yaml
+++ b/skills/workflow-agent-kit/profiles/lazymind.yaml
@@ -1,5 +1,6 @@
 version: workflow.v1
 profile: lazymind
+workflow_tools: [workflow_connection_status, list_workflows, get_workflow, prepare_workflow, start_workflow, get_workflow_state, get_ready_steps, advance_step, advance_step_and_hand_off]
 advance_tools: [advance_step, advance_step_and_hand_off]
 parallel_ready_steps: true
 approval: ask_user

--- a/skills/workflow-agent-kit/profiles/lazymind.yaml
+++ b/skills/workflow-agent-kit/profiles/lazymind.yaml
@@ -1,6 +1,6 @@
 version: workflow.v1
 profile: lazymind
-advance_tools: [advance_step, advance_step_and_handoff]
+advance_tools: [advance_step, advance_step_and_hand_off]
 parallel_ready_steps: true
 approval: ask_user
 handoff: true

--- a/skills/workflow-agent-kit/profiles/lazymind.yaml
+++ b/skills/workflow-agent-kit/profiles/lazymind.yaml
@@ -1,6 +1,6 @@
 version: workflow.v1
 profile: lazymind
-workflow_tools: [workflow_connection_status, list_workflows, get_workflow, prepare_workflow, start_workflow, get_workflow_state, get_ready_steps, advance_step, advance_step_and_hand_off]
+workflow_tools: [workflow_connection_status, list_workflows, get_workflow, prepare_workflow, start_workflow, get_workflow_state, get_ready_steps, advance_step, advance_step_and_hand_off, get_skill_conversion_context, create_workflow_draft, update_workflow_draft_file, validate_workflow_draft, get_workflow_diagnostics, publish_workflow]
 advance_tools: [advance_step, advance_step_and_hand_off]
 parallel_ready_steps: true
 approval: ask_user

--- a/skills/workflow-agent-kit/profiles/lazymind.yaml
+++ b/skills/workflow-agent-kit/profiles/lazymind.yaml
@@ -8,7 +8,7 @@ handoff_requires_durable_supervisor: true
 driver: true
 stop_tool: true
 synthetic_turn: true
-shadow_authority: legacy
+shadow_authority: shared
 write_tools: true
 executor: lazymind
 advance_mode: profile_policy

--- a/skills/workflow-agent-kit/references/artifact-and-authoring.md
+++ b/skills/workflow-agent-kit/references/artifact-and-authoring.md
@@ -15,7 +15,7 @@ resolve rewind and stale propagation.
 1. Pin the source Skill package and revision before analysis.
 2. Decide whether its procedure is representable as a deterministic Workflow.
 3. Generate the draft in the Host; Authoring Tools do not call a model.
-4. Submit files with `create_workflow_draft` or `update_workflow_draft`.
+4. Submit files with `create_workflow_draft` or `update_workflow_draft_file`.
 5. Run deterministic diagnostics and repair every error against the same draft
    revision. Do not silently weaken graph, tool, safety, or Artifact constraints.
 6. Publish only a validated draft using an idempotent command and expected draft

--- a/skills/workflow-agent-kit/references/artifact-policy.md
+++ b/skills/workflow-agent-kit/references/artifact-policy.md
@@ -5,7 +5,7 @@ Input Resources, and predecessor revisions. Verify each required output against
 the step acceptance criteria before reporting success. Missing required output is
 a structured execution failure, never permission to manufacture a result.
 
-Use `patch_artifact` for an intentional model revision. A product UI human edit
+Use `patch_artifact` to store an intentional revision authored by the active Agent. A product UI human edit
 uses its Host adapter. Neither path overwrites history. If an edit invalidates
 downstream results, target the earliest invalidated step and let Runtime propagate
 staleness.

--- a/skills/workflow-agent-kit/references/artifact-policy.md
+++ b/skills/workflow-agent-kit/references/artifact-policy.md
@@ -1,0 +1,11 @@
+# Artifact policy v1
+
+Required outputs are immutable, revisioned Artifacts linked to their Attempt,
+Input Resources, and predecessor revisions. Verify each required output against
+the step acceptance criteria before reporting success. Missing required output is
+a structured execution failure, never permission to manufacture a result.
+
+Use `patch_artifact` for an intentional model revision. A product UI human edit
+uses its Host adapter. Neither path overwrites history. If an edit invalidates
+downstream results, target the earliest invalidated step and let Runtime propagate
+staleness.

--- a/skills/workflow-agent-kit/references/decision-policy.md
+++ b/skills/workflow-agent-kit/references/decision-policy.md
@@ -14,7 +14,7 @@ Apply the first matching rule. Runtime state wins over conversation recollection
 | 8 | Explicit continuous scope/boundary | Wait through prerequisites; hand off only at the requested/final boundary if permitted. |
 | 9 | Ordinary Ready frontier | Use handoff if permitted; otherwise use the waiting tool. |
 
-`advance_step` and `advance_step_and_handoff` request the same Runtime transition.
+`advance_step` and `advance_step_and_hand_off` request the same Runtime transition.
 Only waiting/ownership semantics differ. Codex never selects handoff. LazyMind may
 select it only after durable ownership acceptance.
 

--- a/skills/workflow-agent-kit/references/execution-policy.md
+++ b/skills/workflow-agent-kit/references/execution-policy.md
@@ -1,0 +1,13 @@
+# Execution policy v1
+
+Treat `ready_steps` as a frontier, not display order. Batch only independent,
+simultaneously applicable steps when the Host profile permits parallel execution.
+Do not batch alternatives, blocked work, retries, or speculative downstream work.
+
+`advance_step` waits for the Supervisor to persist a terminal Attempt result.
+`advance_step_and_hand_off` may be used only when the profile permits it and a
+durable Supervisor has accepted ownership. Both request one Runtime transition;
+the Runtime returns `resolved_operation` as execute, retry, or rewind.
+
+The model never manages claim, fencing, heartbeat, progress, or terminal writes.
+Those are deterministic Executor Supervisor responsibilities.

--- a/skills/workflow-agent-kit/references/execution-policy.md
+++ b/skills/workflow-agent-kit/references/execution-policy.md
@@ -11,3 +11,8 @@ the Runtime returns `resolved_operation` as execute, retry, or rewind.
 
 The model never manages claim, fencing, heartbeat, progress, or terminal writes.
 Those are deterministic Executor Supervisor responsibilities.
+
+After Runtime accepts `advance_step`, the Supervisor may create a SubAgent through
+the Host framework to execute the fixed step. That SubAgent is the only permitted
+nested model call. Runtime route selection, operation resolution, lifecycle, and
+Artifact commits remain deterministic before, during, and after SubAgent execution.

--- a/skills/workflow-agent-kit/references/installation-and-connection.md
+++ b/skills/workflow-agent-kit/references/installation-and-connection.md
@@ -1,0 +1,69 @@
+# Install and connect LazyMind
+
+## Check before installing
+
+If `workflow_connection_status` is registered, call it first. A successful result
+contains the resolved Core base URL, discovery source, contract version, and a
+live discovery response. Do not ask the user for a port when automatic discovery
+works.
+
+## Install LazyMind
+
+Use an existing LazyMind Desktop installation when possible. For source setup:
+
+```bash
+git clone https://github.com/LazyAGI/LazyMind.git
+cd LazyMind
+make local-up
+```
+
+Windows PowerShell uses `make local-win-up`. The complete prerequisites and
+Desktop build/download choices are maintained in the repository `README.md`,
+`docs/quick_start.md`, and `desktop/README.md`. Do not silently install system
+packages or start services without user authorization.
+
+## Register the Workflow MCP server
+
+Run the repository adapter with the same Python environment that contains
+LazyMind's `algorithm` requirements:
+
+```bash
+python /absolute/path/to/LazyMind/scripts/lazymind_workflow_mcp.py
+```
+
+Example stdio MCP configuration:
+
+```json
+{
+  "command": "python",
+    "args": ["/absolute/path/to/LazyMind/scripts/lazymind_workflow_mcp.py"],
+    "env": {
+      "LAZYMIND_WORKFLOW_USER_ID": "USER_ID"
+  }
+}
+```
+
+For a shared deployment, also set `LAZYMIND_WORKFLOW_BASE_URL` and
+`LAZYMIND_WORKFLOW_TOKEN`. Never place a token in the Skill or commit it.
+
+## Endpoint discovery order
+
+The SDK resolves Core in this order:
+
+1. `LAZYMIND_WORKFLOW_BASE_URL`.
+2. `LAZYMIND_ENDPOINT_HOST_CORE_BASE_URL`.
+3. `LAZYMIND_CORE_API_URL` or `LAZYMIND_CORE_SERVICE_URL`.
+4. The local runtime's generated `service-endpoints.json` under
+   `LAZYMIND_RUNTIME_ROOT` or the platform LazyMind data directory.
+
+This supports dynamically reassigned Desktop ports. A fixed port such as 18001
+is a development default, not a discovery protocol.
+
+## Diagnose failures
+
+- `LAZYMIND_NOT_FOUND`: start LazyMind or set an explicit base URL.
+- `IDENTITY_REQUIRED`: set `LAZYMIND_WORKFLOW_USER_ID`, or configure bearer-token
+  identity through the deployment gateway.
+- `CONTRACT_VERSION_UNSUPPORTED`: update the adapter and Skill together.
+- Connection refused: inspect LazyMind runtime status and confirm Core is ready.
+- Permission denied: use the same LazyMind identity that owns the Workflow.

--- a/skills/workflow-agent-kit/references/lifecycle.md
+++ b/skills/workflow-agent-kit/references/lifecycle.md
@@ -1,0 +1,12 @@
+# Workflow lifecycle v1
+
+1. Discover an enabled, authorized Workflow and pin its revision.
+2. Call `prepare_workflow`; bind every missing durable Input Resource.
+3. Call `start_workflow` only with a ready, unexpired preparation.
+4. Refresh the projection, select only `ready_steps`, and advance through the
+   tool allowed by the active Host profile.
+5. Review required Artifacts before reporting terminal success.
+6. Stop, resume, retry, or revise only through Workflow tools.
+
+Preparation is not a Session. Conversation memory is not projection state. A
+state-version conflict always requires a fresh projection and a new decision.

--- a/skills/workflow-agent-kit/references/model-execution-boundary.md
+++ b/skills/workflow-agent-kit/references/model-execution-boundary.md
@@ -1,0 +1,40 @@
+# Model execution boundary v1
+
+## Sole permitted nested model path
+
+Only execution of a Workflow step may invoke another model, and only through the
+framework's deterministic Executor Supervisor creating a SubAgent after Runtime
+accepts `advance_step` (or the LazyMind-only handoff variant). The SubAgent receives
+the fixed Attempt Context and permitted Host capabilities, produces step outputs,
+and returns. This is the only nested model boundary in the Agent Kit.
+
+The Supervisor—not the model—claims the Attempt, maintains lease/heartbeat,
+forwards progress, validates required outputs, saves Artifacts, and commits exactly
+one terminal result. A SubAgent cannot publish a Workflow, alter projection state,
+or decide that missing required output is success.
+
+## Tools that must never invoke a model
+
+- connection and discovery;
+- Workflow definition and projection reads;
+- prepare/start, input binding, stop/resume, and state transitions themselves;
+- Ready computation and Runtime execute/retry/rewind resolution;
+- Artifact list/read/patch/persistence and lineage propagation;
+- Skill snapshot and conversion context reads;
+- draft create/update, compile, diagnostics, script audit, and publish;
+- permission, capability, contract-version, and idempotency checks.
+
+`advance_step` is a composite boundary: its Runtime transition and Supervisor
+operations are deterministic, while the explicitly created SubAgent may use the
+Host model to perform the accepted step. No other tool may hide a generation,
+classification, repair, review, or routing model call.
+
+## Agent behavior
+
+The main Agent performs interpretation and authors text using its already-active
+Host model. It must not ask infrastructure tools to “AI generate”, “AI repair”,
+or “AI decide”. For authoring, the main Agent writes file content, then submits
+that exact content to deterministic tools. For lifecycle decisions, it reads the
+projection and applies this Skill. For output review, the main Agent applies
+acceptance criteria; a separate review SubAgent is permitted only when it is an
+explicit Workflow step executed through the same Supervisor boundary.

--- a/skills/workflow-agent-kit/references/recovery-policy.md
+++ b/skills/workflow-agent-kit/references/recovery-policy.md
@@ -1,0 +1,12 @@
+# Recovery policy v1
+
+- Failed or interrupted Attempt: target that step alone; Runtime resolves retry.
+- Changed succeeded result: target the earliest invalidated step; Runtime resolves
+  rewind and downstream staleness.
+- Stopped Session: resume only after explicit user or Host authorization.
+- Version conflict or event gap: refresh the projection before deciding again.
+- Unknown command outcome: reconcile by command id; never blindly replay.
+- Missing Artifact: fail structurally and preserve the Attempt evidence.
+
+Never edit projection state, choose an internal retry/rewind operation, or combine
+recovery with fresh frontier work.

--- a/skills/workflow-agent-kit/references/skill-to-workflow.md
+++ b/skills/workflow-agent-kit/references/skill-to-workflow.md
@@ -1,0 +1,21 @@
+# Skill to Workflow v1
+
+1. Call `get_skill_conversion_context` to pin and read the complete Skill package,
+   its revision, referenced files, and available Workflow tool catalog.
+2. Decide whether the procedure has explicit inputs, executable steps, observable
+   outputs, and acceptance criteria. Decline conversion when essential behavior
+   cannot be represented safely or deterministically.
+3. Design the graph, conditions, durable Input Resources, tools, required
+   Artifacts, and acceptance criteria. Do not copy Host-private paths, credentials,
+   model configuration, or hidden state into the Workflow.
+4. Call `create_workflow_draft`, then update individual files with
+   `update_workflow_draft_file` using the expected draft revision.
+5. Call `validate_workflow_draft` and `get_workflow_diagnostics`. Repair every
+   error against the same pinned Skill revision; do not weaken safety or output
+   requirements to silence diagnostics.
+6. Call `publish_workflow` only after deterministic validation succeeds. Preserve
+   the source Skill revision link and use an idempotent command.
+
+The Host model authors content. Core supplies the snapshot, contracts,
+diagnostics, revision control, and publication gate; authoring tools never invoke
+a model implicitly.

--- a/skills/workflow-agent-kit/references/skill-to-workflow.md
+++ b/skills/workflow-agent-kit/references/skill-to-workflow.md
@@ -1,21 +1,74 @@
 # Skill to Workflow v1
 
-1. Call `get_skill_conversion_context` to pin and read the complete Skill package,
-   its revision, referenced files, and available Workflow tool catalog.
-2. Decide whether the procedure has explicit inputs, executable steps, observable
-   outputs, and acceptance criteria. Decline conversion when essential behavior
-   cannot be represented safely or deterministically.
-3. Design the graph, conditions, durable Input Resources, tools, required
-   Artifacts, and acceptance criteria. Do not copy Host-private paths, credentials,
-   model configuration, or hidden state into the Workflow.
-4. Call `create_workflow_draft`, then update individual files with
-   `update_workflow_draft_file` using the expected draft revision.
-5. Call `validate_workflow_draft` and `get_workflow_diagnostics`. Repair every
-   error against the same pinned Skill revision; do not weaken safety or output
-   requirements to silence diagnostics.
-6. Call `publish_workflow` only after deterministic validation succeeds. Preserve
-   the source Skill revision link and use an idempotent command.
+The Host model reads the Skill and authors Workflow text. Every authoring tool is
+deterministic infrastructure: it reads a snapshot, stores text, compiles, reports
+diagnostics, or publishes. No authoring tool invokes a model or rewrites content.
 
-The Host model authors content. Core supplies the snapshot, contracts,
-diagnostics, revision control, and publication gate; authoring tools never invoke
-a model implicitly.
+## 1. Pin and understand the Skill
+
+Call `get_skill_conversion_context(skill_id, revision_id?)`. This returns the
+complete immutable Skill snapshot, including revision id, tree hash, package files,
+referenced content, and the currently available Workflow tool catalog. Treat the
+returned revision and tree hash as a pair. Reread the snapshot instead of reading
+an unversioned local copy.
+
+Extract, in descriptive language:
+
+- intended user outcome and explicit non-goals;
+- required user-provided files or structured inputs;
+- executable stages and dependencies;
+- tools/capabilities used by each stage;
+- observable intermediate and final outputs;
+- acceptance criteria and human approval boundaries;
+- conditional routes, parallel work, and recoverable failure points.
+
+Decline conversion when essential behavior depends on hidden state, unavailable
+tools, credentials embedded in instructions, unbounded arbitrary code, or an
+outcome that cannot be observed and validated.
+
+## 2. Design the package
+
+Read `workflow-format.md` completely before generating files. Produce at least:
+
+- `plugin.yaml` — compatibility package filename containing public Workflow
+  metadata, steps, materials/slots, and presentation declarations;
+- `scenario/state.yml` — graph transitions and executable step contracts;
+- `scenario/scenario.md` — descriptive usage and step explanation for ChatAgent.
+
+Generate `scenario/layout.json` only when layout is necessary. Avoid custom
+`scripts/` when a framework tool exists; scripts require deterministic audit and
+may block publication.
+
+Inputs must be durable materials/Input Resources, not prompts disguised as data.
+Each non-external material has exactly one producer. Every step output is required,
+observable, and paired with acceptance criteria. A consumer must be downstream of
+its producer. Route conditions must be understandable from user intent or durable
+state; never encode private Host state.
+
+## 3. Create and repair the draft
+
+Call `create_workflow_draft` with the name, pinned `skill_id`, `revision_id`,
+`tree_hash`, and the initial file map. The tool only stores exactly what the Host
+model wrote after checking the snapshot and allowed paths.
+
+Call `validate_workflow_draft(draft_id)` for graph compiler feedback, then
+`get_workflow_diagnostics(draft_id)` for strict package, snapshot, tool availability,
+and script-audit checks. For each error:
+
+1. identify the violated format or safety invariant;
+2. revise the file content in the Host model;
+3. call `update_workflow_draft_file` with the current `expected_version`;
+4. use the returned incremented draft version for the next update;
+5. validate and diagnose again.
+
+Never weaken required outputs, acceptance criteria, safety boundaries, or source
+revision linkage merely to silence a diagnostic. On version conflict, reread the
+latest draft/diagnostics and reconcile deliberately.
+
+## 4. Publish
+
+Call `publish_workflow(draft_id)` only when strict diagnostics return `valid: true`.
+Publish runs the deterministic checks again and creates an immutable Workflow
+revision linked to the source Skill revision. It does not call a model. Report the
+returned Workflow ref/revision and whether it is enabled; publication does not
+imply that a user setting enabled the Workflow.

--- a/skills/workflow-agent-kit/references/source-to-policy-mapping.md
+++ b/skills/workflow-agent-kit/references/source-to-policy-mapping.md
@@ -1,11 +1,11 @@
-# LazyMind legacy source → shared policy ledger
+# LazyMind source → shared policy ledger
 
-This ledger is the audit boundary for PR3. It maps existing behavior; it does not
-make the shared evaluator authoritative.
+This ledger records where the migrated behavior came from. The shared policy is
+now authoritative by default; the former Host policy is a bounded rollback path.
 
-| Legacy source | Existing rule | Shared policy clause | Shadow input/evidence |
+| Original source | Existing rule | Shared policy clause | Shadow input/evidence |
 |---|---|---|---|
-| `chat/workflow/workflow_manager.py::_COLD_START_PLUGIN_PROMPT` | Trigger only for direct intent; explicit named Workflow must trigger | Discover/prepare before start | Cold-start prompt tests remain authoritative; the constant name is a tracked legacy prompt alias |
+| `chat/workflow/workflow_manager.py::_COLD_START_PLUGIN_PROMPT` | Trigger only for direct intent; explicit named Workflow must trigger | Discover/prepare before start | Cold-start prompt tests remain authoritative; the constant is pending internal cleanup and is not public vocabulary |
 | `build_cold_start_tools` preflight | `need_information` blocks start; `ready` produces one valid first step | Missing-input and preparation gates | Existing preflight tests |
 | `_build_cold_execution_policy` | Auto hands off; dynamic waits only for explicit multi-step/no-approval cases | Rules 7–9 | Golden launch cases |
 | `_build_step_status_section` | Go Ready projection is the execution frontier; conditions disambiguate choices | Rules 3 and 6 | `ready_steps`, active edges |
@@ -20,11 +20,10 @@ make the shared evaluator authoritative.
 | `engine/subagent/runner.py::_build_subagent_plan` | Attempt objective, inputs, artifacts and output contract are isolated | Execute/review contract | SubAgent prompt-plan tests |
 | `engine/subagent/runner.py` terminal handling | Artifacts and terminal outcome are reported after execution | Required-Artifact terminal rule | SubAgent artifact tests |
 
-## Migration gate
+## Rollback and observation gate
 
-The production flag is `LAZYMIND_WORKFLOW_POLICY_SHADOW` (default off). When on,
-the active-session prompt path records `workflow.shadow-trace.v1` entries and
-counters (`evaluated`, `equivalent`, `mismatch`) in request agentic configuration
-and structured logs. Legacy remains authoritative. The PR3 golden suite requires
-100% equivalence; default-on/canary and deletion of legacy prompt rules belong to
-later migration PRs.
+`LAZYMIND_WORKFLOW_POLICY_V1` is default-on. Setting it to false explicitly selects
+the bounded former Host policy and increments the rollback counter. Optional
+`workflow.shadow-trace.v1` entries are observational only and record `authority`
+from the path that actually made the decision; they never invoke tools or mutate
+Runtime state.

--- a/skills/workflow-agent-kit/references/tool-contracts.md
+++ b/skills/workflow-agent-kit/references/tool-contracts.md
@@ -1,0 +1,17 @@
+# Workflow tool contracts v1
+
+Agent-facing tools are grouped by responsibility:
+
+- Discovery: `list_workflows`, `get_workflow`.
+- Lifecycle: `prepare_workflow`, `start_workflow`, `get_workflow_state`,
+  `stop_workflow`, `resume_workflow`.
+- Transition: `get_ready_steps`, `advance_step`,
+  `advance_step_and_hand_off`.
+- Artifact: `list_artifacts`, `read_artifact`, `patch_artifact`.
+- Authoring: `get_skill_conversion_context`, `create_workflow_draft`,
+  `update_workflow_draft_file`, `validate_workflow_draft`,
+  `get_workflow_diagnostics`, `publish_workflow`.
+
+Claim, Attempt context, heartbeat/progress, Artifact persistence, and Attempt
+terminal tools are Executor-only. Route facts, database rows, state mutation, and
+Host-private model configuration are never model-facing contracts.

--- a/skills/workflow-agent-kit/references/tool-contracts.md
+++ b/skills/workflow-agent-kit/references/tool-contracts.md
@@ -1,7 +1,13 @@
 # Workflow MCP tool contracts v1
 
-Every mutating call is idempotent. Preserve its `command_id` when reconciling an
-unknown result. Never reuse that id for different arguments.
+Lifecycle transitions use idempotent `command_id`; preserve it when reconciling an
+unknown result and never reuse it for different arguments. Draft file updates use
+`expected_version` optimistic locking. Do not retry publish after an unknown result
+until the draft or published revision has been reread.
+
+All tools below are deterministic and model-free except that `advance_step` may,
+after an accepted transition, cause the framework Supervisor to execute the target
+step with a SubAgent. See `model-execution-boundary.md`.
 
 ## Connection and discovery
 
@@ -73,6 +79,42 @@ MCP tool failures return `isError: true` with structured `code`, `message`,
 - `IDEMPOTENCY_CONFLICT`: generate a new id only for a genuinely new command.
 - `PERMISSION_DENIED`: stop and obtain the correct identity/authority.
 - `LAZYMIND_NOT_FOUND`: follow `installation-and-connection.md`.
+
+## Deterministic Skill-to-Workflow authoring
+
+### `get_skill_conversion_context(skill_id, revision_id?)`
+
+Returns an immutable Skill snapshot with revision id, tree hash, files/references,
+and available Workflow tools. It performs storage reads only and never summarizes,
+classifies, or generates with a model.
+
+### `create_workflow_draft(name, skill_id, revision_id, tree_hash, files)`
+
+`files` maps allowed relative package paths to exact Agent-authored text. The tool
+checks the pinned snapshot and stores that text unchanged. Required initial paths
+are documented in `workflow-format.md`.
+
+### `update_workflow_draft_file(draft_id, path, content, expected_version)`
+
+Stores one exact Agent-authored file using optimistic version checking. Use the
+returned draft version for the next edit. It never generates a patch.
+
+### `validate_workflow_draft(draft_id)`
+
+Runs the deterministic Go graph compiler. It returns validity, graph/hash, and
+path-addressed diagnostics; it does not repair content.
+
+### `get_workflow_diagnostics(draft_id)`
+
+Runs strict deterministic checks for pinned snapshot, package completeness, graph
+validity, framework-tool availability, and script audit. It does not ask a model
+to judge quality.
+
+### `publish_workflow(draft_id)`
+
+Re-runs strict diagnostics and publishes an immutable revision only when valid.
+The response contains Workflow ref and revision metadata. The main Agent must not
+call it until diagnostics are clean. The tool does not generate or revise files.
 
 ## Capability boundary
 

--- a/skills/workflow-agent-kit/references/tool-contracts.md
+++ b/skills/workflow-agent-kit/references/tool-contracts.md
@@ -1,17 +1,82 @@
-# Workflow tool contracts v1
+# Workflow MCP tool contracts v1
 
-Agent-facing tools are grouped by responsibility:
+Every mutating call is idempotent. Preserve its `command_id` when reconciling an
+unknown result. Never reuse that id for different arguments.
 
-- Discovery: `list_workflows`, `get_workflow`.
-- Lifecycle: `prepare_workflow`, `start_workflow`, `get_workflow_state`,
-  `stop_workflow`, `resume_workflow`.
-- Transition: `get_ready_steps`, `advance_step`,
-  `advance_step_and_hand_off`.
-- Artifact: `list_artifacts`, `read_artifact`, `patch_artifact`.
-- Authoring: `get_skill_conversion_context`, `create_workflow_draft`,
-  `update_workflow_draft_file`, `validate_workflow_draft`,
-  `get_workflow_diagnostics`, `publish_workflow`.
+## Connection and discovery
 
-Claim, Attempt context, heartbeat/progress, Artifact persistence, and Attempt
-terminal tools are Executor-only. Route facts, database rows, state mutation, and
-Host-private model configuration are never model-facing contracts.
+### `workflow_connection_status()`
+
+No arguments. Discovers Core, performs a live Workflow read, and returns
+`connected`, `base_url`, `source`, `contract_version`, and the discovery response.
+
+### `list_workflows()`
+
+No arguments. Returns only enabled Workflows visible to the authenticated user.
+Choose by declared capability, required inputs, outputs, and risk.
+
+### `get_workflow(workflow_id)`
+
+- `workflow_id: string` — exact id returned by discovery.
+
+Returns definition and revision metadata. Do not construct ids from display names.
+
+## Preparation and start
+
+### `prepare_workflow(workflow_id, input_bindings?, command_id?)`
+
+- `workflow_id: string`.
+- `input_bindings: object` — durable resource references keyed by material id.
+- `command_id: string` — optional UUID; generate once if omitted.
+
+Returns a preparation record containing its id and plan/status. It does not create
+a Session. Resolve missing inputs before starting.
+
+### `start_workflow(preparation_id, session_id, command_id?)`
+
+- `preparation_id: string` — exact id from prepare.
+- `session_id: string` — stable Host-generated id for this run.
+- `command_id: string` — defaults to the preparation id.
+
+Consumes the preparation idempotently and returns the initial Session result.
+
+## Projection and execution
+
+### `get_workflow_state(session_id)`
+
+Returns the authoritative projection. Always retain `state_version`, terminal or
+active status, Ready frontier, active/failed Attempts, and required outputs.
+
+### `get_ready_steps(session_id)`
+
+Returns `session_id`, `state_version`, `ready_steps`, and the source projection.
+An empty frontier means wait/observe or terminal; it never permits guessing.
+
+### `advance_step(session_id, expected_state_version, steps, command_id?)`
+
+- `expected_state_version: integer` — from the latest projection.
+- `steps: array` with at least `step_id`; optional `task_id`, `objective`,
+  `user_input`, `runtime_instruction`, and `partial_indices`.
+- `command_id: string` — stable UUID for this transition.
+
+Submit multiple steps only when they are independent members of the same Ready
+frontier. Runtime determines `resolved_operation`; never send retry/rewind as an
+operation. On state conflict, refresh and decide again rather than replaying.
+
+## Errors
+
+MCP tool failures return `isError: true` with structured `code`, `message`,
+`retryable`, `status_code`, and `details`. Important handling:
+
+- `STATE_VERSION_CONFLICT`: refresh projection and reconsider targets.
+- `TRANSITION_RESULT_UNKNOWN`: reconcile state/command outcome; do not blindly retry.
+- `IDEMPOTENCY_CONFLICT`: generate a new id only for a genuinely new command.
+- `PERMISSION_DENIED`: stop and obtain the correct identity/authority.
+- `LAZYMIND_NOT_FOUND`: follow `installation-and-connection.md`.
+
+## Capability boundary
+
+The MCP server advertises only implemented public facade tools. At this revision,
+standard stop/resume and Artifact list/read/patch tools are not advertised because
+their Core public facades are not yet complete. Tool-list absence is a capability
+result, not permission to call internal endpoints.

--- a/skills/workflow-agent-kit/references/workflow-format.md
+++ b/skills/workflow-agent-kit/references/workflow-format.md
@@ -1,0 +1,134 @@
+# Workflow package format v1
+
+The package currently retains the physical filename `plugin.yaml` for storage
+compatibility. Its domain content and all Agent-facing language are Workflow.
+
+## Required tree
+
+```text
+plugin.yaml
+scenario/state.yml
+scenario/scenario.md
+```
+
+Optional paths are `scenario/layout.json` and `scripts/<relative-path>`. Absolute
+paths and `..` traversal are invalid.
+
+## `plugin.yaml`
+
+Minimum shape:
+
+```yaml
+id: research-report
+name: Research Report
+description: Produce an evidence-grounded report with reviewable outputs.
+when_to_use: Use when the user requests a researched report; do not use for a quick factual answer.
+steps:
+  - id: collect
+    label: Collect evidence
+  - id: draft
+    label: Draft report
+slots:
+  - id: evidence
+    label: Evidence
+    type: json
+    cardinality: list
+  - id: report
+    label: Report
+    type: text
+    cardinality: single
+```
+
+Rules:
+
+- `id`, `name`, `description`, and step declarations are required.
+- Step ids must exactly match `state.yml` step keys.
+- Slot/material types are `text`, `image`, `file`, or `json`; cardinality is
+  `single` or `list`.
+- Mark a material `external: true` only when the user supplies it separately.
+- User query, task description, topic, prompt, and instructions are not materials;
+  steps receive them through execution context.
+- Every non-external material has exactly one producing step.
+- Optional UI tabs may reference declared slot ids; UI never changes graph state.
+
+## `scenario/state.yml`
+
+```yaml
+initial: __start__
+transitions:
+  __start__:
+    - to: collect
+  collect:
+    - to: draft
+  draft:
+    - to: __end__
+steps:
+  collect:
+    label: Collect evidence
+    prompt: |
+      Collect traceable evidence for {{user_input}}.
+      Save every declared output and stop.
+    tools: [web_search]
+    outputs:
+      - material: evidence
+    acceptance_criteria: Evidence contains sources and directly supports the request.
+  draft:
+    label: Draft report
+    prompt: |
+      Write the report from {{evidence}} for {{user_input}}.
+      Apply {{runtime_instruction}}, save the report output, and stop.
+    inputs:
+      - material: evidence
+        required: true
+    outputs:
+      - material: report
+    acceptance_criteria: Report addresses the request and every material claim is supported.
+```
+
+Rules:
+
+- `initial` is `__start__`; `__start__` and `__end__` are reserved virtual nodes.
+- Every transition target and source must be valid; terminal paths reach `__end__`.
+- A Ready step's required inputs must be produced by control ancestors.
+- Required inputs are AND. One level of `alternatives` provides OR for a single
+  required input. Optional inputs cannot declare alternatives.
+- `route: choice` means the Agent selects one applicable outgoing condition;
+  default/all may expose independent applicable successors.
+- `skip_if` accepts one level of material-based `all` or `any`; do not place free
+  natural-language policy in it.
+- Prompt placeholders are `{{user_input}}`, `{{runtime_instruction}}`, and declared
+  input material ids only.
+- Tools must exist in the conversion context catalog. Credentials and model config
+  never appear in tool declarations or prompts.
+- Every declared output is required. Acceptance criteria must be observable from
+  the output rather than internal reasoning.
+
+## `scenario/scenario.md`
+
+Use descriptive prose for the ChatAgent:
+
+```markdown
+# Research Report
+
+## Appropriate use
+Use for multi-source reports requiring evidence and a reviewable final document.
+Do not use for quick answers without a report deliverable.
+
+## Workflow
+1. `collect` gathers traceable evidence.
+2. `draft` produces the report from that evidence.
+
+## Inputs and outputs
+The user supplies the research request. The Workflow produces evidence and report Artifacts.
+```
+
+Do not repeat framework advance/retry rules here; those belong to this Agent Kit.
+
+## Safety and publication
+
+- Prefer registered framework tools over scripts.
+- Never embed secrets, local absolute paths, temporary URLs, private reasoning,
+  Host model configuration, or direct database operations.
+- Scripts require matching deterministic audit hashes and approved classifications.
+- Compiler and publish diagnostics are authoritative; a syntactically valid YAML
+  file can still be invalid due to graph, lineage, tool, or safety constraints.

--- a/tests/algorithm/chat/test_chat_utils_stream_scanner.py
+++ b/tests/algorithm/chat/test_chat_utils_stream_scanner.py
@@ -1,29 +1,29 @@
 from types import SimpleNamespace
 
-from lazymind.chat.service.utils.citations import ConfigCitationPlugin, CITATION_REFS_KEY
+from lazymind.chat.service.utils.citations import ConfigCitationWorkflow, CITATION_REFS_KEY
 from lazymind.chat.service.utils.stream_scanner import (
-    ImagePlugin,
+    ImageWorkflow,
     IncrementalScanner,
-    MarkdownImageHoldPlugin,
+    MarkdownImageHoldWorkflow,
 )
 
 
-def test_image_plugin_matches_exact_and_fuzzy_urls():
-    plugin = ImagePlugin(
+def test_image_workflow_matches_exact_and_fuzzy_urls():
+    workflow = ImageWorkflow(
         {
             'chart-final.png': 'https://cdn.example.com/chart-final.png',
         }
     )
 
-    _, exact = plugin.match('![alt](chart-final.png)', 0)
-    _, fuzzy = plugin.match('![alt](chart-final-v2.png)', 0)
+    _, exact = workflow.match('![alt](chart-final.png)', 0)
+    _, fuzzy = workflow.match('![alt](chart-final-v2.png)', 0)
 
     assert exact == '![alt](https://cdn.example.com/chart-final.png)'
     assert fuzzy == '![alt](https://cdn.example.com/chart-final.png)'
 
 
-def test_markdown_image_hold_plugin_keeps_partial_image_across_chunks():
-    scanner = IncrementalScanner([MarkdownImageHoldPlugin()], initial_state='BODY')
+def test_markdown_image_hold_workflow_keeps_partial_image_across_chunks():
+    scanner = IncrementalScanner([MarkdownImageHoldWorkflow()], initial_state='BODY')
 
     first = scanner.feed('intro ![dog](/static-files/path/dog.jpg?sig=abc')
     second = scanner.feed('def)\n\ntail')
@@ -44,7 +44,7 @@ def test_incremental_scanner_handles_partial_think_tags_and_plugins():
             },
         },
     }
-    scanner = IncrementalScanner([ConfigCitationPlugin(config)], initial_state='BODY')
+    scanner = IncrementalScanner([ConfigCitationWorkflow(config)], initial_state='BODY')
 
     first = scanner.feed('hello <thi')
     second = scanner.feed('nk>plan</think> cite [[1.1]]')
@@ -67,8 +67,8 @@ def test_citation_plugin_display_numbers_start_from_first_streamed_source():
             '5.1': {'file_name': 'Fifth.md', 'index': '5.1'},
         },
     }
-    plugin = ConfigCitationPlugin(config)
-    scanner = IncrementalScanner([plugin], initial_state='BODY')
+    workflow = ConfigCitationWorkflow(config)
+    scanner = IncrementalScanner([workflow], initial_state='BODY')
 
     segments = scanner.feed('cite [[3.1]] then [[3.2]] and [5](#source-5.1 "Fifth.md")')
 
@@ -80,7 +80,7 @@ def test_citation_plugin_display_numbers_start_from_first_streamed_source():
         ('text', ' and '),
         ('text', '[2](#source-5.1 "Fifth.md")'),
     ]
-    assert plugin.collect()[0]['index'] == '3.1'
-    assert plugin.collect()[0]['display_index'] == 1
-    assert plugin.collect()[2]['index'] == '5.1'
-    assert plugin.collect()[2]['display_index'] == 2
+    assert workflow.collect()[0]['index'] == '3.1'
+    assert workflow.collect()[0]['display_index'] == 1
+    assert workflow.collect()[2]['index'] == '5.1'
+    assert workflow.collect()[2]['display_index'] == 2

--- a/tests/algorithm/chat/test_generate_plugin_staged_routes.py
+++ b/tests/algorithm/chat/test_generate_plugin_staged_routes.py
@@ -2,7 +2,7 @@ import json
 
 import pytest
 
-from lazymind.chat.api import generate_plugin_staged_routes as staged
+from lazymind.chat.api import generate_workflow_staged_routes as staged
 
 
 def test_skeleton_response_prefers_structured_plugin_object():
@@ -16,7 +16,7 @@ def test_skeleton_response_prefers_structured_plugin_object():
         'ui': {'tabs': []},
     }
 
-    assert staged._plugin_dict_from_skeleton_response({'plugin': plugin}, 'system') == plugin
+    assert staged._workflow_dict_from_skeleton_response({'workflow': plugin}, 'system') == plugin
 
 
 def test_skeleton_response_repairs_invalid_legacy_yaml(monkeypatch):
@@ -27,11 +27,11 @@ def test_skeleton_response_repairs_invalid_legacy_yaml(monkeypatch):
     monkeypatch.setattr(
         staged,
         '_call_llm',
-        lambda _prompt: json.dumps({'plugin': repaired_plugin}),
+        lambda _prompt: json.dumps({'workflow': repaired_plugin}),
     )
 
-    result = staged._plugin_dict_from_skeleton_response(
-        {'plugin_yaml': invalid_yaml},
+    result = staged._workflow_dict_from_skeleton_response(
+        {'workflow_yaml': invalid_yaml},
         'system',
     )
 

--- a/tests/algorithm/chat/test_intent_writer.py
+++ b/tests/algorithm/chat/test_intent_writer.py
@@ -5,7 +5,7 @@ import pytest
 
 from lazymind.chat.engine.tools.intent_writer import (
     build_intentwrite_tool,
-    enable_plugin_intent_scopes,
+    enable_workflow_intent_scopes,
     normalize_intent_document,
     render_intent_section,
 )
@@ -28,21 +28,21 @@ def test_conversation_writer_exposes_only_conversation_scope():
     )
 
     assert get_args(get_type_hints(tool)['scope']) == ('conversation',)
-    assert 'plugin_session' not in tool.__doc__
+    assert 'workflow_session' not in tool.__doc__
     assert 'available_steps' not in tool.__doc__
 
 
-def test_plugin_manager_extension_changes_scopes_without_listing_steps():
+def test_workflow_manager_extension_changes_scopes_without_listing_steps():
     tool = build_intentwrite_tool(
         conversation_id='conv-1', current_query='修改初稿', current_intent={},
     )
-    updated = enable_plugin_intent_scopes(
-        tool, session_id='ps-1', plugin_id='writer', valid_step_ids=['outline', 'draft'],
+    updated = enable_workflow_intent_scopes(
+        tool, session_id='ws-1', workflow_id='writer', valid_step_ids=['outline', 'draft'],
     )
 
     assert updated is tool
     assert get_args(get_type_hints(tool)['scope']) == (
-        'conversation', 'plugin_session', 'plugin_step',
+        'conversation', 'workflow_session', 'workflow_step',
     )
     assert 'available_steps' not in tool.__doc__
     assert 'outline' not in tool.__doc__
@@ -91,15 +91,15 @@ def test_intentwrite_rejects_non_user_evidence():
         tool('conversation', [_operation(evidence='用户没有说过')])
 
 
-def test_plugin_step_is_validated_without_exposing_step_list():
+def test_workflow_step_is_validated_without_exposing_step_list():
     tool = build_intentwrite_tool(
         conversation_id='conv-1', current_query='修改初稿', current_intent={},
     )
-    enable_plugin_intent_scopes(
-        tool, session_id='ps-1', plugin_id='writer', valid_step_ids=['draft'],
+    enable_workflow_intent_scopes(
+        tool, session_id='ws-1', workflow_id='writer', valid_step_ids=['draft'],
     )
     with pytest.raises(ValueError, match='unknown step_id'):
-        tool('plugin_step', [_operation(evidence='初稿')], step_id='unknown')
+        tool('workflow_step', [_operation(evidence='初稿')], step_id='unknown')
 
 
 def test_legacy_intent_is_rendered_as_inherited_constraint():
@@ -110,15 +110,15 @@ def test_legacy_intent_is_rendered_as_inherited_constraint():
     assert '执行到初稿后确认' in rendered
 
 
-def test_chat_plugin_intent_section_excludes_step_intents():
-    from lazymind.chat.plugin import plugin_manager
+def test_chat_workflow_intent_section_excludes_step_intents():
+    from lazymind.chat.workflow import workflow_manager
 
     fake_db = type('FakeDB', (), {
         'get_session_intent': lambda self, session_id: '本次执行到初稿后确认',
         'list_step_intents': lambda self, session_id: {'draft': '初稿不超过500字'},
     })()
     with patch('lazymind.chat.engine.subagent.db.TaskQueryDB', return_value=fake_db):
-        section = plugin_manager._build_intent_section('ps-1', step_id='draft')
+        section = workflow_manager._build_intent_section('ws-1', step_id='draft')
 
     assert '本次执行到初稿后确认' in section
     assert '初稿不超过500字' not in section

--- a/tests/algorithm/chat/test_runtime_loader.py
+++ b/tests/algorithm/chat/test_runtime_loader.py
@@ -61,8 +61,8 @@ def test_chat_runtime_loader_is_single_flight(monkeypatch):
         return sentinel
 
     monkeypatch.setattr(loader.importlib, 'import_module', fake_import)
-    from lazymind.chat.plugin import plugin_loader
-    monkeypatch.setattr(plugin_loader, 'ensure_loaded', lambda: None)
+    from lazymind.chat.workflow import workflow_loader
+    monkeypatch.setattr(workflow_loader, 'ensure_loaded', lambda: None)
 
     results = []
     threads = [threading.Thread(target=lambda: results.append(loader.ensure_chat_runtime())) for _ in range(5)]

--- a/tests/algorithm/chat/test_subagent_attachment_access.py
+++ b/tests/algorithm/chat/test_subagent_attachment_access.py
@@ -86,7 +86,7 @@ def test_coerce_dict_accepts_sqlite_blob_params():
     config = runner._build_agentic_config(
         {'conversation_id': 'conversation-1', 'objective': 'use dog.jpg'},
         params,
-        'plugin_step',
+        'workflow_step',
     )
     assert config['history_files_per_turn'] == {'1': ['/uploads/dog.jpg']}
     assert config['files'] == ['/uploads/dog.jpg']

--- a/tests/algorithm/chat/test_task_profile.py
+++ b/tests/algorithm/chat/test_task_profile.py
@@ -240,12 +240,12 @@ KNOWLEDGE_BASE_MENTION_SCENARIOS = [
     for outcome in OUTCOME_NAMES
     for variant in range(2)
 ]
-PLUGIN_MENTION_SCENARIOS = [
+WORKFLOW_MENTION_SCENARIOS = [
     {
-        'id': f'mention-plugin-{outcome}-{variant}',
+        'id': f'mention-workflow-{outcome}-{variant}',
         'query': _chain(outcome, variant=variant),
-        'bindings': {'plugin_refs': [f'plugin/{outcome}']},
-        'expected_plugin_refs': (f'plugin/{outcome}',),
+        'bindings': {'workflow_refs': [f'workflow/{outcome}']},
+        'expected_workflow_refs': (f'workflow/{outcome}',),
         'expected_primary': outcome,
     }
     for outcome in OUTCOME_NAMES
@@ -253,8 +253,8 @@ PLUGIN_MENTION_SCENARIOS = [
 ]
 RESOURCE_PAIR_KINDS = (
     {'skill_names': ['review/selected'], 'knowledge_base_ids': ['kb-selected']},
-    {'skill_names': ['review/selected'], 'plugin_refs': ['plugin/selected']},
-    {'knowledge_base_ids': ['kb-selected'], 'plugin_refs': ['plugin/selected']},
+    {'skill_names': ['review/selected'], 'workflow_refs': ['workflow/selected']},
+    {'knowledge_base_ids': ['kb-selected'], 'workflow_refs': ['workflow/selected']},
 )
 RESOURCE_PAIR_SCENARIOS = [
     {
@@ -272,7 +272,7 @@ RESOURCE_TRIPLE_SCENARIOS = [
         'bindings': {
             'skill_names': ['review/selected'],
             'knowledge_base_ids': ['kb-selected'],
-            'plugin_refs': ['plugin/selected'],
+            'workflow_refs': ['workflow/selected'],
         },
     }
     for variant in range(8)
@@ -310,16 +310,16 @@ RESOURCE_CONFLICT_SCENARIOS = [
     ],
     *[
         {
-            'id': f'mention-conflict-plugin-{variant}',
-            'query': f'解释一下这个主题，但不要启动这个Plugin，变体{variant}',
+            'id': f'mention-conflict-workflow-{variant}',
+            'query': f'解释一下这个主题，但不要启动这个Workflow，变体{variant}',
             'bindings': {
-                'plugin_refs': ['plugin/selected'],
+                'workflow_refs': ['workflow/selected'],
                 'mentions': [{
-                    'resource_type': 'plugin', 'resource_ref': 'plugin/selected',
-                    'display_name': '这个Plugin',
+                    'resource_type': 'workflow', 'resource_ref': 'workflow/selected',
+                    'display_name': '这个Workflow',
                 }],
             },
-            'expected_excluded': ('plugin/selected',),
+            'expected_excluded': ('workflow/selected',),
         }
         for variant in range(5)
     ],
@@ -349,7 +349,7 @@ RESOURCE_CURRENT_VS_DEFAULT_SCENARIOS = [
 RESOURCE_BINDING_SCENARIOS = (
     SKILL_MENTION_SCENARIOS
     + KNOWLEDGE_BASE_MENTION_SCENARIOS
-    + PLUGIN_MENTION_SCENARIOS
+    + WORKFLOW_MENTION_SCENARIOS
     + RESOURCE_PAIR_SCENARIOS
     + RESOURCE_TRIPLE_SCENARIOS
     + RESOURCE_CONFLICT_SCENARIOS
@@ -425,19 +425,19 @@ def test_explicit_resource_binding_scenarios(scenario: dict) -> None:
     if bindings.get('knowledge_base_ids') and not scenario.get('expected_excluded'):
         assert profile.source_strategy == 'knowledge_base'
         assert profile.explicit_resources.knowledge_base_ids == tuple(bindings['knowledge_base_ids'])
-    if bindings.get('plugin_refs') and not scenario.get('expected_excluded'):
-        assert profile.explicit_resources.plugin_refs == tuple(bindings['plugin_refs'])
+    if bindings.get('workflow_refs') and not scenario.get('expected_excluded'):
+        assert profile.explicit_resources.workflow_refs == tuple(bindings['workflow_refs'])
     if 'expected_primary' in scenario:
         assert profile.primary_outcome == scenario['expected_primary']
     if 'expected_skill_mode' in scenario:
         assert profile.skill_mode == scenario['expected_skill_mode']
     if 'expected_source_strategy' in scenario:
         assert profile.source_strategy == scenario['expected_source_strategy']
-    if 'expected_plugin_refs' in scenario:
-        assert profile.explicit_resources.plugin_refs == scenario['expected_plugin_refs']
+    if 'expected_workflow_refs' in scenario:
+        assert profile.explicit_resources.workflow_refs == scenario['expected_workflow_refs']
     if scenario.get('expected_excluded'):
         excluded = profile.excluded_resources
-        actual = excluded.skill_names + excluded.knowledge_base_ids + excluded.plugin_refs
+        actual = excluded.skill_names + excluded.knowledge_base_ids + excluded.workflow_refs
         assert actual == scenario['expected_excluded']
         assert profile.request_assessment.status == 'ready'
     if scenario.get('expected_not_explicit'):
@@ -676,15 +676,15 @@ def test_explicit_knowledge_base_and_explicit_web_request_use_mixed_sources() ->
     assert profile.source_strategy == 'mixed'
 
 
-def test_explicit_plugin_binding_preserves_user_outcome() -> None:
+def test_explicit_workflow_binding_preserves_user_outcome() -> None:
     profile = resolve_task_profile(
         '帮我制定发布计划',
         enable_llm_fallback=False,
-        explicit_resources={'plugin_refs': ['marketing/campaign']},
+        explicit_resources={'workflow_refs': ['marketing/campaign']},
     )
     assert profile.primary_outcome == 'plan'
-    assert profile.explicit_resources.plugin_refs == ('marketing/campaign',)
-    assert 'explicit plugin selection' in profile.reasons
+    assert profile.explicit_resources.workflow_refs == ('marketing/campaign',)
+    assert 'explicit workflow selection' in profile.reasons
 
 
 def test_mixed_resource_allow_and_deny_keeps_only_allowed_mentions() -> None:
@@ -940,10 +940,10 @@ def test_llm_classification_cannot_override_explicit_resources() -> None:
         explicit_resources={
             'skill_names': ['video/ai-production'],
             'knowledge_base_ids': ['kb-video'],
-            'plugin_refs': ['video/workflow'],
+            'workflow_refs': ['video/workflow'],
         },
     )
     assert profile.skill_mode == 'explicit'
     assert profile.source_strategy == 'knowledge_base'
     assert profile.explicit_resources.skill_names == ('video/ai-production',)
-    assert profile.explicit_resources.plugin_refs == ('video/workflow',)
+    assert profile.explicit_resources.workflow_refs == ('video/workflow',)


### PR DESCRIPTION
## What changed

- keep `advance_step_and_hand_off` as the canonical Workflow handoff tool name
- align the shared Skill, Host profiles, runtime/tool contracts, golden fixtures, and execution plan
- update LazyMind policy, tool registration, rendering, client payloads, and tests
- remove the temporary alias metric and compatibility builder introduced for `advance_step_and_handoff`

## Why

The established LazyMind public tool name is `advance_step_and_hand_off`. Keeping that spelling avoids an unnecessary protocol rename and keeps the plan, shared policy, and implementation aligned.

## Validation

- `PYTHONPATH=algorithm:algorithm/lazyllm python3 -m pytest algorithm/tests/test_workflow_policy.py algorithm/tests/test_workflow_policy_shadow.py algorithm/tests/test_workflow_agent_kit.py algorithm/tests/chat/workflows/test_host_policy_convergence.py algorithm/tests/chat/workflows/test_manager.py -q` — 72 passed
- `make lint` — passed
- repository scan confirms no `advance_step_and_handoff` references remain
