### PR TITLE
fix(frontend): restore Memory SDK contract and guard generated clients

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,6 +69,10 @@ jobs:
         with:
           node-version: '20'
 
+      - name: Verify generated OpenAPI clients
+        working-directory: frontend
+        run: node scripts/openapi/check-stale.mjs
+
       - name: Install and test with coverage
         run: |
           cd tests/frontend

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,6 +7,7 @@
   "scripts": {
     "predev": "bash scripts/openapi/generate-auth.sh",
     "dev": "vite --clearScreen false",
+    "prebuild": "node scripts/openapi/check-stale.mjs",
     "build": "vite build",
     "preview": "vite preview",
     "gen:openapi": "node scripts/openapi/generate-api.mjs",

--- a/frontend/scripts/openapi/.openapi-cache.json
+++ b/frontend/scripts/openapi/.openapi-cache.json
@@ -1,6 +1,9 @@
 {
   "auth": "4fc46a4a59a91e07538d22b7855fabab24d2f6cc4c93da3a7a5e9bd5db5a5a5a",
-  "core": "189d176636bc73febefdbec896bc61b79a49231b33ed588c2dc7dd9c62c0635e",
+  "core": {
+    "specHash": "189d176636bc73febefdbec896bc61b79a49231b33ed588c2dc7dd9c62c0635e",
+    "outputHash": "8fbe861f6591b4dfe88f5db4fe4737e744bf93fdb7e4f53cfcee8d4ed2d98f96"
+  },
   "scan": "f26bd2b462f1e95a130bbff6ab4148a2bbdd1dfd873156dad076e4f6ae0af389",
   "channel-gateway": "78ea73040435bdc1bf8d6c767f2e1a017399b68b7001ac013de81fdacb576e4f"
 }

--- a/frontend/scripts/openapi/check-stale.mjs
+++ b/frontend/scripts/openapi/check-stale.mjs
@@ -2,7 +2,7 @@ import fs from "fs";
 import {
   getOpenApiApis,
   getOpenApiCacheFilePath,
-  hashFile,
+  getOpenApiStatus,
 } from "./openapi-manifest.mjs";
 
 const cwdPath = process.cwd();
@@ -22,34 +22,19 @@ if (fs.existsSync(cacheFilePath)) {
   }
 }
 
-const statuses = apis.map((api) => {
-  const exists = fs.existsSync(api.input);
-  const currentHash = exists ? hashFile(api.input) : "";
-  const cachedHash = cache[api.name] || "";
-
-  return {
-    name: api.name,
-    input: api.input,
-    exists,
-    currentHash,
-    cachedHash,
-    stale: exists && currentHash !== cachedHash,
-  };
-});
+const statuses = apis.map((api) => getOpenApiStatus(api, cache[api.name]));
 
 if (jsonOutput) {
   process.stdout.write(`${JSON.stringify(statuses, null, 2)}\n`);
 } else if (!quiet) {
   statuses.forEach((status) => {
-    const state = !status.exists
-      ? "missing"
-      : status.stale
-        ? "stale"
-        : "fresh";
+    const state = status.stale
+      ? `stale (${status.reasons.join(", ")})`
+      : "fresh";
     process.stdout.write(`${status.name}: ${state}\n`);
   });
 }
 
