### PR TITLE
fix(skill): allow enabling a draft without a base revision

### DIFF
--- a/backend/core/skillv2/service/service.go
+++ b/backend/core/skillv2/service/service.go
@@ -1212,13 +1212,15 @@ func mergedDraftEntriesForSkill(ctx context.Context, tx *gorm.DB, skill skillRow
 	if baseRevisionID == "" {
 		baseRevisionID = valueOrEmpty(skill.HeadRevisionID)
 	}
-	if baseRevisionID == "" {
-		return nil, "", fmt.Errorf("skill has no base revision")
-	}
 
 	var baseEntries []skillRevisionEntryRow
-	if err := tx.WithContext(ctx).Where("revision_id = ?", baseRevisionID).Order("path ASC").Find(&baseEntries).Error; err != nil {
-		return nil, "", err
+	// A package created through RemoteFS starts as a draft without a published
+	// revision. Enabling it is its initial commit, so an empty base is valid and
+	// the draft overlays themselves form the complete revision tree.
+	if baseRevisionID != "" {
+		if err := tx.WithContext(ctx).Where("revision_id = ?", baseRevisionID).Order("path ASC").Find(&baseEntries).Error; err != nil {
+			return nil, "", err
+		}
 	}
 	entriesByPath := make(map[string]skillRevisionEntryRow, len(baseEntries))
 	for _, entry := range baseEntries {


### PR DESCRIPTION
Allow newly created skill drafts to be enabled when they do not yet have a base or head revision.

Previously, enabling such a skill returned `skill has no base revision`. The draft overlays now form the initial revision tree, consistent with the existing initial commit behavior.
