### PR TITLE
feat(skill): support fallback metadata for imports

### DIFF
--- a/backend/core/openapi_registry.go
+++ b/backend/core/openapi_registry.go
@@ -1313,10 +1313,10 @@ type skillSourceOpenAPIRequest struct {
 }
 
 type skillCreateManagedOpenAPIRequest struct {
-	Name        string                    `json:"name,omitempty" desc:"Legacy inline-create field. ZIP and URL imports derive name from SKILL.md frontmatter."`
+	Name        string                    `json:"name,omitempty" desc:"Legacy inline-create field. ZIP and URL imports resolve name from SKILL.md frontmatter or package fallback metadata."`
 	Category    string                    `json:"category,omitempty" desc:"Legacy inline-create field. ZIP and URL imports use External."`
 	Source      skillSourceOpenAPIRequest `json:"source"`
-	Description string                    `json:"description,omitempty" desc:"Legacy inline-create field. ZIP and URL imports derive description from SKILL.md frontmatter."`
+	Description string                    `json:"description,omitempty" desc:"Legacy inline-create field. ZIP and URL imports resolve description from SKILL.md frontmatter or the first body paragraph."`
 	Tags        []string                  `json:"tags,omitempty"`
 	AutoEvo     *bool                     `json:"auto_evo,omitempty"`
 	IsEnabled   *bool                     `json:"is_enabled,omitempty"`
@@ -1388,6 +1388,8 @@ type skillDetailOpenAPIResponse struct {
 type skillWriteOpenAPIResponse struct {
 	SkillID        string `json:"skill_id"`
 	HeadRevisionID string `json:"head_revision_id,omitempty"`
+	Name           string `json:"name,omitempty"`
+	Description    string `json:"description,omitempty"`
 }
 
 type skillFileQueryParams struct {
@@ -2710,7 +2712,7 @@ func registeredCoreOperations() []openAPIOperation {
 			Method:      "POST",
 			Path:        "/skills",
 			Summary:     "Create directory skill",
-			Description: "Creates one directory-based skill from an uploaded ZIP or URL. The package must contain SKILL.md; description is product metadata and is not written into SKILL.md front matter.",
+			Description: "Creates one directory-based skill from an uploaded ZIP or URL. The package must contain SKILL.md; missing name and description metadata are resolved without rewriting SKILL.md.",
 			Tags:        []string{"skills"},
 			RequestBody: jsonBodyOf(skillCreateManagedOpenAPIRequest{}, true),
 			Responses:   map[int]openAPIResponse{200: resp("Created skill", skillWriteOpenAPIResponse{})},

--- a/backend/core/skillv2/handler/handler.go
+++ b/backend/core/skillv2/handler/handler.go
@@ -240,6 +240,8 @@ func Create(w http.ResponseWriter, r *http.Request) {
 	common.ReplyOK(w, map[string]any{
 		"skill_id":         resp.SkillID,
 		"head_revision_id": resp.HeadRevisionID,
+		"name":             resp.Name,
+		"description":      resp.Description,
 	})
 }
 

--- a/backend/core/skillv2/market/service.go
+++ b/backend/core/skillv2/market/service.go
@@ -604,10 +604,7 @@ func copyHeadRevision(ctx context.Context, tx *gorm.DB, sourceSkillID, ownerUser
 	if source.HeadRevisionID == nil {
 		return "", "", fmt.Errorf("source skill has no head revision")
 	}
-	meta, err := skillmetadata.FromRevision(ctx, tx, *source.HeadRevisionID)
-	if err != nil {
-		return "", "", err
-	}
+	meta := skillmetadata.Metadata{Name: source.SkillName, Description: source.Description}
 	var conflicts int64
 	if err := tx.Model(&skillRow{}).
 		Where("owner_user_id = ? AND category = ? AND skill_name = ? AND deleted_at IS NULL", ownerUserID, skillmetadata.ExternalCategory, meta.Name).

--- a/backend/core/skillv2/metadata/metadata.go
+++ b/backend/core/skillv2/metadata/metadata.go
@@ -21,39 +21,98 @@ type Metadata struct {
 	Description string
 }
 
+type Parsed struct {
+	Metadata
+	Body           string
+	HasName        bool
+	HasDescription bool
+}
+
 type frontmatter struct {
 	Name        string `yaml:"name"`
 	Description string `yaml:"description"`
 }
 
 func ParseRequired(content []byte) (Metadata, error) {
+	parsed, err := Parse(content)
+	if err != nil {
+		return Metadata{}, err
+	}
+	if !parsed.HasName {
+		return Metadata{}, fmt.Errorf("SKILL.md frontmatter field \"name\" is required")
+	}
+	if err := validatePathSegment(parsed.Name); err != nil {
+		return Metadata{}, fmt.Errorf("invalid SKILL.md frontmatter field \"name\": %w", err)
+	}
+	if !parsed.HasDescription {
+		return Metadata{}, fmt.Errorf("SKILL.md frontmatter field \"description\" is required")
+	}
+	return parsed.Metadata, nil
+}
+
+func Parse(content []byte) (Parsed, error) {
 	normalized := strings.ReplaceAll(string(content), "\r\n", "\n")
 	if !strings.HasPrefix(normalized, "---\n") {
-		return Metadata{}, fmt.Errorf("SKILL.md frontmatter is required")
+		return Parsed{Body: normalized}, nil
 	}
 	rest := strings.TrimPrefix(normalized, "---\n")
 	idx := strings.Index(rest, "\n---")
 	if idx < 0 {
-		return Metadata{}, fmt.Errorf("SKILL.md frontmatter closing separator is required")
+		return Parsed{}, fmt.Errorf("SKILL.md frontmatter closing separator is required")
 	}
 	var raw frontmatter
 	if err := yaml.Unmarshal([]byte(rest[:idx]), &raw); err != nil {
-		return Metadata{}, fmt.Errorf("invalid SKILL.md frontmatter: %w", err)
+		return Parsed{}, fmt.Errorf("invalid SKILL.md frontmatter: %w", err)
 	}
-	meta := Metadata{
-		Name:        strings.TrimSpace(raw.Name),
-		Description: strings.TrimSpace(raw.Description),
+	name := strings.TrimSpace(raw.Name)
+	description := strings.TrimSpace(raw.Description)
+	body := strings.TrimPrefix(rest[idx+len("\n---"):], "\n")
+	return Parsed{
+		Metadata: Metadata{
+			Name:        name,
+			Description: description,
+		},
+		Body:           body,
+		HasName:        name != "",
+		HasDescription: description != "",
+	}, nil
+}
+
+func FirstBodyParagraph(body string) string {
+	lines := strings.Split(strings.ReplaceAll(body, "\r\n", "\n"), "\n")
+	paragraph := make([]string, 0)
+	started := false
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if !started {
+			if trimmed == "" || isMarkdownHeading(trimmed) {
+				continue
+			}
+			started = true
+		}
+		if trimmed == "" {
+			break
+		}
+		paragraph = append(paragraph, trimmed)
 	}
-	if meta.Name == "" {
-		return Metadata{}, fmt.Errorf("SKILL.md frontmatter field \"name\" is required")
+	text := strings.Join(strings.Fields(strings.Join(paragraph, " ")), " ")
+	runes := []rune(text)
+	if len(runes) > 100 {
+		return string(runes[:100]) + "…"
 	}
-	if err := validatePathSegment(meta.Name); err != nil {
-		return Metadata{}, fmt.Errorf("invalid SKILL.md frontmatter field \"name\": %w", err)
+	return text
+}
+
+func isMarkdownHeading(line string) bool {
+	line = strings.TrimLeft(line, " \t")
+	count := 0
+	for count < len(line) && line[count] == '#' {
+		count++
 	}
-	if meta.Description == "" {
-		return Metadata{}, fmt.Errorf("SKILL.md frontmatter field \"description\" is required")
+	if count == 0 || count > 6 || count >= len(line) {
+		return false
 	}
-	return meta, nil
+	return line[count] == ' ' || line[count] == '\t'
 }
 
 func FromFiles(files map[string][]byte) (Metadata, error) {
@@ -65,24 +124,40 @@ func FromFiles(files map[string][]byte) (Metadata, error) {
 }
 
 func FromEntries(ctx context.Context, tx *gorm.DB, entries map[string]versionfs.Entry) (Metadata, error) {
+	content, err := skillMDContent(ctx, tx, entries)
+	if err != nil {
+		return Metadata{}, err
+	}
+	return ParseRequired(content)
+}
+
+func skillMDContent(ctx context.Context, tx *gorm.DB, entries map[string]versionfs.Entry) ([]byte, error) {
 	entry, ok := entries["SKILL.md"]
 	if !ok || entry.EntryType != versionfs.EntryTypeFile || strings.TrimSpace(entry.BlobHash) == "" {
-		return Metadata{}, fmt.Errorf("skill package must contain SKILL.md")
+		return nil, fmt.Errorf("skill package must contain SKILL.md")
 	}
 	var blob orm.SkillV2Blob
 	if err := tx.WithContext(ctx).Where("hash = ?", entry.BlobHash).Take(&blob).Error; err != nil {
-		return Metadata{}, err
+		return nil, err
 	}
 	if blob.Binary || blob.StorageBackend != "postgres" {
-		return Metadata{}, fmt.Errorf("SKILL.md must be a text file")
+		return nil, fmt.Errorf("SKILL.md must be a text file")
 	}
-	return ParseRequired(blob.Content)
+	return blob.Content, nil
 }
 
 func FromRevision(ctx context.Context, tx *gorm.DB, revisionID string) (Metadata, error) {
+	entries, err := entriesFromRevision(ctx, tx, revisionID)
+	if err != nil {
+		return Metadata{}, err
+	}
+	return FromEntries(ctx, tx, entries)
+}
+
+func entriesFromRevision(ctx context.Context, tx *gorm.DB, revisionID string) (map[string]versionfs.Entry, error) {
 	var rows []orm.SkillV2RevisionEntry
 	if err := tx.WithContext(ctx).Where("revision_id = ?", revisionID).Find(&rows).Error; err != nil {
-		return Metadata{}, err
+		return nil, err
 	}
 	entries := make(map[string]versionfs.Entry, len(rows))
 	for _, row := range rows {
@@ -101,10 +176,18 @@ func FromRevision(ctx context.Context, tx *gorm.DB, revisionID string) (Metadata
 			Mode:      row.Mode,
 		}
 	}
-	return FromEntries(ctx, tx, entries)
+	return entries, nil
 }
 
 func SyncPublished(ctx context.Context, tx *gorm.DB, skillID string, entries map[string]versionfs.Entry, now time.Time) error {
+	var skill orm.SkillV2Skill
+	if err := tx.WithContext(ctx).Where("id = ? AND deleted_at IS NULL", skillID).Take(&skill).Error; err != nil {
+		return err
+	}
+	if skill.Category == ExternalCategory {
+		_, err := skillMDContent(ctx, tx, entries)
+		return err
+	}
 	meta, err := FromEntries(ctx, tx, entries)
 	if err != nil {
 		return err
@@ -113,11 +196,11 @@ func SyncPublished(ctx context.Context, tx *gorm.DB, skillID string, entries map
 }
 
 func SyncRevision(ctx context.Context, tx *gorm.DB, skillID, revisionID string, now time.Time) error {
-	meta, err := FromRevision(ctx, tx, revisionID)
+	entries, err := entriesFromRevision(ctx, tx, revisionID)
 	if err != nil {
 		return err
 	}
-	return Sync(ctx, tx, skillID, meta, now)
+	return SyncPublished(ctx, tx, skillID, entries, now)
 }
 
 func Sync(ctx context.Context, tx *gorm.DB, skillID string, meta Metadata, now time.Time) error {

--- a/backend/core/skillv2/metadata/metadata_test.go
+++ b/backend/core/skillv2/metadata/metadata_test.go
@@ -33,3 +33,40 @@ func TestParseRequiredRejectsMissingFields(t *testing.T) {
 		})
 	}
 }
+
+func TestParseAllowsMissingFrontmatterFields(t *testing.T) {
+	parsed, err := Parse([]byte("---\ndescription: Imported description\n---\n# Skill\n\n正文首段。\n"))
+	if err != nil {
+		t.Fatalf("Parse returned error: %v", err)
+	}
+	if parsed.HasName || !parsed.HasDescription {
+		t.Fatalf("Parse presence = name:%v description:%v", parsed.HasName, parsed.HasDescription)
+	}
+	if parsed.Description != "Imported description" || parsed.Body != "# Skill\n\n正文首段。\n" {
+		t.Fatalf("Parse result = %#v", parsed)
+	}
+
+	parsed, err = Parse([]byte("# Skill\r\n\r\n正文首段。\r\n"))
+	if err != nil {
+		t.Fatalf("Parse without frontmatter returned error: %v", err)
+	}
+	if parsed.HasName || parsed.HasDescription || parsed.Body != "# Skill\n\n正文首段。\n" {
+		t.Fatalf("Parse without frontmatter result = %#v", parsed)
+	}
+}
+
+func TestFirstBodyParagraphSkipsHeadingsAndTruncatesRunes(t *testing.T) {
+	if got := FirstBodyParagraph("# 标题\n\n这是第一段。\n仍是第一段。\n\n这是第二段。\n"); got != "这是第一段。 仍是第一段。" {
+		t.Fatalf("FirstBodyParagraph = %q", got)
+	}
+
+	long := strings.Repeat("技", 101)
+	if got := FirstBodyParagraph("## 标题\n\n" + long); got != strings.Repeat("技", 100)+"…" {
+		t.Fatalf("FirstBodyParagraph long result length = %d, value = %q", len([]rune(got)), got)
+	}
+
+	exact := strings.Repeat("能", 100)
+	if got := FirstBodyParagraph(exact); got != exact {
+		t.Fatalf("FirstBodyParagraph exact result = %q", got)
+	}
+}

--- a/backend/core/skillv2/revision/commit_draft_test.go
+++ b/backend/core/skillv2/revision/commit_draft_test.go
@@ -158,6 +158,33 @@ func TestCommitDraft_InvalidFrontmatterRollsBackAndKeepsDraft(t *testing.T) {
 	}
 }
 
+func TestCommitDraft_ExternalSkillKeepsDatabaseMetadataWithoutFrontmatter(t *testing.T) {
+	db := testutil.NewTestDB(t)
+	testutil.SeedSkillWithRevision(t, db, "skill1", "rev1")
+	if err := db.Model(&testutil.SkillRow{}).Where("id = ?", "skill1").Updates(map[string]any{
+		"category":      "external",
+		"relative_root": "external/论文精读",
+	}).Error; err != nil {
+		t.Fatalf("mark skill external: %v", err)
+	}
+	testutil.SeedTextBlob(t, db, "h_external_no_frontmatter", "# Missing frontmatter\n\n更新后的正文。\n")
+	testutil.SeedDraftEntry(t, db, "skill1", "SKILL.md", "upsert", "file", "h_external_no_frontmatter")
+	service := NewService(ServiceDeps{DB: db.DB, BlobStore: NewBlobStore(db.DB, NewLocalObjectStore(t.TempDir()))})
+
+	resp, err := service.CommitDraft(context.Background(), CommitDraftRequest{SkillID: "skill1", UserID: "user_001", DraftVersion: 1})
+	if err != nil {
+		t.Fatalf("CommitDraft returned error: %v", err)
+	}
+	testutil.AssertHeadRevision(t, db, "skill1", resp.RevisionID)
+	var skill testutil.SkillRow
+	if err := db.Where("id = ?", "skill1").Take(&skill).Error; err != nil {
+		t.Fatalf("query skill: %v", err)
+	}
+	if skill.SkillName != "论文精读" || skill.Description != "用于阅读和总结论文的技能" || skill.RelativeRoot != "external/论文精读" {
+		t.Fatalf("database metadata changed: %#v", skill)
+	}
+}
+
 func TestCommitDraft_RejectsEmptyCommit(t *testing.T) {
 	db := testutil.NewTestDB(t)
 	testutil.SeedSkillWithRevision(t, db, "skill1", "rev1")

--- a/backend/core/skillv2/service/create_skill_validation_test.go
+++ b/backend/core/skillv2/service/create_skill_validation_test.go
@@ -32,22 +32,110 @@ func TestCreateSkillFromUploadedZip_RequiresSkillMD(t *testing.T) {
 	assertNoSkillTruthRows(t, db)
 }
 
-func TestCreateSkillFromUploadedZip_RequiresFrontmatterMetadata(t *testing.T) {
+func TestCreateSkillFromUploadedZip_ResolvesMissingFrontmatterMetadata(t *testing.T) {
+	tests := []struct {
+		name            string
+		filename        string
+		entryPath       string
+		content         []byte
+		wantName        string
+		wantDescription string
+		wantGenerated   bool
+	}{
+		{
+			name:            "missing frontmatter at archive root",
+			filename:        "frontmatter.zip",
+			entryPath:       "SKILL.md",
+			content:         []byte("# Skill\n\n正文首段。\n"),
+			wantName:        "frontmatter",
+			wantDescription: "正文首段。",
+		},
+		{
+			name:            "missing name uses package root",
+			filename:        "archive-name.zip",
+			entryPath:       "package-root/SKILL.md",
+			content:         []byte("---\ndescription: description\n---\n# Skill\n"),
+			wantName:        "package-root",
+			wantDescription: "description",
+		},
+		{
+			name:            "invalid package root uses archive filename",
+			filename:        "archive-name.zip",
+			entryPath:       " /SKILL.md",
+			content:         []byte("---\ndescription: description\n---\n# Skill\n"),
+			wantName:        "archive-name",
+			wantDescription: "description",
+		},
+		{
+			name:            "missing package root and archive filename uses generated id",
+			entryPath:       "SKILL.md",
+			content:         []byte("---\ndescription: description\n---\n# Skill\n"),
+			wantDescription: "description",
+			wantGenerated:   true,
+		},
+		{
+			name:            "missing description uses first body paragraph",
+			filename:        "skill.zip",
+			entryPath:       "SKILL.md",
+			content:         []byte("---\nname: skill\n---\n# Skill\n\n第一段。\n继续第一段。\n\n第二段。\n"),
+			wantName:        "skill",
+			wantDescription: "第一段。 继续第一段。",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			db := newSkillV2TestDB(t)
+			storedFilename := tc.filename
+			if storedFilename == "" {
+				storedFilename = "stored.zip"
+			}
+			zipPath := filepath.Join(t.TempDir(), storedFilename)
+			writeSkillZip(t, zipPath, map[string][]byte{tc.entryPath: tc.content})
+			uploadStore := newFakeUploadStore()
+			uploadID := "upload_" + strings.ReplaceAll(tc.name, " ", "_")
+			uploadStore.Put(UploadSession{UploadID: uploadID, OwnerUserID: "user_001", State: "completed", StoredPath: zipPath, Filename: tc.filename})
+			svc := newCreateSkillValidationService(t, db, uploadStore)
+
+			resp, err := svc.CreateSkill(context.Background(), validCreateSkillRequest(uploadID))
+			if err != nil {
+				t.Fatalf("CreateSkill returned error: %v", err)
+			}
+			wantName := tc.wantName
+			if tc.wantGenerated {
+				wantName = "lazymind-skill-" + resp.SkillID
+			}
+			if resp.Name != wantName || resp.Description != tc.wantDescription {
+				t.Fatalf("CreateSkill metadata = (%q, %q), want (%q, %q)", resp.Name, resp.Description, wantName, tc.wantDescription)
+			}
+			var skill testSkillV2SkillRow
+			if err := db.Where("id = ?", resp.SkillID).Take(&skill).Error; err != nil {
+				t.Fatalf("query created skill: %v", err)
+			}
+			if skill.SkillName != wantName || skill.Description != tc.wantDescription {
+				t.Fatalf("stored metadata = (%q, %q), want (%q, %q)", skill.SkillName, skill.Description, wantName, tc.wantDescription)
+			}
+			blob := getBlobByPath(t, db, resp.HeadRevisionID, "SKILL.md")
+			if string(blob.Content) != string(tc.content) {
+				t.Fatalf("stored SKILL.md changed: got %q want %q", blob.Content, tc.content)
+			}
+		})
+	}
+}
+
+func TestCreateSkillFromUploadedZip_RejectsInvalidExistingFrontmatter(t *testing.T) {
 	for name, content := range map[string][]byte{
-		"frontmatter": []byte("# Skill\n"),
-		"name":        []byte("---\ndescription: description\n---\n# Skill\n"),
-		"description": []byte("---\nname: skill\n---\n# Skill\n"),
+		"malformed yaml": []byte("---\nname: [broken\n---\n正文。\n"),
+		"invalid name":   []byte("---\nname: bad/name\ndescription: description\n---\n正文。\n"),
 	} {
 		t.Run(name, func(t *testing.T) {
 			db := newSkillV2TestDB(t)
-			zipPath := filepath.Join(t.TempDir(), name+".zip")
+			zipPath := filepath.Join(t.TempDir(), "skill.zip")
 			writeSkillZip(t, zipPath, map[string][]byte{"SKILL.md": content})
 			uploadStore := newFakeUploadStore()
-			uploadID := "upload_missing_" + name
-			uploadStore.Put(UploadSession{UploadID: uploadID, OwnerUserID: "user_001", State: "completed", StoredPath: zipPath, Filename: name + ".zip"})
+			uploadStore.Put(UploadSession{UploadID: "upload_invalid", OwnerUserID: "user_001", State: "completed", StoredPath: zipPath, Filename: "skill.zip"})
 			svc := newCreateSkillValidationService(t, db, uploadStore)
 
-			if _, err := svc.CreateSkill(context.Background(), validCreateSkillRequest(uploadID)); err == nil {
+			if _, err := svc.CreateSkill(context.Background(), validCreateSkillRequest("upload_invalid")); err == nil {
 				t.Fatal("CreateSkill succeeded")
 			}
 			assertNoSkillTruthRows(t, db)

--- a/backend/core/skillv2/service/crud_and_import_test.go
+++ b/backend/core/skillv2/service/crud_and_import_test.go
@@ -54,6 +54,38 @@ func TestCreateSkillFromURL_CreatesInitialRevision(t *testing.T) {
 	assertBlobRouting(t, db, resp.HeadRevisionID)
 }
 
+func TestCreateSkillFromURL_ResolvesMissingMetadata(t *testing.T) {
+	db := newSkillV2TestDB(t)
+	zipPath := filepath.Join(t.TempDir(), "url-skill.zip")
+	content := []byte("# URL Skill\n\nURL 正文首段。\n")
+	writeSkillZip(t, zipPath, map[string][]byte{"SKILL.md": content})
+	downloader := NewFakeZipDownloader(map[string]string{
+		"https://example.test/url-skill.zip": zipPath,
+	})
+	svc := NewSkillService(SkillServiceDeps{
+		DB:         db,
+		Downloader: downloader,
+		BlobStore:  NewBlobStore(db, NewLocalObjectStore(t.TempDir())),
+		Clock:      fixedClock(),
+	})
+
+	resp, err := svc.CreateSkill(context.Background(), CreateSkillRequest{
+		OwnerUserID:  "user_001",
+		CreateUserID: "user_001",
+		Source:       SourceInput{Type: "url", URL: "https://example.test/url-skill.zip"},
+	})
+	if err != nil {
+		t.Fatalf("CreateSkill from URL returned error: %v", err)
+	}
+	if resp.Name != "url-skill" || resp.Description != "URL 正文首段。" {
+		t.Fatalf("resolved URL metadata = (%q, %q)", resp.Name, resp.Description)
+	}
+	blob := getBlobByPath(t, db, resp.HeadRevisionID, "SKILL.md")
+	if string(blob.Content) != string(content) {
+		t.Fatalf("stored SKILL.md changed: got %q want %q", blob.Content, content)
+	}
+}
+
 func TestCreateSkillFromURL_DownloadFailureDoesNotCreateSkill(t *testing.T) {
 	db := newSkillV2TestDB(t)
 	downloader := NewFakeZipDownloader(map[string]string{})

--- a/backend/core/skillv2/service/service.go
+++ b/backend/core/skillv2/service/service.go
@@ -9,6 +9,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"net/url"
 	"path"
 	"sort"
 	"strings"
@@ -47,15 +48,17 @@ func (s *SkillService) CreateSkill(ctx context.Context, req CreateSkillRequest) 
 	req.Name = strings.TrimSpace(req.Name)
 	req.Category = strings.TrimSpace(req.Category)
 	req.Description = strings.TrimSpace(req.Description)
-	files, sourceRefType, sourceRefID, err := s.filesFromSource(ctx, req.OwnerUserID, req.Source)
+	skillID := newID()
+	pkg, sourceRefType, sourceRefID, err := s.filesFromSource(ctx, req.OwnerUserID, req.Source)
 	if err != nil {
 		return CreateSkillResponse{}, err
 	}
+	files := pkg.Files
 	if err := validateSkillFiles(files); err != nil {
 		return CreateSkillResponse{}, err
 	}
 	if isExternalImportSource(req.Source.Type) {
-		meta, err := skillmetadata.FromFiles(files)
+		meta, err := resolveExternalMetadata(pkg, skillID)
 		if err != nil {
 			return CreateSkillResponse{}, err
 		}
@@ -71,7 +74,6 @@ func (s *SkillService) CreateSkill(ctx context.Context, req CreateSkillRequest) 
 		return CreateSkillResponse{}, err
 	}
 
-	skillID := newID()
 	revisionID := newID()
 	now := s.clock.Now()
 	tags, _ := json.Marshal(req.Tags)
@@ -130,7 +132,7 @@ func (s *SkillService) CreateSkill(ctx context.Context, req CreateSkillRequest) 
 	if err != nil {
 		return CreateSkillResponse{}, err
 	}
-	return CreateSkillResponse{SkillID: skillID, HeadRevisionID: revisionID}, nil
+	return CreateSkillResponse{SkillID: skillID, HeadRevisionID: revisionID, Name: req.Name, Description: req.Description}, nil
 }
 
 func isExternalImportSource(sourceType string) bool {
@@ -290,10 +292,11 @@ func (s *SkillService) PatchSkill(ctx context.Context, req PatchSkillRequest) (P
 		if draftEntries > 0 {
 			return fmt.Errorf("cannot replace source while draft overlay exists")
 		}
-		files, sourceRefType, sourceRefID, err := s.filesFromSource(ctx, skill.OwnerUserID, *req.Source)
+		pkg, sourceRefType, sourceRefID, err := s.filesFromSource(ctx, skill.OwnerUserID, *req.Source)
 		if err != nil {
 			return err
 		}
+		files := pkg.Files
 		if err := validateSkillFiles(files); err != nil {
 			return err
 		}
@@ -302,7 +305,7 @@ func (s *SkillService) PatchSkill(ctx context.Context, req PatchSkillRequest) (P
 		nextDescription := skill.Description
 		externalImport := isExternalImportSource(req.Source.Type)
 		if externalImport {
-			meta, err := skillmetadata.FromFiles(files)
+			meta, err := resolveExternalMetadata(pkg, skill.ID)
 			if err != nil {
 				return err
 			}
@@ -937,43 +940,49 @@ func (s *SkillService) entriesFromFiles(ctx context.Context, tx *gorm.DB, revisi
 	return entries, hashTree(entries), nil
 }
 
-func (s *SkillService) filesFromSource(ctx context.Context, ownerUserID string, source SourceInput) (map[string][]byte, string, string, error) {
+type sourcePackage struct {
+	Files           map[string][]byte
+	PackageRoot     string
+	ArchiveFilename string
+}
+
+func (s *SkillService) filesFromSource(ctx context.Context, ownerUserID string, source SourceInput) (sourcePackage, string, string, error) {
 	switch source.Type {
 	case "uploaded_zip":
 		if s.uploadStore == nil {
-			return nil, "", "", fmt.Errorf("upload store is not configured")
+			return sourcePackage{}, "", "", fmt.Errorf("upload store is not configured")
 		}
 		session, err := s.uploadStore.Get(ctx, source.UploadID)
 		if err != nil {
-			return nil, "", "", err
+			return sourcePackage{}, "", "", err
 		}
 		if session.OwnerUserID != ownerUserID {
-			return nil, "", "", fmt.Errorf("upload belongs to another user")
+			return sourcePackage{}, "", "", fmt.Errorf("upload belongs to another user")
 		}
 		if session.State != "completed" {
-			return nil, "", "", fmt.Errorf("upload is not completed")
+			return sourcePackage{}, "", "", fmt.Errorf("upload is not completed")
 		}
-		files, err := readZipFiles(session.StoredPath)
-		return files, "upload", source.UploadID, err
+		pkg, err := readZipFiles(session.StoredPath, session.Filename)
+		return pkg, "upload", source.UploadID, err
 	case "local_zip":
 		if strings.TrimSpace(source.StoredPath) == "" {
-			return nil, "", "", fmt.Errorf("stored_path required")
+			return sourcePackage{}, "", "", fmt.Errorf("stored_path required")
 		}
-		files, err := readZipFiles(source.StoredPath)
-		return files, "local_zip", source.Filename, err
+		pkg, err := readZipFiles(source.StoredPath, source.Filename)
+		return pkg, "local_zip", source.Filename, err
 	case "url":
 		if s.downloader == nil {
-			return nil, "", "", fmt.Errorf("downloader is not configured")
+			return sourcePackage{}, "", "", fmt.Errorf("downloader is not configured")
 		}
 		zipPath, err := s.downloader.Download(ctx, source.URL)
 		if err != nil {
-			return nil, "", "", err
+			return sourcePackage{}, "", "", err
 		}
-		files, err := readZipFiles(zipPath)
-		ensureURLImportDefaults(files)
-		return files, "url", source.URL, err
+		pkg, err := readZipFiles(zipPath, archiveFilenameFromURL(source.URL))
+		ensureURLImportDefaults(pkg.Files)
+		return pkg, "url", source.URL, err
 	default:
-		return nil, "", "", fmt.Errorf("unsupported source type %q", source.Type)
+		return sourcePackage{}, "", "", fmt.Errorf("unsupported source type %q", source.Type)
 	}
 }
 
@@ -986,10 +995,10 @@ func ensureURLImportDefaults(files map[string][]byte) {
 	}
 }
 
-func readZipFiles(zipPath string) (map[string][]byte, error) {
+func readZipFiles(zipPath, archiveFilename string) (sourcePackage, error) {
 	reader, err := zip.OpenReader(zipPath)
 	if err != nil {
-		return nil, err
+		return sourcePackage{}, err
 	}
 	defer reader.Close()
 
@@ -997,51 +1006,52 @@ func readZipFiles(zipPath string) (map[string][]byte, error) {
 	for _, entry := range reader.File {
 		if entry.FileInfo().IsDir() {
 			if _, err := cleanSkillPath(strings.TrimSuffix(entry.Name, "/")); err != nil {
-				return nil, err
+				return sourcePackage{}, err
 			}
 			continue
 		}
 		name, err := cleanSkillPath(entry.Name)
 		if err != nil {
-			return nil, err
+			return sourcePackage{}, err
 		}
 		rc, err := entry.Open()
 		if err != nil {
-			return nil, err
+			return sourcePackage{}, err
 		}
 		data, readErr := io.ReadAll(rc)
 		closeErr := rc.Close()
 		if readErr != nil {
-			return nil, readErr
+			return sourcePackage{}, readErr
 		}
 		if closeErr != nil {
-			return nil, closeErr
+			return sourcePackage{}, closeErr
 		}
 		files[name] = data
 	}
-	return normalizeSkillPackageRoot(files), nil
+	normalized, packageRoot := normalizeSkillPackageRoot(files)
+	return sourcePackage{Files: normalized, PackageRoot: packageRoot, ArchiveFilename: archiveFilename}, nil
 }
 
-func normalizeSkillPackageRoot(files map[string][]byte) map[string][]byte {
+func normalizeSkillPackageRoot(files map[string][]byte) (map[string][]byte, string) {
 	if _, ok := files["SKILL.md"]; ok {
-		return files
+		return files, ""
 	}
 	root := ""
 	for filePath := range files {
 		parts := strings.SplitN(filePath, "/", 2)
 		if len(parts) != 2 || parts[1] == "" {
-			return files
+			return files, ""
 		}
 		if root == "" {
 			root = parts[0]
 			continue
 		}
 		if root != parts[0] {
-			return files
+			return files, ""
 		}
 	}
 	if root == "" {
-		return files
+		return files, ""
 	}
 	normalized := make(map[string][]byte, len(files))
 	prefix := root + "/"
@@ -1050,9 +1060,55 @@ func normalizeSkillPackageRoot(files map[string][]byte) map[string][]byte {
 		normalized[relPath] = data
 	}
 	if _, ok := normalized["SKILL.md"]; ok {
-		return normalized
+		return normalized, root
 	}
-	return files
+	return files, ""
+}
+
+func resolveExternalMetadata(pkg sourcePackage, skillID string) (skillmetadata.Metadata, error) {
+	content, ok := pkg.Files["SKILL.md"]
+	if !ok {
+		return skillmetadata.Metadata{}, fmt.Errorf("skill package must contain SKILL.md")
+	}
+	parsed, err := skillmetadata.Parse(content)
+	if err != nil {
+		return skillmetadata.Metadata{}, err
+	}
+	name := parsed.Name
+	if parsed.HasName {
+		if err := validatePathSegment(name); err != nil {
+			return skillmetadata.Metadata{}, fmt.Errorf("invalid SKILL.md frontmatter field \"name\": %w", err)
+		}
+	} else {
+		name = strings.TrimSpace(pkg.PackageRoot)
+		if err := validatePathSegment(name); err != nil {
+			name = archiveStem(pkg.ArchiveFilename)
+		}
+		if err := validatePathSegment(name); err != nil {
+			name = "lazymind-skill-" + skillID
+		}
+	}
+	description := parsed.Description
+	if !parsed.HasDescription {
+		description = skillmetadata.FirstBodyParagraph(parsed.Body)
+	}
+	return skillmetadata.Metadata{Name: name, Description: description}, nil
+}
+
+func archiveStem(filename string) string {
+	filename = strings.TrimSpace(path.Base(strings.ReplaceAll(filename, `\`, "/")))
+	if strings.EqualFold(path.Ext(filename), ".zip") {
+		filename = filename[:len(filename)-len(path.Ext(filename))]
+	}
+	return strings.TrimSpace(filename)
+}
+
+func archiveFilenameFromURL(rawURL string) string {
+	parsed, err := url.Parse(strings.TrimSpace(rawURL))
+	if err != nil {
+		return ""
+	}
+	return path.Base(parsed.Path)
 }
 
 func cleanSkillPath(name string) (string, error) {

--- a/backend/core/skillv2/service/types.go
+++ b/backend/core/skillv2/service/types.go
@@ -73,6 +73,8 @@ type CreateSkillRequest struct {
 type CreateSkillResponse struct {
 	SkillID        string
 	HeadRevisionID string
+	Name           string
+	Description    string
 }
 
 type PatchSkillRequest struct {

--- a/frontend/scripts/openapi/.openapi-cache.json
+++ b/frontend/scripts/openapi/.openapi-cache.json
@@ -1,8 +1,8 @@
 {
   "auth": "4fc46a4a59a91e07538d22b7855fabab24d2f6cc4c93da3a7a5e9bd5db5a5a5a",
   "core": {
-    "specHash": "6188813bbf6cdf3c569a3e1eb6d91730b5a99786369038b03475cdc44d66d1d7",
-    "outputHash": "c55daf00bcaed11d3672e48e581f9ea80429cde681df8aa49a15b597afd3bb70"
+    "specHash": "4177af2420c85fc3eb70c484a7bc3d6d4c8b0946ab63ab92052ef9e955ba13e6",
+    "outputHash": "e94dea0403f794bd11f7d49240c191adcb2956653c326f6fe53ee9171a3c8520"
   },
   "scan": "f26bd2b462f1e95a130bbff6ab4148a2bbdd1dfd873156dad076e4f6ae0af389",
   "channel-gateway": "78ea73040435bdc1bf8d6c767f2e1a017399b68b7001ac013de81fdacb576e4f"

--- a/frontend/scripts/openapi/specs/core.yaml
+++ b/frontend/scripts/openapi/specs/core.yaml
@@ -5205,12 +5205,12 @@ components:
                     description: Legacy inline-create field. ZIP and URL imports use External.
                     type: string
                 description:
-                    description: Legacy inline-create field. ZIP and URL imports derive description from SKILL.md frontmatter.
+                    description: Legacy inline-create field. ZIP and URL imports resolve description from SKILL.md frontmatter or the first body paragraph.
                     type: string
                 is_enabled:
                     type: boolean
                 name:
-                    description: Legacy inline-create field. ZIP and URL imports derive name from SKILL.md frontmatter.
+                    description: Legacy inline-create field. ZIP and URL imports resolve name from SKILL.md frontmatter or package fallback metadata.
                     type: string
                 source:
                     $ref: '#/components/schemas/skillSourceOpenAPIRequest'
@@ -6061,7 +6061,11 @@ components:
             type: object
         skillWriteOpenAPIResponse:
             properties:
+                description:
+                    type: string
                 head_revision_id:
+                    type: string
+                name:
                     type: string
                 skill_id:
                     type: string
@@ -12269,7 +12273,7 @@ paths:
             tags:
                 - skills
         post:
-            description: Creates one directory-based skill from an uploaded ZIP or URL. The package must contain SKILL.md; description is product metadata and is not written into SKILL.md front matter.
+            description: Creates one directory-based skill from an uploaded ZIP or URL. The package must contain SKILL.md; missing name and description metadata are resolved without rewriting SKILL.md.
             requestBody:
                 content:
                     application/json:

--- a/frontend/src/api/generated/core-client/api.ts
+++ b/frontend/src/api/generated/core-client/api.ts
@@ -2410,7 +2410,9 @@ export interface SkillUpdateManagedOpenAPIRequest {
     'tags'?: Array<string>;
 }
 export interface SkillWriteOpenAPIResponse {
+    'description'?: string;
     'head_revision_id'?: string;
+    'name'?: string;
     'skill_id': string;
 }
 export interface StartTaskRequest {

--- a/frontend/src/modules/memory/index.tsx
+++ b/frontend/src/modules/memory/index.tsx
@@ -2401,7 +2401,7 @@ export default function MemoryManagement({ embeddedTab }: MemoryManagementProps 
     setSkillSaving(true);
 
     try {
-      await createSkillAsset({
+      const created = await createSkillAsset({
         name: t("admin.memorySkillUploadDefaultName"),
         description: t("admin.memorySkillUploadPersonalDesc"),
         category: "personal",
@@ -2412,7 +2412,7 @@ export default function MemoryManagement({ embeddedTab }: MemoryManagementProps 
       await Promise.all([refreshSkillAssets(), refreshSkillCategories()]);
       message.success(
         t("admin.memorySkillUploadSuccess", {
-          name: t("admin.memorySkillUploadDefaultName"),
+          name: created.name,
         }),
       );
     } catch (error) {
@@ -2449,7 +2449,7 @@ export default function MemoryManagement({ embeddedTab }: MemoryManagementProps 
     try {
       setSkillSaving(true);
       const upload = await uploadSkillTempFile(file);
-      await createSkillAsset({
+      const created = await createSkillAsset({
         name: inferredName,
         description: t("admin.memorySkillUploadPersonalDesc"),
         category: "personal",
@@ -2459,7 +2459,7 @@ export default function MemoryManagement({ embeddedTab }: MemoryManagementProps 
       });
       await Promise.all([refreshSkillAssets(), refreshSkillCategories()]);
       message.success(
-        t("admin.memorySkillUploadSuccess", { name: inferredName }),
+        t("admin.memorySkillUploadSuccess", { name: created.name }),
       );
     } catch (error) {
       console.error("Upload skill package failed:", error);

--- a/frontend/src/modules/memory/skillApi.ts
+++ b/frontend/src/modules/memory/skillApi.ts
@@ -410,6 +410,12 @@ export interface CreateSkillPayload {
     | { type: "url"; url: string };
 }
 
+export interface CreateSkillResult {
+  skillId: string;
+  name: string;
+  description: string;
+}
+
 export interface PublishSkillToMarketPayload {
   name: string;
   tags: string[];
@@ -987,7 +993,9 @@ export async function getSkillAssetDetail(
   return normalizeSkillItem(payload, content);
 }
 
-export async function createSkillAsset(payload: CreateSkillPayload): Promise<string> {
+export async function createSkillAsset(
+  payload: CreateSkillPayload,
+): Promise<CreateSkillResult> {
   const request: SkillCreateManagedOpenAPIRequest = {
     name: payload.name,
     description: payload.description,
@@ -1004,8 +1012,16 @@ export async function createSkillAsset(payload: CreateSkillPayload): Promise<str
   const response = await skillsApi.apiCoreSkillsPost({
     skillCreateManagedOpenAPIRequest: request,
   });
-  const body = unwrapEnvelope<{ skill_id?: string }>(response.data);
-  return body.skill_id || "";
+  const body = unwrapEnvelope<{
+    skill_id?: string;
+    name?: string;
+    description?: string;
+  }>(response.data);
+  return {
+    skillId: body.skill_id || "",
+    name: body.name || payload.name,
+    description: body.description || "",
+  };
 }
 
 export async function enableBuiltinSkill(


### PR DESCRIPTION
## Summary

完善外部 Skill 导入时的元数据兼容逻辑，使缺失 `name` 或 `description` 的 `SKILL.md` 也能正常导入。

## Changes

- `name` 按以下优先级生成：
  1. front matter 中的 `name`
  2. Skill 包根目录名
  3. 无包根目录时使用 ZIP 文件名
  4. ZIP 文件名也不可用时生成 `lazymind-skill-<ID>`
- 缺少 `description` 时，使用 `SKILL.md` 正文首段。
- 描述超过 100 个字符时截断并追加省略号。
- 保留原始 ZIP 和 `SKILL.md` 内容，不回写兜底字段。
- 补充上传 ZIP、URL 导入及版本操作相关测试。

## Notes

本 PR 仅实现自动兜底逻辑。允许用户修改 Skill 名称和描述的功能将在后续 PR 中实现。