### PR TITLE
fix(chat): refresh skill mention candidates after installation

### DIFF
--- a/frontend/src/modules/chat/components/ChatInput/MentionEditor.test.tsx
+++ b/frontend/src/modules/chat/components/ChatInput/MentionEditor.test.tsx
@@ -1,6 +1,13 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import MentionEditor from "./MentionEditor";
+
+type ScrollablePrototype = typeof HTMLElement.prototype & {
+  scrollTo?: (...args: unknown[]) => void;
+};
+
+const scrollablePrototype = HTMLElement.prototype as ScrollablePrototype;
+const originalScrollTo = scrollablePrototype.scrollTo;
 
 const mocks = vi.hoisted(() => ({
   listSkillAssetsPage: vi.fn(),
@@ -42,6 +49,11 @@ vi.mock("@/modules/chat/utils/request", () => ({
 
 describe("MentionEditor", () => {
   beforeEach(() => {
+    Object.defineProperty(scrollablePrototype, "scrollTo", {
+      configurable: true,
+      value: vi.fn(),
+    });
+
     mocks.listSkillAssetsPage.mockReset();
     mocks.listToolAssetsPage.mockReset();
     mocks.listDatasets.mockReset();
@@ -55,6 +67,19 @@ describe("MentionEditor", () => {
     mocks.listPrompts.mockResolvedValue({ data: { prompts: [] } });
     mocks.listConversations.mockResolvedValue({ data: { conversations: [] } });
     mocks.axiosGet.mockResolvedValue({ data: { workflows: [] } });
+  });
+
+  afterEach(() => {
+    window.getSelection()?.removeAllRanges();
+    if (originalScrollTo) {
+      Object.defineProperty(scrollablePrototype, "scrollTo", {
+        configurable: true,
+        value: originalScrollTo,
+      });
+    } else {
+      Reflect.deleteProperty(scrollablePrototype, "scrollTo");
+    }
+    vi.restoreAllMocks();
   });
 
   it("reloads skills after a previously cached empty list", async () => {

--- a/frontend/src/modules/chat/components/ChatInput/MentionEditor.test.tsx
+++ b/frontend/src/modules/chat/components/ChatInput/MentionEditor.test.tsx
@@ -1,0 +1,103 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import MentionEditor from "./MentionEditor";
+
+const mocks = vi.hoisted(() => ({
+  listSkillAssetsPage: vi.fn(),
+  listToolAssetsPage: vi.fn(),
+  listDatasets: vi.fn(),
+  listPrompts: vi.fn(),
+  listConversations: vi.fn(),
+  axiosGet: vi.fn(),
+}));
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+vi.mock("@/modules/memory/skillApi", () => ({
+  listSkillAssetsPage: mocks.listSkillAssetsPage,
+}));
+
+vi.mock("@/modules/memory/toolApi", () => ({
+  listToolAssetsPage: mocks.listToolAssetsPage,
+}));
+
+vi.mock("@/components/request", () => ({
+  BASE_URL: "",
+  axiosInstance: { get: mocks.axiosGet },
+}));
+
+vi.mock("@/modules/chat/utils/request", () => ({
+  ChatServiceApi: () => ({
+    conversationServiceListConversations: mocks.listConversations,
+  }),
+  KnowledgeBaseServiceApi: () => ({
+    datasetServiceListDatasets: mocks.listDatasets,
+  }),
+  PromptServiceApi: () => ({
+    listPrompts: mocks.listPrompts,
+  }),
+}));
+
+describe("MentionEditor", () => {
+  beforeEach(() => {
+    mocks.listSkillAssetsPage.mockReset();
+    mocks.listToolAssetsPage.mockReset();
+    mocks.listDatasets.mockReset();
+    mocks.listPrompts.mockReset();
+    mocks.listConversations.mockReset();
+    mocks.axiosGet.mockReset();
+
+    mocks.listSkillAssetsPage.mockResolvedValue({ records: [] });
+    mocks.listToolAssetsPage.mockResolvedValue({ records: [] });
+    mocks.listDatasets.mockResolvedValue({ data: { datasets: [] } });
+    mocks.listPrompts.mockResolvedValue({ data: { prompts: [] } });
+    mocks.listConversations.mockResolvedValue({ data: { conversations: [] } });
+    mocks.axiosGet.mockResolvedValue({ data: { workflows: [] } });
+  });
+
+  it("reloads skills after a previously cached empty list", async () => {
+    render(
+      <MentionEditor
+        value=""
+        placeholder="message"
+        onChange={vi.fn()}
+        onMentionsChange={vi.fn()}
+        onPaste={vi.fn()}
+        onSend={vi.fn()}
+        onCompositionChange={vi.fn()}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(mocks.listSkillAssetsPage).toHaveBeenCalledTimes(1);
+    });
+
+    mocks.listSkillAssetsPage.mockResolvedValue({
+      records: [
+        {
+          id: "skill-new",
+          name: "新增技能",
+          description: "刚刚添加的技能",
+        },
+      ],
+    });
+
+    const editor = screen.getByRole("textbox");
+    editor.textContent = "@skill:";
+    const range = document.createRange();
+    const textNode = editor.firstChild;
+    if (!textNode) {
+      throw new Error("Mention editor did not create a text node");
+    }
+    range.setStart(textNode, textNode.textContent?.length || 0);
+    range.collapse(true);
+    window.getSelection()?.removeAllRanges();
+    window.getSelection()?.addRange(range);
+    fireEvent.input(editor);
+
+    expect(await screen.findByRole("option", { name: "新增技能" })).toBeInTheDocument();
+    expect(mocks.listSkillAssetsPage).toHaveBeenCalledTimes(2);
+  });
+});

--- a/frontend/src/modules/chat/components/ChatInput/MentionEditor.tsx
+++ b/frontend/src/modules/chat/components/ChatInput/MentionEditor.tsx
@@ -97,6 +97,9 @@ const MENU_VIEWPORT_OFFSET = 16;
 const cacheKey = (type: CandidateType, keyword: string) =>
   `${type}:${keyword.trim().toLocaleLowerCase()}`;
 
+const bypassCandidateCache = (type: CandidateType) =>
+  type === "skill" || type === "tool";
+
 function escapeHtml(value: string) {
   return value.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
 }
@@ -213,7 +216,7 @@ async function loadCandidates(type: CandidateType, keyword: string): Promise<Can
 }
 
 function loadAndCacheCandidates(type: CandidateType, keyword: string) {
-  if (type === "tool") return loadCandidates(type, keyword);
+  if (bypassCandidateCache(type)) return loadCandidates(type, keyword);
   const key = cacheKey(type, keyword);
   const cached = candidateCache.get(key);
   if (cached) return Promise.resolve(cached);
@@ -241,7 +244,7 @@ function loadAndCacheCandidates(type: CandidateType, keyword: string) {
 }
 
 function cachedCandidates(type: CandidateType, keyword: string) {
-  if (type === "tool") return [];
+  if (bypassCandidateCache(type)) return [];
   const exact = candidateCache.get(cacheKey(type, keyword));
   if (exact) return exact;
   const base = candidateCache.get(cacheKey(type, ""));
@@ -355,7 +358,7 @@ const MentionEditor = forwardRef<MentionEditorRef, {
       setLoading(false);
     }
     const hasExactCache = targetGroups.every((item) =>
-      item.type !== "tool" && candidateCache.has(cacheKey(item.type, query.keyword)),
+      !bypassCandidateCache(item.type) && candidateCache.has(cacheKey(item.type, query.keyword)),
     );
     if (hasExactCache) {
       setCandidates(targetGroups.flatMap((item) => cachedCandidates(item.type, query.keyword)));


### PR DESCRIPTION
## Summary

修复 Skill 创建、安装或删除后，聊天 `@skill:` 候选列表仍显示旧数据的问题。

## Changes

- 让 `@skill:` 候选与工具候选一样不复用持久缓存，每次打开或输入时重新请求最新 Skill 列表。
- 保持知识库、工作流、提示词和会话候选的原有缓存策略不变。
- 新增回归测试，覆盖已缓存空列表后新增 Skill 能立即显示的场景。

## Notes

- 已通过新增 MentionEditor Vitest 用例、ESLint 和前端生产构建。
- 已重建本地前端镜像，并在浏览器手工验证删除 `frontend-slides` 后不再出现在 `@skill:` 列表中。
- `typecheck:all` 仍受当前基线既有生成 API 与其他模块类型错误影响，未由本次改动引入。
