### PR TITLE
Fix GitHub URL imports for Skills

### DIFF
--- a/backend/core/common/error_catalog_additional.go
+++ b/backend/core/common/error_catalog_additional.go
@@ -377,6 +377,10 @@ func init() {
 	registerAdditionalErrorPattern("skill package exceeds %d uncompressed bytes", "Invalid skill package", http.StatusBadRequest, 2002294)
 	registerAdditionalErrorPattern("skill name cannot exceed %d characters", "Skill name cannot exceed 80 characters", http.StatusBadRequest, 2002305)
 	registerAdditionalErrorPattern("skill description cannot exceed %d characters", "Skill description cannot exceed 1024 characters", http.StatusBadRequest, 2002306)
+	registerAdditionalErrorPattern("github ref lookup failed with http status %d", "Invalid request", http.StatusBadRequest, 2000103)
+	registerAdditionalErrorAlias("github ref lookup failed", "Invalid request", http.StatusBadRequest, 2000103)
+	registerAdditionalErrorAlias("github ref lookup returned invalid json", "Invalid request", http.StatusBadRequest, 2000103)
+	registerAdditionalErrorPattern("skill package download exceeds %d bytes", "Invalid skill package", http.StatusBadRequest, 2002294)
 
 	// Personal recovery and archive lifecycle errors.
 	registerAdditionalError("query archive folders failed", http.StatusInternalServerError, 2002098)

--- a/backend/core/common/response.go
+++ b/backend/core/common/response.go
@@ -72,7 +72,7 @@ func ReplyJSON(w http.ResponseWriter, v any) {
 // ErrorCodeFromHTTPStatus maps HTTP non-200 codes to core business error codes.
 func ErrorCodeFromHTTPStatus(statusCode int) int {
 	switch statusCode {
-	case http.StatusBadRequest, http.StatusMethodNotAllowed:
+	case http.StatusBadRequest, http.StatusMethodNotAllowed, http.StatusUnprocessableEntity:
 		return ErrCodeInvalidParams
 	case http.StatusUnauthorized:
 		return ErrCodeUnauthorized

--- a/backend/core/common/response_test.go
+++ b/backend/core/common/response_test.go
@@ -92,6 +92,7 @@ func TestErrorCodeFromHTTPStatus(t *testing.T) {
 	}{
 		{http.StatusBadRequest, ErrCodeInvalidParams},
 		{http.StatusMethodNotAllowed, ErrCodeInvalidParams},
+		{http.StatusUnprocessableEntity, ErrCodeInvalidParams},
 		{http.StatusUnauthorized, ErrCodeUnauthorized},
 		{http.StatusForbidden, ErrCodeForbidden},
 		{http.StatusNotFound, ErrCodeResourceAbsent},

--- a/backend/core/skillv2/handler/handler.go
+++ b/backend/core/skillv2/handler/handler.go
@@ -16,6 +16,7 @@ import (
 	"strconv"
 	"strings"
 	"time"
+	"unicode"
 
 	"gopkg.in/yaml.v3"
 	"gorm.io/gorm"
@@ -213,7 +214,7 @@ func Create(w http.ResponseWriter, r *http.Request) {
 		replyError(w, "name/category required", http.StatusBadRequest)
 		return
 	}
-	source, cleanup, err := createSkillSourceFromRequest(name, category, strings.TrimSpace(req.Description), req.Content, req.Children, req.Source)
+	source, cleanup, err := createSkillSourceFromRequest(r.Context(), name, category, strings.TrimSpace(req.Description), req.Content, req.Children, req.Source)
 	if err != nil {
 		replyError(w, err.Error(), http.StatusBadRequest)
 		return
@@ -296,7 +297,7 @@ func Patch(w http.ResponseWriter, r *http.Request) {
 	tags := compactStringSlicePtr(req.Tags)
 	var source *skillservice.SourceInput
 	if req.Source != nil {
-		converted, err := req.Source.toServiceSource()
+		converted, err := req.Source.toServiceSource(r.Context())
 		if err != nil {
 			replyError(w, err.Error(), http.StatusBadRequest)
 			return
@@ -1232,7 +1233,7 @@ func MarketEdit(w http.ResponseWriter, r *http.Request) {
 		}
 		var source *skillservice.SourceInput
 		if req.Source != nil {
-			converted, err := req.Source.toServiceSource()
+			converted, err := req.Source.toServiceSource(r.Context())
 			if err != nil {
 				replyError(w, err.Error(), http.StatusBadRequest)
 				return
@@ -1598,7 +1599,7 @@ func InternalCreate(w http.ResponseWriter, r *http.Request) {
 	common.ReplyOK(w, map[string]any{"skill_id": resp.SkillID, "head_revision_id": resp.HeadRevisionID})
 }
 
-func (s skillSourceRequest) toServiceSource() (skillservice.SourceInput, error) {
+func (s skillSourceRequest) toServiceSource(ctx context.Context) (skillservice.SourceInput, error) {
 	sourceType := strings.TrimSpace(s.Type)
 	if sourceType == "" {
 		if strings.TrimSpace(s.UploadID) != "" {
@@ -1617,7 +1618,7 @@ func (s skillSourceRequest) toServiceSource() (skillservice.SourceInput, error) 
 		if strings.TrimSpace(s.URL) == "" {
 			return skillservice.SourceInput{}, fmt.Errorf("url required")
 		}
-		downloadURL, pathPrefix, err := normalizeSkillImportURL(strings.TrimSpace(s.URL))
+		downloadURL, pathPrefix, err := normalizeSkillImportURL(ctx, strings.TrimSpace(s.URL))
 		if err != nil {
 			return skillservice.SourceInput{}, err
 		}
@@ -1627,7 +1628,13 @@ func (s skillSourceRequest) toServiceSource() (skillservice.SourceInput, error) 
 	}
 }
 
-func normalizeSkillImportURL(rawURL string) (string, string, error) {
+const githubAPIBaseURL = "https://api.github.com"
+
+func normalizeSkillImportURL(ctx context.Context, rawURL string) (string, string, error) {
+	return normalizeSkillImportURLWithResolver(ctx, rawURL, &http.Client{Timeout: 10 * time.Second}, githubAPIBaseURL)
+}
+
+func normalizeSkillImportURLWithResolver(ctx context.Context, rawURL string, client *http.Client, apiBaseURL string) (string, string, error) {
 	parsed, err := url.ParseRequestURI(rawURL)
 	if err != nil || parsed.Scheme == "" || parsed.Host == "" {
 		return "", "", skillImportURLValidationError("invalid skill import URL")
@@ -1638,24 +1645,149 @@ func normalizeSkillImportURL(rawURL string) (string, string, error) {
 	if !strings.EqualFold(strings.TrimPrefix(parsed.Hostname(), "www."), "github.com") {
 		return rawURL, "", nil
 	}
-	parts := strings.Split(strings.Trim(parsed.EscapedPath(), "/"), "/")
+	if parsed.User != nil || parsed.Port() != "" || parsed.RawQuery != "" || parsed.Fragment != "" {
+		return "", "", skillImportURLValidationError("GitHub URL must not contain credentials, query, or fragment")
+	}
+	parts, err := githubURLPathParts(parsed.EscapedPath())
+	if err != nil {
+		return "", "", err
+	}
 	if len(parts) < 2 || parts[0] == "" || parts[1] == "" {
 		return "", "", skillImportURLValidationError("GitHub URL must identify a repository")
 	}
 	owner := parts[0]
 	repository := strings.TrimSuffix(parts[1], ".git")
-	if repository == "" {
+	if !isValidGitHubName(owner) || !isValidGitHubName(repository) {
 		return "", "", skillImportURLValidationError("GitHub URL must identify a repository")
 	}
+	if ref, ok := githubArchiveRef(parts); ok {
+		return githubArchiveURL(owner, repository, ref), "", nil
+	}
 	if len(parts) == 2 {
-		return "https://github.com/" + owner + "/" + repository + "/archive/HEAD.zip", "", nil
+		ref, err := resolveGitHubDefaultBranch(ctx, client, apiBaseURL, owner, repository)
+		if err != nil {
+			return "", "", err
+		}
+		return githubArchiveURL(owner, repository, ref), "", nil
 	}
-	if len(parts) < 4 || parts[2] != "tree" || parts[3] == "" {
-		return rawURL, "", nil
+	if len(parts) < 5 || parts[2] != "tree" {
+		return "", "", skillImportURLValidationError("GitHub URL must point to a repository root or /tree/<ref>/<skill-path>")
 	}
-	ref := parts[3]
-	pathPrefix := strings.Join(parts[4:], "/")
-	return "https://github.com/" + owner + "/" + repository + "/archive/refs/heads/" + url.PathEscape(ref) + ".zip", pathPrefix, nil
+	ref, pathPrefix, err := resolveGitHubTreeRef(ctx, client, apiBaseURL, owner, repository, parts[3:])
+	if err != nil {
+		return "", "", err
+	}
+	return githubArchiveURL(owner, repository, ref), pathPrefix, nil
+}
+
+func githubArchiveRef(parts []string) (string, bool) {
+	if len(parts) < 4 || parts[2] != "archive" {
+		return "", false
+	}
+	refParts := parts[3:]
+	if len(refParts) >= 3 && refParts[0] == "refs" && (refParts[1] == "heads" || refParts[1] == "tags") {
+		refParts = refParts[2:]
+	} else if len(refParts) != 1 {
+		return "", false
+	}
+	last := refParts[len(refParts)-1]
+	if !strings.HasSuffix(last, ".zip") {
+		return "", false
+	}
+	refParts[len(refParts)-1] = strings.TrimSuffix(last, ".zip")
+	if refParts[len(refParts)-1] == "" {
+		return "", false
+	}
+	return strings.Join(refParts, "/"), true
+}
+
+func githubURLPathParts(escapedPath string) ([]string, error) {
+	rawParts := strings.Split(strings.Trim(escapedPath, "/"), "/")
+	if len(rawParts) == 1 && rawParts[0] == "" {
+		return nil, skillImportURLValidationError("GitHub URL must identify a repository")
+	}
+	parts := make([]string, 0, len(rawParts))
+	for _, rawPart := range rawParts {
+		part, err := url.PathUnescape(rawPart)
+		if err != nil || part == "" || part == "." || part == ".." || strings.ContainsAny(part, `/\\`) || strings.ContainsRune(part, 0) {
+			return nil, skillImportURLValidationError("GitHub URL contains an invalid path segment")
+		}
+		parts = append(parts, part)
+	}
+	return parts, nil
+}
+
+func resolveGitHubDefaultBranch(ctx context.Context, client *http.Client, apiBaseURL, owner, repository string) (string, error) {
+	var response struct {
+		DefaultBranch string `json:"default_branch"`
+	}
+	status, err := githubAPIGet(ctx, client, apiBaseURL+"/repos/"+url.PathEscape(owner)+"/"+url.PathEscape(repository), &response)
+	if err != nil {
+		return "", err
+	}
+	if status < 200 || status >= 300 || strings.TrimSpace(response.DefaultBranch) == "" {
+		return "", skillImportURLValidationError("GitHub repository default branch could not be resolved")
+	}
+	return response.DefaultBranch, nil
+}
+
+func resolveGitHubTreeRef(ctx context.Context, client *http.Client, apiBaseURL, owner, repository string, treeParts []string) (string, string, error) {
+	for split := len(treeParts) - 1; split > 0; split-- {
+		ref := strings.Join(treeParts[:split], "/")
+		pathPrefix := strings.Join(treeParts[split:], "/")
+		status, err := githubAPIGet(ctx, client, apiBaseURL+"/repos/"+url.PathEscape(owner)+"/"+url.PathEscape(repository)+"/commits/"+url.PathEscape(ref), nil)
+		if err != nil {
+			return "", "", err
+		}
+		if status == http.StatusNotFound || status == http.StatusUnprocessableEntity {
+			continue
+		}
+		if status >= 200 && status < 300 {
+			return ref, pathPrefix, nil
+		}
+		return "", "", fmt.Errorf("GitHub ref lookup failed with HTTP status %d", status)
+	}
+	return "", "", skillImportURLValidationError("GitHub URL ref could not be resolved")
+}
+
+func githubAPIGet(ctx context.Context, client *http.Client, endpoint string, out any) (int, error) {
+	if client == nil {
+		client = &http.Client{Timeout: 10 * time.Second}
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return 0, err
+	}
+	req.Header.Set("Accept", "application/vnd.github+json")
+	req.Header.Set("User-Agent", "LazyMind-Skill-Importer")
+	resp, err := client.Do(req)
+	if err != nil {
+		return 0, fmt.Errorf("GitHub ref lookup failed: %w", err)
+	}
+	defer resp.Body.Close()
+	if out != nil && resp.StatusCode >= 200 && resp.StatusCode < 300 {
+		if err := json.NewDecoder(io.LimitReader(resp.Body, 1<<20)).Decode(out); err != nil {
+			return 0, fmt.Errorf("GitHub ref lookup returned invalid JSON: %w", err)
+		}
+	}
+	return resp.StatusCode, nil
+}
+
+func githubArchiveURL(owner, repository, ref string) string {
+	return "https://github.com/" + url.PathEscape(owner) + "/" + url.PathEscape(repository) + "/archive/" + url.PathEscape(ref) + ".zip"
+}
+
+func isValidGitHubName(value string) bool {
+	if value == "" {
+		return false
+	}
+	for _, char := range value {
+		if unicode.IsLetter(char) || unicode.IsDigit(char) || char == '-' || char == '_' || char == '.' {
+			continue
+		}
+		return false
+	}
+	return true
 }
 
 type skillImportURLValidationError string
@@ -1664,9 +1796,9 @@ func (e skillImportURLValidationError) Error() string {
 	return string(e)
 }
 
-func createSkillSourceFromRequest(name, category, description, content string, children []legacyChildSkillInput, sourceReq skillSourceRequest) (skillservice.SourceInput, func(), error) {
+func createSkillSourceFromRequest(ctx context.Context, name, category, description, content string, children []legacyChildSkillInput, sourceReq skillSourceRequest) (skillservice.SourceInput, func(), error) {
 	if strings.TrimSpace(content) == "" && len(children) == 0 {
-		source, err := sourceReq.toServiceSource()
+		source, err := sourceReq.toServiceSource(ctx)
 		return source, nil, err
 	}
 	files, err := legacySkillFiles(name, category, description, content, children)
@@ -1867,7 +1999,7 @@ func newMarketService(db *gorm.DB) *skillmarket.Service {
 	return skillmarket.NewService(skillmarket.ServiceDeps{
 		DB:         db,
 		BlobStore:  skillmarket.NewBlobStore(db, skillmarket.NewLocalObjectStore(skillObjectRoot())),
-		Downloader: httpZipDownloader{},
+		Downloader: marketHTTPZipDownloader{},
 	})
 }
 
@@ -2160,6 +2292,18 @@ func (s dbUploadStore) Get(ctx context.Context, uploadID string) (skillservice.U
 
 type httpZipDownloader struct{}
 
+const maxSkillDownloadBytes int64 = 20 << 20
+
+type marketHTTPZipDownloader struct{}
+
+func (marketHTTPZipDownloader) Download(ctx context.Context, rawURL string) (string, error) {
+	downloaded, err := (httpZipDownloader{}).Download(ctx, rawURL)
+	if err != nil {
+		return "", err
+	}
+	return downloaded.Path, nil
+}
+
 func (httpZipDownloader) Download(ctx context.Context, rawURL string) (skillservice.DownloadedZip, error) {
 	rawURL = strings.TrimSpace(rawURL)
 	if rawURL == "" {
@@ -2182,10 +2326,21 @@ func (httpZipDownloader) Download(ctx context.Context, rawURL string) (skillserv
 	if err != nil {
 		return skillservice.DownloadedZip{}, err
 	}
-	if _, err := io.Copy(f, resp.Body); err != nil {
+	if resp.ContentLength > maxSkillDownloadBytes {
+		_ = f.Close()
+		_ = os.Remove(f.Name())
+		return skillservice.DownloadedZip{}, fmt.Errorf("skill package download exceeds %d bytes", maxSkillDownloadBytes)
+	}
+	written, err := io.Copy(f, io.LimitReader(resp.Body, maxSkillDownloadBytes+1))
+	if err != nil {
 		_ = f.Close()
 		_ = os.Remove(f.Name())
 		return skillservice.DownloadedZip{}, err
+	}
+	if written > maxSkillDownloadBytes {
+		_ = f.Close()
+		_ = os.Remove(f.Name())
+		return skillservice.DownloadedZip{}, fmt.Errorf("skill package download exceeds %d bytes", maxSkillDownloadBytes)
 	}
 	if err := f.Close(); err != nil {
 		_ = os.Remove(f.Name())

--- a/backend/core/skillv2/handler/handler.go
+++ b/backend/core/skillv2/handler/handler.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"os"
 	"path"
 	"path/filepath"
@@ -1616,10 +1617,51 @@ func (s skillSourceRequest) toServiceSource() (skillservice.SourceInput, error) 
 		if strings.TrimSpace(s.URL) == "" {
 			return skillservice.SourceInput{}, fmt.Errorf("url required")
 		}
-		return skillservice.SourceInput{Type: "url", URL: strings.TrimSpace(s.URL)}, nil
+		downloadURL, pathPrefix, err := normalizeSkillImportURL(strings.TrimSpace(s.URL))
+		if err != nil {
+			return skillservice.SourceInput{}, err
+		}
+		return skillservice.SourceInput{Type: "url", URL: downloadURL, SourceURL: strings.TrimSpace(s.URL), PathPrefix: pathPrefix}, nil
 	default:
 		return skillservice.SourceInput{}, fmt.Errorf("unsupported source type %q", sourceType)
 	}
+}
+
+func normalizeSkillImportURL(rawURL string) (string, string, error) {
+	parsed, err := url.ParseRequestURI(rawURL)
+	if err != nil || parsed.Scheme == "" || parsed.Host == "" {
+		return "", "", skillImportURLValidationError("invalid skill import URL")
+	}
+	if parsed.Scheme != "http" && parsed.Scheme != "https" {
+		return "", "", skillImportURLValidationError("skill import URL must use HTTP or HTTPS")
+	}
+	if !strings.EqualFold(strings.TrimPrefix(parsed.Hostname(), "www."), "github.com") {
+		return rawURL, "", nil
+	}
+	parts := strings.Split(strings.Trim(parsed.EscapedPath(), "/"), "/")
+	if len(parts) < 2 || parts[0] == "" || parts[1] == "" {
+		return "", "", skillImportURLValidationError("GitHub URL must identify a repository")
+	}
+	owner := parts[0]
+	repository := strings.TrimSuffix(parts[1], ".git")
+	if repository == "" {
+		return "", "", skillImportURLValidationError("GitHub URL must identify a repository")
+	}
+	if len(parts) == 2 {
+		return "https://github.com/" + owner + "/" + repository + "/archive/HEAD.zip", "", nil
+	}
+	if len(parts) < 4 || parts[2] != "tree" || parts[3] == "" {
+		return rawURL, "", nil
+	}
+	ref := parts[3]
+	pathPrefix := strings.Join(parts[4:], "/")
+	return "https://github.com/" + owner + "/" + repository + "/archive/refs/heads/" + url.PathEscape(ref) + ".zip", pathPrefix, nil
+}
+
+type skillImportURLValidationError string
+
+func (e skillImportURLValidationError) Error() string {
+	return string(e)
 }
 
 func createSkillSourceFromRequest(name, category, description, content string, children []legacyChildSkillInput, sourceReq skillSourceRequest) (skillservice.SourceInput, func(), error) {
@@ -2118,34 +2160,38 @@ func (s dbUploadStore) Get(ctx context.Context, uploadID string) (skillservice.U
 
 type httpZipDownloader struct{}
 
-func (httpZipDownloader) Download(ctx context.Context, rawURL string) (string, error) {
+func (httpZipDownloader) Download(ctx context.Context, rawURL string) (skillservice.DownloadedZip, error) {
 	rawURL = strings.TrimSpace(rawURL)
 	if rawURL == "" {
-		return "", fmt.Errorf("url required")
+		return skillservice.DownloadedZip{}, fmt.Errorf("url required")
 	}
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, rawURL, nil)
 	if err != nil {
-		return "", err
+		return skillservice.DownloadedZip{}, err
 	}
 	client := &http.Client{Timeout: 30 * time.Second}
 	resp, err := client.Do(req)
 	if err != nil {
-		return "", err
+		return skillservice.DownloadedZip{}, err
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return "", fmt.Errorf("download failed: %s", resp.Status)
+		return skillservice.DownloadedZip{}, fmt.Errorf("download failed: %s", resp.Status)
 	}
 	f, err := os.CreateTemp("", "lazymind-skill-*.zip")
 	if err != nil {
-		return "", err
+		return skillservice.DownloadedZip{}, err
 	}
-	defer f.Close()
 	if _, err := io.Copy(f, resp.Body); err != nil {
+		_ = f.Close()
 		_ = os.Remove(f.Name())
-		return "", err
+		return skillservice.DownloadedZip{}, err
 	}
-	return f.Name(), nil
+	if err := f.Close(); err != nil {
+		_ = os.Remove(f.Name())
+		return skillservice.DownloadedZip{}, err
+	}
+	return skillservice.DownloadedZip{Path: f.Name(), Cleanup: func() { _ = os.Remove(f.Name()) }}, nil
 }
 
 func writeInlineSkillZip(content string) (string, error) {

--- a/backend/core/skillv2/handler/url_import_test.go
+++ b/backend/core/skillv2/handler/url_import_test.go
@@ -2,9 +2,13 @@ package handler
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
+	"strconv"
+	"strings"
 	"testing"
 
 	"lazymind/core/common"
@@ -12,6 +16,26 @@ import (
 )
 
 func TestNormalizeSkillImportURL(t *testing.T) {
+	apiServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/repos/example/skills" {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"default_branch":"main"}`))
+			return
+		}
+		const commitsPrefix = "/repos/example/skills/commits/"
+		if strings.HasPrefix(r.URL.EscapedPath(), commitsPrefix) {
+			ref, err := url.PathUnescape(strings.TrimPrefix(r.URL.EscapedPath(), commitsPrefix))
+			if err == nil && map[string]bool{"main": true, "feature/foo": true, "v1.2.3": true, "0123456789abcdef0123456789abcdef01234567": true}[ref] {
+				w.WriteHeader(http.StatusOK)
+				return
+			}
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer apiServer.Close()
+
 	tests := []struct {
 		name       string
 		rawURL     string
@@ -22,13 +46,46 @@ func TestNormalizeSkillImportURL(t *testing.T) {
 		{
 			name:    "GitHub repository root",
 			rawURL:  "https://github.com/example/skills",
-			wantURL: "https://github.com/example/skills/archive/HEAD.zip",
+			wantURL: "https://github.com/example/skills/archive/main.zip",
 		},
 		{
 			name:       "GitHub tree subdirectory",
 			rawURL:     "https://github.com/example/skills/tree/main/skills/target",
-			wantURL:    "https://github.com/example/skills/archive/refs/heads/main.zip",
+			wantURL:    "https://github.com/example/skills/archive/main.zip",
 			wantPrefix: "skills/target",
+		},
+		{
+			name:       "GitHub branch containing slash",
+			rawURL:     "https://github.com/example/skills/tree/feature/foo/skills/target",
+			wantURL:    "https://github.com/example/skills/archive/feature%2Ffoo.zip",
+			wantPrefix: "skills/target",
+		},
+		{
+			name:       "GitHub tag",
+			rawURL:     "https://github.com/example/skills/tree/v1.2.3/skills/target",
+			wantURL:    "https://github.com/example/skills/archive/v1.2.3.zip",
+			wantPrefix: "skills/target",
+		},
+		{
+			name:       "GitHub commit SHA",
+			rawURL:     "https://github.com/example/skills/tree/0123456789abcdef0123456789abcdef01234567/skills/target",
+			wantURL:    "https://github.com/example/skills/archive/0123456789abcdef0123456789abcdef01234567.zip",
+			wantPrefix: "skills/target",
+		},
+		{
+			name:    "GitHub tag archive URL",
+			rawURL:  "https://github.com/example/skills/archive/refs/tags/v1.2.3.zip",
+			wantURL: "https://github.com/example/skills/archive/v1.2.3.zip",
+		},
+		{
+			name:    "GitHub branch archive URL",
+			rawURL:  "https://github.com/example/skills/archive/refs/heads/main.zip",
+			wantURL: "https://github.com/example/skills/archive/main.zip",
+		},
+		{
+			name:    "GitHub branch archive URL containing slash",
+			rawURL:  "https://github.com/example/skills/archive/refs/heads/feature/foo.zip",
+			wantURL: "https://github.com/example/skills/archive/feature%2Ffoo.zip",
 		},
 		{
 			name:    "direct zip URL",
@@ -40,11 +97,21 @@ func TestNormalizeSkillImportURL(t *testing.T) {
 			rawURL:  "ftp://example.test/skills.zip",
 			wantErr: true,
 		},
+		{
+			name:    "GitHub tree missing path",
+			rawURL:  "https://github.com/example/skills/tree/main",
+			wantErr: true,
+		},
+		{
+			name:    "GitHub URL with query",
+			rawURL:  "https://github.com/example/skills?download=1",
+			wantErr: true,
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			gotURL, gotPrefix, err := normalizeSkillImportURL(tt.rawURL)
+			gotURL, gotPrefix, err := normalizeSkillImportURLWithResolver(context.Background(), tt.rawURL, apiServer.Client(), apiServer.URL)
 			if tt.wantErr {
 				if err == nil {
 					t.Fatal("normalizeSkillImportURL returned nil error")
@@ -98,5 +165,18 @@ func TestCreateSkillFromInvalidURLReturnsInvalidParams(t *testing.T) {
 	}
 	if got := testutil.CountRows(t, db, "skills", ""); got != 0 {
 		t.Fatalf("skills count = %d, want 0", got)
+	}
+}
+
+func TestHTTPZipDownloaderRejectsOversizedContentLength(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Length", strconv.FormatInt(maxSkillDownloadBytes+1, 10))
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	_, err := (httpZipDownloader{}).Download(context.Background(), server.URL)
+	if err == nil || !strings.Contains(err.Error(), "download exceeds") {
+		t.Fatalf("error = %v, want download size error", err)
 	}
 }

--- a/backend/core/skillv2/handler/url_import_test.go
+++ b/backend/core/skillv2/handler/url_import_test.go
@@ -1,0 +1,102 @@
+package handler
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"lazymind/core/common"
+	"lazymind/core/skillv2/testutil"
+)
+
+func TestNormalizeSkillImportURL(t *testing.T) {
+	tests := []struct {
+		name       string
+		rawURL     string
+		wantURL    string
+		wantPrefix string
+		wantErr    bool
+	}{
+		{
+			name:    "GitHub repository root",
+			rawURL:  "https://github.com/example/skills",
+			wantURL: "https://github.com/example/skills/archive/HEAD.zip",
+		},
+		{
+			name:       "GitHub tree subdirectory",
+			rawURL:     "https://github.com/example/skills/tree/main/skills/target",
+			wantURL:    "https://github.com/example/skills/archive/refs/heads/main.zip",
+			wantPrefix: "skills/target",
+		},
+		{
+			name:    "direct zip URL",
+			rawURL:  "https://example.test/skills.zip",
+			wantURL: "https://example.test/skills.zip",
+		},
+		{
+			name:    "invalid scheme",
+			rawURL:  "ftp://example.test/skills.zip",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotURL, gotPrefix, err := normalizeSkillImportURL(tt.rawURL)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("normalizeSkillImportURL returned nil error")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("normalizeSkillImportURL returned error: %v", err)
+			}
+			if gotURL != tt.wantURL || gotPrefix != tt.wantPrefix {
+				t.Fatalf("normalizeSkillImportURL = (%q, %q), want (%q, %q)", gotURL, gotPrefix, tt.wantURL, tt.wantPrefix)
+			}
+		})
+	}
+}
+
+func TestCreateSkillFromInvalidURLReturnsInvalidParams(t *testing.T) {
+	db := testutil.NewTestDB(t)
+	withHandlerDB(t, db)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/html")
+		_, _ = w.Write([]byte("<html>not a zip</html>"))
+	}))
+	defer server.Close()
+
+	payload, err := json.Marshal(map[string]any{
+		"source": map[string]any{
+			"type": "url",
+			"url":  server.URL + "/skill",
+		},
+	})
+	if err != nil {
+		t.Fatalf("marshal request: %v", err)
+	}
+	req := httptest.NewRequest(http.MethodPost, "/api/core/skills", bytes.NewReader(payload))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-User-Id", "user_001")
+	rec := httptest.NewRecorder()
+
+	Create(rec, req)
+
+	if rec.Code != http.StatusUnprocessableEntity {
+		t.Fatalf("Create status = %d, want %d; body=%s", rec.Code, http.StatusUnprocessableEntity, rec.Body.String())
+	}
+	var response common.APIResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &response); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if response.Code != common.ErrCodeInvalidParams {
+		t.Fatalf("response code = %d, want %d", response.Code, common.ErrCodeInvalidParams)
+	}
+	if got := testutil.CountRows(t, db, "skills", ""); got != 0 {
+		t.Fatalf("skills count = %d, want 0", got)
+	}
+}

--- a/backend/core/skillv2/service/crud_and_import_test.go
+++ b/backend/core/skillv2/service/crud_and_import_test.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"context"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -82,6 +83,121 @@ func TestCreateSkillFromURL_DownloadFailureDoesNotCreateSkill(t *testing.T) {
 	if got := countRows(t, db, "skill_blobs", ""); got != 0 {
 		t.Fatalf("skill_blobs count = %d, want 0", got)
 	}
+}
+
+func TestCreateSkillFromURL_RejectsPackageWithoutSkillMD(t *testing.T) {
+	db := newSkillV2TestDB(t)
+	zipPath := filepath.Join(t.TempDir(), "missing-skill-md.zip")
+	writeSkillZip(t, zipPath, map[string][]byte{
+		"references/a.md": []byte("# 参考资料\n"),
+	})
+	svc := NewSkillService(SkillServiceDeps{
+		DB: db,
+		Downloader: NewFakeZipDownloader(map[string]string{
+			"https://example.test/missing-skill-md.zip": zipPath,
+		}),
+		BlobStore: NewBlobStore(db, NewLocalObjectStore(t.TempDir())),
+		Clock:     fixedClock(),
+	})
+
+	_, err := svc.CreateSkill(context.Background(), CreateSkillRequest{
+		OwnerUserID:  "user_001",
+		CreateUserID: "user_001",
+		Source: SourceInput{
+			Type: "url",
+			URL:  "https://example.test/missing-skill-md.zip",
+		},
+	})
+	if err == nil {
+		t.Fatal("CreateSkill succeeded for URL package without SKILL.md")
+	}
+	assertNoSkillTruthRows(t, db)
+}
+
+func TestCreateSkillFromURL_ImportsGitHubTreeSubdirectory(t *testing.T) {
+	db := newSkillV2TestDB(t)
+	zipPath := filepath.Join(t.TempDir(), "github-tree.zip")
+	writeSkillZip(t, zipPath, map[string][]byte{
+		"skills-main/skills/target/SKILL.md":        externalSkillMD("目标技能", "从 GitHub 子目录导入"),
+		"skills-main/skills/target/references/a.md": []byte("# 目标资料\n"),
+		"skills-main/skills/target/assets/logo.png": minimalPNGBytes(),
+		"skills-main/skills/ignored/SKILL.md":       externalSkillMD("忽略技能", "不应导入"),
+	})
+	archiveURL := "https://github.com/example/skills/archive/refs/heads/main.zip"
+	svc := NewSkillService(SkillServiceDeps{
+		DB: db,
+		Downloader: NewFakeZipDownloader(map[string]string{
+			archiveURL: zipPath,
+		}),
+		BlobStore: NewBlobStore(db, NewLocalObjectStore(t.TempDir())),
+		Clock:     fixedClock(),
+	})
+
+	resp, err := svc.CreateSkill(context.Background(), CreateSkillRequest{
+		OwnerUserID:    "user_001",
+		OwnerUserName:  "张三",
+		CreateUserID:   "user_001",
+		CreateUserName: "张三",
+		Source: SourceInput{
+			Type:       "url",
+			URL:        archiveURL,
+			SourceURL:  "https://github.com/example/skills/tree/main/skills/target",
+			PathPrefix: "skills/target",
+		},
+	})
+	if err != nil {
+		t.Fatalf("CreateSkill from GitHub tree URL returned error: %v", err)
+	}
+	var imported testSkillV2SkillRow
+	if err := db.Where("id = ?", resp.SkillID).Take(&imported).Error; err != nil {
+		t.Fatalf("query GitHub imported skill: %v", err)
+	}
+	if imported.SkillName != "目标技能" || imported.Description != "从 GitHub 子目录导入" {
+		t.Fatalf("GitHub imported metadata = %#v", imported)
+	}
+	assertInitialRevision(t, db, resp.SkillID, resp.HeadRevisionID)
+	assertRevisionEntries(t, db, resp.HeadRevisionID)
+	if got := countRows(t, db, "skill_revision_entries", "revision_id = ? AND path LIKE ?", resp.HeadRevisionID, "ignored/%"); got != 0 {
+		t.Fatalf("ignored subtree entry count = %d, want 0", got)
+	}
+}
+
+type cleanupZipDownloader struct {
+	path string
+}
+
+func (d cleanupZipDownloader) Download(context.Context, string) (DownloadedZip, error) {
+	return DownloadedZip{Path: d.path, Cleanup: func() { _ = os.Remove(d.path) }}, nil
+}
+
+func TestCreateSkillFromURL_CleansDownloadedArchiveAfterFailure(t *testing.T) {
+	db := newSkillV2TestDB(t)
+	archivePath := filepath.Join(t.TempDir(), "not-a-zip.zip")
+	if err := os.WriteFile(archivePath, []byte("not a zip"), 0o600); err != nil {
+		t.Fatalf("write downloaded archive: %v", err)
+	}
+	svc := NewSkillService(SkillServiceDeps{
+		DB:         db,
+		Downloader: cleanupZipDownloader{path: archivePath},
+		BlobStore:  NewBlobStore(db, NewLocalObjectStore(t.TempDir())),
+		Clock:      fixedClock(),
+	})
+
+	_, err := svc.CreateSkill(context.Background(), CreateSkillRequest{
+		OwnerUserID:  "user_001",
+		CreateUserID: "user_001",
+		Source: SourceInput{
+			Type: "url",
+			URL:  "https://example.test/not-a-zip.zip",
+		},
+	})
+	if err == nil {
+		t.Fatal("CreateSkill succeeded for non-zip URL")
+	}
+	if _, statErr := os.Stat(archivePath); !os.IsNotExist(statErr) {
+		t.Fatalf("downloaded archive stat error = %v, want not exist", statErr)
+	}
+	assertNoSkillTruthRows(t, db)
 }
 
 func TestReplaceSkillContentFromUploadedZip_CreatesNewRevision(t *testing.T) {

--- a/backend/core/skillv2/service/crud_and_import_test.go
+++ b/backend/core/skillv2/service/crud_and_import_test.go
@@ -118,10 +118,12 @@ func TestCreateSkillFromURL_ImportsGitHubTreeSubdirectory(t *testing.T) {
 	db := newSkillV2TestDB(t)
 	zipPath := filepath.Join(t.TempDir(), "github-tree.zip")
 	writeSkillZip(t, zipPath, map[string][]byte{
-		"skills-main/skills/target/SKILL.md":        externalSkillMD("目标技能", "从 GitHub 子目录导入"),
-		"skills-main/skills/target/references/a.md": []byte("# 目标资料\n"),
-		"skills-main/skills/target/assets/logo.png": minimalPNGBytes(),
-		"skills-main/skills/ignored/SKILL.md":       externalSkillMD("忽略技能", "不应导入"),
+		"skills-main/skills/target/SKILL.md":            externalSkillMD("目标技能", "从 GitHub 子目录导入"),
+		"skills-main/skills/target/references/a.md":     []byte("# 目标资料\n"),
+		"skills-main/skills/target/assets/logo.png":     minimalPNGBytes(),
+		"skills-main/skills/ignored/SKILL.md":           externalSkillMD("忽略技能", "不应导入"),
+		"skills-main/skills/target/.DS_Store":           []byte("finder metadata"),
+		"__MACOSX/skills-main/skills/target/._SKILL.md": []byte("macOS metadata"),
 	})
 	archiveURL := "https://github.com/example/skills/archive/refs/heads/main.zip"
 	svc := NewSkillService(SkillServiceDeps{
@@ -159,6 +161,9 @@ func TestCreateSkillFromURL_ImportsGitHubTreeSubdirectory(t *testing.T) {
 	assertRevisionEntries(t, db, resp.HeadRevisionID)
 	if got := countRows(t, db, "skill_revision_entries", "revision_id = ? AND path LIKE ?", resp.HeadRevisionID, "ignored/%"); got != 0 {
 		t.Fatalf("ignored subtree entry count = %d, want 0", got)
+	}
+	if got := countRows(t, db, "skill_revision_entries", "revision_id = ? AND path LIKE ?", resp.HeadRevisionID, "%DS_Store%"); got != 0 {
+		t.Fatalf("system metadata entry count = %d, want 0", got)
 	}
 }
 

--- a/backend/core/skillv2/service/fake_downloader.go
+++ b/backend/core/skillv2/service/fake_downloader.go
@@ -18,18 +18,18 @@ func (d *FakeZipDownloader) Fail(url string) {
 	d.fails[url] = true
 }
 
-func (d *FakeZipDownloader) Download(ctx context.Context, url string) (string, error) {
+func (d *FakeZipDownloader) Download(ctx context.Context, url string) (DownloadedZip, error) {
 	select {
 	case <-ctx.Done():
-		return "", ctx.Err()
+		return DownloadedZip{}, ctx.Err()
 	default:
 	}
 	if d.fails[url] {
-		return "", fmt.Errorf("download failed: %s", url)
+		return DownloadedZip{}, fmt.Errorf("download failed: %s", url)
 	}
 	path, ok := d.paths[url]
 	if !ok {
-		return "", fmt.Errorf("download not found: %s", url)
+		return DownloadedZip{}, fmt.Errorf("download not found: %s", url)
 	}
-	return path, nil
+	return DownloadedZip{Path: path}, nil
 }

--- a/backend/core/skillv2/service/service.go
+++ b/backend/core/skillv2/service/service.go
@@ -1010,13 +1010,29 @@ func (s *SkillService) filesFromSource(ctx context.Context, ownerUserID string, 
 		if s.downloader == nil {
 			return nil, "", "", fmt.Errorf("downloader is not configured")
 		}
-		zipPath, err := s.downloader.Download(ctx, source.URL)
+		downloaded, err := s.downloader.Download(ctx, source.URL)
 		if err != nil {
 			return nil, "", "", err
 		}
-		files, err := skillpackage.ReadZip(zipPath)
+		if downloaded.Cleanup != nil {
+			defer downloaded.Cleanup()
+		}
+		files, err := skillpackage.ReadZip(downloaded.Path)
+		if err != nil {
+			return nil, "", "", err
+		}
+		if source.PathPrefix != "" {
+			files, err = filesFromSkillSubdirectory(files, source.PathPrefix)
+			if err != nil {
+				return nil, "", "", err
+			}
+		}
 		ensureURLImportDefaults(files)
-		return files, "url", source.URL, err
+		sourceRef := source.SourceURL
+		if sourceRef == "" {
+			sourceRef = source.URL
+		}
+		return files, "url", sourceRef, nil
 	default:
 		return nil, "", "", fmt.Errorf("unsupported source type %q", source.Type)
 	}
@@ -1031,6 +1047,23 @@ func ensureURLImportDefaults(files map[string][]byte) {
 	}
 }
 
+func filesFromSkillSubdirectory(files map[string][]byte, prefix string) (map[string][]byte, error) {
+	prefix, err := cleanSkillPath(prefix)
+	if err != nil {
+		return nil, err
+	}
+	selected := make(map[string][]byte)
+	prefixWithSlash := prefix + "/"
+	for filePath, data := range files {
+		if strings.HasPrefix(filePath, prefixWithSlash) {
+			selected[strings.TrimPrefix(filePath, prefixWithSlash)] = data
+		}
+	}
+	if _, ok := selected["SKILL.md"]; !ok {
+		return nil, fmt.Errorf("skill package must contain SKILL.md")
+	}
+	return selected, nil
+}
 func cleanSkillPath(name string) (string, error) {
 	if name == "" || strings.HasPrefix(name, "/") || strings.Contains(name, `\`) || strings.Contains(name, "//") {
 		return "", fmt.Errorf("unsafe path %q", name)

--- a/backend/core/skillv2/service/types.go
+++ b/backend/core/skillv2/service/types.go
@@ -28,7 +28,12 @@ type UploadStore interface {
 }
 
 type ZipDownloader interface {
-	Download(ctx context.Context, url string) (string, error)
+	Download(ctx context.Context, url string) (DownloadedZip, error)
+}
+
+type DownloadedZip struct {
+	Path    string
+	Cleanup func()
 }
 
 type SkillServiceDeps struct {
@@ -53,6 +58,8 @@ type SourceInput struct {
 	Filename   string
 	StoredPath string
 	URL        string
+	SourceURL  string
+	PathPrefix string
 }
 
 type CreateSkillRequest struct {

--- a/backend/core/skillv2/skillpackage/package.go
+++ b/backend/core/skillv2/skillpackage/package.go
@@ -201,10 +201,7 @@ func normalizeRoot(files map[string][]byte) map[string][]byte {
 	for filePath, data := range files {
 		normalized[strings.TrimPrefix(filePath, prefix)] = data
 	}
-	if _, ok := normalized["SKILL.md"]; ok {
-		return normalized
-	}
-	return files
+	return normalized
 }
 
 func isIgnoredMetadata(name string) bool {

--- a/backend/core/skillv2/skillpackage/package_test.go
+++ b/backend/core/skillv2/skillpackage/package_test.go
@@ -29,6 +29,20 @@ func TestReadZipNormalizesSingleRootAndHashesDeterministically(t *testing.T) {
 	}
 }
 
+func TestReadZipNormalizesRepositoryRootWithoutRootSkillMD(t *testing.T) {
+	zipPath := writeZip(t, map[string]string{
+		"repository-ref/skills/target/SKILL.md": "content",
+		"repository-ref/skills/other/SKILL.md":  "other",
+	})
+	files, err := ReadZip(zipPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(files["skills/target/SKILL.md"]) != "content" || string(files["repository-ref/skills/target/SKILL.md"]) != "" {
+		t.Fatalf("unexpected normalized files: %#v", files)
+	}
+}
+
 func TestReadZipIgnoresSystemMetadataAndNormalizesRoot(t *testing.T) {
 	zipPath := writeZip(t, map[string]string{
 		"wrapped/SKILL.md":            "---\nname: demo\ndescription: demo\n---\n",
@@ -68,6 +82,64 @@ func TestReadZipRejectsUnsafeAndOversizedEntries(t *testing.T) {
 				t.Fatalf("error = %v, want %q", err, tt.want)
 			}
 		})
+	}
+}
+
+func TestReadZipRejectsDuplicatePath(t *testing.T) {
+	zipPath := filepath.Join(t.TempDir(), "duplicate.zip")
+	file, err := os.Create(zipPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	writer := zip.NewWriter(file)
+	for _, content := range []string{"first", "second"} {
+		entry, err := writer.Create("SKILL.md")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, err := entry.Write([]byte(content)); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := writer.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := file.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = ReadZip(zipPath)
+	if err == nil || !strings.Contains(err.Error(), "duplicate path") {
+		t.Fatalf("error = %v, want duplicate path error", err)
+	}
+}
+
+func TestReadZipRejectsSymlink(t *testing.T) {
+	zipPath := filepath.Join(t.TempDir(), "symlink.zip")
+	file, err := os.Create(zipPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	writer := zip.NewWriter(file)
+	header := &zip.FileHeader{Name: "link"}
+	header.SetMode(os.ModeSymlink | 0o777)
+	entry, err := writer.CreateHeader(header)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := entry.Write([]byte("SKILL.md")); err != nil {
+		t.Fatal(err)
+	}
+	if err := writer.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := file.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = ReadZip(zipPath)
+	if err == nil || !strings.Contains(err.Error(), "cannot contain symlink") {
+		t.Fatalf("error = %v, want symlink error", err)
 	}
 }
 


### PR DESCRIPTION
## Summary

修复从 URL 导入 Skill 时 GitHub 仓库、tree 子目录及 GitHub archive ZIP 直链导入失败的问题，并完善下载失败和 ZIP 包校验的错误处理。

## Changes

- 支持公开 GitHub 仓库根链接，并解析默认分支生成 ZIP 归档。
- 支持 /tree/<ref>/<目录> 链接、带斜杠分支、Tag 和 Commit SHA。
- 支持 /archive/refs/tags/<tag>.zip 与 /archive/refs/heads/<branch>.zip GitHub ZIP 直链。
- 保留其他站点 HTTP(S) ZIP 直链原样下载，并支持重定向。
- 为下载大小、ZIP 路径、重复文件、系统元数据及包内容增加安全校验。
- 统一无效 URL、下载失败、非 ZIP、缺少 SKILL.md 等用户可修正错误的业务映射。

## Notes

- 已基于 LazyAGI/LazyMind 最新 main 重放提交。
- 已通过 go test ./skillv2/handler ./skillv2/service ./skillv2/skillpackage。
- 已重建并验证 core 容器健康，健康接口和前端页面均返回 200。
- 已在浏览器实际导入 https://github.com/zarazhangrui/frontend-slides/archive/refs/tags/v2.1.0.zip，技能列表从 10 条增加至 11 条并显示 frontend-slides。