### PR TITLE
feat: add opt-in trusted local mode for desktop builds

### DIFF
--- a/algorithm/lazymind/chat/engine/agent_runtime/executor.py
+++ b/algorithm/lazymind/chat/engine/agent_runtime/executor.py
@@ -185,7 +185,7 @@ class AgentExecutor:
         kwargs = {
             'stream': True,
             'max_retries': options.max_retries or _cfg['max_retries'],
-            'enable_builtin_tools': False,
+            'enable_builtin_tools': bool(_cfg['trusted_local_mode']),
             'force_summarize': True,
             'force_summarize_context': plan.force_summarize_context,
             'on_max_retries': (

--- a/algorithm/lazymind/chat/engine/tools/chat_artifact.py
+++ b/algorithm/lazymind/chat/engine/tools/chat_artifact.py
@@ -103,9 +103,21 @@ def _resolve_workspace_path(path: str, user_id: str, conversation_id: str) -> tu
     workspace = os.path.realpath(chat_agent_workspace(user_id, conversation_id))
     candidate = path if os.path.isabs(path) else os.path.join(workspace, path)
     resolved = os.path.realpath(candidate)
-    if os.path.commonpath((workspace, resolved)) != workspace:
+    if _cfg['trusted_local_mode']:
+        return workspace, resolved
+    try:
+        inside_workspace = os.path.commonpath((workspace, resolved)) == workspace
+    except ValueError:
+        # Windows raises ValueError when the workspace and requested path use
+        # different drive letters. That is still an outside-workspace path.
+        inside_workspace = False
+    if not inside_workspace:
         raise ValueError('path must stay inside the current main-Agent workspace')
     return workspace, resolved
+
+
+def _file_tool_root(workspace: str) -> Optional[str]:
+    return None if _cfg['trusted_local_mode'] else workspace
 
 
 def _resolve_source_file(path: str, user_id: str, conversation_id: str) -> str:
@@ -234,10 +246,10 @@ def write_file(
     create_parents: bool = True,
     allow_unsafe: bool = False,
 ) -> Dict[str, Any]:
-    """Write a text file in the current chat workspace.
+    """Write a text file in the current chat workspace or an allowed host path.
 
     Args:
-        path: Workspace-relative path or absolute path inside the workspace.
+        path: Workspace-relative path. In trusted local mode, absolute host paths are also allowed.
         content: Text to write.
         mode: "overwrite" or "append".
         encoding: Text encoding.
@@ -251,7 +263,7 @@ def write_file(
         content,
         mode=mode,
         encoding=encoding,
-        root=workspace,
+        root=_file_tool_root(workspace),
         create_parents=create_parents,
         allow_unsafe=allow_unsafe,
     )
@@ -265,10 +277,10 @@ def read_file(
     errors: str = 'replace',
     max_chars: int = 200000,
 ) -> Dict[str, Any]:
-    """Read a text file from the current chat workspace.
+    """Read a text file from the current chat workspace or an allowed host path.
 
     Args:
-        path: Workspace-relative path or absolute path inside the workspace.
+        path: Workspace-relative path. In trusted local mode, absolute host paths are also allowed.
         start_line: Optional 1-based first line.
         end_line: Optional 1-based last line.
         encoding: Text encoding.
@@ -283,16 +295,16 @@ def read_file(
         end_line=end_line,
         encoding=encoding,
         errors=errors,
-        root=workspace,
+        root=_file_tool_root(workspace),
         max_chars=max_chars,
     )
 
 
 def list_dir(path: str = '.', recursive: bool = False, max_depth: int = 5) -> Dict[str, Any]:
-    """List files in the current chat workspace.
+    """List files in the current chat workspace or an allowed host path.
 
     Args:
-        path: Workspace-relative directory or absolute directory inside the workspace.
+        path: Workspace-relative directory. In trusted local mode, absolute host paths are also allowed.
         recursive: Recursively include descendants.
         max_depth: Maximum recursive depth.
     """
@@ -302,5 +314,5 @@ def list_dir(path: str = '.', recursive: bool = False, max_depth: int = 5) -> Di
         directory,
         recursive=recursive,
         max_depth=max_depth,
-        root=workspace,
+        root=_file_tool_root(workspace),
     )

--- a/algorithm/lazymind/chat/service/chat_service.py
+++ b/algorithm/lazymind/chat/service/chat_service.py
@@ -720,16 +720,26 @@ async def _handle_chat_impl(
         task_profile=task_profile,
         dynamic_prompt_modules=_cfg['dynamic_prompt_modules'],
     )
-    prompt_builder.system(
-        'chat_workspace',
-        'Workspace',
-        (
+    if _cfg['trusted_local_mode']:
+        workspace_policy = (
+            f'Use `{workspace}` as the default working directory for generated and intermediate files. '
+            'Trusted local mode is active: when the user requests it, you may read and write absolute local '
+            'paths outside this workspace and use `shell_tool` to run local commands. Keep relative paths '
+            'inside the default workspace. Use `read_file`, `write_file`, and `list_dir` for file operations, '
+            'then publish completed downloadable files with `save_chat_artifact`.'
+        )
+    else:
+        workspace_policy = (
             f'Use `{workspace}` as the single working directory for all generated and intermediate files. '
             'When a skill requires an output directory, create it under this workspace and pass its absolute '
             'path to skill scripts. Treat files outside this workspace as read-only inputs. Use `read_file`, '
             '`write_file`, and `list_dir` to inspect and update workspace files, then publish completed files '
             'with `save_chat_artifact`.'
-        ),
+        )
+    prompt_builder.system(
+        'chat_workspace',
+        'Workspace',
+        workspace_policy,
         'agent.workspace',
         priority=70,
     )

--- a/algorithm/lazymind/config.py
+++ b/algorithm/lazymind/config.py
@@ -147,6 +147,8 @@ config.add('agentic_expanded_max_rounds', int, 200, 'AGENTIC_EXPANDED_MAX_ROUNDS
            description='Maximum ReAct rounds for one ChatAgent invocation after the user continues.')
 config.add('agentic_workspace', str, './workspace', 'AGENTIC_WORKSPACE',
            description='Workspace directory for agentic tools.')
+config.add('trusted_local_mode', bool, False, 'TRUSTED_LOCAL_MODE',
+           description='Allow agents to access host paths outside their workspace and use local command tools.')
 config.add('agentic_keep_full_turns', int, 0, 'AGENTIC_KEEP_FULL_TURNS',
            description='Number of full turns retained in agentic history; 0 disables rolling compaction.')
 config.add('dynamic_prompt_modules', bool, True, 'DYNAMIC_PROMPT_MODULES',

--- a/desktop/README.md
+++ b/desktop/README.md
@@ -64,6 +64,19 @@ Windows Desktop supports Windows 10/11 x64, runs as the current user, and does n
 
 The assisted installer supports in-place upgrades, blocks downgrades, and warms the bundled Python, Node, and local services before completing. On a fresh or repair install, existing `%LOCALAPPDATA%\LazyMind` data can be retained (the default) or cleared. Upgrades always retain it. The uninstaller similarly defaults to removing the program only and can optionally clear Local AppData. Neither workflow reads, deletes, or moves `%USERPROFILE%\Documents\LazyMind`.
 
+## Trusted local mode
+
+Desktop packages restrict agent file writes to the per-conversation workspace and disable local command tools by default. For a trusted, single-user package, set `LAZYMIND_TRUSTED_LOCAL_MODE=true` when building:
+
+```powershell
+$env:LAZYMIND_TRUSTED_LOCAL_MODE = 'true'
+make desktop-windows-x64-installer
+```
+
+The build records the feature in the packaged runtime manifest, so the installed app keeps the setting without requiring the user to configure an environment variable. In this mode, agents may read and write user-requested absolute host paths and can use LazyLLM's local command tool. Existing overwrite, delete, move, and dangerous-command approval checks still apply. Do not enable this mode in packages distributed to untrusted or multi-user environments.
+
+For source-based Local runs, setting the same environment variable before `make local-win-up` or `make local-up` enables the mode for that process without changing a desktop package.
+
 ## Runtime behavior
 
 Desktop binds only to `127.0.0.1`. It retains the normal Local/Desktop auto-login flow through `/_local/admin-session`, while LAN auto-login remains disabled.

--- a/desktop/scripts/build-darwin-arm64.sh
+++ b/desktop/scripts/build-darwin-arm64.sh
@@ -223,8 +223,14 @@ rsync -a --delete \
 
 prune_runtime_app "${RUNTIME_ROOT}/app"
 assert_desktop_runtime_app "${RUNTIME_ROOT}/app"
+TRUSTED_LOCAL_MODE=false
+if [[ "${LAZYMIND_TRUSTED_LOCAL_MODE:-}" == "true" ]]; then
+  TRUSTED_LOCAL_MODE=true
+  echo "==> Trusted local mode enabled for this desktop package"
+fi
 node "${ROOT}/desktop/scripts/write-runtime-manifest.mjs" \
-  "${RUNTIME_ROOT}" --platform darwin --arch arm64
+  "${RUNTIME_ROOT}" --platform darwin --arch arm64 \
+  --trusted-local-mode "${TRUSTED_LOCAL_MODE}"
 
 echo "==> Packaging Electron app"
 if [[ ! -f "${APP_ICON}" ]]; then

--- a/desktop/scripts/build-windows-x64.ps1
+++ b/desktop/scripts/build-windows-x64.ps1
@@ -272,7 +272,17 @@ function Finalize-Desktop([ValidateSet('zip', 'installer')][string]$PackageKind 
 
     Write-Host '==> Staging runtime application files'
     Copy-RuntimeApp
-    Invoke-Native 'node.exe' @((Join-Path $repoRoot 'desktop\scripts\write-runtime-manifest.mjs'), $runtimeRoot, '--platform', 'windows', '--arch', 'amd64')
+    $trustedLocalMode = if ($env:LAZYMIND_TRUSTED_LOCAL_MODE -eq 'true') { 'true' } else { 'false' }
+    if ($trustedLocalMode -eq 'true') {
+        Write-Host '==> Trusted local mode enabled for this desktop package'
+    }
+    Invoke-Native 'node.exe' @(
+        (Join-Path $repoRoot 'desktop\scripts\write-runtime-manifest.mjs'),
+        $runtimeRoot,
+        '--platform', 'windows',
+        '--arch', 'amd64',
+        '--trusted-local-mode', $trustedLocalMode
+    )
     $reparse = @(Get-ChildItem -LiteralPath $runtimeRoot -Recurse -Force -ErrorAction SilentlyContinue | Where-Object { $_.Attributes -band [IO.FileAttributes]::ReparsePoint })
     if ($reparse.Count -gt 0) {
         throw "Desktop runtime contains non-portable reparse points; first path: $($reparse[0].FullName)"

--- a/desktop/scripts/desktop-build.test.mjs
+++ b/desktop/scripts/desktop-build.test.mjs
@@ -61,6 +61,7 @@ for (const target of [
       const manifest = JSON.parse(readFileSync(path.join(root, "manifest.json"), "utf8"));
       assert.equal(manifest.platform, target.platform);
       assert.equal(manifest.arch, target.arch);
+      assert.deepEqual(manifest.features, { trustedLocalMode: false });
       assert.equal(manifest.binaries.core, `bin/core${target.suffix}`);
       assert.ok(manifest.checksums[`bin/core${target.suffix}`]);
       assert.equal(Object.keys(manifest.checksums).some((key) => key.includes("\\")), false);
@@ -69,6 +70,23 @@ for (const target of [
     }
   });
 }
+
+test("writes trusted local mode into the desktop runtime manifest", () => {
+  const root = mkdtempSync(path.join(os.tmpdir(), "lazymind-manifest-trusted-"));
+  try {
+    execFileSync(process.execPath, [
+      manifestScript,
+      root,
+      "--platform", "windows",
+      "--arch", "amd64",
+      "--trusted-local-mode", "true",
+    ]);
+    const manifest = JSON.parse(readFileSync(path.join(root, "manifest.json"), "utf8"));
+    assert.deepEqual(manifest.features, { trustedLocalMode: true });
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
 
 test("generates a multi-resolution Windows ICO from the macOS icon", () => {
   const root = mkdtempSync(path.join(os.tmpdir(), "lazymind-icon-"));
@@ -212,6 +230,8 @@ test("Windows NSIS installer uses electron-builder's default LZMA payload", () =
   assert.match(buildScript, /maximumAttempts = 3/);
   assert.match(buildScript, /ELECTRON_CACHE/);
   assert.match(buildScript, /ELECTRON_BUILDER_CACHE/);
+  assert.match(buildScript, /LAZYMIND_TRUSTED_LOCAL_MODE/);
+  assert.match(buildScript, /--trusted-local-mode', \$trustedLocalMode/);
   assert.match(workflow, /Cache Electron and electron-builder downloads/);
   assert.match(workflow, /Submodule checkout attempt \$attempt\/3 failed/);
   assert.match(workflow, /pnpm activation attempt \$attempt\/3 failed/);
@@ -228,6 +248,8 @@ test("macOS distribution build signs packages while CI owns notarization sequenc
   assert.doesNotMatch(workflow, /pythonPrerelease|prereleaseNames/);
   assert.match(source, /PACKAGE_KIND=.*zip/);
   assert.match(source, /SIGNING_MODE=.*adhoc/);
+  assert.match(source, /LAZYMIND_TRUSTED_LOCAL_MODE/);
+  assert.match(source, /--trusted-local-mode "\$\{TRUSTED_LOCAL_MODE\}"/);
   assert.doesNotMatch(source, /notarytool submit/);
   assert.match(source, /Authority=Developer ID Application:/);
   assert.match(source, /signature_info="\$\(codesign -dv --verbose=4/);

--- a/desktop/scripts/write-runtime-manifest.mjs
+++ b/desktop/scripts/write-runtime-manifest.mjs
@@ -18,7 +18,13 @@ while (args.length > 0) {
 }
 
 if (!runtimeRoot || !options.platform || !options.arch) {
-  console.error("usage: write-runtime-manifest.mjs <runtime-root> --platform darwin|windows --arch arm64|amd64");
+  console.error("usage: write-runtime-manifest.mjs <runtime-root> --platform darwin|windows --arch arm64|amd64 [--trusted-local-mode true|false]");
+  process.exit(2);
+}
+
+const trustedLocalModeOption = options["trusted-local-mode"] ?? "false";
+if (!new Set(["true", "false"]).has(trustedLocalModeOption)) {
+  console.error("--trusted-local-mode must be true or false");
   process.exit(2);
 }
 
@@ -58,6 +64,9 @@ const manifest = {
   profile: "desktop",
   platform: options.platform,
   arch: options.arch,
+  features: {
+    trustedLocalMode: trustedLocalModeOption === "true"
+  },
   binaries: {
     "process-supervisor": executable("process-compose"),
     "local-proxy": executable("local-proxy"),

--- a/local/config.win.env.example
+++ b/local/config.win.env.example
@@ -1,5 +1,8 @@
 # Optional Windows-only overrides. Copy this file to local/config.win.env.
 # Values inherited from the shell or make command line take precedence.
 CGO_ENABLED=0
+# Trusted single-user builds only: bake unrestricted host file access and local
+# command tools into the Desktop package. Default: false.
+# LAZYMIND_TRUSTED_LOCAL_MODE=true
 # LAZYMIND_AUTH_SERVICE_UV=C:\Users\you\scoop\shims\uv.exe
 # PNPM=C:\Users\you\AppData\Roaming\npm\pnpm.cmd

--- a/local/local-runtime-manager/algorithm_service.go
+++ b/local/local-runtime-manager/algorithm_service.go
@@ -554,8 +554,10 @@ func algorithmServiceEnv(cfg RuntimeConfig, paths RuntimePaths, service string) 
 	noProxy := envText("no_proxy", "127.0.0.1,localhost,::1,core,chat,evo-api,doc-server,lazyllm-algo,parsing,milvus,opensearch,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16")
 	noProxyUpper := envText("NO_PROXY", noProxy)
 	routerPoolStart, routerPoolEnd := localRouterPortPool(cfg)
+	trustedLocalMode := paths.TrustedLocalMode || envBool("LAZYMIND_TRUSTED_LOCAL_MODE", false)
 	env := []string{
 		"LAZYMIND_RUNTIME_MODE=local",
+		"LAZYMIND_TRUSTED_LOCAL_MODE=" + strconv.FormatBool(trustedLocalMode),
 		"PYTHONPATH=" + pythonPath,
 		"LAZYMIND_HOME=" + paths.AlgorithmHome,
 		"LAZYLLM_HOME=" + paths.LazyLLMHome,

--- a/local/local-runtime-manager/algorithm_service_test.go
+++ b/local/local-runtime-manager/algorithm_service_test.go
@@ -120,6 +120,36 @@ func TestAlgorithmServiceEnvPinsLocalRouterHost(t *testing.T) {
 	assertEnvContains(t, env, "LAZYMIND_ROUTER_HOST=127.0.0.1")
 }
 
+func TestAlgorithmServiceEnvTrustedLocalMode(t *testing.T) {
+	repo := t.TempDir()
+	writeComposeFixture(t, repo)
+	cfg, paths, err := NewRuntimeConfig(defaultProfileValue(), repo)
+	if err != nil {
+		t.Fatalf("runtime config: %v", err)
+	}
+
+	for _, tc := range []struct {
+		name        string
+		manifest    bool
+		environment string
+		want        string
+	}{
+		{name: "disabled by default", want: "LAZYMIND_TRUSTED_LOCAL_MODE=false"},
+		{name: "enabled by desktop manifest", manifest: true, want: "LAZYMIND_TRUSTED_LOCAL_MODE=true"},
+		{name: "enabled by source environment", environment: "true", want: "LAZYMIND_TRUSTED_LOCAL_MODE=true"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("LAZYMIND_TRUSTED_LOCAL_MODE", tc.environment)
+			testPaths := paths
+			testPaths.TrustedLocalMode = tc.manifest
+
+			env := algorithmServiceEnv(cfg, testPaths, chatProcessName)
+
+			assertEnvContains(t, env, tc.want)
+		})
+	}
+}
+
 func TestDesktopAlgorithmRegisterPolicyForInstallVersion(t *testing.T) {
 	repo := t.TempDir()
 	writeComposeFixture(t, repo)

--- a/local/local-runtime-manager/config.go
+++ b/local/local-runtime-manager/config.go
@@ -216,6 +216,7 @@ type RuntimePaths struct {
 	AlgorithmHome            string
 	FrontendNodeModules      string
 	AlgorithmPIDDir          string
+	TrustedLocalMode         bool
 }
 
 type RuntimeConfig struct {
@@ -965,6 +966,7 @@ func applyDesktopManifestPaths(paths *RuntimePaths) error {
 		}
 		return filepath.Join(paths.ResourcesRoot, value)
 	}
+	paths.TrustedLocalMode = manifest.Features.TrustedLocalMode
 	if value := joinResource(manifest.Binaries[processComposeServiceName]); value != "" {
 		paths.ProcessComposeBin = value
 	}

--- a/local/local-runtime-manager/manifest.go
+++ b/local/local-runtime-manager/manifest.go
@@ -15,10 +15,15 @@ type RuntimeManifest struct {
 	Profile   string                     `json:"profile"`
 	Platform  string                     `json:"platform"`
 	Arch      string                     `json:"arch"`
+	Features  RuntimeManifestFeatures    `json:"features,omitempty"`
 	Binaries  map[string]string          `json:"binaries"`
 	Paths     RuntimeManifestPaths       `json:"paths"`
 	Services  map[string]ManifestService `json:"services,omitempty"`
 	Checksums map[string]string          `json:"checksums,omitempty"`
+}
+
+type RuntimeManifestFeatures struct {
+	TrustedLocalMode bool `json:"trustedLocalMode,omitempty"`
 }
 
 type RuntimeManifestPaths struct {

--- a/local/local-runtime-manager/manifest_test.go
+++ b/local/local-runtime-manager/manifest_test.go
@@ -1,0 +1,36 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+func TestApplyDesktopManifestPathsLoadsTrustedLocalMode(t *testing.T) {
+	resourcesRoot := t.TempDir()
+	manifest := RuntimeManifest{
+		Version:  1,
+		Profile:  "desktop",
+		Platform: runtime.GOOS,
+		Arch:     runtime.GOARCH,
+		Features: RuntimeManifestFeatures{TrustedLocalMode: true},
+	}
+	body, err := json.Marshal(manifest)
+	if err != nil {
+		t.Fatalf("marshal runtime manifest: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(resourcesRoot, runtimeManifestFileName), body, 0o644); err != nil {
+		t.Fatalf("write runtime manifest: %v", err)
+	}
+	paths := RuntimePaths{ResourcesRoot: resourcesRoot}
+
+	if err := applyDesktopManifestPaths(&paths); err != nil {
+		t.Fatalf("apply desktop runtime manifest: %v", err)
+	}
+
+	if !paths.TrustedLocalMode {
+		t.Fatal("trusted local mode was not loaded from the desktop runtime manifest")
+	}
+}

--- a/tests/algorithm/chat/test_agent_executor.py
+++ b/tests/algorithm/chat/test_agent_executor.py
@@ -56,6 +56,17 @@ def test_executor_does_not_pause_subagent_on_round_limit(monkeypatch) -> None:
     assert constructor.call_args.kwargs['on_max_retries'] is None
 
 
+def test_executor_enables_builtin_tools_in_trusted_local_mode(monkeypatch) -> None:
+    agent = MagicMock()
+    constructor = MagicMock(return_value=agent)
+    monkeypatch.setattr(executor_mod._agent_mod, 'ReactAgent', constructor)
+
+    with executor_mod._cfg.temp('trusted_local_mode', True):
+        AgentExecutor().create_agent('llm', _plan())
+
+    assert constructor.call_args.kwargs['enable_builtin_tools'] is True
+
+
 def test_executor_auto_expands_after_plugin_or_subagent_tool(monkeypatch) -> None:
     agent = MagicMock()
     agent._tools_manager = MagicMock(return_value=[{'ok': True}])

--- a/tests/algorithm/chat/test_windows_tool_compatibility.py
+++ b/tests/algorithm/chat/test_windows_tool_compatibility.py
@@ -2,6 +2,8 @@ import os
 import ntpath
 from pathlib import Path
 
+import pytest
+
 from lazyllm.tools.fs import client as fs_client
 from lazymind.chat.engine.tools import chat_artifact
 
@@ -91,3 +93,34 @@ def test_chat_write_file_append_does_not_require_overwrite_approval(tmp_path, mo
     assert first['status'] == 'ok'
     assert appended['status'] == 'ok'
     assert chat_artifact.read_file('document.md')['content'] == 'first second'
+
+
+def test_chat_file_tools_reject_outside_workspace_by_default(tmp_path, monkeypatch):
+    workspace = tmp_path / 'workspace'
+    outside = tmp_path / 'outside' / 'document.md'
+    monkeypatch.setattr(chat_artifact, 'chat_agent_workspace', lambda *_args: str(workspace))
+    monkeypatch.setattr(
+        chat_artifact, '_current_artifact_scope', lambda: ('windows-user', 'windows-conversation'),
+    )
+
+    with pytest.raises(ValueError, match='inside the current main-Agent workspace'):
+        chat_artifact.write_file(str(outside), 'blocked')
+
+
+def test_chat_file_tools_allow_absolute_host_paths_in_trusted_local_mode(tmp_path, monkeypatch):
+    workspace = tmp_path / 'workspace'
+    outside_dir = tmp_path / 'outside'
+    outside = outside_dir / 'document.md'
+    monkeypatch.setattr(chat_artifact, 'chat_agent_workspace', lambda *_args: str(workspace))
+    monkeypatch.setattr(
+        chat_artifact, '_current_artifact_scope', lambda: ('windows-user', 'windows-conversation'),
+    )
+
+    with chat_artifact._cfg.temp('trusted_local_mode', True):
+        written = chat_artifact.write_file(str(outside), 'trusted')
+        loaded = chat_artifact.read_file(str(outside))
+        listed = chat_artifact.list_dir(str(outside_dir))
+
+    assert written['status'] == 'ok'
+    assert loaded['content'] == 'trusted'
+    assert listed['entries'] == ['document.md']


### PR DESCRIPTION
Adds an opt-in trusted local mode controlled by `LAZYMIND_TRUSTED_LOCAL_MODE`.
When enabled, LazyMind can:

- Read and write files outside the workspace, including paths on other drives.
- Use command-line tools such as shell_tool.
- Propagate the setting through desktop packaging and local runtime startup.

<img width="1488" height="894" alt="image" src="https://github.com/user-attachments/assets/bd5a4274-7eb2-4080-826f-4ed287e2b46e" />