-if (statuses.some((status) => status.stale || !status.exists)) {
+if (statuses.some((status) => status.stale)) {
   process.exit(1);
 }

--- a/frontend/scripts/openapi/generate-api.mjs
+++ b/frontend/scripts/openapi/generate-api.mjs
@@ -11,7 +11,12 @@ import {
   getOpenApiApis,
   getOpenApiCacheFilePath,
   hashFile,
+  normalizeOpenApiCacheEntry,
 } from "./openapi-manifest.mjs";
+import {
+  inspectGeneratedClientOutput,
+  postProcessGeneratedClient,
+} from "./generated-client-utils.mjs";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -36,8 +41,12 @@ if (target && selectedApis.length === 0) {
 
 const cacheFilePath = getOpenApiCacheFilePath(cwdPath);
 let cache = {};
-if (!skipCache && fs.existsSync(cacheFilePath)) {
-  cache = JSON.parse(fs.readFileSync(cacheFilePath, "utf-8"));
+if (fs.existsSync(cacheFilePath)) {
+  try {
+    cache = JSON.parse(fs.readFileSync(cacheFilePath, "utf-8"));
+  } catch {
+    cache = {};
+  }
 }
 
 function resolveOpenApiGeneratorCommand() {
@@ -81,76 +90,6 @@ function commandExists(command) {
   }
 }
 
-/**
- * Patch generated base.ts to use VITE_API_BASE_URL env variable instead of
- * the hardcoded "http://localhost" that the OpenAPI generator emits by default.
- */
-function patchBasePath(outputDir) {
-  const baseTsPath = path.resolve(outputDir, 'base.ts');
-  if (!fs.existsSync(baseTsPath)) return;
-
-  const original = fs.readFileSync(baseTsPath, 'utf-8');
-  const patched = original.replace(
-    /export const BASE_PATH\s*=\s*"[^"]*"\.replace\(.*?\);/,
-    'export const BASE_PATH = (typeof import.meta !== "undefined" && import.meta.env?.VITE_API_BASE_URL) ? import.meta.env.VITE_API_BASE_URL.replace(/\\/+$/, "") : "http://localhost";',
-  );
-
-  if (patched !== original) {
-    fs.writeFileSync(baseTsPath, patched, 'utf-8');
-    console.log(`🔧 Patched BASE_PATH in ${path.relative(cwdPath, baseTsPath)}`);
-  }
-}
-
-function patchNullableRecursiveMemoryValue(outputDir) {
-  const apiTsPath = path.resolve(outputDir, "api.ts");
-  if (!fs.existsSync(apiTsPath)) return;
-
-  const original = fs.readFileSync(apiTsPath, "utf-8");
-  const patched = original.replace(
-    /export type CurrentMemoryDocumentValue = (?!null \| )/,
-    "export type CurrentMemoryDocumentValue = null | ",
-  );
-  if (patched !== original) {
-    fs.writeFileSync(apiTsPath, patched, "utf-8");
-    console.log(
-      `🔧 Preserved nullable CurrentMemoryDocumentValue in ${path.relative(cwdPath, apiTsPath)}`,
-    );
-  }
-}
-
-function removeUnusedGeneratedFiles(outputDir) {
-  const unusedFiles = ["git_push.sh"];
-
-  for (const filename of unusedFiles) {
-    const filePath = path.resolve(outputDir, filename);
-    if (fs.existsSync(filePath)) {
-      fs.rmSync(filePath);
-      console.log(`🧹 Removed unused generated file ${path.relative(cwdPath, filePath)}`);
-    }
-  }
-}
-
-function normalizeGeneratedTypeScript(outputDir) {
-  for (const filename of [
-    "api.ts",
-    "base.ts",
-    "common.ts",
-    "configuration.ts",
-    "index.ts",
-  ]) {
-    const filePath = path.resolve(outputDir, filename);
-    if (!fs.existsSync(filePath)) continue;
-
-    const original = fs.readFileSync(filePath, "utf-8");
-    const normalized = `${original
-      .replace(/[ \t]+$/gm, "")
-      .replace(/[\r\n]+$/u, "")}\n`;
-    if (normalized !== original) {
-      fs.writeFileSync(filePath, normalized, "utf-8");
-    }
-  }
-}
-
 let updated = false;
 const openApiGeneratorCommand = resolveOpenApiGeneratorCommand();
 for (const api of selectedApis) {
@@ -161,9 +100,14 @@ for (const api of selectedApis) {
     continue;
   }
   const currentHash = hashFile(api.input);
-  const prevHash = cache[api.name];
+  const cached = normalizeOpenApiCacheEntry(cache[api.name]);
+  const currentOutput = inspectGeneratedClientOutput(api.output);
+  const outputMatches =
+    !cached.strictOutput ||
+    (currentOutput.missingFiles.length === 0 &&
+      currentOutput.hash === cached.outputHash);
 
-  if (!skipCache && currentHash === prevHash) {
+  if (!skipCache && currentHash === cached.specHash && outputMatches) {
     console.log(`✅ ${api.name}: No changes detected.`);
     continue;
   }
@@ -176,11 +120,17 @@ for (const api of selectedApis) {
       `${openApiGeneratorCommand} generate --skip-validate-spec -c scripts/openapi/openapi-generator-config.json -i "${api.input}" -o "${api.output}"`,
       { stdio: "inherit", cwd: cwdPath },
     );
-    patchBasePath(api.output);
-    patchNullableRecursiveMemoryValue(api.output);
-    removeUnusedGeneratedFiles(api.output);
-    normalizeGeneratedTypeScript(api.output);
-    cache[api.name] = currentHash;
+    postProcessGeneratedClient(api.output, { cwdPath });
+    const generatedOutput = inspectGeneratedClientOutput(api.output);
+    if (generatedOutput.missingFiles.length > 0) {
+      throw new Error(
+        `Generated output is incomplete: ${generatedOutput.missingFiles.join(", ")}`,
+      );
+    }
+    cache[api.name] = {
+      specHash: currentHash,
+      outputHash: generatedOutput.hash,
+    };
     updated = true;
   } catch (error) {
     console.error(`❌ Failed to generate API "${api.name}":`, error);
@@ -188,7 +138,7 @@ for (const api of selectedApis) {
   }
 }
 
-if (!skipCache && updated) {
+if (updated) {
   fs.writeFileSync(cacheFilePath, JSON.stringify(cache, null, 2));
   console.log("💾 Cache updated");
 }

--- a/frontend/scripts/openapi/generated-client-utils.mjs
+++ b/frontend/scripts/openapi/generated-client-utils.mjs
@@ -1,0 +1,104 @@
+import { createHash } from "crypto";
+import fs from "fs";
+import path from "path";
+
+export const GENERATED_TYPESCRIPT_FILES = Object.freeze([
+  "api.ts",
+  "base.ts",
+  "common.ts",
+  "configuration.ts",
+  "index.ts",
+]);
+
+export function hashFile(filePath) {
+  if (!fs.existsSync(filePath)) return "";
+  return createHash("sha256").update(fs.readFileSync(filePath)).digest("hex");
+}
+
+export function inspectGeneratedClientOutput(outputDir) {
+  const missingFiles = GENERATED_TYPESCRIPT_FILES.filter(
+    (filename) => !fs.existsSync(path.resolve(outputDir, filename)),
+  );
+
+  if (missingFiles.length > 0) {
+    return { hash: "", missingFiles };
+  }
+
+  const hash = createHash("sha256");
+  for (const filename of GENERATED_TYPESCRIPT_FILES) {
+    hash.update(filename);
+    hash.update("\0");
+    hash.update(fs.readFileSync(path.resolve(outputDir, filename)));
+    hash.update("\0");
+  }
+
+  return { hash: hash.digest("hex"), missingFiles: [] };
+}
+
+function patchBasePath(outputDir, cwdPath, logger) {
+  const baseTsPath = path.resolve(outputDir, "base.ts");
+  if (!fs.existsSync(baseTsPath)) return;
+
+  const original = fs.readFileSync(baseTsPath, "utf-8");
+  const patched = original.replace(
+    /export const BASE_PATH\s*=\s*"[^"]*"\.replace\(.*?\);/,
+    'export const BASE_PATH = (typeof import.meta !== "undefined" && import.meta.env?.VITE_API_BASE_URL) ? import.meta.env.VITE_API_BASE_URL.replace(/\\/+$/, "") : "http://localhost";',
+  );
+
+  if (patched !== original) {
+    fs.writeFileSync(baseTsPath, patched, "utf-8");
+    logger.log(`🔧 Patched BASE_PATH in ${path.relative(cwdPath, baseTsPath)}`);
+  }
+}
+
+function patchNullableRecursiveMemoryValue(outputDir, cwdPath, logger) {
+  const apiTsPath = path.resolve(outputDir, "api.ts");
+  if (!fs.existsSync(apiTsPath)) return;
+
+  const original = fs.readFileSync(apiTsPath, "utf-8");
+  const patched = original.replace(
+    /export type CurrentMemoryDocumentValue = (?!null \| )/,
+    "export type CurrentMemoryDocumentValue = null | ",
+  );
+  if (patched !== original) {
+    fs.writeFileSync(apiTsPath, patched, "utf-8");
+    logger.log(
+      `🔧 Preserved nullable CurrentMemoryDocumentValue in ${path.relative(cwdPath, apiTsPath)}`,
+    );
+  }
+}
+
+function removeUnusedGeneratedFiles(outputDir, cwdPath, logger) {
+  for (const filename of ["git_push.sh"]) {
+    const filePath = path.resolve(outputDir, filename);
+    if (fs.existsSync(filePath)) {
+      fs.rmSync(filePath);
+      logger.log(`🧹 Removed unused generated file ${path.relative(cwdPath, filePath)}`);
+    }
+  }
+}
+
+function normalizeGeneratedTypeScript(outputDir) {
+  for (const filename of GENERATED_TYPESCRIPT_FILES) {
+    const filePath = path.resolve(outputDir, filename);
+    if (!fs.existsSync(filePath)) continue;
+
+    const original = fs.readFileSync(filePath, "utf-8");
+    const normalized = `${original
+      .replace(/[ \t]+$/gm, "")
+      .replace(/[\r\n]+$/u, "")}\n`;
+    if (normalized !== original) {
+      fs.writeFileSync(filePath, normalized, "utf-8");
+    }
+  }
+}
+
+export function postProcessGeneratedClient(
+  outputDir,
+  { cwdPath = process.cwd(), logger = console } = {},
+) {
+  patchBasePath(outputDir, cwdPath, logger);
+  patchNullableRecursiveMemoryValue(outputDir, cwdPath, logger);
+  removeUnusedGeneratedFiles(outputDir, cwdPath, logger);
+  normalizeGeneratedTypeScript(outputDir);
+}

--- a/frontend/scripts/openapi/openapi-manifest.mjs
+++ b/frontend/scripts/openapi/openapi-manifest.mjs
@@ -1,6 +1,10 @@
-import fs from "fs";
 import path from "path";
-import { createHash } from "crypto";
+import {
+  hashFile,
+  inspectGeneratedClientOutput,
+} from "./generated-client-utils.mjs";
+
+export { hashFile } from "./generated-client-utils.mjs";
 
 export function getOpenApiApis(cwdPath = process.cwd()) {
   const outputDirname = path.resolve(cwdPath, "src/api/generated");
@@ -34,8 +38,54 @@ export function getOpenApiCacheFilePath(cwdPath = process.cwd()) {
   return path.resolve(cwdPath, "scripts/openapi/.openapi-cache.json");
 }
 
-export function hashFile(filePath) {
-  if (!fs.existsSync(filePath)) return "";
-  const content = fs.readFileSync(filePath);
-  return createHash("sha256").update(content).digest("hex");
+export function normalizeOpenApiCacheEntry(entry) {
+  if (typeof entry === "string") {
+    return { specHash: entry, outputHash: "", strictOutput: false };
+  }
+
+  if (entry && typeof entry === "object" && !Array.isArray(entry)) {
+    return {
+      specHash: typeof entry.specHash === "string" ? entry.specHash : "",
+      outputHash: typeof entry.outputHash === "string" ? entry.outputHash : "",
+      strictOutput: true,
+    };
+  }
+
+  return { specHash: "", outputHash: "", strictOutput: false };
+}
+
+export function getOpenApiStatus(api, cacheEntry) {
+  const cached = normalizeOpenApiCacheEntry(cacheEntry);
+  const currentSpecHash = hashFile(api.input);
+  const output = inspectGeneratedClientOutput(api.output);
+  const reasons = [];
+
+  if (!currentSpecHash) {
+    reasons.push("missing_spec");
+  } else if (currentSpecHash !== cached.specHash) {
+    reasons.push("spec_changed");
+  }
+
+  if (cached.strictOutput) {
+    if (output.missingFiles.length > 0) {
+      reasons.push("missing_output");
+    } else if (output.hash !== cached.outputHash) {
+      reasons.push("output_changed");
+    }
+  }
+
+  return {
+    name: api.name,
+    input: api.input,
+    output: api.output,
+    exists: Boolean(currentSpecHash),
+    currentHash: currentSpecHash,
+    cachedHash: cached.specHash,
+    currentOutputHash: output.hash,
+    cachedOutputHash: cached.outputHash,
+    missingOutputFiles: output.missingFiles,
+    strictOutput: cached.strictOutput,
+    reasons,
+    stale: reasons.length > 0,
+  };
 }

--- a/frontend/src/api/generated/core-client/api.ts
+++ b/frontend/src/api/generated/core-client/api.ts
@@ -2659,6 +2659,263 @@ export interface WriterDocumentSyncOpenAPIRequest {
     'revised_document'?: { [key: string]: object; };
     'source_document'?: { [key: string]: object; };
 }
+export interface CurrentMemoryAvatarData {
+    'content_type': CurrentMemoryAvatarDataContentTypeEnum;
+    'kind': CurrentMemoryAvatarDataKindEnum;
+    'size': number;
+    'updated_at': number;
+}
+
+
+export const CurrentMemoryAvatarDataContentTypeEnum = {
+    ImagePng: 'image/png',
+    ImageJpeg: 'image/jpeg',
+    ImageWebp: 'image/webp'
+} as const;
+
+
+export type CurrentMemoryAvatarDataContentTypeEnum = typeof CurrentMemoryAvatarDataContentTypeEnum[keyof typeof CurrentMemoryAvatarDataContentTypeEnum];
+
+export const CurrentMemoryAvatarDataKindEnum = {
+    Soul: 'soul',
+    Profile: 'profile'
+} as const;
+
+
+export type CurrentMemoryAvatarDataKindEnum = typeof CurrentMemoryAvatarDataKindEnum[keyof typeof CurrentMemoryAvatarDataKindEnum];
+
+
+export interface CurrentMemoryAvatarResponse {
+    'code': number;
+    'data': CurrentMemoryAvatarData;
+    'message': string;
+}
+
+export interface CurrentMemoryConflictData {
+    'current_etag'?: string;
+}
+
+/**
+ * @type CurrentMemoryDocumentValue
+ */
+export type CurrentMemoryDocumentValue = null | Array<string> | string | { [key: string]: CurrentMemoryDocumentValue; };
+
+
+export interface CurrentMemoryErrorResponse {
+    'code': number;
+    'data'?: CurrentMemoryConflictData;
+    'message': string;
+}
+
+export interface CurrentMemoryOperation {
+    'op': CurrentMemoryOperationOpEnum;
+    'path': string;
+    'value'?: string;
+}
+
+
+export const CurrentMemoryOperationOpEnum = {
+    Set: 'set',
+    Clear: 'clear',
+    Add: 'add',
+    Remove: 'remove'
+} as const;
+
+
+export type CurrentMemoryOperationOpEnum = typeof CurrentMemoryOperationOpEnum[keyof typeof CurrentMemoryOperationOpEnum];
+
+
+export interface CurrentMemoryOperationsRequest {
+    'operations': Array<CurrentMemoryOperation>;
+}
+
+export interface CurrentMemoryPreferenceDetailData {
+    'item': CurrentMemoryPreferenceItem;
+    'reference': CurrentMemoryReference | null;
+    'reference_status': CurrentMemoryPreferenceDetailDataReferenceStatusEnum;
+}
+
+
+export const CurrentMemoryPreferenceDetailDataReferenceStatusEnum = {
+    Available: 'available',
+    Missing: 'missing'
+} as const;
+
+
+export type CurrentMemoryPreferenceDetailDataReferenceStatusEnum = typeof CurrentMemoryPreferenceDetailDataReferenceStatusEnum[keyof typeof CurrentMemoryPreferenceDetailDataReferenceStatusEnum];
+
+
+export interface CurrentMemoryPreferenceDetailResponse {
+    'code': number;
+    'data': CurrentMemoryPreferenceDetailData;
+    'message': string;
+}
+
+export interface CurrentMemoryPreferenceItem {
+    'created_at': string;
+    'name': string;
+    'summary': string;
+    'updated_at': string;
+}
+
+export interface CurrentMemoryPreferenceListData {
+    'etag': string;
+    'items': Array<CurrentMemoryPreferenceItem>;
+    'resident_index_usage': CurrentMemoryPreferenceResidentIndexUsage;
+    'total_size': number;
+    'updated_at': number;
+}
+
+export interface CurrentMemoryPreferenceListResponse {
+    'code': number;
+    'data': CurrentMemoryPreferenceListData;
+    'message': string;
+}
+
+export interface CurrentMemoryPreferenceOrderRequest {
+    'expected_etag': string;
+    'ordered_names': Array<string>;
+}
+
+export interface CurrentMemoryPreferenceResidentIndexUsage {
+    'max_items': number;
+    'over_limit': boolean;
+    'used_items': number;
+}
+
+export interface CurrentMemoryPresentation {
+    'fallbacks': { [key: string]: { [key: string]: string; }; };
+    'sections': Array<CurrentMemoryPresentationSection>;
+}
+
+export interface CurrentMemoryPresentationField {
+    'labels': { [key: string]: string; };
+    'path': string;
+    'summary_role': CurrentMemoryPresentationFieldSummaryRoleEnum;
+}
+
+
+export const CurrentMemoryPresentationFieldSummaryRoleEnum = {
+    Title: 'title',
+    Subtitle: 'subtitle',
+    Description: 'description',
+    Tag: 'tag',
+    None: 'none'
+} as const;
+
+
+export type CurrentMemoryPresentationFieldSummaryRoleEnum = typeof CurrentMemoryPresentationFieldSummaryRoleEnum[keyof typeof CurrentMemoryPresentationFieldSummaryRoleEnum];
+
+
+export interface CurrentMemoryPresentationSection {
+    'fields': Array<CurrentMemoryPresentationField>;
+    'labels': { [key: string]: string; };
+    'path': string;
+}
+
+export interface CurrentMemoryProfileData {
+    'document': { [key: string]: CurrentMemoryDocumentValue; };
+    'presentation': CurrentMemoryPresentation;
+    'template_version': number;
+    'updated_at': number;
+}
+
+export interface CurrentMemoryProfileResponse {
+    'code': number;
+    'data': CurrentMemoryProfileData;
+    'message': string;
+}
+
+export interface CurrentMemoryReference {
+    'application_scenarios': string;
+    'created_at': string;
+    'name': string;
+    'preference_details': string;
+    'reason': string;
+    'source': CurrentMemoryReferenceSource;
+    'summary': string;
+    'updated_at': string;
+}
+
+export interface CurrentMemoryReferenceSource {
+    'conversation_id': string;
+    'kind': CurrentMemoryReferenceSourceKindEnum;
+}
+
+
+export const CurrentMemoryReferenceSourceKindEnum = {
+    MemoryReview: 'memory_review',
+    ChatExplicit: 'chat_explicit'
+} as const;
+
+
+export type CurrentMemoryReferenceSourceKindEnum = typeof CurrentMemoryReferenceSourceKindEnum[keyof typeof CurrentMemoryReferenceSourceKindEnum];
+
+
+export interface CurrentMemorySoulData {
+    'document': { [key: string]: CurrentMemoryDocumentValue; };
+    'presentation': CurrentMemoryPresentation;
+    'template_version': number;
+    'updated_at': number;
+}
+
+export interface CurrentMemorySoulResponse {
+    'code': number;
+    'data': CurrentMemorySoulData;
+    'message': string;
+}
+
+export interface EpisodeMemory {
+    'conversation_id': string;
+    'episode_type': EpisodeMemoryEpisodeTypeEnum;
+    'hit_count': number;
+    'id': string;
+    'occurred_at_ms': number;
+    'recorded_at_ms': number;
+    'source_kind': EpisodeMemorySourceKindEnum;
+    'summary': string;
+}
+
+
+export const EpisodeMemoryEpisodeTypeEnum = {
+    Decision: 'decision',
+    Progress: 'progress',
+    Result: 'result',
+    Blocker: 'blocker',
+    Event: 'event'
+} as const;
+
+
+export type EpisodeMemoryEpisodeTypeEnum = typeof EpisodeMemoryEpisodeTypeEnum[keyof typeof EpisodeMemoryEpisodeTypeEnum];
+
+export const EpisodeMemorySourceKindEnum = {
+    ChatExplicit: 'chat_explicit',
+    MemoryReview: 'memory_review'
+} as const;
+
+
+export type EpisodeMemorySourceKindEnum = typeof EpisodeMemorySourceKindEnum[keyof typeof EpisodeMemorySourceKindEnum];
+
+
+export interface EpisodeMemoryDetailResponse {
+    'code': number;
+    'data': EpisodeMemory;
+    'message': string;
+}
+
+export interface EpisodeMemoryListData {
+    'items': Array<EpisodeMemory>;
+    'next_page_token': string;
+    'total_size': number;
+}
+
+export interface EpisodeMemoryListResponse {
+    'code': number;
+    'data': EpisodeMemoryListData;
+    'message': string;
+}
+
+
 
 /**
  * AgentApi - axios parameter creator
@@ -12200,6 +12457,577 @@ export const DefaultApiAxiosParamCreator = function (configuration?: Configurati
                 options: localVarRequestOptions,
             };
         },
+        /**
+         *
+         * @summary Delete an Episode Memory item
+         * @param {string} episodeId
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        apiCoreMemoryEpisodesEpisodeIdDelete: async (episodeId: string, options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
+            // verify required parameter 'episodeId' is not null or undefined
+            assertParamExists('apiCoreMemoryEpisodesEpisodeIdDelete', 'episodeId', episodeId)
+            const localVarPath = `/api/core/memory/episodes/{episode_id}`
+                .replace(`{${"episode_id"}}`, encodeURIComponent(String(episodeId)));
+            // use dummy base URL string because the URL constructor only accepts absolute URLs.
+            const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
+            let baseOptions;
+            if (configuration) {
+                baseOptions = configuration.baseOptions;
+            }
+
+            const localVarRequestOptions = { method: 'DELETE', ...baseOptions, ...options};
+            const localVarHeaderParameter = {} as any;
+            const localVarQueryParameter = {} as any;
+
+            localVarHeaderParameter['Accept'] = 'application/json';
+
+            setSearchParams(localVarUrlObj, localVarQueryParameter);
+            let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+
+            return {
+                url: toPathString(localVarUrlObj),
+                options: localVarRequestOptions,
+            };
+        },
+        /**
+         *
+         * @summary Get an Episode Memory item
+         * @param {string} episodeId
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        apiCoreMemoryEpisodesEpisodeIdGet: async (episodeId: string, options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
+            // verify required parameter 'episodeId' is not null or undefined
+            assertParamExists('apiCoreMemoryEpisodesEpisodeIdGet', 'episodeId', episodeId)
+            const localVarPath = `/api/core/memory/episodes/{episode_id}`
+                .replace(`{${"episode_id"}}`, encodeURIComponent(String(episodeId)));
+            // use dummy base URL string because the URL constructor only accepts absolute URLs.
+            const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
+            let baseOptions;
+            if (configuration) {
+                baseOptions = configuration.baseOptions;
+            }
+
+            const localVarRequestOptions = { method: 'GET', ...baseOptions, ...options};
+            const localVarHeaderParameter = {} as any;
+            const localVarQueryParameter = {} as any;
+
+            localVarHeaderParameter['Accept'] = 'application/json';
+
+            setSearchParams(localVarUrlObj, localVarQueryParameter);
+            let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+
+            return {
+                url: toPathString(localVarUrlObj),
+                options: localVarRequestOptions,
+            };
+        },
+        /**
+         *
+         * @summary List current user\'s Episode Memory
+         * @param {number} [pageSize]
+         * @param {string} [pageToken]
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        apiCoreMemoryEpisodesGet: async (pageSize?: number, pageToken?: string, options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
+            const localVarPath = `/api/core/memory/episodes`;
+            // use dummy base URL string because the URL constructor only accepts absolute URLs.
+            const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
+            let baseOptions;
+            if (configuration) {
+                baseOptions = configuration.baseOptions;
+            }
+
+            const localVarRequestOptions = { method: 'GET', ...baseOptions, ...options};
+            const localVarHeaderParameter = {} as any;
+            const localVarQueryParameter = {} as any;
+
+            if (pageSize !== undefined) {
+                localVarQueryParameter['page_size'] = pageSize;
+            }
+
+            if (pageToken !== undefined) {
+                localVarQueryParameter['page_token'] = pageToken;
+            }
+
+            localVarHeaderParameter['Accept'] = 'application/json';
+
+            setSearchParams(localVarUrlObj, localVarQueryParameter);
+            let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+
+            return {
+                url: toPathString(localVarUrlObj),
+                options: localVarRequestOptions,
+            };
+        },
+        /**
+         *
+         * @summary List current user\'s Preference memory
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        apiCoreMemoryPreferencesGet: async (options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
+            const localVarPath = `/api/core/memory/preferences`;
+            // use dummy base URL string because the URL constructor only accepts absolute URLs.
+            const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
+            let baseOptions;
+            if (configuration) {
+                baseOptions = configuration.baseOptions;
+            }
+
+            const localVarRequestOptions = { method: 'GET', ...baseOptions, ...options};
+            const localVarHeaderParameter = {} as any;
+            const localVarQueryParameter = {} as any;
+
+            localVarHeaderParameter['Accept'] = 'application/json';
+
+            setSearchParams(localVarUrlObj, localVarQueryParameter);
+            let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+
+            return {
+                url: toPathString(localVarUrlObj),
+                options: localVarRequestOptions,
+            };
+        },
+        /**
+         * Atomically removes the item and its now-unreferenced reference file. Missing items, including other users\' items, are idempotent success.
+         * @summary Delete a current Preference item
+         * @param {string} name
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        apiCoreMemoryPreferencesNameDelete: async (name: string, options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
+            // verify required parameter 'name' is not null or undefined
+            assertParamExists('apiCoreMemoryPreferencesNameDelete', 'name', name)
+            const localVarPath = `/api/core/memory/preferences/{name}`
+                .replace(`{${"name"}}`, encodeURIComponent(String(name)));
+            // use dummy base URL string because the URL constructor only accepts absolute URLs.
+            const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
+            let baseOptions;
+            if (configuration) {
+                baseOptions = configuration.baseOptions;
+            }
+
+            const localVarRequestOptions = { method: 'DELETE', ...baseOptions, ...options};
+            const localVarHeaderParameter = {} as any;
+            const localVarQueryParameter = {} as any;
+
+            localVarHeaderParameter['Accept'] = 'application/json';
+
+            setSearchParams(localVarUrlObj, localVarQueryParameter);
+            let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+
+            return {
+                url: toPathString(localVarUrlObj),
+                options: localVarRequestOptions,
+            };
+        },
+        /**
+         * A missing reference file is represented by HTTP 200 with reference_status=missing and reference=null.
+         * @summary Get a current Preference item and its reference detail
+         * @param {string} name
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        apiCoreMemoryPreferencesNameGet: async (name: string, options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
+            // verify required parameter 'name' is not null or undefined
+            assertParamExists('apiCoreMemoryPreferencesNameGet', 'name', name)
+            const localVarPath = `/api/core/memory/preferences/{name}`
+                .replace(`{${"name"}}`, encodeURIComponent(String(name)));
+            // use dummy base URL string because the URL constructor only accepts absolute URLs.
+            const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
+            let baseOptions;
+            if (configuration) {
+                baseOptions = configuration.baseOptions;
+            }
+
+            const localVarRequestOptions = { method: 'GET', ...baseOptions, ...options};
+            const localVarHeaderParameter = {} as any;
+            const localVarQueryParameter = {} as any;
+
+            localVarHeaderParameter['Accept'] = 'application/json';
+
+            setSearchParams(localVarUrlObj, localVarQueryParameter);
+            let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+
+            return {
+                url: toPathString(localVarUrlObj),
+                options: localVarRequestOptions,
+            };
+        },
+        /**
+         * ordered_names must be an exact, unnormalized permutation of every current Preference name. expected_etag must equal the list response etag.
+         * @summary Replace the order of current user\'s Preference items
+         * @param {CurrentMemoryPreferenceOrderRequest} currentMemoryPreferenceOrderRequest
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        apiCoreMemoryPreferencesOrderPut: async (currentMemoryPreferenceOrderRequest: CurrentMemoryPreferenceOrderRequest, options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
+            // verify required parameter 'currentMemoryPreferenceOrderRequest' is not null or undefined
+            assertParamExists('apiCoreMemoryPreferencesOrderPut', 'currentMemoryPreferenceOrderRequest', currentMemoryPreferenceOrderRequest)
+            const localVarPath = `/api/core/memory/preferences:order`;
+            // use dummy base URL string because the URL constructor only accepts absolute URLs.
+            const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
+            let baseOptions;
+            if (configuration) {
+                baseOptions = configuration.baseOptions;
+            }
+
+            const localVarRequestOptions = { method: 'PUT', ...baseOptions, ...options};
+            const localVarHeaderParameter = {} as any;
+            const localVarQueryParameter = {} as any;
+
+            localVarHeaderParameter['Content-Type'] = 'application/json';
+            localVarHeaderParameter['Accept'] = 'application/json';
+
+            setSearchParams(localVarUrlObj, localVarQueryParameter);
+            let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.data = serializeDataIfNeeded(currentMemoryPreferenceOrderRequest, localVarRequestOptions, configuration)
+
+            return {
+                url: toPathString(localVarUrlObj),
+                options: localVarRequestOptions,
+            };
+        },
+        /**
+         *
+         * @summary Delete current user\'s Profile avatar
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        apiCoreMemoryProfileAvatarDelete: async (options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
+            const localVarPath = `/api/core/memory/profile/avatar`;
+            // use dummy base URL string because the URL constructor only accepts absolute URLs.
+            const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
+            let baseOptions;
+            if (configuration) {
+                baseOptions = configuration.baseOptions;
+            }
+
+            const localVarRequestOptions = { method: 'DELETE', ...baseOptions, ...options};
+            const localVarHeaderParameter = {} as any;
+            const localVarQueryParameter = {} as any;
+
+            localVarHeaderParameter['Accept'] = 'application/json';
+
+            setSearchParams(localVarUrlObj, localVarQueryParameter);
+            let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+
+            return {
+                url: toPathString(localVarUrlObj),
+                options: localVarRequestOptions,
+            };
+        },
+        /**
+         *
+         * @summary Get current user\'s Profile avatar
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        apiCoreMemoryProfileAvatarGet: async (options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
+            const localVarPath = `/api/core/memory/profile/avatar`;
+            // use dummy base URL string because the URL constructor only accepts absolute URLs.
+            const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
+            let baseOptions;
+            if (configuration) {
+                baseOptions = configuration.baseOptions;
+            }
+
+            const localVarRequestOptions = { method: 'GET', ...baseOptions, ...options};
+            const localVarHeaderParameter = {} as any;
+            const localVarQueryParameter = {} as any;
+
+            localVarHeaderParameter['Accept'] = 'image/jpeg,image/png,image/webp,application/json';
+
+            setSearchParams(localVarUrlObj, localVarQueryParameter);
+            let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+
+            return {
+                url: toPathString(localVarUrlObj),
+                options: localVarRequestOptions,
+            };
+        },
+        /**
+         *
+         * @summary Upload current user\'s Profile avatar
+         * @param {File} file
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        apiCoreMemoryProfileAvatarPut: async (file: File, options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
+            // verify required parameter 'file' is not null or undefined
+            assertParamExists('apiCoreMemoryProfileAvatarPut', 'file', file)
+            const localVarPath = `/api/core/memory/profile/avatar`;
+            // use dummy base URL string because the URL constructor only accepts absolute URLs.
+            const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
+            let baseOptions;
+            if (configuration) {
+                baseOptions = configuration.baseOptions;
+            }
+
+            const localVarRequestOptions = { method: 'PUT', ...baseOptions, ...options};
+            const localVarHeaderParameter = {} as any;
+            const localVarQueryParameter = {} as any;
+            const localVarFormParams = new ((configuration && configuration.formDataCtor) || FormData)();
+
+
+            if (file !== undefined) {
+                localVarFormParams.append('file', file as any);
+            }
+            localVarHeaderParameter['Content-Type'] = 'multipart/form-data';
+            localVarHeaderParameter['Accept'] = 'application/json';
+
+            setSearchParams(localVarUrlObj, localVarQueryParameter);
+            let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.data = localVarFormParams;
+
+            return {
+                url: toPathString(localVarUrlObj),
+                options: localVarRequestOptions,
+            };
+        },
+        /**
+         *
+         * @summary Get current user\'s Profile memory
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        apiCoreMemoryProfileGet: async (options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
+            const localVarPath = `/api/core/memory/profile`;
+            // use dummy base URL string because the URL constructor only accepts absolute URLs.
+            const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
+            let baseOptions;
+            if (configuration) {
+                baseOptions = configuration.baseOptions;
+            }
+
+            const localVarRequestOptions = { method: 'GET', ...baseOptions, ...options};
+            const localVarHeaderParameter = {} as any;
+            const localVarQueryParameter = {} as any;
+
+            localVarHeaderParameter['Accept'] = 'application/json';
+
+            setSearchParams(localVarUrlObj, localVarQueryParameter);
+            let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+
+            return {
+                url: toPathString(localVarUrlObj),
+                options: localVarRequestOptions,
+            };
+        },
+        /**
+         * Applies an atomic batch. Scalar fields accept set/clear; list fields accept add/remove/clear.
+         * @summary Apply operations to current user\'s Profile memory
+         * @param {CurrentMemoryOperationsRequest} currentMemoryOperationsRequest
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        apiCoreMemoryProfilePatch: async (currentMemoryOperationsRequest: CurrentMemoryOperationsRequest, options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
+            // verify required parameter 'currentMemoryOperationsRequest' is not null or undefined
+            assertParamExists('apiCoreMemoryProfilePatch', 'currentMemoryOperationsRequest', currentMemoryOperationsRequest)
+            const localVarPath = `/api/core/memory/profile`;
+            // use dummy base URL string because the URL constructor only accepts absolute URLs.
+            const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
+            let baseOptions;
+            if (configuration) {
+                baseOptions = configuration.baseOptions;
+            }
+
+            const localVarRequestOptions = { method: 'PATCH', ...baseOptions, ...options};
+            const localVarHeaderParameter = {} as any;
+            const localVarQueryParameter = {} as any;
+
+            localVarHeaderParameter['Content-Type'] = 'application/json';
+            localVarHeaderParameter['Accept'] = 'application/json';
+
+            setSearchParams(localVarUrlObj, localVarQueryParameter);
+            let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.data = serializeDataIfNeeded(currentMemoryOperationsRequest, localVarRequestOptions, configuration)
+
+            return {
+                url: toPathString(localVarUrlObj),
+                options: localVarRequestOptions,
+            };
+        },
+        /**
+         *
+         * @summary Delete current user\'s Soul avatar
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        apiCoreMemorySoulAvatarDelete: async (options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
+            const localVarPath = `/api/core/memory/soul/avatar`;
+            // use dummy base URL string because the URL constructor only accepts absolute URLs.
+            const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
+            let baseOptions;
+            if (configuration) {
+                baseOptions = configuration.baseOptions;
+            }
+
+            const localVarRequestOptions = { method: 'DELETE', ...baseOptions, ...options};
+            const localVarHeaderParameter = {} as any;
+            const localVarQueryParameter = {} as any;
+
+            localVarHeaderParameter['Accept'] = 'application/json';
+
+            setSearchParams(localVarUrlObj, localVarQueryParameter);
+            let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+
+            return {
+                url: toPathString(localVarUrlObj),
+                options: localVarRequestOptions,
+            };
+        },
+        /**
+         *
+         * @summary Get current user\'s Soul avatar
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        apiCoreMemorySoulAvatarGet: async (options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
+            const localVarPath = `/api/core/memory/soul/avatar`;
+            // use dummy base URL string because the URL constructor only accepts absolute URLs.
+            const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
+            let baseOptions;
+            if (configuration) {
+                baseOptions = configuration.baseOptions;
+            }
+
+            const localVarRequestOptions = { method: 'GET', ...baseOptions, ...options};
+            const localVarHeaderParameter = {} as any;
+            const localVarQueryParameter = {} as any;
+
+            localVarHeaderParameter['Accept'] = 'image/jpeg,image/png,image/webp,application/json';
+
+            setSearchParams(localVarUrlObj, localVarQueryParameter);
+            let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+
+            return {
+                url: toPathString(localVarUrlObj),
+                options: localVarRequestOptions,
+            };
+        },
+        /**
+         *
+         * @summary Upload current user\'s Soul avatar
+         * @param {File} file
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        apiCoreMemorySoulAvatarPut: async (file: File, options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
+            // verify required parameter 'file' is not null or undefined
+            assertParamExists('apiCoreMemorySoulAvatarPut', 'file', file)
+            const localVarPath = `/api/core/memory/soul/avatar`;
+            // use dummy base URL string because the URL constructor only accepts absolute URLs.
+            const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
+            let baseOptions;
+            if (configuration) {
+                baseOptions = configuration.baseOptions;
+            }
+
+            const localVarRequestOptions = { method: 'PUT', ...baseOptions, ...options};
+            const localVarHeaderParameter = {} as any;
+            const localVarQueryParameter = {} as any;
+            const localVarFormParams = new ((configuration && configuration.formDataCtor) || FormData)();
+
+
+            if (file !== undefined) {
+                localVarFormParams.append('file', file as any);
+            }
+            localVarHeaderParameter['Content-Type'] = 'multipart/form-data';
+            localVarHeaderParameter['Accept'] = 'application/json';
+
+            setSearchParams(localVarUrlObj, localVarQueryParameter);
+            let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.data = localVarFormParams;
+
+            return {
+                url: toPathString(localVarUrlObj),
+                options: localVarRequestOptions,
+            };
+        },
+        /**
+         *
+         * @summary Get current user\'s Soul memory
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        apiCoreMemorySoulGet: async (options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
+            const localVarPath = `/api/core/memory/soul`;
+            // use dummy base URL string because the URL constructor only accepts absolute URLs.
+            const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
+            let baseOptions;
+            if (configuration) {
+                baseOptions = configuration.baseOptions;
+            }
+
+            const localVarRequestOptions = { method: 'GET', ...baseOptions, ...options};
+            const localVarHeaderParameter = {} as any;
+            const localVarQueryParameter = {} as any;
+
+            localVarHeaderParameter['Accept'] = 'application/json';
+
+            setSearchParams(localVarUrlObj, localVarQueryParameter);
+            let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+
+            return {
+                url: toPathString(localVarUrlObj),
+                options: localVarRequestOptions,
+            };
+        },
+        /**
+         * Applies an atomic batch of set operations. Core migrates legacy content and retries an internal content compare-and-swap up to three times.
+         * @summary Apply operations to current user\'s Soul memory
+         * @param {CurrentMemoryOperationsRequest} currentMemoryOperationsRequest
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        apiCoreMemorySoulPatch: async (currentMemoryOperationsRequest: CurrentMemoryOperationsRequest, options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
+            // verify required parameter 'currentMemoryOperationsRequest' is not null or undefined
+            assertParamExists('apiCoreMemorySoulPatch', 'currentMemoryOperationsRequest', currentMemoryOperationsRequest)
+            const localVarPath = `/api/core/memory/soul`;
+            // use dummy base URL string because the URL constructor only accepts absolute URLs.
+            const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
+            let baseOptions;
+            if (configuration) {
+                baseOptions = configuration.baseOptions;
+            }
+
+            const localVarRequestOptions = { method: 'PATCH', ...baseOptions, ...options};
+            const localVarHeaderParameter = {} as any;
+            const localVarQueryParameter = {} as any;
+
+            localVarHeaderParameter['Content-Type'] = 'application/json';
+            localVarHeaderParameter['Accept'] = 'application/json';
+
+            setSearchParams(localVarUrlObj, localVarQueryParameter);
+            let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.data = serializeDataIfNeeded(currentMemoryOperationsRequest, localVarRequestOptions, configuration)
+
+            return {
+                url: toPathString(localVarUrlObj),
+                options: localVarRequestOptions,
+            };
+        },
     }
 };
 
@@ -14220,6 +15048,221 @@ export const DefaultApiFp = function(configuration?: Configuration) {
             const localVarOperationServerBasePath = operationServerMap['DefaultApi.apiCoreUserChatSettingsPatch']?.[localVarOperationServerIndex]?.url;
             return (axios, basePath) => createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration)(axios, localVarOperationServerBasePath || basePath);
         },
+        /**
+         *
+         * @summary Delete an Episode Memory item
+         * @param {string} episodeId
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        async apiCoreMemoryEpisodesEpisodeIdDelete(episodeId: string, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.apiCoreMemoryEpisodesEpisodeIdDelete(episodeId, options);
+            const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
+            const localVarOperationServerBasePath = operationServerMap['DefaultApi.apiCoreMemoryEpisodesEpisodeIdDelete']?.[localVarOperationServerIndex]?.url;
+            return (axios, basePath) => createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration)(axios, localVarOperationServerBasePath || basePath);
+        },
+        /**
+         *
+         * @summary Get an Episode Memory item
+         * @param {string} episodeId
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        async apiCoreMemoryEpisodesEpisodeIdGet(episodeId: string, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<EpisodeMemoryDetailResponse>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.apiCoreMemoryEpisodesEpisodeIdGet(episodeId, options);
+            const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
+            const localVarOperationServerBasePath = operationServerMap['DefaultApi.apiCoreMemoryEpisodesEpisodeIdGet']?.[localVarOperationServerIndex]?.url;
+            return (axios, basePath) => createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration)(axios, localVarOperationServerBasePath || basePath);
+        },
+        /**
+         *
+         * @summary List current user\'s Episode Memory
+         * @param {number} [pageSize]
+         * @param {string} [pageToken]
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        async apiCoreMemoryEpisodesGet(pageSize?: number, pageToken?: string, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<EpisodeMemoryListResponse>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.apiCoreMemoryEpisodesGet(pageSize, pageToken, options);
+            const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
+            const localVarOperationServerBasePath = operationServerMap['DefaultApi.apiCoreMemoryEpisodesGet']?.[localVarOperationServerIndex]?.url;
+            return (axios, basePath) => createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration)(axios, localVarOperationServerBasePath || basePath);
+        },
+        /**
+         *
+         * @summary List current user\'s Preference memory
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        async apiCoreMemoryPreferencesGet(options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<CurrentMemoryPreferenceListResponse>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.apiCoreMemoryPreferencesGet(options);
+            const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
+            const localVarOperationServerBasePath = operationServerMap['DefaultApi.apiCoreMemoryPreferencesGet']?.[localVarOperationServerIndex]?.url;
+            return (axios, basePath) => createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration)(axios, localVarOperationServerBasePath || basePath);
+        },
+        /**
+         * Atomically removes the item and its now-unreferenced reference file. Missing items, including other users\' items, are idempotent success.
+         * @summary Delete a current Preference item
+         * @param {string} name
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        async apiCoreMemoryPreferencesNameDelete(name: string, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.apiCoreMemoryPreferencesNameDelete(name, options);
+            const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
+            const localVarOperationServerBasePath = operationServerMap['DefaultApi.apiCoreMemoryPreferencesNameDelete']?.[localVarOperationServerIndex]?.url;
+            return (axios, basePath) => createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration)(axios, localVarOperationServerBasePath || basePath);
+        },
+        /**
+         * A missing reference file is represented by HTTP 200 with reference_status=missing and reference=null.
+         * @summary Get a current Preference item and its reference detail
+         * @param {string} name
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        async apiCoreMemoryPreferencesNameGet(name: string, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<CurrentMemoryPreferenceDetailResponse>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.apiCoreMemoryPreferencesNameGet(name, options);
+            const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
+            const localVarOperationServerBasePath = operationServerMap['DefaultApi.apiCoreMemoryPreferencesNameGet']?.[localVarOperationServerIndex]?.url;
+            return (axios, basePath) => createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration)(axios, localVarOperationServerBasePath || basePath);
+        },
+        /**
+         * ordered_names must be an exact, unnormalized permutation of every current Preference name. expected_etag must equal the list response etag.
+         * @summary Replace the order of current user\'s Preference items
+         * @param {CurrentMemoryPreferenceOrderRequest} currentMemoryPreferenceOrderRequest
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        async apiCoreMemoryPreferencesOrderPut(currentMemoryPreferenceOrderRequest: CurrentMemoryPreferenceOrderRequest, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<CurrentMemoryPreferenceListResponse>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.apiCoreMemoryPreferencesOrderPut(currentMemoryPreferenceOrderRequest, options);
+            const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
+            const localVarOperationServerBasePath = operationServerMap['DefaultApi.apiCoreMemoryPreferencesOrderPut']?.[localVarOperationServerIndex]?.url;
+            return (axios, basePath) => createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration)(axios, localVarOperationServerBasePath || basePath);
+        },
+        /**
+         *
+         * @summary Delete current user\'s Profile avatar
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        async apiCoreMemoryProfileAvatarDelete(options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.apiCoreMemoryProfileAvatarDelete(options);
+            const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
+            const localVarOperationServerBasePath = operationServerMap['DefaultApi.apiCoreMemoryProfileAvatarDelete']?.[localVarOperationServerIndex]?.url;
+            return (axios, basePath) => createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration)(axios, localVarOperationServerBasePath || basePath);
+        },
+        /**
+         *
+         * @summary Get current user\'s Profile avatar
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        async apiCoreMemoryProfileAvatarGet(options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<File>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.apiCoreMemoryProfileAvatarGet(options);
+            const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
+            const localVarOperationServerBasePath = operationServerMap['DefaultApi.apiCoreMemoryProfileAvatarGet']?.[localVarOperationServerIndex]?.url;
+            return (axios, basePath) => createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration)(axios, localVarOperationServerBasePath || basePath);
+        },
+        /**
+         *
+         * @summary Upload current user\'s Profile avatar
+         * @param {File} file
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        async apiCoreMemoryProfileAvatarPut(file: File, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<CurrentMemoryAvatarResponse>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.apiCoreMemoryProfileAvatarPut(file, options);
+            const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
+            const localVarOperationServerBasePath = operationServerMap['DefaultApi.apiCoreMemoryProfileAvatarPut']?.[localVarOperationServerIndex]?.url;
+            return (axios, basePath) => createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration)(axios, localVarOperationServerBasePath || basePath);
+        },
+        /**
+         *
+         * @summary Get current user\'s Profile memory
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        async apiCoreMemoryProfileGet(options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<CurrentMemoryProfileResponse>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.apiCoreMemoryProfileGet(options);
+            const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
+            const localVarOperationServerBasePath = operationServerMap['DefaultApi.apiCoreMemoryProfileGet']?.[localVarOperationServerIndex]?.url;
+            return (axios, basePath) => createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration)(axios, localVarOperationServerBasePath || basePath);
+        },
+        /**
+         * Applies an atomic batch. Scalar fields accept set/clear; list fields accept add/remove/clear.
+         * @summary Apply operations to current user\'s Profile memory
+         * @param {CurrentMemoryOperationsRequest} currentMemoryOperationsRequest
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        async apiCoreMemoryProfilePatch(currentMemoryOperationsRequest: CurrentMemoryOperationsRequest, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<CurrentMemoryProfileResponse>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.apiCoreMemoryProfilePatch(currentMemoryOperationsRequest, options);
+            const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
+            const localVarOperationServerBasePath = operationServerMap['DefaultApi.apiCoreMemoryProfilePatch']?.[localVarOperationServerIndex]?.url;
+            return (axios, basePath) => createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration)(axios, localVarOperationServerBasePath || basePath);
+        },
+        /**
+         *
+         * @summary Delete current user\'s Soul avatar
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        async apiCoreMemorySoulAvatarDelete(options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.apiCoreMemorySoulAvatarDelete(options);
+            const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
+            const localVarOperationServerBasePath = operationServerMap['DefaultApi.apiCoreMemorySoulAvatarDelete']?.[localVarOperationServerIndex]?.url;
+            return (axios, basePath) => createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration)(axios, localVarOperationServerBasePath || basePath);
+        },
+        /**
+         *
+         * @summary Get current user\'s Soul avatar
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        async apiCoreMemorySoulAvatarGet(options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<File>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.apiCoreMemorySoulAvatarGet(options);
+            const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
+            const localVarOperationServerBasePath = operationServerMap['DefaultApi.apiCoreMemorySoulAvatarGet']?.[localVarOperationServerIndex]?.url;
+            return (axios, basePath) => createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration)(axios, localVarOperationServerBasePath || basePath);
+        },
+        /**
+         *
+         * @summary Upload current user\'s Soul avatar
+         * @param {File} file
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        async apiCoreMemorySoulAvatarPut(file: File, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<CurrentMemoryAvatarResponse>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.apiCoreMemorySoulAvatarPut(file, options);
+            const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
+            const localVarOperationServerBasePath = operationServerMap['DefaultApi.apiCoreMemorySoulAvatarPut']?.[localVarOperationServerIndex]?.url;
+            return (axios, basePath) => createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration)(axios, localVarOperationServerBasePath || basePath);
+        },
+        /**
+         *
+         * @summary Get current user\'s Soul memory
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        async apiCoreMemorySoulGet(options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<CurrentMemorySoulResponse>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.apiCoreMemorySoulGet(options);
+            const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
+            const localVarOperationServerBasePath = operationServerMap['DefaultApi.apiCoreMemorySoulGet']?.[localVarOperationServerIndex]?.url;
+            return (axios, basePath) => createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration)(axios, localVarOperationServerBasePath || basePath);
+        },
+        /**
+         * Applies an atomic batch of set operations. Core migrates legacy content and retries an internal content compare-and-swap up to three times.
+         * @summary Apply operations to current user\'s Soul memory
+         * @param {CurrentMemoryOperationsRequest} currentMemoryOperationsRequest
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        async apiCoreMemorySoulPatch(currentMemoryOperationsRequest: CurrentMemoryOperationsRequest, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<CurrentMemorySoulResponse>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.apiCoreMemorySoulPatch(currentMemoryOperationsRequest, options);
+            const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
+            const localVarOperationServerBasePath = operationServerMap['DefaultApi.apiCoreMemorySoulPatch']?.[localVarOperationServerIndex]?.url;
+            return (axios, basePath) => createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration)(axios, localVarOperationServerBasePath || basePath);
+        },
     }
 };
 
@@ -15717,6 +16760,169 @@ export const DefaultApiFactory = function (configuration?: Configuration, basePa
         apiCoreUserChatSettingsPatch(options?: RawAxiosRequestConfig): AxiosPromise<void> {
             return localVarFp.apiCoreUserChatSettingsPatch(options).then((request) => request(axios, basePath));
         },
+        /**
+         *
+         * @summary Delete an Episode Memory item
+         * @param {DefaultApiApiCoreMemoryEpisodesEpisodeIdDeleteRequest} requestParameters Request parameters.
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        apiCoreMemoryEpisodesEpisodeIdDelete(requestParameters: DefaultApiApiCoreMemoryEpisodesEpisodeIdDeleteRequest, options?: RawAxiosRequestConfig): AxiosPromise<void> {
+            return localVarFp.apiCoreMemoryEpisodesEpisodeIdDelete(requestParameters.episodeId, options).then((request) => request(axios, basePath));
+        },
+        /**
+         *
+         * @summary Get an Episode Memory item
+         * @param {DefaultApiApiCoreMemoryEpisodesEpisodeIdGetRequest} requestParameters Request parameters.
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        apiCoreMemoryEpisodesEpisodeIdGet(requestParameters: DefaultApiApiCoreMemoryEpisodesEpisodeIdGetRequest, options?: RawAxiosRequestConfig): AxiosPromise<EpisodeMemoryDetailResponse> {
+            return localVarFp.apiCoreMemoryEpisodesEpisodeIdGet(requestParameters.episodeId, options).then((request) => request(axios, basePath));
+        },
+        /**
+         *
+         * @summary List current user\'s Episode Memory
+         * @param {DefaultApiApiCoreMemoryEpisodesGetRequest} requestParameters Request parameters.
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        apiCoreMemoryEpisodesGet(requestParameters: DefaultApiApiCoreMemoryEpisodesGetRequest = {}, options?: RawAxiosRequestConfig): AxiosPromise<EpisodeMemoryListResponse> {
+            return localVarFp.apiCoreMemoryEpisodesGet(requestParameters.pageSize, requestParameters.pageToken, options).then((request) => request(axios, basePath));
+        },
+        /**
+         *
+         * @summary List current user\'s Preference memory
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        apiCoreMemoryPreferencesGet(options?: RawAxiosRequestConfig): AxiosPromise<CurrentMemoryPreferenceListResponse> {
+            return localVarFp.apiCoreMemoryPreferencesGet(options).then((request) => request(axios, basePath));
+        },
+        /**
+         * Atomically removes the item and its now-unreferenced reference file. Missing items, including other users\' items, are idempotent success.
+         * @summary Delete a current Preference item
+         * @param {DefaultApiApiCoreMemoryPreferencesNameDeleteRequest} requestParameters Request parameters.
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        apiCoreMemoryPreferencesNameDelete(requestParameters: DefaultApiApiCoreMemoryPreferencesNameDeleteRequest, options?: RawAxiosRequestConfig): AxiosPromise<void> {
+            return localVarFp.apiCoreMemoryPreferencesNameDelete(requestParameters.name, options).then((request) => request(axios, basePath));
+        },
+        /**
+         * A missing reference file is represented by HTTP 200 with reference_status=missing and reference=null.
+         * @summary Get a current Preference item and its reference detail
+         * @param {DefaultApiApiCoreMemoryPreferencesNameGetRequest} requestParameters Request parameters.
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        apiCoreMemoryPreferencesNameGet(requestParameters: DefaultApiApiCoreMemoryPreferencesNameGetRequest, options?: RawAxiosRequestConfig): AxiosPromise<CurrentMemoryPreferenceDetailResponse> {
+            return localVarFp.apiCoreMemoryPreferencesNameGet(requestParameters.name, options).then((request) => request(axios, basePath));
+        },
+        /**
+         * ordered_names must be an exact, unnormalized permutation of every current Preference name. expected_etag must equal the list response etag.
+         * @summary Replace the order of current user\'s Preference items
+         * @param {DefaultApiApiCoreMemoryPreferencesOrderPutRequest} requestParameters Request parameters.
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        apiCoreMemoryPreferencesOrderPut(requestParameters: DefaultApiApiCoreMemoryPreferencesOrderPutRequest, options?: RawAxiosRequestConfig): AxiosPromise<CurrentMemoryPreferenceListResponse> {
+            return localVarFp.apiCoreMemoryPreferencesOrderPut(requestParameters.currentMemoryPreferenceOrderRequest, options).then((request) => request(axios, basePath));
+        },
+        /**
+         *
+         * @summary Delete current user\'s Profile avatar
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        apiCoreMemoryProfileAvatarDelete(options?: RawAxiosRequestConfig): AxiosPromise<void> {
+            return localVarFp.apiCoreMemoryProfileAvatarDelete(options).then((request) => request(axios, basePath));
+        },
+        /**
+         *
+         * @summary Get current user\'s Profile avatar
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        apiCoreMemoryProfileAvatarGet(options?: RawAxiosRequestConfig): AxiosPromise<File> {
+            return localVarFp.apiCoreMemoryProfileAvatarGet(options).then((request) => request(axios, basePath));
+        },
+        /**
+         *
+         * @summary Upload current user\'s Profile avatar
+         * @param {DefaultApiApiCoreMemoryProfileAvatarPutRequest} requestParameters Request parameters.
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        apiCoreMemoryProfileAvatarPut(requestParameters: DefaultApiApiCoreMemoryProfileAvatarPutRequest, options?: RawAxiosRequestConfig): AxiosPromise<CurrentMemoryAvatarResponse> {
+            return localVarFp.apiCoreMemoryProfileAvatarPut(requestParameters.file, options).then((request) => request(axios, basePath));
+        },
+        /**
+         *
+         * @summary Get current user\'s Profile memory
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        apiCoreMemoryProfileGet(options?: RawAxiosRequestConfig): AxiosPromise<CurrentMemoryProfileResponse> {
+            return localVarFp.apiCoreMemoryProfileGet(options).then((request) => request(axios, basePath));
+        },
+        /**
+         * Applies an atomic batch. Scalar fields accept set/clear; list fields accept add/remove/clear.
+         * @summary Apply operations to current user\'s Profile memory
+         * @param {DefaultApiApiCoreMemoryProfilePatchRequest} requestParameters Request parameters.
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        apiCoreMemoryProfilePatch(requestParameters: DefaultApiApiCoreMemoryProfilePatchRequest, options?: RawAxiosRequestConfig): AxiosPromise<CurrentMemoryProfileResponse> {
+            return localVarFp.apiCoreMemoryProfilePatch(requestParameters.currentMemoryOperationsRequest, options).then((request) => request(axios, basePath));
+        },
+        /**
+         *
+         * @summary Delete current user\'s Soul avatar
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        apiCoreMemorySoulAvatarDelete(options?: RawAxiosRequestConfig): AxiosPromise<void> {
+            return localVarFp.apiCoreMemorySoulAvatarDelete(options).then((request) => request(axios, basePath));
+        },
+        /**
+         *
+         * @summary Get current user\'s Soul avatar
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        apiCoreMemorySoulAvatarGet(options?: RawAxiosRequestConfig): AxiosPromise<File> {
+            return localVarFp.apiCoreMemorySoulAvatarGet(options).then((request) => request(axios, basePath));
+        },
+        /**
+         *
+         * @summary Upload current user\'s Soul avatar
+         * @param {DefaultApiApiCoreMemorySoulAvatarPutRequest} requestParameters Request parameters.
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        apiCoreMemorySoulAvatarPut(requestParameters: DefaultApiApiCoreMemorySoulAvatarPutRequest, options?: RawAxiosRequestConfig): AxiosPromise<CurrentMemoryAvatarResponse> {
+            return localVarFp.apiCoreMemorySoulAvatarPut(requestParameters.file, options).then((request) => request(axios, basePath));
+        },
+        /**
+         *
+         * @summary Get current user\'s Soul memory
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        apiCoreMemorySoulGet(options?: RawAxiosRequestConfig): AxiosPromise<CurrentMemorySoulResponse> {
+            return localVarFp.apiCoreMemorySoulGet(options).then((request) => request(axios, basePath));
+        },
+        /**
+         * Applies an atomic batch of set operations. Core migrates legacy content and retries an internal content compare-and-swap up to three times.
+         * @summary Apply operations to current user\'s Soul memory
+         * @param {DefaultApiApiCoreMemorySoulPatchRequest} requestParameters Request parameters.
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        apiCoreMemorySoulPatch(requestParameters: DefaultApiApiCoreMemorySoulPatchRequest, options?: RawAxiosRequestConfig): AxiosPromise<CurrentMemorySoulResponse> {
+            return localVarFp.apiCoreMemorySoulPatch(requestParameters.currentMemoryOperationsRequest, options).then((request) => request(axios, basePath));
+        },
     };
 };
 
@@ -16624,6 +17830,89 @@ export interface DefaultApiApiCoreTasksTaskIdStreamGetRequest {
 export interface DefaultApiApiCoreTempUploadsPostRequest {
     readonly files?: Array<File>
 }
+
+/**
+ * Request parameters for apiCoreMemoryEpisodesEpisodeIdDelete operation in DefaultApi.
+ */
+export interface DefaultApiApiCoreMemoryEpisodesEpisodeIdDeleteRequest {
+    readonly episodeId: string
+}
+
+
+/**
+ * Request parameters for apiCoreMemoryEpisodesEpisodeIdGet operation in DefaultApi.
+ */
+export interface DefaultApiApiCoreMemoryEpisodesEpisodeIdGetRequest {
+    readonly episodeId: string
+}
+
+
+/**
+ * Request parameters for apiCoreMemoryEpisodesGet operation in DefaultApi.
+ */
+export interface DefaultApiApiCoreMemoryEpisodesGetRequest {
+    readonly pageSize?: number
+
+    readonly pageToken?: string
+}
+
+
+/**
+ * Request parameters for apiCoreMemoryPreferencesNameDelete operation in DefaultApi.
+ */
+export interface DefaultApiApiCoreMemoryPreferencesNameDeleteRequest {
+    readonly name: string
+}
+
+
+/**
+ * Request parameters for apiCoreMemoryPreferencesNameGet operation in DefaultApi.
+ */
+export interface DefaultApiApiCoreMemoryPreferencesNameGetRequest {
+    readonly name: string
+}
+
+
+/**
+ * Request parameters for apiCoreMemoryPreferencesOrderPut operation in DefaultApi.
+ */
+export interface DefaultApiApiCoreMemoryPreferencesOrderPutRequest {
+    readonly currentMemoryPreferenceOrderRequest: CurrentMemoryPreferenceOrderRequest
+}
+
+
+/**
+ * Request parameters for apiCoreMemoryProfileAvatarPut operation in DefaultApi.
+ */
+export interface DefaultApiApiCoreMemoryProfileAvatarPutRequest {
+    readonly file: File
+}
+
+
+/**
+ * Request parameters for apiCoreMemoryProfilePatch operation in DefaultApi.
+ */
+export interface DefaultApiApiCoreMemoryProfilePatchRequest {
+    readonly currentMemoryOperationsRequest: CurrentMemoryOperationsRequest
+}
+
+
+/**
+ * Request parameters for apiCoreMemorySoulAvatarPut operation in DefaultApi.
+ */
+export interface DefaultApiApiCoreMemorySoulAvatarPutRequest {
+    readonly file: File
+}
+
+
+/**
+ * Request parameters for apiCoreMemorySoulPatch operation in DefaultApi.
+ */
+export interface DefaultApiApiCoreMemorySoulPatchRequest {
+    readonly currentMemoryOperationsRequest: CurrentMemoryOperationsRequest
+}
+
+
 
 /**
  * DefaultApi - object-oriented interface
@@ -18268,6 +19557,185 @@ export class DefaultApi extends BaseAPI {
      */
     public apiCoreUserChatSettingsPatch(options?: RawAxiosRequestConfig) {
         return DefaultApiFp(this.configuration).apiCoreUserChatSettingsPatch(options).then((request) => request(this.axios, this.basePath));
+    }
+    /**
+     *
+     * @summary Delete an Episode Memory item
+     * @param {DefaultApiApiCoreMemoryEpisodesEpisodeIdDeleteRequest} requestParameters Request parameters.
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     */
+    public apiCoreMemoryEpisodesEpisodeIdDelete(requestParameters: DefaultApiApiCoreMemoryEpisodesEpisodeIdDeleteRequest, options?: RawAxiosRequestConfig) {
+        return DefaultApiFp(this.configuration).apiCoreMemoryEpisodesEpisodeIdDelete(requestParameters.episodeId, options).then((request) => request(this.axios, this.basePath));
+    }
+
+    /**
+     *
+     * @summary Get an Episode Memory item
+     * @param {DefaultApiApiCoreMemoryEpisodesEpisodeIdGetRequest} requestParameters Request parameters.
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     */
+    public apiCoreMemoryEpisodesEpisodeIdGet(requestParameters: DefaultApiApiCoreMemoryEpisodesEpisodeIdGetRequest, options?: RawAxiosRequestConfig) {
+        return DefaultApiFp(this.configuration).apiCoreMemoryEpisodesEpisodeIdGet(requestParameters.episodeId, options).then((request) => request(this.axios, this.basePath));
+    }
+
+    /**
+     *
+     * @summary List current user\'s Episode Memory
+     * @param {DefaultApiApiCoreMemoryEpisodesGetRequest} requestParameters Request parameters.
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     */
+    public apiCoreMemoryEpisodesGet(requestParameters: DefaultApiApiCoreMemoryEpisodesGetRequest = {}, options?: RawAxiosRequestConfig) {
+        return DefaultApiFp(this.configuration).apiCoreMemoryEpisodesGet(requestParameters.pageSize, requestParameters.pageToken, options).then((request) => request(this.axios, this.basePath));
+    }
+
+    /**
+     *
+     * @summary List current user\'s Preference memory
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     */
+    public apiCoreMemoryPreferencesGet(options?: RawAxiosRequestConfig) {
+        return DefaultApiFp(this.configuration).apiCoreMemoryPreferencesGet(options).then((request) => request(this.axios, this.basePath));
+    }
+
+    /**
+     * Atomically removes the item and its now-unreferenced reference file. Missing items, including other users\' items, are idempotent success.
+     * @summary Delete a current Preference item
+     * @param {DefaultApiApiCoreMemoryPreferencesNameDeleteRequest} requestParameters Request parameters.
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     */
+    public apiCoreMemoryPreferencesNameDelete(requestParameters: DefaultApiApiCoreMemoryPreferencesNameDeleteRequest, options?: RawAxiosRequestConfig) {
+        return DefaultApiFp(this.configuration).apiCoreMemoryPreferencesNameDelete(requestParameters.name, options).then((request) => request(this.axios, this.basePath));
+    }
+
+    /**
+     * A missing reference file is represented by HTTP 200 with reference_status=missing and reference=null.
+     * @summary Get a current Preference item and its reference detail
+     * @param {DefaultApiApiCoreMemoryPreferencesNameGetRequest} requestParameters Request parameters.
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     */
+    public apiCoreMemoryPreferencesNameGet(requestParameters: DefaultApiApiCoreMemoryPreferencesNameGetRequest, options?: RawAxiosRequestConfig) {
+        return DefaultApiFp(this.configuration).apiCoreMemoryPreferencesNameGet(requestParameters.name, options).then((request) => request(this.axios, this.basePath));
+    }
+
+    /**
+     * ordered_names must be an exact, unnormalized permutation of every current Preference name. expected_etag must equal the list response etag.
+     * @summary Replace the order of current user\'s Preference items
+     * @param {DefaultApiApiCoreMemoryPreferencesOrderPutRequest} requestParameters Request parameters.
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     */
+    public apiCoreMemoryPreferencesOrderPut(requestParameters: DefaultApiApiCoreMemoryPreferencesOrderPutRequest, options?: RawAxiosRequestConfig) {
+        return DefaultApiFp(this.configuration).apiCoreMemoryPreferencesOrderPut(requestParameters.currentMemoryPreferenceOrderRequest, options).then((request) => request(this.axios, this.basePath));
+    }
+
+    /**
+     *
+     * @summary Delete current user\'s Profile avatar
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     */
+    public apiCoreMemoryProfileAvatarDelete(options?: RawAxiosRequestConfig) {
+        return DefaultApiFp(this.configuration).apiCoreMemoryProfileAvatarDelete(options).then((request) => request(this.axios, this.basePath));
+    }
+
+    /**
+     *
+     * @summary Get current user\'s Profile avatar
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     */
+    public apiCoreMemoryProfileAvatarGet(options?: RawAxiosRequestConfig) {
+        return DefaultApiFp(this.configuration).apiCoreMemoryProfileAvatarGet(options).then((request) => request(this.axios, this.basePath));
+    }
+
+    /**
+     *
+     * @summary Upload current user\'s Profile avatar
+     * @param {DefaultApiApiCoreMemoryProfileAvatarPutRequest} requestParameters Request parameters.
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     */
+    public apiCoreMemoryProfileAvatarPut(requestParameters: DefaultApiApiCoreMemoryProfileAvatarPutRequest, options?: RawAxiosRequestConfig) {
+        return DefaultApiFp(this.configuration).apiCoreMemoryProfileAvatarPut(requestParameters.file, options).then((request) => request(this.axios, this.basePath));
+    }
+
+    /**
+     *
+     * @summary Get current user\'s Profile memory
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     */
+    public apiCoreMemoryProfileGet(options?: RawAxiosRequestConfig) {
+        return DefaultApiFp(this.configuration).apiCoreMemoryProfileGet(options).then((request) => request(this.axios, this.basePath));
+    }
+
+    /**
+     * Applies an atomic batch. Scalar fields accept set/clear; list fields accept add/remove/clear.
+     * @summary Apply operations to current user\'s Profile memory
+     * @param {DefaultApiApiCoreMemoryProfilePatchRequest} requestParameters Request parameters.
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     */
+    public apiCoreMemoryProfilePatch(requestParameters: DefaultApiApiCoreMemoryProfilePatchRequest, options?: RawAxiosRequestConfig) {
+        return DefaultApiFp(this.configuration).apiCoreMemoryProfilePatch(requestParameters.currentMemoryOperationsRequest, options).then((request) => request(this.axios, this.basePath));
+    }
+
+    /**
+     *
+     * @summary Delete current user\'s Soul avatar
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     */
+    public apiCoreMemorySoulAvatarDelete(options?: RawAxiosRequestConfig) {
+        return DefaultApiFp(this.configuration).apiCoreMemorySoulAvatarDelete(options).then((request) => request(this.axios, this.basePath));
+    }
+
+    /**
+     *
+     * @summary Get current user\'s Soul avatar
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     */
+    public apiCoreMemorySoulAvatarGet(options?: RawAxiosRequestConfig) {
+        return DefaultApiFp(this.configuration).apiCoreMemorySoulAvatarGet(options).then((request) => request(this.axios, this.basePath));
+    }
+
+    /**
+     *
+     * @summary Upload current user\'s Soul avatar
+     * @param {DefaultApiApiCoreMemorySoulAvatarPutRequest} requestParameters Request parameters.
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     */
+    public apiCoreMemorySoulAvatarPut(requestParameters: DefaultApiApiCoreMemorySoulAvatarPutRequest, options?: RawAxiosRequestConfig) {
+        return DefaultApiFp(this.configuration).apiCoreMemorySoulAvatarPut(requestParameters.file, options).then((request) => request(this.axios, this.basePath));
+    }
+
+    /**
+     *
+     * @summary Get current user\'s Soul memory
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     */
+    public apiCoreMemorySoulGet(options?: RawAxiosRequestConfig) {
+        return DefaultApiFp(this.configuration).apiCoreMemorySoulGet(options).then((request) => request(this.axios, this.basePath));
+    }
+
+    /**
+     * Applies an atomic batch of set operations. Core migrates legacy content and retries an internal content compare-and-swap up to three times.
+     * @summary Apply operations to current user\'s Soul memory
+     * @param {DefaultApiApiCoreMemorySoulPatchRequest} requestParameters Request parameters.
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     */
+    public apiCoreMemorySoulPatch(requestParameters: DefaultApiApiCoreMemorySoulPatchRequest, options?: RawAxiosRequestConfig) {
+        return DefaultApiFp(this.configuration).apiCoreMemorySoulPatch(requestParameters.currentMemoryOperationsRequest, options).then((request) => request(this.axios, this.basePath));
     }
 }
 

--- a/tests/frontend/coreMemoryGeneratedContract.test.js
+++ b/tests/frontend/coreMemoryGeneratedContract.test.js
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+
+import { DefaultApiFactory } from "../../frontend/src/api/generated/core-client/index.ts";
+
+const MEMORY_METHODS = [
+  "apiCoreMemoryEpisodesEpisodeIdDelete",
+  "apiCoreMemoryEpisodesEpisodeIdGet",
+  "apiCoreMemoryEpisodesGet",
+  "apiCoreMemoryPreferencesGet",
+  "apiCoreMemoryPreferencesNameDelete",
+  "apiCoreMemoryPreferencesNameGet",
+  "apiCoreMemoryPreferencesOrderPut",
+  "apiCoreMemoryProfileAvatarDelete",
+  "apiCoreMemoryProfileAvatarGet",
+  "apiCoreMemoryProfileAvatarPut",
+  "apiCoreMemoryProfileGet",
+  "apiCoreMemoryProfilePatch",
+  "apiCoreMemorySoulAvatarDelete",
+  "apiCoreMemorySoulAvatarGet",
+  "apiCoreMemorySoulAvatarPut",
+  "apiCoreMemorySoulGet",
+  "apiCoreMemorySoulPatch",
+];
+
+describe("generated Core Memory SDK contract", () => {
+  it("exposes all Memory operations on the real DefaultApiFactory", () => {
+    const client = DefaultApiFactory();
+
+    for (const method of MEMORY_METHODS) {
+      expect(client[method], method).toBeTypeOf("function");
+    }
+  });
+});

--- a/tests/frontend/openapiStale.test.js
+++ b/tests/frontend/openapiStale.test.js
@@ -1,0 +1,92 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  GENERATED_TYPESCRIPT_FILES,
+  inspectGeneratedClientOutput,
+} from "../../frontend/scripts/openapi/generated-client-utils.mjs";
+import {
+  getOpenApiStatus,
+  hashFile,
+} from "../../frontend/scripts/openapi/openapi-manifest.mjs";
+
+const temporaryDirectories = [];
+
+afterEach(() => {
+  for (const directory of temporaryDirectories.splice(0)) {
+    fs.rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+function createFixture() {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "openapi-stale-"));
+  temporaryDirectories.push(root);
+  const input = path.join(root, "core.yaml");
+  const output = path.join(root, "core-client");
+  fs.mkdirSync(output);
+  fs.writeFileSync(input, "openapi: 3.0.0\n");
+  for (const filename of GENERATED_TYPESCRIPT_FILES) {
+    fs.writeFileSync(path.join(output, filename), `// ${filename}\n`);
+  }
+
+  const api = { name: "core", input, output };
+  const cacheEntry = {
+    specHash: hashFile(input),
+    outputHash: inspectGeneratedClientOutput(output).hash,
+  };
+  return { api, cacheEntry };
+}
+
+describe("OpenAPI generated output staleness", () => {
+  it("accepts matching spec and generated output hashes", () => {
+    const { api, cacheEntry } = createFixture();
+
+    expect(getOpenApiStatus(api, cacheEntry)).toMatchObject({
+      stale: false,
+      reasons: [],
+      strictOutput: true,
+    });
+  });
+
+  it("reports spec_changed when the authoritative spec changes", () => {
+    const { api, cacheEntry } = createFixture();
+    fs.appendFileSync(api.input, "info: {}\n");
+
+    expect(getOpenApiStatus(api, cacheEntry).reasons).toEqual([
+      "spec_changed",
+    ]);
+  });
+
+  it("reports output_changed when a public generated file changes", () => {
+    const { api, cacheEntry } = createFixture();
+    fs.appendFileSync(path.join(api.output, "api.ts"), "// drift\n");
+
+    expect(getOpenApiStatus(api, cacheEntry).reasons).toEqual([
+      "output_changed",
+    ]);
+  });
+
+  it("reports missing_output when a public generated file is absent", () => {
+    const { api, cacheEntry } = createFixture();
+    fs.rmSync(path.join(api.output, "index.ts"));
+
+    expect(getOpenApiStatus(api, cacheEntry)).toMatchObject({
+      stale: true,
+      reasons: ["missing_output"],
+      missingOutputFiles: ["index.ts"],
+    });
+  });
+
+  it("keeps legacy string cache entries spec-only compatible", () => {
+    const { api, cacheEntry } = createFixture();
+    fs.rmSync(api.output, { recursive: true });
+
+    expect(getOpenApiStatus(api, cacheEntry.specHash)).toMatchObject({
+      stale: false,
+      reasons: [],
+      strictOutput: false,
+    });
+  });
+});


### PR DESCRIPTION
## What changed

- Restore the 17 generated Core Memory operations used by Soul, Profile, avatars, Preferences, and Episodes while preserving the existing `DefaultApiFactory` integration.
- Add a real generated-client contract test so missing Memory operations fail without relying on mocks.
- Extend the OpenAPI cache to support `{ specHash, outputHash }`, keeping legacy string entries compatible.
- Add deterministic hashing for the five public generated TypeScript files and report `spec_changed`, `output_changed`, and `missing_output` drift reasons.
- Run the stale check during frontend `prebuild` and frontend CI.

## Root cause

Workflow refactoring replaced the generated Core client while Memory business modules continued calling the previously generated methods. The existing cache checked only the OpenAPI spec hash, so it could report the client as fresh even when committed generated output no longer matched the contract.

## Impact

- Restores Memory page initialization without changing backend APIs, database schemas, Memory data structures, or other business modules.
- Preserves the existing 406 Core SDK operations and adds only the 17 missing Memory operations plus deterministic formatting changes.
- Keeps non-Core clients on the legacy cache format until their next normal regeneration.
- Centralizes hashing, generated-file enumeration, and post-processing in a shared OpenAPI utility instead of adding a Memory-specific base class.

## Validation

- 33/33 targeted frontend tests passed, including the real SDK contract and five stale-checker scenarios.
- Frontend production build passed.
- Containerized frontend build passed with OpenAPI Generator fixed at 7.20.0.
- Runtime verification on the existing 8090 environment returned HTTP 200 for Soul, Profile, Preferences, and Episodes; absent avatars returned the expected HTTP 404 state.
- The new frontend bundle produced no `is not a function` console errors.
