### PR TITLE
fix(skill): provide runtime metadata fallback for imports

### DIFF
--- a/backend/core/cmd/builtin-skill-bundle/main.go
+++ b/backend/core/cmd/builtin-skill-bundle/main.go
@@ -54,20 +54,22 @@ type bundledSource struct {
 }
 
 type sourceSpec struct {
-	SourceURL   string
-	ResolvedURL string
-	Identity    string
-	Key         string
-	UID         string
-	Category    string
-	Version     string
-	LocalPath   string
+	SourceURL    string
+	ResolvedURL  string
+	Identity     string
+	Key          string
+	FallbackName string
+	UID          string
+	Category     string
+	Version      string
+	LocalPath    string
 }
 
 type sourceInput struct {
 	URL           string
 	Bundled       *bundledSource
 	MarketVisible bool
+	FallbackName  string
 }
 
 type packageMeta struct {
@@ -153,7 +155,7 @@ func run(ctx context.Context, opts options, client *http.Client) error {
 			if definition.Status != showcase.StatusPublished {
 				continue
 			}
-			input, source, err := featuredSourceInput(definition.Skill.SourceURL, definition.Skill.RequiredVersion)
+			input, source, err := featuredSourceInput(definition.Skill.SourceURL, definition.Skill.RequiredVersion, definition.ID)
 			if err != nil {
 				return bundleFailure("featured Skill %s: %v", definition.ID, err)
 			}
@@ -214,16 +216,7 @@ func run(ctx context.Context, opts options, client *http.Client) error {
 			if skillbuiltin.CatalogSkillMarketVisible(locked) != source.MarketVisible {
 				return bundleFailure("distribution changed for %s", spec.SourceURL)
 			}
-			entry = locked
-			archivePath, appliedPatches, err = materializeFrozen(ctx, client, spec, locked, opts.Cache, patchCatalog)
-			if err == nil {
-				pkg, readErr := skillpackage.ReadZip(archivePath)
-				if readErr != nil {
-					err = readErr
-				} else {
-					entry.Content = string(pkg.Files["SKILL.md"])
-				}
-			}
+			entry, archivePath, appliedPatches, err = materializeFrozen(ctx, client, spec, locked, opts.Cache, patchCatalog)
 		} else {
 			entry, archivePath, appliedPatches, err = resolveEntry(ctx, client, spec, opts.Cache, patchCatalog)
 		}
@@ -359,7 +352,12 @@ func loadSources(path string) (sourceList, error) {
 
 func resolveSourceInput(source sourceInput, sourcesRoot string) (sourceSpec, error) {
 	if source.Bundled == nil {
-		return resolveSource(source.URL)
+		spec, err := resolveSource(source.URL)
+		if err != nil {
+			return sourceSpec{}, err
+		}
+		spec.FallbackName = source.FallbackName
+		return spec, nil
 	}
 	localPath := filepath.Join(sourcesRoot, filepath.FromSlash(source.Bundled.Path))
 	info, err := os.Stat(localPath)
@@ -371,21 +369,21 @@ func resolveSourceInput(source sourceInput, sourcesRoot string) (sourceSpec, err
 		SourceURL: sourceURL, ResolvedURL: sourceURL, Identity: sourceURL,
 		Key: filepath.Base(source.Bundled.Path), UID: source.Bundled.UID,
 		Category: source.Bundled.Category, Version: source.Bundled.Version,
-		LocalPath: localPath,
+		LocalPath: localPath, FallbackName: source.FallbackName,
 	}, nil
 }
 
-func featuredSourceInput(raw, requiredVersion string) (sourceInput, string, error) {
+func featuredSourceInput(raw, requiredVersion, fallbackName string) (sourceInput, string, error) {
 	source := strings.TrimSpace(raw)
 	if _, err := resolveSource(source); err == nil {
-		return sourceInput{URL: source}, source, nil
+		return sourceInput{URL: source, FallbackName: fallbackName}, source, nil
 	}
 	cleaned, err := skillpackage.CleanPath(source)
 	if err != nil {
 		return sourceInput{}, "", bundleFailure("invalid local Skill path %q", source)
 	}
 	bundled := &bundledSource{Path: cleaned, Version: strings.TrimSpace(requiredVersion)}
-	return sourceInput{Bundled: bundled}, bundledSourceURL(cleaned), nil
+	return sourceInput{Bundled: bundled, FallbackName: fallbackName}, bundledSourceURL(cleaned), nil
 }
 
 func bundledSourceURL(relativePath string) string {
@@ -429,6 +427,7 @@ func resolveSource(raw string) (sourceSpec, error) {
 type originPackage struct {
 	ArchivePath string
 	Files       map[string][]byte
+	PackageRoot string
 	ArchiveHash string
 	TreeHash    string
 	ArchiveSize int64
@@ -471,6 +470,7 @@ func inspectOrigin(archivePath string) (originPackage, error) {
 	return originPackage{
 		ArchivePath: archivePath,
 		Files:       files,
+		PackageRoot: pkg.PackageRoot,
 		ArchiveHash: hash,
 		TreeHash:    skillpackage.TreeHash(files),
 		ArchiveSize: size,
@@ -487,88 +487,92 @@ func finalizeEntry(spec sourceSpec, origin originPackage, cacheDir string, patch
 	if err != nil {
 		return skillbuiltin.CatalogSkill{}, "", nil, err
 	}
-	if len(patched.AppliedPatches) == 0 {
-		entry, err := inspectEntry(spec, origin.ArchivePath)
-		return entry, origin.ArchivePath, nil, err
+	archivePath := origin.ArchivePath
+	if len(patched.AppliedPatches) > 0 {
+		tempPath, err := skillpackage.WriteZip(patched.Files, cacheDir)
+		if err != nil {
+			return skillbuiltin.CatalogSkill{}, "", nil, err
+		}
+		defer os.Remove(tempPath)
+		hash, size, err := fileDigest(tempPath)
+		if err != nil {
+			return skillbuiltin.CatalogSkill{}, "", nil, err
+		}
+		if size > maxArchiveBytes {
+			return skillbuiltin.CatalogSkill{}, "", nil, bundleFailure("archive exceeds %d bytes", maxArchiveBytes)
+		}
+		archivePath = filepath.Join(cacheDir, hash+".zip")
+		if err := copyFile(tempPath, archivePath); err != nil {
+			return skillbuiltin.CatalogSkill{}, "", nil, err
+		}
 	}
-
-	tempPath, err := skillpackage.WriteZip(patched.Files, cacheDir)
+	entry, err := inspectEntry(spec, archivePath, patched.Files, origin.PackageRoot, patched.SkillMDPatched)
 	if err != nil {
 		return skillbuiltin.CatalogSkill{}, "", nil, err
 	}
-	defer os.Remove(tempPath)
-	hash, size, err := fileDigest(tempPath)
-	if err != nil {
-		return skillbuiltin.CatalogSkill{}, "", nil, err
+	if len(patched.AppliedPatches) > 0 {
+		entry.OriginArchiveSHA256 = origin.ArchiveHash
+		entry.OriginTreeSHA256 = origin.TreeHash
+		entry.OriginArchiveSize = origin.ArchiveSize
+		entry.PatchSetSHA256 = patched.PatchSetSHA256
+		entry.AppliedPatches = catalogPatches(patched.AppliedPatches)
 	}
-	if size > maxArchiveBytes {
-		return skillbuiltin.CatalogSkill{}, "", nil, bundleFailure("archive exceeds %d bytes", maxArchiveBytes)
-	}
-	cachePath := filepath.Join(cacheDir, hash+".zip")
-	if err := copyFile(tempPath, cachePath); err != nil {
-		return skillbuiltin.CatalogSkill{}, "", nil, err
-	}
-	entry, err := inspectEntry(spec, cachePath)
-	if err != nil {
-		return skillbuiltin.CatalogSkill{}, "", nil, err
-	}
-	entry.OriginArchiveSHA256 = origin.ArchiveHash
-	entry.OriginTreeSHA256 = origin.TreeHash
-	entry.OriginArchiveSize = origin.ArchiveSize
-	entry.PatchSetSHA256 = patched.PatchSetSHA256
-	entry.AppliedPatches = catalogPatches(patched.AppliedPatches)
-	return entry, cachePath, patched.AppliedPatches, nil
+	return entry, archivePath, patched.AppliedPatches, nil
 }
 
 func originSkillVersion(spec sourceSpec, files map[string][]byte, treeHash string) string {
 	metadataVersion := ""
 	if content, ok := files["SKILL.md"]; ok {
-		if meta, err := skillmetadata.ParseRequired(content); err == nil {
+		if meta, err := skillmetadata.Parse(content); err == nil {
 			metadataVersion = meta.Version
 		}
 	}
 	return resolvedSkillVersion(spec, metadataVersion, files, treeHash)
 }
 
-func inspectEntry(spec sourceSpec, archivePath string) (skillbuiltin.CatalogSkill, error) {
+func inspectEntry(spec sourceSpec, archivePath string, files map[string][]byte, packageRoot string, strictSkillMD bool) (skillbuiltin.CatalogSkill, error) {
 	hash, size, err := fileDigest(archivePath)
 	if err != nil {
 		return skillbuiltin.CatalogSkill{}, err
 	}
-	pkg, err := skillpackage.ReadZip(archivePath)
-	if err != nil {
-		return skillbuiltin.CatalogSkill{}, err
-	}
-	files := pkg.Files
 	content, ok := files["SKILL.md"]
 	if !ok {
 		return skillbuiltin.CatalogSkill{}, bundleFailure("skill package must contain SKILL.md")
 	}
-	meta, err := skillmetadata.ParseRequired(content)
+	uid := resolvedSkillUID(spec)
+	var resolved skillmetadata.Resolved
+	if strictSkillMD {
+		meta, err := skillmetadata.ParseRequired(content)
+		if err != nil {
+			return skillbuiltin.CatalogSkill{}, err
+		}
+		resolved = skillmetadata.Resolved{Metadata: meta, Content: content}
+	} else {
+		resolved, err = skillmetadata.Resolve(content, spec.FallbackName, packageRoot, spec.Key, "lazymind-skill-"+uid)
+	}
 	if err != nil {
 		return skillbuiltin.CatalogSkill{}, err
 	}
 	treeHash := skillpackage.TreeHash(files)
-	version := resolvedSkillVersion(spec, meta.Version, files, treeHash)
+	version := resolvedSkillVersion(spec, resolved.Version, files, treeHash)
 	category := spec.Category
 	if category == "" {
-		category = meta.Category
+		category = resolved.Category
 	}
 	if category == "" {
 		category = "external"
 	}
-	uid := resolvedSkillUID(spec)
 	return skillbuiltin.CatalogSkill{
 		Key:           spec.Key,
 		UID:           uid,
 		SourceURL:     spec.SourceURL,
 		ResolvedURL:   spec.ResolvedURL,
 		Version:       version,
-		Name:          meta.Name,
-		Description:   meta.Description,
+		Name:          resolved.Name,
+		Description:   resolved.Description,
 		Category:      category,
-		Tags:          meta.Tags,
-		Content:       string(content),
+		Tags:          resolved.Tags,
+		Content:       string(resolved.Content),
 		ArchiveSHA256: hash,
 		TreeSHA256:    treeHash,
 		ArchiveSize:   size,
@@ -631,6 +635,7 @@ func resolveBundledEntry(spec sourceSpec, cacheDir string, patchCatalog skillpat
 	origin := originPackage{
 		ArchivePath: cachePath,
 		Files:       files,
+		PackageRoot: "",
 		ArchiveHash: hash,
 		TreeHash:    skillpackage.TreeHash(files),
 		ArchiveSize: size,
@@ -695,16 +700,16 @@ func readBundledFiles(root string) (map[string][]byte, error) {
 	return files, nil
 }
 
-func materializeFrozen(ctx context.Context, client *http.Client, spec sourceSpec, locked skillbuiltin.CatalogSkill, cacheDir string, patchCatalog skillpatch.Catalog) (string, []skillpatch.AppliedPatch, error) {
+func materializeFrozen(ctx context.Context, client *http.Client, spec sourceSpec, locked skillbuiltin.CatalogSkill, cacheDir string, patchCatalog skillpatch.Catalog) (skillbuiltin.CatalogSkill, string, []skillpatch.AppliedPatch, error) {
 	if spec.LocalPath != "" {
 		current, archivePath, appliedPatches, err := resolveBundledEntry(spec, cacheDir, patchCatalog)
 		if err != nil {
-			return "", nil, err
+			return skillbuiltin.CatalogSkill{}, "", nil, err
 		}
 		if err := validateFrozenEntry(current, locked); err != nil {
-			return "", nil, bundleFailure("bundled skill does not match frozen lock: %v", err)
+			return skillbuiltin.CatalogSkill{}, "", nil, bundleFailure("bundled skill does not match frozen lock: %v", err)
 		}
-		return archivePath, appliedPatches, validateLockedArchive(archivePath, locked)
+		return current, archivePath, appliedPatches, validateLockedArchive(archivePath, locked)
 	}
 	expectedOriginHash := locked.ArchiveSHA256
 	expectedOriginSize := locked.ArchiveSize
@@ -718,35 +723,38 @@ func materializeFrozen(ctx context.Context, client *http.Client, spec sourceSpec
 	if hash, size, err := fileDigest(originPath); err != nil || hash != expectedOriginHash || expectedOriginSize > 0 && size != expectedOriginSize {
 		tempPath, err := download(ctx, client, spec.ResolvedURL, cacheDir)
 		if err != nil {
-			return "", nil, err
+			return skillbuiltin.CatalogSkill{}, "", nil, err
 		}
 		defer os.Remove(tempPath)
 		hash, size, err := fileDigest(tempPath)
 		if err != nil {
-			return "", nil, err
+			return skillbuiltin.CatalogSkill{}, "", nil, err
 		}
 		if hash != expectedOriginHash || expectedOriginSize > 0 && size != expectedOriginSize {
-			return "", nil, bundleFailure("download does not match frozen lock origin")
+			return skillbuiltin.CatalogSkill{}, "", nil, bundleFailure("download does not match frozen lock origin")
 		}
 		if err := copyFile(tempPath, originPath); err != nil {
-			return "", nil, err
+			return skillbuiltin.CatalogSkill{}, "", nil, err
 		}
 	}
 	origin, err := inspectOrigin(originPath)
 	if err != nil {
-		return "", nil, err
+		return skillbuiltin.CatalogSkill{}, "", nil, err
 	}
 	if origin.TreeHash != expectedOriginTree {
-		return "", nil, bundleFailure("origin package tree does not match frozen lock")
+		return skillbuiltin.CatalogSkill{}, "", nil, bundleFailure("origin package tree does not match frozen lock")
 	}
 	current, archivePath, appliedPatches, err := finalizeEntry(spec, origin, cacheDir, patchCatalog)
 	if err != nil {
-		return "", nil, err
+		return skillbuiltin.CatalogSkill{}, "", nil, err
 	}
 	if err := validateFrozenEntry(current, locked); err != nil {
-		return "", nil, err
+		return skillbuiltin.CatalogSkill{}, "", nil, err
 	}
-	return archivePath, appliedPatches, validateLockedArchive(archivePath, locked)
+	if err := validateLockedArchive(archivePath, locked); err != nil {
+		return skillbuiltin.CatalogSkill{}, "", nil, err
+	}
+	return current, archivePath, appliedPatches, nil
 }
 
 func validateFrozenEntry(current, locked skillbuiltin.CatalogSkill) error {

--- a/backend/core/cmd/builtin-skill-bundle/main.go
+++ b/backend/core/cmd/builtin-skill-bundle/main.go
@@ -217,11 +217,11 @@ func run(ctx context.Context, opts options, client *http.Client) error {
 			entry = locked
 			archivePath, appliedPatches, err = materializeFrozen(ctx, client, spec, locked, opts.Cache, patchCatalog)
 			if err == nil {
-				files, readErr := skillpackage.ReadZip(archivePath)
+				pkg, readErr := skillpackage.ReadZip(archivePath)
 				if readErr != nil {
 					err = readErr
 				} else {
-					entry.Content = string(files["SKILL.md"])
+					entry.Content = string(pkg.Files["SKILL.md"])
 				}
 			}
 		} else {
@@ -463,10 +463,11 @@ func inspectOrigin(archivePath string) (originPackage, error) {
 	if err != nil {
 		return originPackage{}, err
 	}
-	files, err := skillpackage.ReadZip(archivePath)
+	pkg, err := skillpackage.ReadZip(archivePath)
 	if err != nil {
 		return originPackage{}, err
 	}
+	files := pkg.Files
 	return originPackage{
 		ArchivePath: archivePath,
 		Files:       files,
@@ -534,10 +535,11 @@ func inspectEntry(spec sourceSpec, archivePath string) (skillbuiltin.CatalogSkil
 	if err != nil {
 		return skillbuiltin.CatalogSkill{}, err
 	}
-	files, err := skillpackage.ReadZip(archivePath)
+	pkg, err := skillpackage.ReadZip(archivePath)
 	if err != nil {
 		return skillbuiltin.CatalogSkill{}, err
 	}
+	files := pkg.Files
 	content, ok := files["SKILL.md"]
 	if !ok {
 		return skillbuiltin.CatalogSkill{}, bundleFailure("skill package must contain SKILL.md")
@@ -766,10 +768,11 @@ func validateFrozenEntry(current, locked skillbuiltin.CatalogSkill) error {
 }
 
 func validateLockedArchive(path string, locked skillbuiltin.CatalogSkill) error {
-	files, err := skillpackage.ReadZip(path)
+	pkg, err := skillpackage.ReadZip(path)
 	if err != nil {
 		return err
 	}
+	files := pkg.Files
 	if skillpackage.TreeHash(files) != locked.TreeSHA256 {
 		return bundleFailure("package tree does not match frozen lock")
 	}

--- a/backend/core/cmd/builtin-skill-bundle/main_test.go
+++ b/backend/core/cmd/builtin-skill-bundle/main_test.go
@@ -19,6 +19,7 @@ import (
 
 	"lazymind/core/showcase"
 	skillbuiltin "lazymind/core/skillv2/builtin"
+	skillmetadata "lazymind/core/skillv2/metadata"
 	skillpackage "lazymind/core/skillv2/skillpackage"
 )
 
@@ -170,7 +171,7 @@ func TestRunAppliesPatchToDownloadedSkillAndFreezesProvenance(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if got := string(packageFiles["script.py"]); got != "print('patched')\n" {
+	if got := string(packageFiles.Files["script.py"]); got != "print('patched')\n" {
 		t.Fatalf("patched script = %q", got)
 	}
 
@@ -234,7 +235,7 @@ skills: []
 	if err != nil {
 		t.Fatal(err)
 	}
-	if got := string(packageFiles["references/guide.md"]); got != "patched guide\n" || len(entry.AppliedPatches) != 1 {
+	if got := string(packageFiles.Files["references/guide.md"]); got != "patched guide\n" || len(entry.AppliedPatches) != 1 {
 		t.Fatalf("patched guide = %q, provenance = %#v", got, entry.AppliedPatches)
 	}
 	opts.Output = filepath.Join(root, "runtime-frozen", "builtin-skills")
@@ -272,6 +273,18 @@ func TestRunCanPatchInvalidSkillMetadataBeforeStrictInspection(t *testing.T) {
 	catalog := readCatalog(t, filepath.Join(opts.Output, "catalog.json"))
 	if len(catalog.Skills) != 1 || catalog.Skills[0].Name != "repaired" || catalog.Skills[0].Version != "1.0.0" {
 		t.Fatalf("repaired catalog = %#v", catalog)
+	}
+	entry := catalog.Skills[0]
+	patched, err := skillpackage.ReadZip(filepath.Join(opts.Output, filepath.FromSlash(entry.PackageFile)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	meta, err := skillmetadata.ParseRequired(patched.Files["SKILL.md"])
+	if err != nil || meta.Name != "repaired" || meta.Description != "repaired skill" {
+		t.Fatalf("patched SKILL.md metadata = %#v, err=%v", meta, err)
+	}
+	if string(files["SKILL.md"]) != "---\nname: broken\n---\n# Broken\n" || entry.OriginTreeSHA256 != originTree || len(entry.AppliedPatches) != 1 {
+		t.Fatalf("source or patch provenance changed: source=%q catalog=%#v", files["SKILL.md"], entry)
 	}
 }
 
@@ -378,7 +391,7 @@ func TestRunBuildsFeaturedCatalogFromLocalDirectory(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if string(packageFiles["references/guide.md"]) != "guide\n" {
+	if string(packageFiles.Files["references/guide.md"]) != "guide\n" {
 		t.Fatalf("package files = %#v", packageFiles)
 	}
 	featuredCatalog := readFeaturedCatalog(t, filepath.Join(opts.FeaturedOutput, "catalog.json"))

--- a/backend/core/cmd/builtin-skill-bundle/main_test.go
+++ b/backend/core/cmd/builtin-skill-bundle/main_test.go
@@ -288,6 +288,101 @@ func TestRunCanPatchInvalidSkillMetadataBeforeStrictInspection(t *testing.T) {
 	}
 }
 
+func TestRunFallsBackMetadataWithoutSkillMDPatchAndFreezes(t *testing.T) {
+	files := map[string][]byte{
+		"SKILL.md": []byte("---\nversion: 1.2.3\n---\n# Demo\n\nUseful bundled description.\n"),
+	}
+	archive := makeSkillZipFromFiles(t, files)
+	client := &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+		return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(bytes.NewReader(archive)), ContentLength: int64(len(archive)), Header: make(http.Header)}, nil
+	})}
+	root := t.TempDir()
+	sourceURL := "https://example.test/demo.zip"
+	sources := filepath.Join(root, "sources.yaml")
+	if err := os.WriteFile(sources, []byte("schema_version: 1\nskills:\n  - "+sourceURL+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	opts := options{Sources: sources, Lock: filepath.Join(root, "lock.json"), Cache: filepath.Join(root, "cache"), Output: filepath.Join(root, "runtime", "builtin-skills")}
+	if err := run(context.Background(), opts, client); err != nil {
+		t.Fatal(err)
+	}
+	normal := readCatalog(t, filepath.Join(opts.Output, "catalog.json")).Skills[0]
+	originHash := sha256.Sum256(archive)
+	if normal.Name != "demo" || normal.Description != "Useful bundled description." || normal.ArchiveSHA256 != hex.EncodeToString(originHash[:]) || normal.TreeSHA256 != skillpackage.TreeHash(files) || len(normal.AppliedPatches) != 0 {
+		t.Fatalf("fallback catalog = %#v", normal)
+	}
+	meta, err := skillmetadata.ParseRequired([]byte(normal.Content))
+	if err != nil || meta.Name != normal.Name || meta.Description != normal.Description {
+		t.Fatalf("catalog runtime content = %q, metadata=%#v, err=%v", normal.Content, meta, err)
+	}
+	pkg, err := skillpackage.ReadZip(filepath.Join(opts.Output, filepath.FromSlash(normal.PackageFile)))
+	if err != nil || !bytes.Equal(pkg.Files["SKILL.md"], files["SKILL.md"]) {
+		t.Fatalf("packaged SKILL.md changed: pkg=%#v err=%v", pkg, err)
+	}
+
+	opts.Output = filepath.Join(root, "runtime-frozen", "builtin-skills")
+	opts.FrozenLockfile = true
+	if err := run(context.Background(), opts, http.DefaultClient); err != nil {
+		t.Fatalf("frozen fallback build failed: %v", err)
+	}
+	frozen := readCatalog(t, filepath.Join(opts.Output, "catalog.json")).Skills[0]
+	if frozen.Name != normal.Name || frozen.Description != normal.Description || frozen.Content != normal.Content || frozen.ArchiveSHA256 != normal.ArchiveSHA256 || frozen.TreeSHA256 != normal.TreeSHA256 {
+		t.Fatalf("frozen catalog = %#v, normal = %#v", frozen, normal)
+	}
+}
+
+func TestRunRejectsInvalidSkillMDPatchInsteadOfFallingBack(t *testing.T) {
+	files := map[string][]byte{"SKILL.md": []byte("---\nname: original\n---\n# Demo\n\nUseful description.\n")}
+	archive := makeSkillZipFromFiles(t, files)
+	client := &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+		return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(bytes.NewReader(archive)), ContentLength: int64(len(archive)), Header: make(http.Header)}, nil
+	})}
+	root := t.TempDir()
+	sourceURL := "https://example.test/invalid-patch.zip"
+	spec, err := resolveSource(sourceURL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	version := "0.0.0+" + skillpackage.TreeHash(files)[:12]
+	writeSinglePatch(t, root, resolvedSkillUID(spec), version, files, "SKILL.md", "---\nname: patched\n---\n# Patched\n")
+	sources := filepath.Join(root, "sources.yaml")
+	if err := os.WriteFile(sources, []byte("schema_version: 1\npatch_catalog: patches/catalog.yaml\nskills:\n  - "+sourceURL+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	err = run(context.Background(), options{Sources: sources, Lock: filepath.Join(root, "lock.json"), Cache: filepath.Join(root, "cache"), Output: filepath.Join(root, "runtime", "builtin-skills")}, client)
+	if err == nil || !strings.Contains(err.Error(), "description") {
+		t.Fatalf("invalid SKILL.md patch error = %v", err)
+	}
+}
+
+func TestRunUsesFeaturedDefinitionIDForFallbackName(t *testing.T) {
+	files := map[string][]byte{"SKILL.md": []byte("---\nversion: 1.2.3\n---\n# Demo\n\nFeatured fallback description.\n")}
+	archive := makeSkillZipFromFiles(t, files)
+	client := &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+		return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(bytes.NewReader(archive)), ContentLength: int64(len(archive)), Header: make(http.Header)}, nil
+	})}
+	root := t.TempDir()
+	featuredSources := filepath.Join(root, "featured")
+	featuredDir := filepath.Join(featuredSources, "demo")
+	writeTestPNG(t, filepath.Join(featuredDir, "assets", "cover.png"))
+	definition := strings.Replace(testFeaturedDefinition("https://example.test/skill.zip", "1.2.3"), "id: demo-featured", "id: demo", 1)
+	if err := os.WriteFile(filepath.Join(featuredDir, "featured.yaml"), []byte(definition), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	sources := filepath.Join(root, "sources.yaml")
+	if err := os.WriteFile(sources, []byte("schema_version: 1\nskills: []\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	opts := options{Sources: sources, Lock: filepath.Join(root, "lock.json"), Cache: filepath.Join(root, "cache"), Output: filepath.Join(root, "runtime", "builtin-skills"), FeaturedSources: featuredSources, FeaturedOutput: filepath.Join(root, "runtime", "featured-skills")}
+	if err := run(context.Background(), opts, client); err != nil {
+		t.Fatal(err)
+	}
+	entry := readCatalog(t, filepath.Join(opts.Output, "catalog.json")).Skills[0]
+	if entry.Name != "demo" {
+		t.Fatalf("featured fallback name = %q, want demo", entry.Name)
+	}
+}
+
 func TestRunBuildsFeaturedCatalogAndKeepsSkillOutOfMarket(t *testing.T) {
 	archive := makeSkillZip(t)
 	client := &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {

--- a/backend/core/skillv2/builtin/catalog.go
+++ b/backend/core/skillv2/builtin/catalog.go
@@ -225,10 +225,11 @@ func catalogPackageByUID(catalogPath, uid string) (Package, bool, error) {
 		if err := verifyArchive(archivePath, entry.ArchiveSHA256, entry.ArchiveSize); err != nil {
 			return Package{}, false, catalogFailure("builtin skill %s: %v", uid, err)
 		}
-		files, err := skillpackage.ReadZip(archivePath)
+		pkg, err := skillpackage.ReadZip(archivePath)
 		if err != nil {
 			return Package{}, false, err
 		}
+		files := pkg.Files
 		if _, ok := files["SKILL.md"]; !ok {
 			return Package{}, false, catalogFailure("builtin skill %s missing SKILL.md", uid)
 		}

--- a/backend/core/skillv2/market/market_install_test.go
+++ b/backend/core/skillv2/market/market_install_test.go
@@ -74,6 +74,51 @@ func TestMarketInstall_CopiesSkillTreeForUser(t *testing.T) {
 	}
 }
 
+func TestMarketInstall_CopiesExternalFallbackSkill(t *testing.T) {
+	db := testutil.NewTestDB(t)
+	testutil.SeedSkillWithRevision(t, db, "market_skill", "market_rev1")
+	original := []byte("---\nversion: 1.0.0\n---\n# Fallback skill\n\nOriginal body.\n")
+	if err := db.Model(&testutil.SkillRow{}).Where("id = ?", "market_skill").Updates(map[string]any{
+		"category":      "external",
+		"skill_name":    "fallback-skill",
+		"description":   "Fallback description",
+		"relative_root": "external/fallback-skill",
+	}).Error; err != nil {
+		t.Fatalf("configure source skill: %v", err)
+	}
+	if err := db.Model(&testutil.SkillBlobRow{}).Where("hash = ?", "h_skill_market_rev1").Updates(map[string]any{"content": original, "size": len(original)}).Error; err != nil {
+		t.Fatalf("configure source SKILL.md: %v", err)
+	}
+	testutil.MustCreate(t, db, &testutil.SkillMarketItemRow{ID: "market_item1", SourceSkillID: "market_skill", Status: "published", CreatedAt: testutil.TimeFixture(), UpdatedAt: testutil.TimeFixture()})
+	service := NewService(ServiceDeps{DB: db.DB, BlobStore: NewBlobStore(db.DB, NewLocalObjectStore(t.TempDir()))})
+
+	resp, err := service.Install(context.Background(), InstallRequest{MarketItemID: "market_item1", UserID: "user_002", UserName: "李四"})
+	if err != nil {
+		t.Fatalf("Install returned error: %v", err)
+	}
+	var copied testutil.SkillRow
+	if err := db.Where("id = ?", resp.SkillID).Take(&copied).Error; err != nil {
+		t.Fatalf("query installed skill: %v", err)
+	}
+	if copied.Category != "external" || copied.SkillName != "fallback-skill" || copied.Description != "Fallback description" {
+		t.Fatalf("installed fallback metadata = %#v", copied)
+	}
+	if copied.HeadRevisionID == nil {
+		t.Fatal("installed skill has no revision")
+	}
+	var entry testutil.SkillRevisionEntryRow
+	if err := db.Where("revision_id = ? AND path = ?", *copied.HeadRevisionID, "SKILL.md").Take(&entry).Error; err != nil || entry.BlobHash == nil {
+		t.Fatalf("query installed SKILL.md entry: entry=%#v err=%v", entry, err)
+	}
+	var blob testutil.SkillBlobRow
+	if err := db.Where("hash = ?", *entry.BlobHash).Take(&blob).Error; err != nil {
+		t.Fatalf("query installed SKILL.md blob: %v", err)
+	}
+	if string(blob.Content) != string(original) {
+		t.Fatalf("installed SKILL.md = %q, want %q", blob.Content, original)
+	}
+}
+
 func TestMarketInstall_RestoresTrashedInstalledSkill(t *testing.T) {
 	db := testutil.NewTestDB(t)
 	testutil.SeedSkillWithRevision(t, db, "market_skill", "market_rev1")

--- a/backend/core/skillv2/market/service.go
+++ b/backend/core/skillv2/market/service.go
@@ -675,7 +675,16 @@ func copyHeadRevision(ctx context.Context, tx *gorm.DB, sourceSkillID, ownerUser
 	if source.HeadRevisionID == nil {
 		return "", "", fmt.Errorf("source skill has no head revision")
 	}
-	meta, err := skillmetadata.FromRevision(ctx, tx, *source.HeadRevisionID)
+	var meta skillmetadata.Metadata
+	var err error
+	if source.Category == skillmetadata.ExternalCategory {
+		meta, err = skillmetadata.FromRevisionWithFallback(ctx, tx, *source.HeadRevisionID, skillmetadata.Metadata{
+			Name:        source.SkillName,
+			Description: source.Description,
+		})
+	} else {
+		meta, err = skillmetadata.FromRevision(ctx, tx, *source.HeadRevisionID)
+	}
 	if err != nil {
 		return "", "", err
 	}
@@ -864,10 +873,11 @@ func (s *Service) filesFromSource(ctx context.Context, source SourceInput) (map[
 	if zipPath == "" {
 		return nil, fmt.Errorf("skill package stored path is required")
 	}
-	files, err := skillpackage.ReadZip(zipPath)
+	pkg, err := skillpackage.ReadZip(zipPath)
 	if err != nil {
 		return nil, err
 	}
+	files := pkg.Files
 	if _, ok := files["SKILL.md"]; !ok {
 		return nil, fmt.Errorf("skill package must contain SKILL.md")
 	}

--- a/backend/core/skillv2/metadata/metadata.go
+++ b/backend/core/skillv2/metadata/metadata.go
@@ -38,6 +38,12 @@ type Parsed struct {
 	HasDescription bool
 }
 
+type Resolved struct {
+	Metadata
+	Content      []byte
+	UsedFallback bool
+}
+
 type LengthError struct {
 	Field string
 	Max   int
@@ -142,6 +148,39 @@ func FirstBodyParagraph(body string) string {
 	return text
 }
 
+func Resolve(content []byte, fallbackNames ...string) (Resolved, error) {
+	parsed, err := Parse(content)
+	if err != nil {
+		return Resolved{}, err
+	}
+	if parsed.HasName && parsed.HasDescription {
+		return Resolved{Metadata: parsed.Metadata, Content: content}, nil
+	}
+	name := parsed.Name
+	if !parsed.HasName {
+		for _, candidate := range fallbackNames {
+			candidate = strings.TrimSpace(candidate)
+			if ValidateName(candidate) == nil {
+				name = candidate
+				break
+			}
+		}
+	}
+	description := parsed.Description
+	if !parsed.HasDescription {
+		description = FirstBodyParagraph(parsed.Body)
+	}
+	effective, err := EffectiveDocument(content, name, description)
+	if err != nil {
+		return Resolved{}, err
+	}
+	meta, err := ParseRequired(effective)
+	if err != nil {
+		return Resolved{}, err
+	}
+	return Resolved{Metadata: meta, Content: effective, UsedFallback: true}, nil
+}
+
 func EffectiveDocument(content []byte, name, description string) ([]byte, error) {
 	if _, err := ParseRequired(content); err == nil {
 		return content, nil
@@ -196,6 +235,17 @@ func ValidateNameLength(name string) error {
 		return &LengthError{Field: "name", Max: MaxSkillNameLength}
 	}
 	return nil
+}
+
+func ValidateName(name string) error {
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return fmt.Errorf("name required")
+	}
+	if err := validatePathSegment(name); err != nil {
+		return err
+	}
+	return ValidateNameLength(name)
 }
 
 func ValidateDescriptionLength(description string) error {
@@ -311,7 +361,7 @@ func SyncPublished(ctx context.Context, tx *gorm.DB, skillID string, entries map
 	if err != nil {
 		return err
 	}
-	if skill.Category == ExternalCategory {
+	if skill.Category == ExternalCategory || strings.TrimSpace(skill.OriginBuiltinSkillUID) != "" {
 		parsed, err := Parse(content)
 		if err != nil {
 			return err

--- a/backend/core/skillv2/metadata/metadata.go
+++ b/backend/core/skillv2/metadata/metadata.go
@@ -31,6 +31,13 @@ type Metadata struct {
 	Tags        []string
 }
 
+type Parsed struct {
+	Metadata
+	Body           string
+	HasName        bool
+	HasDescription bool
+}
+
 type LengthError struct {
 	Field string
 	Max   int
@@ -54,18 +61,32 @@ type frontmatter struct {
 }
 
 func ParseRequired(content []byte) (Metadata, error) {
+	parsed, err := Parse(content)
+	if err != nil {
+		return Metadata{}, err
+	}
+	if !parsed.HasName {
+		return Metadata{}, fmt.Errorf("SKILL.md frontmatter field \"name\" is required")
+	}
+	if !parsed.HasDescription {
+		return Metadata{}, fmt.Errorf("SKILL.md frontmatter field \"description\" is required")
+	}
+	return parsed.Metadata, nil
+}
+
+func Parse(content []byte) (Parsed, error) {
 	normalized := strings.ReplaceAll(string(content), "\r\n", "\n")
 	if !strings.HasPrefix(normalized, "---\n") {
-		return Metadata{}, fmt.Errorf("SKILL.md frontmatter is required")
+		return Parsed{Body: normalized}, nil
 	}
 	rest := strings.TrimPrefix(normalized, "---\n")
 	idx := strings.Index(rest, "\n---")
 	if idx < 0 {
-		return Metadata{}, fmt.Errorf("SKILL.md frontmatter closing separator is required")
+		return Parsed{}, fmt.Errorf("SKILL.md frontmatter closing separator is required")
 	}
 	var raw frontmatter
 	if err := yaml.Unmarshal([]byte(rest[:idx]), &raw); err != nil {
-		return Metadata{}, fmt.Errorf("invalid SKILL.md frontmatter: %w", err)
+		return Parsed{}, fmt.Errorf("invalid SKILL.md frontmatter: %w", err)
 	}
 	meta := Metadata{
 		Name:        strings.TrimSpace(raw.Name),
@@ -74,22 +95,100 @@ func ParseRequired(content []byte) (Metadata, error) {
 		Category:    strings.TrimSpace(raw.Category),
 		Tags:        compact(raw.Tags),
 	}
-	if meta.Name == "" {
-		return Metadata{}, fmt.Errorf("SKILL.md frontmatter field \"name\" is required")
+	if meta.Name != "" {
+		if err := validatePathSegment(meta.Name); err != nil {
+			return Parsed{}, fmt.Errorf("invalid SKILL.md frontmatter field \"name\": %w", err)
+		}
+		if err := ValidateNameLength(meta.Name); err != nil {
+			return Parsed{}, err
+		}
 	}
-	if err := validatePathSegment(meta.Name); err != nil {
-		return Metadata{}, fmt.Errorf("invalid SKILL.md frontmatter field \"name\": %w", err)
+	if meta.Description != "" {
+		if err := ValidateDescriptionLength(meta.Description); err != nil {
+			return Parsed{}, err
+		}
 	}
-	if err := ValidateNameLength(meta.Name); err != nil {
-		return Metadata{}, err
+	body := strings.TrimPrefix(rest[idx+len("\n---"):], "\n")
+	return Parsed{
+		Metadata:       meta,
+		Body:           body,
+		HasName:        meta.Name != "",
+		HasDescription: meta.Description != "",
+	}, nil
+}
+
+func FirstBodyParagraph(body string) string {
+	lines := strings.Split(strings.ReplaceAll(body, "\r\n", "\n"), "\n")
+	paragraph := make([]string, 0)
+	started := false
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if !started {
+			if trimmed == "" || isMarkdownHeading(trimmed) {
+				continue
+			}
+			started = true
+		}
+		if trimmed == "" {
+			break
+		}
+		paragraph = append(paragraph, trimmed)
 	}
-	if meta.Description == "" {
-		return Metadata{}, fmt.Errorf("SKILL.md frontmatter field \"description\" is required")
+	text := strings.Join(strings.Fields(strings.Join(paragraph, " ")), " ")
+	runes := []rune(text)
+	if len(runes) > 100 {
+		return string(runes[:100]) + "…"
 	}
-	if err := ValidateDescriptionLength(meta.Description); err != nil {
-		return Metadata{}, err
+	return text
+}
+
+func EffectiveDocument(content []byte, name, description string) ([]byte, error) {
+	if _, err := ParseRequired(content); err == nil {
+		return content, nil
 	}
-	return meta, nil
+	parsed, err := Parse(content)
+	if err != nil {
+		return nil, err
+	}
+	metadata := map[string]any{}
+	normalized := strings.ReplaceAll(string(content), "\r\n", "\n")
+	if strings.HasPrefix(normalized, "---\n") {
+		rest := strings.TrimPrefix(normalized, "---\n")
+		idx := strings.Index(rest, "\n---")
+		if idx < 0 {
+			return nil, fmt.Errorf("SKILL.md frontmatter closing separator is required")
+		}
+		if err := yaml.Unmarshal([]byte(rest[:idx]), &metadata); err != nil {
+			return nil, fmt.Errorf("invalid SKILL.md frontmatter: %w", err)
+		}
+	}
+	if !parsed.HasName {
+		metadata["name"] = strings.TrimSpace(name)
+	}
+	if !parsed.HasDescription {
+		metadata["description"] = strings.TrimSpace(description)
+	}
+	frontmatter, err := yaml.Marshal(metadata)
+	if err != nil {
+		return nil, err
+	}
+	effective := []byte(fmt.Sprintf("---\n%s---\n%s", frontmatter, parsed.Body))
+	if _, err := ParseRequired(effective); err != nil {
+		return nil, err
+	}
+	return effective, nil
+}
+
+func isMarkdownHeading(line string) bool {
+	line = strings.TrimLeft(line, " \t")
+	count := 0
+	for count < len(line) && line[count] == '#' {
+		count++
+	}
+	if count == 0 || count > 6 || count >= len(line) {
+		return false
+	}
+	return line[count] == ' ' || line[count] == '\t'
 }
 
 func ValidateNameLength(name string) error {
@@ -132,24 +231,56 @@ func FromFiles(files map[string][]byte) (Metadata, error) {
 }
 
 func FromEntries(ctx context.Context, tx *gorm.DB, entries map[string]versionfs.Entry) (Metadata, error) {
+	content, err := skillMDContent(ctx, tx, entries)
+	if err != nil {
+		return Metadata{}, err
+	}
+	return ParseRequired(content)
+}
+
+func skillMDContent(ctx context.Context, tx *gorm.DB, entries map[string]versionfs.Entry) ([]byte, error) {
 	entry, ok := entries["SKILL.md"]
 	if !ok || entry.EntryType != versionfs.EntryTypeFile || strings.TrimSpace(entry.BlobHash) == "" {
-		return Metadata{}, fmt.Errorf("skill package must contain SKILL.md")
+		return nil, fmt.Errorf("skill package must contain SKILL.md")
 	}
 	var blob orm.SkillV2Blob
 	if err := tx.WithContext(ctx).Where("hash = ?", entry.BlobHash).Take(&blob).Error; err != nil {
-		return Metadata{}, err
+		return nil, err
 	}
 	if blob.Binary || blob.StorageBackend != "postgres" {
-		return Metadata{}, fmt.Errorf("SKILL.md must be a text file")
+		return nil, fmt.Errorf("SKILL.md must be a text file")
 	}
-	return ParseRequired(blob.Content)
+	return blob.Content, nil
 }
 
 func FromRevision(ctx context.Context, tx *gorm.DB, revisionID string) (Metadata, error) {
+	entries, err := entriesFromRevision(ctx, tx, revisionID)
+	if err != nil {
+		return Metadata{}, err
+	}
+	return FromEntries(ctx, tx, entries)
+}
+
+func FromRevisionWithFallback(ctx context.Context, tx *gorm.DB, revisionID string, fallback Metadata) (Metadata, error) {
+	entries, err := entriesFromRevision(ctx, tx, revisionID)
+	if err != nil {
+		return Metadata{}, err
+	}
+	content, err := skillMDContent(ctx, tx, entries)
+	if err != nil {
+		return Metadata{}, err
+	}
+	effective, err := EffectiveDocument(content, fallback.Name, fallback.Description)
+	if err != nil {
+		return Metadata{}, err
+	}
+	return ParseRequired(effective)
+}
+
+func entriesFromRevision(ctx context.Context, tx *gorm.DB, revisionID string) (map[string]versionfs.Entry, error) {
 	var rows []orm.SkillV2RevisionEntry
 	if err := tx.WithContext(ctx).Where("revision_id = ?", revisionID).Find(&rows).Error; err != nil {
-		return Metadata{}, err
+		return nil, err
 	}
 	entries := make(map[string]versionfs.Entry, len(rows))
 	for _, row := range rows {
@@ -168,11 +299,29 @@ func FromRevision(ctx context.Context, tx *gorm.DB, revisionID string) (Metadata
 			Mode:      row.Mode,
 		}
 	}
-	return FromEntries(ctx, tx, entries)
+	return entries, nil
 }
 
 func SyncPublished(ctx context.Context, tx *gorm.DB, skillID string, entries map[string]versionfs.Entry, now time.Time) error {
-	meta, err := FromEntries(ctx, tx, entries)
+	var skill orm.SkillV2Skill
+	if err := tx.WithContext(ctx).Where("id = ? AND deleted_at IS NULL", skillID).Take(&skill).Error; err != nil {
+		return err
+	}
+	content, err := skillMDContent(ctx, tx, entries)
+	if err != nil {
+		return err
+	}
+	if skill.Category == ExternalCategory {
+		parsed, err := Parse(content)
+		if err != nil {
+			return err
+		}
+		if !parsed.HasName || !parsed.HasDescription {
+			return nil
+		}
+		return Sync(ctx, tx, skillID, parsed.Metadata, now)
+	}
+	meta, err := ParseRequired(content)
 	if err != nil {
 		return err
 	}
@@ -180,11 +329,11 @@ func SyncPublished(ctx context.Context, tx *gorm.DB, skillID string, entries map
 }
 
 func SyncRevision(ctx context.Context, tx *gorm.DB, skillID, revisionID string, now time.Time) error {
-	meta, err := FromRevision(ctx, tx, revisionID)
+	entries, err := entriesFromRevision(ctx, tx, revisionID)
 	if err != nil {
 		return err
 	}
-	return Sync(ctx, tx, skillID, meta, now)
+	return SyncPublished(ctx, tx, skillID, entries, now)
 }
 
 func Sync(ctx context.Context, tx *gorm.DB, skillID string, meta Metadata, now time.Time) error {

--- a/backend/core/skillv2/metadata/metadata.go
+++ b/backend/core/skillv2/metadata/metadata.go
@@ -149,6 +149,10 @@ func FirstBodyParagraph(body string) string {
 }
 
 func Resolve(content []byte, fallbackNames ...string) (Resolved, error) {
+	return ResolveWithFallback(content, Metadata{}, fallbackNames...)
+}
+
+func ResolveWithFallback(content []byte, fallback Metadata, fallbackNames ...string) (Resolved, error) {
 	parsed, err := Parse(content)
 	if err != nil {
 		return Resolved{}, err
@@ -158,7 +162,8 @@ func Resolve(content []byte, fallbackNames ...string) (Resolved, error) {
 	}
 	name := parsed.Name
 	if !parsed.HasName {
-		for _, candidate := range fallbackNames {
+		candidates := append([]string{fallback.Name}, fallbackNames...)
+		for _, candidate := range candidates {
 			candidate = strings.TrimSpace(candidate)
 			if ValidateName(candidate) == nil {
 				name = candidate
@@ -168,7 +173,10 @@ func Resolve(content []byte, fallbackNames ...string) (Resolved, error) {
 	}
 	description := parsed.Description
 	if !parsed.HasDescription {
-		description = FirstBodyParagraph(parsed.Body)
+		description = strings.TrimSpace(fallback.Description)
+		if description == "" {
+			description = FirstBodyParagraph(parsed.Body)
+		}
 	}
 	effective, err := EffectiveDocument(content, name, description)
 	if err != nil {
@@ -320,11 +328,11 @@ func FromRevisionWithFallback(ctx context.Context, tx *gorm.DB, revisionID strin
 	if err != nil {
 		return Metadata{}, err
 	}
-	effective, err := EffectiveDocument(content, fallback.Name, fallback.Description)
+	resolved, err := ResolveWithFallback(content, fallback)
 	if err != nil {
 		return Metadata{}, err
 	}
-	return ParseRequired(effective)
+	return resolved.Metadata, nil
 }
 
 func entriesFromRevision(ctx context.Context, tx *gorm.DB, revisionID string) (map[string]versionfs.Entry, error) {
@@ -362,14 +370,11 @@ func SyncPublished(ctx context.Context, tx *gorm.DB, skillID string, entries map
 		return err
 	}
 	if skill.Category == ExternalCategory || strings.TrimSpace(skill.OriginBuiltinSkillUID) != "" {
-		parsed, err := Parse(content)
+		resolved, err := ResolveWithFallback(content, Metadata{Name: skill.SkillName, Description: skill.Description})
 		if err != nil {
 			return err
 		}
-		if !parsed.HasName || !parsed.HasDescription {
-			return nil
-		}
-		return Sync(ctx, tx, skillID, parsed.Metadata, now)
+		return Sync(ctx, tx, skillID, resolved.Metadata, now)
 	}
 	meta, err := ParseRequired(content)
 	if err != nil {

--- a/backend/core/skillv2/metadata/metadata_test.go
+++ b/backend/core/skillv2/metadata/metadata_test.go
@@ -70,6 +70,49 @@ func TestParseRequiredRejectsTooLongFields(t *testing.T) {
 	}
 }
 
+func TestParseAllowsMissingMetadataAndFindsFirstBodyParagraph(t *testing.T) {
+	parsed, err := Parse([]byte("---\nversion: 1.2.3\n---\n# Skill\n\nFirst useful paragraph\ncontinues here.\n\nSecond paragraph.\n"))
+	if err != nil {
+		t.Fatalf("Parse returned error: %v", err)
+	}
+	if parsed.HasName || parsed.HasDescription || parsed.Version != "1.2.3" {
+		t.Fatalf("Parse result = %#v", parsed)
+	}
+	if got := FirstBodyParagraph(parsed.Body); got != "First useful paragraph continues here." {
+		t.Fatalf("FirstBodyParagraph = %q", got)
+	}
+}
+
+func TestEffectiveDocumentUsesMetadataOnlyForRuntimeView(t *testing.T) {
+	original := []byte("---\nversion: 1.2.3\n---\n# Skill\n\nA useful runtime description.\n")
+	effective, err := EffectiveDocument(original, "runtime-skill", "A useful runtime description.")
+	if err != nil {
+		t.Fatalf("EffectiveDocument returned error: %v", err)
+	}
+	meta, err := ParseRequired(effective)
+	if err != nil {
+		t.Fatalf("runtime view is not strictly valid: %v", err)
+	}
+	if meta.Name != "runtime-skill" || meta.Description != "A useful runtime description." || meta.Version != "1.2.3" {
+		t.Fatalf("runtime metadata = %#v", meta)
+	}
+	if !strings.Contains(string(effective), "# Skill") {
+		t.Fatalf("runtime view lost body: %q", effective)
+	}
+	if string(original) != "---\nversion: 1.2.3\n---\n# Skill\n\nA useful runtime description.\n" {
+		t.Fatalf("EffectiveDocument mutated original: %q", original)
+	}
+
+	complete := []byte("---\nname: source-skill\ndescription: Source description\n---\n# Source\n")
+	unchanged, err := EffectiveDocument(complete, "ignored", "ignored")
+	if err != nil {
+		t.Fatalf("EffectiveDocument complete returned error: %v", err)
+	}
+	if string(unchanged) != string(complete) {
+		t.Fatalf("complete document changed: %q", unchanged)
+	}
+}
+
 func TestIsNameLengthError(t *testing.T) {
 	nameErr := ValidateNameLength(strings.Repeat("a", MaxSkillNameLength+1))
 	if !IsNameLengthError(nameErr) {

--- a/backend/core/skillv2/metadata/metadata_test.go
+++ b/backend/core/skillv2/metadata/metadata_test.go
@@ -113,6 +113,42 @@ func TestEffectiveDocumentUsesMetadataOnlyForRuntimeView(t *testing.T) {
 	}
 }
 
+func TestResolveWithFallbackPrefersPresentFieldsAndRetainsMissingStoredField(t *testing.T) {
+	tests := []struct {
+		name     string
+		content  string
+		wantName string
+		wantDesc string
+	}{
+		{
+			name:     "name only",
+			content:  "---\nname: evolved-name\n---\n# Skill\n\nNew body.\n",
+			wantName: "evolved-name",
+			wantDesc: "Stored description",
+		},
+		{
+			name:     "description only",
+			content:  "---\ndescription: Evolved description\n---\n# Skill\n",
+			wantName: "stored-name",
+			wantDesc: "Evolved description",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resolved, err := ResolveWithFallback([]byte(tt.content), Metadata{Name: "stored-name", Description: "Stored description"})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if resolved.Name != tt.wantName || resolved.Description != tt.wantDesc {
+				t.Fatalf("resolved metadata = %#v", resolved.Metadata)
+			}
+			if _, err := ParseRequired(resolved.Content); err != nil {
+				t.Fatalf("runtime content is not strict: %v", err)
+			}
+		})
+	}
+}
+
 func TestIsNameLengthError(t *testing.T) {
 	nameErr := ValidateNameLength(strings.Repeat("a", MaxSkillNameLength+1))
 	if !IsNameLengthError(nameErr) {

--- a/backend/core/skillv2/remotefs/remote_fs.go
+++ b/backend/core/skillv2/remotefs/remote_fs.go
@@ -584,11 +584,12 @@ func (h *Handler) readContent(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if parsed.relPath == skill.SkillMDPath && (skill.Category == skillmetadata.ExternalCategory || skill.OriginBuiltinSkillUID != "") {
-		data, err = skillmetadata.EffectiveDocument(data, skill.SkillName, skill.Description)
-		if err != nil {
-			writeHTTPError(w, err)
+		resolved, resolveErr := skillmetadata.ResolveWithFallback(data, skillmetadata.Metadata{Name: skill.SkillName, Description: skill.Description})
+		if resolveErr != nil {
+			writeHTTPError(w, resolveErr)
 			return
 		}
+		data = resolved.Content
 	}
 	switch r.URL.Query().Get("encoding") {
 	case "base64":

--- a/backend/core/skillv2/remotefs/remote_fs.go
+++ b/backend/core/skillv2/remotefs/remote_fs.go
@@ -583,7 +583,7 @@ func (h *Handler) readContent(w http.ResponseWriter, r *http.Request) {
 		writeHTTPError(w, err)
 		return
 	}
-	if parsed.relPath == skill.SkillMDPath && skill.Category == skillmetadata.ExternalCategory {
+	if parsed.relPath == skill.SkillMDPath && (skill.Category == skillmetadata.ExternalCategory || skill.OriginBuiltinSkillUID != "") {
 		data, err = skillmetadata.EffectiveDocument(data, skill.SkillName, skill.Description)
 		if err != nil {
 			writeHTTPError(w, err)
@@ -1356,32 +1356,33 @@ type systemClock struct{}
 func (systemClock) Now() time.Time { return time.Now() }
 
 type skillRow struct {
-	ID                 string     `gorm:"column:id;type:varchar(36);primaryKey"`
-	OwnerUserID        string     `gorm:"column:owner_user_id;type:text;not null"`
-	OwnerUserName      string     `gorm:"column:owner_user_name;type:text;not null;default:''"`
-	CreateUserID       string     `gorm:"column:create_user_id;type:text;not null"`
-	CreateUserName     string     `gorm:"column:create_user_name;type:text;not null;default:''"`
-	Category           string     `gorm:"column:category;type:text;not null"`
-	SkillName          string     `gorm:"column:skill_name;type:text;not null"`
-	Description        string     `gorm:"column:description;type:text"`
-	Tags               []byte     `gorm:"column:tags;type:json"`
-	RelativeRoot       string     `gorm:"column:relative_root;type:text;not null"`
-	SkillMDPath        string     `gorm:"column:skill_md_path;type:text;not null;default:'SKILL.md'"`
-	HeadRevisionID     *string    `gorm:"column:head_revision_id;type:varchar(36)"`
-	Version            int64      `gorm:"column:version;not null;default:1"`
-	AutoEvo            bool       `gorm:"column:auto_evo;not null;default:false"`
-	AutoEvoApplyStatus string     `gorm:"column:auto_evo_apply_status;type:text;not null;default:'idle'"`
-	AutoEvoGeneration  int64      `gorm:"column:auto_evo_generation;not null;default:0"`
-	AutoEvoStartedAt   *time.Time `gorm:"column:auto_evo_started_at"`
-	AutoEvoFinishedAt  *time.Time `gorm:"column:auto_evo_finished_at"`
-	AutoEvoError       string     `gorm:"column:auto_evo_error;type:text;not null;default:''"`
-	IsEnabled          bool       `gorm:"column:is_enabled;not null;default:true"`
-	UpdateStatus       string     `gorm:"column:update_status;type:text;not null;default:'up_to_date'"`
-	Ext                []byte     `gorm:"column:ext;type:json"`
-	DeletedAt          *time.Time `gorm:"column:deleted_at"`
-	DeletedBy          *string    `gorm:"column:deleted_by;type:text"`
-	CreatedAt          time.Time  `gorm:"column:created_at;not null"`
-	UpdatedAt          time.Time  `gorm:"column:updated_at;not null"`
+	ID                    string     `gorm:"column:id;type:varchar(36);primaryKey"`
+	OwnerUserID           string     `gorm:"column:owner_user_id;type:text;not null"`
+	OwnerUserName         string     `gorm:"column:owner_user_name;type:text;not null;default:''"`
+	CreateUserID          string     `gorm:"column:create_user_id;type:text;not null"`
+	CreateUserName        string     `gorm:"column:create_user_name;type:text;not null;default:''"`
+	Category              string     `gorm:"column:category;type:text;not null"`
+	SkillName             string     `gorm:"column:skill_name;type:text;not null"`
+	Description           string     `gorm:"column:description;type:text"`
+	Tags                  []byte     `gorm:"column:tags;type:json"`
+	RelativeRoot          string     `gorm:"column:relative_root;type:text;not null"`
+	SkillMDPath           string     `gorm:"column:skill_md_path;type:text;not null;default:'SKILL.md'"`
+	HeadRevisionID        *string    `gorm:"column:head_revision_id;type:varchar(36)"`
+	Version               int64      `gorm:"column:version;not null;default:1"`
+	AutoEvo               bool       `gorm:"column:auto_evo;not null;default:false"`
+	AutoEvoApplyStatus    string     `gorm:"column:auto_evo_apply_status;type:text;not null;default:'idle'"`
+	AutoEvoGeneration     int64      `gorm:"column:auto_evo_generation;not null;default:0"`
+	AutoEvoStartedAt      *time.Time `gorm:"column:auto_evo_started_at"`
+	AutoEvoFinishedAt     *time.Time `gorm:"column:auto_evo_finished_at"`
+	AutoEvoError          string     `gorm:"column:auto_evo_error;type:text;not null;default:''"`
+	IsEnabled             bool       `gorm:"column:is_enabled;not null;default:true"`
+	OriginBuiltinSkillUID string     `gorm:"column:origin_builtin_skill_uid;type:text;not null;default:''"`
+	UpdateStatus          string     `gorm:"column:update_status;type:text;not null;default:'up_to_date'"`
+	Ext                   []byte     `gorm:"column:ext;type:json"`
+	DeletedAt             *time.Time `gorm:"column:deleted_at"`
+	DeletedBy             *string    `gorm:"column:deleted_by;type:text"`
+	CreatedAt             time.Time  `gorm:"column:created_at;not null"`
+	UpdatedAt             time.Time  `gorm:"column:updated_at;not null"`
 }
 
 func (skillRow) TableName() string { return "skills" }

--- a/backend/core/skillv2/remotefs/remote_fs.go
+++ b/backend/core/skillv2/remotefs/remote_fs.go
@@ -23,6 +23,7 @@ import (
 	"gorm.io/gorm"
 
 	skillhttperr "lazymind/core/skillv2/httperr"
+	skillmetadata "lazymind/core/skillv2/metadata"
 	"lazymind/core/skillv2/revision"
 	skillsearch "lazymind/core/skillv2/search"
 	skillservice "lazymind/core/skillv2/service"
@@ -581,6 +582,13 @@ func (h *Handler) readContent(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		writeHTTPError(w, err)
 		return
+	}
+	if parsed.relPath == skill.SkillMDPath && skill.Category == skillmetadata.ExternalCategory {
+		data, err = skillmetadata.EffectiveDocument(data, skill.SkillName, skill.Description)
+		if err != nil {
+			writeHTTPError(w, err)
+			return
+		}
 	}
 	switch r.URL.Query().Get("encoding") {
 	case "base64":

--- a/backend/core/skillv2/remotefs/remote_fs_test.go
+++ b/backend/core/skillv2/remotefs/remote_fs_test.go
@@ -9,10 +9,13 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"os"
 	"strings"
 	"testing"
 
 	skillmetadata "lazymind/core/skillv2/metadata"
+	skillservice "lazymind/core/skillv2/service"
+	skillpackage "lazymind/core/skillv2/skillpackage"
 	"lazymind/core/skillv2/testutil"
 )
 
@@ -54,6 +57,39 @@ func TestRemoteFSExternalSkillMDReturnsStrictRuntimeViewWithoutChangingBlob(t *t
 	}
 	if !bytes.Equal(blob.Content, original) {
 		t.Fatalf("stored SKILL.md changed: %q", blob.Content)
+	}
+}
+
+func TestRemoteFSBuiltinSkillMDReturnsStrictRuntimeViewWithoutChangingBlob(t *testing.T) {
+	db := testutil.NewTestDB(t)
+	original := []byte("---\nversion: 1.0.0\n---\n# Runtime skill\n\nUseful runtime description.\n")
+	archivePath, err := skillpackage.WriteZip(map[string][]byte{"SKILL.md": original}, t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(archivePath)
+	created, err := skillservice.NewSkillService(skillservice.SkillServiceDeps{DB: db.DB, BlobStore: skillservice.NewBlobStore(db.DB, skillservice.NewLocalObjectStore(t.TempDir()))}).CreateSkill(context.Background(), skillservice.CreateSkillRequest{
+		OwnerUserID: "user_001", CreateUserID: "user_001", Name: "runtime-skill", Category: "research", Description: "Useful runtime description.", OriginBuiltinSkillUID: "bsk_runtime_skill",
+		Source: skillservice.SourceInput{Type: "builtin_zip", StoredPath: archivePath, Filename: "bsk_runtime_skill.zip"},
+	})
+	if err != nil {
+		t.Fatalf("install builtin Skill: %v", err)
+	}
+	handler := NewHandler(HandlerDeps{DB: db.DB, BlobStore: NewBlobStore(db.DB, NewLocalObjectStore(t.TempDir()))})
+	rec := httptest.NewRecorder()
+	handler.Content(rec, httptest.NewRequest(http.MethodGet, remoteContentURL("skills/research/runtime-skill/SKILL.md", "user_001", "task1", ""), nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("content status=%d body=%s", rec.Code, rec.Body.String())
+	}
+	if _, err := skillmetadata.ParseRequired(rec.Body.Bytes()); err != nil {
+		t.Fatalf("runtime SKILL.md is not strictly valid: %v", err)
+	}
+	var skill testutil.SkillRow
+	if err := db.Where("id = ?", created.SkillID).Take(&skill).Error; err != nil {
+		t.Fatal(err)
+	}
+	if skill.OriginBuiltinSkillUID != "bsk_runtime_skill" {
+		t.Fatalf("installed skill = %#v", skill)
 	}
 }
 

--- a/backend/core/skillv2/remotefs/remote_fs_test.go
+++ b/backend/core/skillv2/remotefs/remote_fs_test.go
@@ -12,8 +12,50 @@ import (
 	"strings"
 	"testing"
 
+	skillmetadata "lazymind/core/skillv2/metadata"
 	"lazymind/core/skillv2/testutil"
 )
+
+func TestRemoteFSExternalSkillMDReturnsStrictRuntimeViewWithoutChangingBlob(t *testing.T) {
+	db := testutil.NewTestDB(t)
+	testutil.SeedSkillWithRevision(t, db, "skill1", "rev1")
+	original := []byte("---\nversion: 1.0.0\n---\n# Runtime skill\n\nUseful runtime description.\n")
+	if err := db.Model(&testutil.SkillRow{}).Where("id = ?", "skill1").Updates(map[string]any{
+		"category":      skillmetadata.ExternalCategory,
+		"skill_name":    "runtime-skill",
+		"description":   "Useful runtime description.",
+		"relative_root": skillmetadata.ExternalCategory + "/runtime-skill",
+	}).Error; err != nil {
+		t.Fatalf("configure external skill: %v", err)
+	}
+	if err := db.Model(&testutil.SkillBlobRow{}).Where("hash = ?", "h_skill_rev1").Updates(map[string]any{
+		"content": original,
+		"size":    len(original),
+	}).Error; err != nil {
+		t.Fatalf("replace original SKILL.md blob: %v", err)
+	}
+	handler := NewHandler(HandlerDeps{DB: db.DB, BlobStore: NewBlobStore(db.DB, NewLocalObjectStore(t.TempDir()))})
+
+	rec := httptest.NewRecorder()
+	handler.Content(rec, httptest.NewRequest(http.MethodGet, remoteContentURL("skills/external/runtime-skill/SKILL.md", "user_001", "task1", ""), nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("content status=%d body=%s", rec.Code, rec.Body.String())
+	}
+	meta, err := skillmetadata.ParseRequired(rec.Body.Bytes())
+	if err != nil {
+		t.Fatalf("runtime SKILL.md is not strictly valid: %v", err)
+	}
+	if meta.Name != "runtime-skill" || meta.Description != "Useful runtime description." || !strings.Contains(rec.Body.String(), "# Runtime skill") {
+		t.Fatalf("runtime SKILL.md = %q", rec.Body.String())
+	}
+	var blob testutil.SkillBlobRow
+	if err := db.Where("hash = ?", "h_skill_rev1").Take(&blob).Error; err != nil {
+		t.Fatalf("query original blob: %v", err)
+	}
+	if !bytes.Equal(blob.Content, original) {
+		t.Fatalf("stored SKILL.md changed: %q", blob.Content)
+	}
+}
 
 func TestRemoteFSWriteText_IsVisibleInSameTask(t *testing.T) {
 	db := testutil.NewTestDB(t)

--- a/backend/core/skillv2/revision/commit_draft_test.go
+++ b/backend/core/skillv2/revision/commit_draft_test.go
@@ -198,6 +198,71 @@ func TestCommitDraft_ExternalSkillAllowsMissingMetadataAndKeepsStoredIdentity(t 
 	}
 }
 
+func TestCommitDraft_ExternalSkillUpdatesPresentPartialMetadata(t *testing.T) {
+	tests := []struct {
+		name     string
+		content  string
+		wantName string
+		wantDesc string
+		wantRoot string
+	}{
+		{
+			name:     "name only",
+			content:  "---\nname: evolved-name\n---\n# Skill\n\nUpdated body.\n",
+			wantName: "evolved-name",
+			wantDesc: "Stored fallback description",
+			wantRoot: "external/evolved-name",
+		},
+		{
+			name:     "description only",
+			content:  "---\ndescription: Evolved description\n---\n# Skill\n",
+			wantName: "fallback-skill",
+			wantDesc: "Evolved description",
+			wantRoot: "external/fallback-skill",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			db := testutil.NewTestDB(t)
+			testutil.SeedSkillWithRevision(t, db, "skill1", "rev1")
+			if err := db.Model(&testutil.SkillRow{}).Where("id = ?", "skill1").Updates(map[string]any{
+				"category":      "external",
+				"skill_name":    "fallback-skill",
+				"description":   "Stored fallback description",
+				"relative_root": "external/fallback-skill",
+			}).Error; err != nil {
+				t.Fatalf("configure external skill: %v", err)
+			}
+			testutil.SeedTextBlob(t, db, "h_external_partial", tt.content)
+			testutil.SeedDraftEntry(t, db, "skill1", "SKILL.md", "upsert", "file", "h_external_partial")
+			service := NewService(ServiceDeps{DB: db.DB, BlobStore: NewBlobStore(db.DB, NewLocalObjectStore(t.TempDir()))})
+
+			resp, err := service.CommitDraft(context.Background(), CommitDraftRequest{SkillID: "skill1", UserID: "user_001", DraftVersion: 1})
+			if err != nil {
+				t.Fatalf("CommitDraft returned error: %v", err)
+			}
+			var skill testutil.SkillRow
+			if err := db.Where("id = ?", "skill1").Take(&skill).Error; err != nil {
+				t.Fatal(err)
+			}
+			if skill.SkillName != tt.wantName || skill.Description != tt.wantDesc || skill.RelativeRoot != tt.wantRoot {
+				t.Fatalf("synchronized metadata = %#v", skill)
+			}
+			var entry testutil.SkillRevisionEntryRow
+			if err := db.Where("revision_id = ? AND path = ?", resp.RevisionID, "SKILL.md").Take(&entry).Error; err != nil || entry.BlobHash == nil {
+				t.Fatalf("committed SKILL.md entry: %#v err=%v", entry, err)
+			}
+			var blob testutil.SkillBlobRow
+			if err := db.Where("hash = ?", *entry.BlobHash).Take(&blob).Error; err != nil {
+				t.Fatal(err)
+			}
+			if string(blob.Content) != tt.content {
+				t.Fatalf("committed SKILL.md = %q, want %q", blob.Content, tt.content)
+			}
+		})
+	}
+}
+
 func TestCommitDraft_RejectsEmptyCommit(t *testing.T) {
 	db := testutil.NewTestDB(t)
 	testutil.SeedSkillWithRevision(t, db, "skill1", "rev1")

--- a/backend/core/skillv2/revision/commit_draft_test.go
+++ b/backend/core/skillv2/revision/commit_draft_test.go
@@ -158,6 +158,46 @@ func TestCommitDraft_InvalidFrontmatterRollsBackAndKeepsDraft(t *testing.T) {
 	}
 }
 
+func TestCommitDraft_ExternalSkillAllowsMissingMetadataAndKeepsStoredIdentity(t *testing.T) {
+	db := testutil.NewTestDB(t)
+	testutil.SeedSkillWithRevision(t, db, "skill1", "rev1")
+	if err := db.Model(&testutil.SkillRow{}).Where("id = ?", "skill1").Updates(map[string]any{
+		"category":      "external",
+		"skill_name":    "fallback-skill",
+		"description":   "Stored fallback description",
+		"relative_root": "external/fallback-skill",
+	}).Error; err != nil {
+		t.Fatalf("configure external skill: %v", err)
+	}
+	original := "---\nversion: 1.0.0\n---\n# Skill\n\nDraft body remains readable.\n"
+	testutil.SeedTextBlob(t, db, "h_external_partial", original)
+	testutil.SeedDraftEntry(t, db, "skill1", "SKILL.md", "upsert", "file", "h_external_partial")
+	service := NewService(ServiceDeps{DB: db.DB, BlobStore: NewBlobStore(db.DB, NewLocalObjectStore(t.TempDir()))})
+
+	resp, err := service.CommitDraft(context.Background(), CommitDraftRequest{SkillID: "skill1", UserID: "user_001", DraftVersion: 1})
+	if err != nil {
+		t.Fatalf("CommitDraft returned error: %v", err)
+	}
+	var skill testutil.SkillRow
+	if err := db.Where("id = ?", "skill1").Take(&skill).Error; err != nil {
+		t.Fatalf("query skill: %v", err)
+	}
+	if skill.SkillName != "fallback-skill" || skill.Description != "Stored fallback description" || skill.RelativeRoot != "external/fallback-skill" {
+		t.Fatalf("fallback metadata changed: %#v", skill)
+	}
+	var entry testutil.SkillRevisionEntryRow
+	if err := db.Where("revision_id = ? AND path = ?", resp.RevisionID, "SKILL.md").Take(&entry).Error; err != nil || entry.BlobHash == nil {
+		t.Fatalf("query committed SKILL.md entry: entry=%#v err=%v", entry, err)
+	}
+	var blob testutil.SkillBlobRow
+	if err := db.Where("hash = ?", *entry.BlobHash).Take(&blob).Error; err != nil {
+		t.Fatalf("query committed SKILL.md blob: %v", err)
+	}
+	if string(blob.Content) != original {
+		t.Fatalf("committed SKILL.md = %q, want %q", blob.Content, original)
+	}
+}
+
 func TestCommitDraft_RejectsEmptyCommit(t *testing.T) {
 	db := testutil.NewTestDB(t)
 	testutil.SeedSkillWithRevision(t, db, "skill1", "rev1")

--- a/backend/core/skillv2/revision/rollback_test.go
+++ b/backend/core/skillv2/revision/rollback_test.go
@@ -41,6 +41,39 @@ func TestRollback_MovesHeadWithoutCreatingRevision(t *testing.T) {
 	}
 }
 
+func TestRollback_ExternalIncompleteSkillMDKeepsRuntimeMetadata(t *testing.T) {
+	db := testutil.NewTestDB(t)
+	testutil.SeedSkillWithRevision(t, db, "skill1", "rev1")
+	partial := "---\nversion: 1.0.0\n---\n# Original skill\n\nOriginal body.\n"
+	if err := db.Model(&testutil.SkillBlobRow{}).Where("hash = ?", "h_skill_rev1").Updates(map[string]any{"content": []byte(partial), "size": len(partial)}).Error; err != nil {
+		t.Fatalf("configure incomplete original blob: %v", err)
+	}
+	if err := db.Model(&testutil.SkillRow{}).Where("id = ?", "skill1").Updates(map[string]any{
+		"category":      "external",
+		"skill_name":    "fallback-skill",
+		"description":   "Fallback description",
+		"relative_root": "external/fallback-skill",
+	}).Error; err != nil {
+		t.Fatalf("configure external skill: %v", err)
+	}
+	seedSecondRevision(t, db, "skill1", "rev1", "rev2")
+	if err := db.Model(&testutil.SkillRow{}).Where("id = ?", "skill1").Update("relative_root", "external/论文精读-v2").Error; err != nil {
+		t.Fatalf("restore external root after seed: %v", err)
+	}
+	service := NewService(ServiceDeps{DB: db.DB, BlobStore: NewBlobStore(db.DB, NewLocalObjectStore(t.TempDir()))})
+
+	if _, err := service.Rollback(context.Background(), RollbackRequest{SkillID: "skill1", UserID: "user_001", TargetRevisionID: "rev1"}); err != nil {
+		t.Fatalf("Rollback returned error: %v", err)
+	}
+	var skill testutil.SkillRow
+	if err := db.Where("id = ?", "skill1").Take(&skill).Error; err != nil {
+		t.Fatalf("query rolled back skill: %v", err)
+	}
+	if skill.Category != "external" || skill.SkillName != "论文精读-v2" || skill.Description != "第二版描述" || skill.RelativeRoot != "external/论文精读-v2" {
+		t.Fatalf("rollback changed retained metadata: %#v", skill)
+	}
+}
+
 func TestRollback_CommitCreatesNextRevisionFromRolledBackHead(t *testing.T) {
 	db := testutil.NewTestDB(t)
 	testutil.SeedSkillWithRevision(t, db, "skill1", "rev1")

--- a/backend/core/skillv2/service/create_skill_validation_test.go
+++ b/backend/core/skillv2/service/create_skill_validation_test.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"bytes"
 	"context"
 	"path/filepath"
 	"strings"
@@ -34,22 +35,105 @@ func TestCreateSkillFromUploadedZip_RequiresSkillMD(t *testing.T) {
 	assertNoSkillTruthRows(t, db)
 }
 
-func TestCreateSkillFromUploadedZip_RequiresFrontmatterMetadata(t *testing.T) {
+func TestCreateSkillFromUploadedZip_FallsBackMissingMetadataWithoutRewritingSkillMD(t *testing.T) {
+	tests := []struct {
+		name        string
+		filename    string
+		entryPath   string
+		content     []byte
+		wantName    string
+		wantDesc    string
+		generatedID bool
+	}{
+		{
+			name:      "no frontmatter uses archive filename",
+			filename:  "frontmatter.zip",
+			entryPath: "SKILL.md",
+			content:   []byte("# Skill\n\nFirst useful paragraph.\n\nSecond paragraph.\n"),
+			wantName:  "frontmatter",
+			wantDesc:  "First useful paragraph.",
+		},
+		{
+			name:      "missing name uses package root",
+			filename:  "ignored.zip",
+			entryPath: "wrapped-skill/SKILL.md",
+			content:   []byte("---\ndescription: Existing description\n---\n# Skill\n"),
+			wantName:  "wrapped-skill",
+			wantDesc:  "Existing description",
+		},
+		{
+			name:      "missing description uses body",
+			filename:  "ignored.zip",
+			entryPath: "SKILL.md",
+			content:   []byte("---\nname: existing-name\n---\n# Skill\n\nDescription from the body.\n"),
+			wantName:  "existing-name",
+			wantDesc:  "Description from the body.",
+		},
+		{
+			name:        "no naming source uses generated id",
+			entryPath:   "SKILL.md",
+			content:     []byte("# Skill\n\nGenerated fallback description.\n"),
+			wantDesc:    "Generated fallback description.",
+			generatedID: true,
+		},
+		{
+			name:      "complete frontmatter remains authoritative",
+			filename:  "ignored.zip",
+			entryPath: "SKILL.md",
+			content:   externalSkillMD("source-name", "Source description"),
+			wantName:  "source-name",
+			wantDesc:  "Source description",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			db := newSkillV2TestDB(t)
+			zipPath := filepath.Join(t.TempDir(), "source.zip")
+			writeSkillZip(t, zipPath, map[string][]byte{tt.entryPath: tt.content})
+			uploadStore := newFakeUploadStore()
+			uploadID := "upload_missing_metadata"
+			uploadStore.Put(UploadSession{UploadID: uploadID, OwnerUserID: "user_001", State: "completed", StoredPath: zipPath, Filename: tt.filename})
+			svc := newCreateSkillValidationService(t, db, uploadStore)
+
+			resp, err := svc.CreateSkill(context.Background(), validCreateSkillRequest(uploadID))
+			if err != nil {
+				t.Fatalf("CreateSkill returned error: %v", err)
+			}
+			var skill testSkillV2SkillRow
+			if err := db.Where("id = ?", resp.SkillID).Take(&skill).Error; err != nil {
+				t.Fatalf("query skill: %v", err)
+			}
+			wantName := tt.wantName
+			if tt.generatedID {
+				wantName = "lazymind-skill-" + resp.SkillID
+			}
+			if skill.Category != skillmetadata.ExternalCategory || skill.SkillName != wantName || skill.Description != tt.wantDesc {
+				t.Fatalf("skill metadata = %#v, want category=%q name=%q description=%q", skill, skillmetadata.ExternalCategory, wantName, tt.wantDesc)
+			}
+			blob := getBlobByPath(t, db, resp.HeadRevisionID, "SKILL.md")
+			if !bytes.Equal(blob.Content, tt.content) {
+				t.Fatalf("stored SKILL.md = %q, want original %q", blob.Content, tt.content)
+			}
+		})
+	}
+}
+
+func TestCreateSkillFromUploadedZip_RejectsInvalidMetadata(t *testing.T) {
 	for name, content := range map[string][]byte{
-		"frontmatter": []byte("# Skill\n"),
-		"name":        []byte("---\ndescription: description\n---\n# Skill\n"),
-		"description": []byte("---\nname: skill\n---\n# Skill\n"),
+		"invalid yaml":     []byte("---\nname: [\n---\n# Skill\n"),
+		"invalid name":     []byte("---\nname: bad/name\ndescription: description\n---\n# Skill\n"),
+		"long name":        []byte("---\nname: " + strings.Repeat("a", skillmetadata.MaxSkillNameLength+1) + "\ndescription: description\n---\n# Skill\n"),
+		"long description": []byte("---\nname: valid-name\ndescription: " + strings.Repeat("a", skillmetadata.MaxSkillDescriptionLength+1) + "\n---\n# Skill\n"),
 	} {
 		t.Run(name, func(t *testing.T) {
 			db := newSkillV2TestDB(t)
-			zipPath := filepath.Join(t.TempDir(), name+".zip")
+			zipPath := filepath.Join(t.TempDir(), "invalid.zip")
 			writeSkillZip(t, zipPath, map[string][]byte{"SKILL.md": content})
 			uploadStore := newFakeUploadStore()
-			uploadID := "upload_missing_" + name
-			uploadStore.Put(UploadSession{UploadID: uploadID, OwnerUserID: "user_001", State: "completed", StoredPath: zipPath, Filename: name + ".zip"})
-			svc := newCreateSkillValidationService(t, db, uploadStore)
+			uploadStore.Put(UploadSession{UploadID: "upload_invalid_metadata", OwnerUserID: "user_001", State: "completed", StoredPath: zipPath, Filename: "invalid.zip"})
 
-			if _, err := svc.CreateSkill(context.Background(), validCreateSkillRequest(uploadID)); err == nil {
+			_, err := newCreateSkillValidationService(t, db, uploadStore).CreateSkill(context.Background(), validCreateSkillRequest("upload_invalid_metadata"))
+			if err == nil {
 				t.Fatal("CreateSkill succeeded")
 			}
 			assertNoSkillTruthRows(t, db)

--- a/backend/core/skillv2/service/crud_and_import_test.go
+++ b/backend/core/skillv2/service/crud_and_import_test.go
@@ -55,6 +55,41 @@ func TestCreateSkillFromURL_CreatesInitialRevision(t *testing.T) {
 	assertBlobRouting(t, db, resp.HeadRevisionID)
 }
 
+func TestCreateSkillFromURL_FallsBackToURLFilename(t *testing.T) {
+	db := newSkillV2TestDB(t)
+	zipPath := filepath.Join(t.TempDir(), "download.zip")
+	original := []byte("# URL Skill\n\nImported from a URL without frontmatter.\n")
+	writeSkillZip(t, zipPath, map[string][]byte{"SKILL.md": original})
+	svc := NewSkillService(SkillServiceDeps{
+		DB:         db,
+		Downloader: NewFakeZipDownloader(map[string]string{"https://example.test/releases/url-fallback.zip": zipPath}),
+		BlobStore:  NewBlobStore(db, NewLocalObjectStore(t.TempDir())),
+		Clock:      fixedClock(),
+	})
+
+	resp, err := svc.CreateSkill(context.Background(), CreateSkillRequest{
+		OwnerUserID:  "user_001",
+		CreateUserID: "user_001",
+		Source: SourceInput{
+			Type: "url",
+			URL:  "https://example.test/releases/url-fallback.zip",
+		},
+	})
+	if err != nil {
+		t.Fatalf("CreateSkill from URL returned error: %v", err)
+	}
+	var imported testSkillV2SkillRow
+	if err := db.Where("id = ?", resp.SkillID).Take(&imported).Error; err != nil {
+		t.Fatalf("query URL imported skill: %v", err)
+	}
+	if imported.SkillName != "url-fallback" || imported.Description != "Imported from a URL without frontmatter." || imported.Category != "external" {
+		t.Fatalf("URL fallback metadata = %#v", imported)
+	}
+	if blob := getBlobByPath(t, db, resp.HeadRevisionID, "SKILL.md"); string(blob.Content) != string(original) {
+		t.Fatalf("stored URL SKILL.md = %q, want %q", blob.Content, original)
+	}
+}
+
 func TestCreateSkillFromURL_DownloadFailureDoesNotCreateSkill(t *testing.T) {
 	db := newSkillV2TestDB(t)
 	downloader := NewFakeZipDownloader(map[string]string{})
@@ -252,6 +287,36 @@ func TestReplaceSkillContentFromUploadedZip_CreatesNewRevision(t *testing.T) {
 	}
 	assertInitialReplacementRevision(t, db, "skill1", resp.HeadRevisionID)
 	assertDraftInitialized(t, db, "skill1", resp.HeadRevisionID)
+}
+
+func TestReplaceSkillContentFromUploadedZip_KeepsFallbackMetadataAndRawSkillMD(t *testing.T) {
+	db := newSkillV2TestDB(t)
+	seedSkillWithHeadRevision(t, db, "skill1", "rev1")
+	zipPath := filepath.Join(t.TempDir(), "replacement-fallback.zip")
+	original := []byte("---\ndescription: Replacement description\n---\n# Replacement\n")
+	writeSkillZip(t, zipPath, map[string][]byte{"replacement-root/SKILL.md": original})
+	uploadStore := newFakeUploadStore()
+	uploadStore.Put(UploadSession{UploadID: "upload_replace_fallback", OwnerUserID: "user_001", State: "completed", StoredPath: zipPath, Filename: "replacement.zip"})
+	svc := NewSkillService(SkillServiceDeps{DB: db, UploadStore: uploadStore, BlobStore: NewBlobStore(db, NewLocalObjectStore(t.TempDir())), Clock: fixedClock()})
+
+	resp, err := svc.PatchSkill(context.Background(), PatchSkillRequest{
+		SkillID: "skill1",
+		UserID:  "user_001",
+		Source:  &SourceInput{Type: "uploaded_zip", UploadID: "upload_replace_fallback"},
+	})
+	if err != nil {
+		t.Fatalf("PatchSkill source replacement returned error: %v", err)
+	}
+	var replaced testSkillV2SkillRow
+	if err := db.Where("id = ?", "skill1").Take(&replaced).Error; err != nil {
+		t.Fatalf("query replaced skill: %v", err)
+	}
+	if replaced.SkillName != "replacement-root" || replaced.Description != "Replacement description" || replaced.Category != "external" {
+		t.Fatalf("replacement fallback metadata = %#v", replaced)
+	}
+	if blob := getBlobByPath(t, db, resp.HeadRevisionID, "SKILL.md"); string(blob.Content) != string(original) {
+		t.Fatalf("stored replacement SKILL.md = %q, want %q", blob.Content, original)
+	}
 }
 
 func TestReplaceSkillContent_RejectsWhenDraftExists(t *testing.T) {

--- a/backend/core/skillv2/service/service.go
+++ b/backend/core/skillv2/service/service.go
@@ -1093,31 +1093,11 @@ func resolveExternalMetadata(pkg sourcePackage, skillID string) (skillmetadata.M
 	if !ok {
 		return skillmetadata.Metadata{}, fmt.Errorf("skill package must contain SKILL.md")
 	}
-	parsed, err := skillmetadata.Parse(content)
+	resolved, err := skillmetadata.Resolve(content, pkg.PackageRoot, archiveStem(pkg.ArchiveFilename), "lazymind-skill-"+skillID)
 	if err != nil {
 		return skillmetadata.Metadata{}, err
 	}
-	name := parsed.Name
-	if !parsed.HasName {
-		name = strings.TrimSpace(pkg.PackageRoot)
-		if err := validateSkillName(name); err != nil {
-			name = archiveStem(pkg.ArchiveFilename)
-		}
-		if err := validateSkillName(name); err != nil {
-			name = "lazymind-skill-" + skillID
-		}
-	}
-	description := parsed.Description
-	if !parsed.HasDescription {
-		description = skillmetadata.FirstBodyParagraph(parsed.Body)
-	}
-	if err := validateSkillName(name); err != nil {
-		return skillmetadata.Metadata{}, fmt.Errorf("invalid SKILL.md frontmatter field \"name\": %w", err)
-	}
-	if err := validateSkillDescription(description); err != nil {
-		return skillmetadata.Metadata{}, err
-	}
-	return skillmetadata.Metadata{Name: name, Description: description}, nil
+	return resolved.Metadata, nil
 }
 
 func archiveStem(filename string) string {

--- a/backend/core/skillv2/service/service.go
+++ b/backend/core/skillv2/service/service.go
@@ -7,6 +7,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"net/url"
 	"path"
 	"sort"
 	"strings"
@@ -47,15 +48,17 @@ func (s *SkillService) CreateSkill(ctx context.Context, req CreateSkillRequest) 
 	req.Name = strings.TrimSpace(req.Name)
 	req.Category = strings.TrimSpace(req.Category)
 	req.Description = strings.TrimSpace(req.Description)
-	files, sourceRefType, sourceRefID, err := s.filesFromSource(ctx, req.OwnerUserID, req.Source)
+	skillID := newID()
+	pkg, sourceRefType, sourceRefID, err := s.filesFromSource(ctx, req.OwnerUserID, req.Source)
 	if err != nil {
 		return CreateSkillResponse{}, err
 	}
+	files := pkg.Files
 	if err := validateSkillFiles(files); err != nil {
 		return CreateSkillResponse{}, err
 	}
 	if isExternalImportSource(req.Source.Type) {
-		meta, err := skillmetadata.FromFiles(files)
+		meta, err := resolveExternalMetadata(pkg, skillID)
 		if err != nil {
 			return CreateSkillResponse{}, err
 		}
@@ -66,12 +69,14 @@ func (s *SkillService) CreateSkill(ctx context.Context, req CreateSkillRequest) 
 		if err := validateSkillPackageMetadata(req.Name, req.Category, req.Description, files); err != nil {
 			return CreateSkillResponse{}, err
 		}
-		if err := validateSkillIdentity(req.Name, req.Category); err != nil {
-			return CreateSkillResponse{}, err
-		}
+	}
+	if err := validateSkillIdentity(req.Name, req.Category); err != nil {
+		return CreateSkillResponse{}, err
+	}
+	if err := validateSkillDescription(req.Description); err != nil {
+		return CreateSkillResponse{}, err
 	}
 
-	skillID := newID()
 	revisionID := newID()
 	now := s.clock.Now()
 	tags, _ := json.Marshal(req.Tags)
@@ -301,10 +306,11 @@ func (s *SkillService) PatchSkill(ctx context.Context, req PatchSkillRequest) (P
 		if draftEntries > 0 {
 			return fmt.Errorf("cannot replace source while draft overlay exists")
 		}
-		files, sourceRefType, sourceRefID, err := s.filesFromSource(ctx, skill.OwnerUserID, *req.Source)
+		pkg, sourceRefType, sourceRefID, err := s.filesFromSource(ctx, skill.OwnerUserID, *req.Source)
 		if err != nil {
 			return err
 		}
+		files := pkg.Files
 		if err := validateSkillFiles(files); err != nil {
 			return err
 		}
@@ -313,7 +319,7 @@ func (s *SkillService) PatchSkill(ctx context.Context, req PatchSkillRequest) (P
 		nextDescription := skill.Description
 		externalImport := isExternalImportSource(req.Source.Type)
 		if externalImport {
-			meta, err := skillmetadata.FromFiles(files)
+			meta, err := resolveExternalMetadata(pkg, skill.ID)
 			if err != nil {
 				return err
 			}
@@ -333,6 +339,12 @@ func (s *SkillService) PatchSkill(ctx context.Context, req PatchSkillRequest) (P
 			if err := validateSkillPackageMetadata(nextName, nextCategory, nextDescription, files); err != nil {
 				return err
 			}
+		}
+		if err := validateSkillIdentity(nextName, nextCategory); err != nil {
+			return err
+		}
+		if err := validateSkillDescription(nextDescription); err != nil {
+			return err
 		}
 		parentID := ""
 		if skill.HeadRevisionID != nil {
@@ -976,65 +988,76 @@ func (s *SkillService) entriesFromFiles(ctx context.Context, tx *gorm.DB, revisi
 	return entries, hashTree(entries), nil
 }
 
-func (s *SkillService) filesFromSource(ctx context.Context, ownerUserID string, source SourceInput) (map[string][]byte, string, string, error) {
+type sourcePackage struct {
+	Files           map[string][]byte
+	PackageRoot     string
+	ArchiveFilename string
+}
+
+func (s *SkillService) filesFromSource(ctx context.Context, ownerUserID string, source SourceInput) (sourcePackage, string, string, error) {
 	switch source.Type {
 	case "uploaded_zip":
 		if s.uploadStore == nil {
-			return nil, "", "", fmt.Errorf("upload store is not configured")
+			return sourcePackage{}, "", "", fmt.Errorf("upload store is not configured")
 		}
 		session, err := s.uploadStore.Get(ctx, source.UploadID)
 		if err != nil {
-			return nil, "", "", err
+			return sourcePackage{}, "", "", err
 		}
 		if session.OwnerUserID != ownerUserID {
-			return nil, "", "", fmt.Errorf("upload belongs to another user")
+			return sourcePackage{}, "", "", fmt.Errorf("upload belongs to another user")
 		}
 		if session.State != "completed" {
-			return nil, "", "", fmt.Errorf("upload is not completed")
+			return sourcePackage{}, "", "", fmt.Errorf("upload is not completed")
 		}
-		files, err := skillpackage.ReadZip(session.StoredPath)
-		return files, "upload", source.UploadID, err
+		pkg, err := skillpackage.ReadZip(session.StoredPath)
+		return sourcePackage{Files: pkg.Files, PackageRoot: pkg.PackageRoot, ArchiveFilename: session.Filename}, "upload", source.UploadID, err
 	case "local_zip":
 		if strings.TrimSpace(source.StoredPath) == "" {
-			return nil, "", "", fmt.Errorf("stored_path required")
+			return sourcePackage{}, "", "", fmt.Errorf("stored_path required")
 		}
-		files, err := skillpackage.ReadZip(source.StoredPath)
-		return files, "local_zip", source.Filename, err
+		pkg, err := skillpackage.ReadZip(source.StoredPath)
+		return sourcePackage{Files: pkg.Files, PackageRoot: pkg.PackageRoot, ArchiveFilename: source.Filename}, "local_zip", source.Filename, err
 	case "builtin_zip":
 		if strings.TrimSpace(source.StoredPath) == "" {
-			return nil, "", "", fmt.Errorf("stored_path required")
+			return sourcePackage{}, "", "", fmt.Errorf("stored_path required")
 		}
-		files, err := skillpackage.ReadZip(source.StoredPath)
-		return files, "builtin_package", source.Filename, err
+		pkg, err := skillpackage.ReadZip(source.StoredPath)
+		return sourcePackage{Files: pkg.Files, PackageRoot: pkg.PackageRoot, ArchiveFilename: source.Filename}, "builtin_package", source.Filename, err
 	case "url":
 		if s.downloader == nil {
-			return nil, "", "", fmt.Errorf("downloader is not configured")
+			return sourcePackage{}, "", "", fmt.Errorf("downloader is not configured")
 		}
 		downloaded, err := s.downloader.Download(ctx, source.URL)
 		if err != nil {
-			return nil, "", "", err
+			return sourcePackage{}, "", "", err
 		}
 		if downloaded.Cleanup != nil {
 			defer downloaded.Cleanup()
 		}
-		files, err := skillpackage.ReadZip(downloaded.Path)
+		pkg, err := skillpackage.ReadZip(downloaded.Path)
 		if err != nil {
-			return nil, "", "", err
+			return sourcePackage{}, "", "", err
 		}
 		if source.PathPrefix != "" {
-			files, err = filesFromSkillSubdirectory(files, source.PathPrefix)
+			prefix, err := cleanSkillPath(source.PathPrefix)
 			if err != nil {
-				return nil, "", "", err
+				return sourcePackage{}, "", "", err
 			}
+			pkg.Files, err = filesFromSkillSubdirectory(pkg.Files, prefix)
+			if err != nil {
+				return sourcePackage{}, "", "", err
+			}
+			pkg.PackageRoot = path.Base(prefix)
 		}
-		ensureURLImportDefaults(files)
+		ensureURLImportDefaults(pkg.Files)
 		sourceRef := source.SourceURL
 		if sourceRef == "" {
 			sourceRef = source.URL
 		}
-		return files, "url", sourceRef, nil
+		return sourcePackage{Files: pkg.Files, PackageRoot: pkg.PackageRoot, ArchiveFilename: archiveFilenameFromURL(source.URL)}, "url", sourceRef, nil
 	default:
-		return nil, "", "", fmt.Errorf("unsupported source type %q", source.Type)
+		return sourcePackage{}, "", "", fmt.Errorf("unsupported source type %q", source.Type)
 	}
 }
 
@@ -1063,6 +1086,54 @@ func filesFromSkillSubdirectory(files map[string][]byte, prefix string) (map[str
 		return nil, fmt.Errorf("skill package must contain SKILL.md")
 	}
 	return selected, nil
+}
+
+func resolveExternalMetadata(pkg sourcePackage, skillID string) (skillmetadata.Metadata, error) {
+	content, ok := pkg.Files["SKILL.md"]
+	if !ok {
+		return skillmetadata.Metadata{}, fmt.Errorf("skill package must contain SKILL.md")
+	}
+	parsed, err := skillmetadata.Parse(content)
+	if err != nil {
+		return skillmetadata.Metadata{}, err
+	}
+	name := parsed.Name
+	if !parsed.HasName {
+		name = strings.TrimSpace(pkg.PackageRoot)
+		if err := validateSkillName(name); err != nil {
+			name = archiveStem(pkg.ArchiveFilename)
+		}
+		if err := validateSkillName(name); err != nil {
+			name = "lazymind-skill-" + skillID
+		}
+	}
+	description := parsed.Description
+	if !parsed.HasDescription {
+		description = skillmetadata.FirstBodyParagraph(parsed.Body)
+	}
+	if err := validateSkillName(name); err != nil {
+		return skillmetadata.Metadata{}, fmt.Errorf("invalid SKILL.md frontmatter field \"name\": %w", err)
+	}
+	if err := validateSkillDescription(description); err != nil {
+		return skillmetadata.Metadata{}, err
+	}
+	return skillmetadata.Metadata{Name: name, Description: description}, nil
+}
+
+func archiveStem(filename string) string {
+	filename = strings.TrimSpace(path.Base(strings.ReplaceAll(filename, `\`, "/")))
+	if strings.EqualFold(path.Ext(filename), ".zip") {
+		filename = filename[:len(filename)-len(path.Ext(filename))]
+	}
+	return strings.TrimSpace(filename)
+}
+
+func archiveFilenameFromURL(rawURL string) string {
+	parsed, err := url.Parse(strings.TrimSpace(rawURL))
+	if err != nil {
+		return ""
+	}
+	return path.Base(parsed.Path)
 }
 func cleanSkillPath(name string) (string, error) {
 	if name == "" || strings.HasPrefix(name, "/") || strings.Contains(name, `\`) || strings.Contains(name, "//") {

--- a/backend/core/skillv2/skillpackage/package.go
+++ b/backend/core/skillv2/skillpackage/package.go
@@ -19,10 +19,15 @@ const (
 	MaxTotalBytes = 128 << 20
 )
 
-func ReadZip(zipPath string) (map[string][]byte, error) {
+type Package struct {
+	Files       map[string][]byte
+	PackageRoot string
+}
+
+func ReadZip(zipPath string) (Package, error) {
 	reader, err := zip.OpenReader(zipPath)
 	if err != nil {
-		return nil, err
+		return Package{}, err
 	}
 	defer reader.Close()
 	return readFiles(reader.File)
@@ -126,9 +131,9 @@ func WriteZip(files map[string][]byte, directory string) (string, error) {
 	return archivePath, nil
 }
 
-func readFiles(entries []*zip.File) (map[string][]byte, error) {
+func readFiles(entries []*zip.File) (Package, error) {
 	if len(entries) > MaxFiles {
-		return nil, fmt.Errorf("skill package contains too many entries: %d > %d", len(entries), MaxFiles)
+		return Package{}, fmt.Errorf("skill package contains too many entries: %d > %d", len(entries), MaxFiles)
 	}
 	files := make(map[string][]byte, len(entries))
 	var total uint64
@@ -139,69 +144,70 @@ func readFiles(entries []*zip.File) (map[string][]byte, error) {
 		entryName := strings.TrimSuffix(entry.Name, "/")
 		name, err := CleanPath(entryName)
 		if err != nil {
-			return nil, err
+			return Package{}, err
 		}
 		if entry.Mode()&os.ModeSymlink != 0 {
-			return nil, fmt.Errorf("skill package cannot contain symlink %q", name)
+			return Package{}, fmt.Errorf("skill package cannot contain symlink %q", name)
 		}
 		if entry.FileInfo().IsDir() {
 			continue
 		}
 		if _, exists := files[name]; exists {
-			return nil, fmt.Errorf("skill package contains duplicate path %q", name)
+			return Package{}, fmt.Errorf("skill package contains duplicate path %q", name)
 		}
 		if entry.UncompressedSize64 > MaxFileBytes {
-			return nil, fmt.Errorf("skill package file %q exceeds %d bytes", name, MaxFileBytes)
+			return Package{}, fmt.Errorf("skill package file %q exceeds %d bytes", name, MaxFileBytes)
 		}
 		total += entry.UncompressedSize64
 		if total > MaxTotalBytes {
-			return nil, fmt.Errorf("skill package exceeds %d uncompressed bytes", MaxTotalBytes)
+			return Package{}, fmt.Errorf("skill package exceeds %d uncompressed bytes", MaxTotalBytes)
 		}
 		rc, err := entry.Open()
 		if err != nil {
-			return nil, err
+			return Package{}, err
 		}
 		data, readErr := io.ReadAll(io.LimitReader(rc, MaxFileBytes+1))
 		closeErr := rc.Close()
 		if readErr != nil {
-			return nil, readErr
+			return Package{}, readErr
 		}
 		if closeErr != nil {
-			return nil, closeErr
+			return Package{}, closeErr
 		}
 		if len(data) > MaxFileBytes {
-			return nil, fmt.Errorf("skill package file %q exceeds %d bytes", name, MaxFileBytes)
+			return Package{}, fmt.Errorf("skill package file %q exceeds %d bytes", name, MaxFileBytes)
 		}
 		files[name] = data
 	}
-	return normalizeRoot(files), nil
+	files, packageRoot := normalizeRoot(files)
+	return Package{Files: files, PackageRoot: packageRoot}, nil
 }
 
-func normalizeRoot(files map[string][]byte) map[string][]byte {
+func normalizeRoot(files map[string][]byte) (map[string][]byte, string) {
 	if _, ok := files["SKILL.md"]; ok {
-		return files
+		return files, ""
 	}
 	root := ""
 	for filePath := range files {
 		parts := strings.SplitN(filePath, "/", 2)
 		if len(parts) != 2 || parts[1] == "" {
-			return files
+			return files, ""
 		}
 		if root == "" {
 			root = parts[0]
 		} else if root != parts[0] {
-			return files
+			return files, ""
 		}
 	}
 	if root == "" {
-		return files
+		return files, ""
 	}
 	normalized := make(map[string][]byte, len(files))
 	prefix := root + "/"
 	for filePath, data := range files {
 		normalized[strings.TrimPrefix(filePath, prefix)] = data
 	}
-	return normalized
+	return normalized, root
 }
 
 func isIgnoredMetadata(name string) bool {

--- a/backend/core/skillv2/skillpackage/package_test.go
+++ b/backend/core/skillv2/skillpackage/package_test.go
@@ -14,9 +14,13 @@ func TestReadZipNormalizesSingleRootAndHashesDeterministically(t *testing.T) {
 		"wrapped/SKILL.md":       "---\nname: demo\ndescription: demo\n---\n",
 		"wrapped/scripts/run.py": "print('ok')\n",
 	})
-	files, err := ReadZip(zipPath)
+	pkg, err := ReadZip(zipPath)
 	if err != nil {
 		t.Fatal(err)
+	}
+	files := pkg.Files
+	if pkg.PackageRoot != "wrapped" {
+		t.Fatalf("PackageRoot = %q, want wrapped", pkg.PackageRoot)
 	}
 	if string(files["SKILL.md"]) == "" || string(files["scripts/run.py"]) == "" {
 		t.Fatalf("unexpected normalized files: %#v", files)
@@ -34,9 +38,13 @@ func TestReadZipNormalizesRepositoryRootWithoutRootSkillMD(t *testing.T) {
 		"repository-ref/skills/target/SKILL.md": "content",
 		"repository-ref/skills/other/SKILL.md":  "other",
 	})
-	files, err := ReadZip(zipPath)
+	pkg, err := ReadZip(zipPath)
 	if err != nil {
 		t.Fatal(err)
+	}
+	files := pkg.Files
+	if pkg.PackageRoot != "repository-ref" {
+		t.Fatalf("PackageRoot = %q, want repository-ref", pkg.PackageRoot)
 	}
 	if string(files["skills/target/SKILL.md"]) != "content" || string(files["repository-ref/skills/target/SKILL.md"]) != "" {
 		t.Fatalf("unexpected normalized files: %#v", files)
@@ -51,9 +59,13 @@ func TestReadZipIgnoresSystemMetadataAndNormalizesRoot(t *testing.T) {
 		"__MACOSX/wrapped/._SKILL.md": "macOS metadata",
 		"wrapped/Thumbs.db":           "windows thumbnail",
 	})
-	files, err := ReadZip(zipPath)
+	pkg, err := ReadZip(zipPath)
 	if err != nil {
 		t.Fatal(err)
+	}
+	files := pkg.Files
+	if pkg.PackageRoot != "wrapped" {
+		t.Fatalf("PackageRoot = %q, want wrapped", pkg.PackageRoot)
 	}
 	if string(files["SKILL.md"]) == "" || string(files["scripts/run.py"]) == "" {
 		t.Fatalf("unexpected normalized files: %#v", files)
@@ -85,7 +97,7 @@ func TestReadZipRejectsUnsafeAndOversizedEntries(t *testing.T) {
 	}
 }
 
-func TestReadZipRejectsDuplicatePath(t *testing.T) {
+func TestReadZipRejectsDuplicateAndSymlinkEntries(t *testing.T) {
 	zipPath := filepath.Join(t.TempDir(), "duplicate.zip")
 	file, err := os.Create(zipPath)
 	if err != nil {
@@ -107,39 +119,33 @@ func TestReadZipRejectsDuplicatePath(t *testing.T) {
 	if err := file.Close(); err != nil {
 		t.Fatal(err)
 	}
-
-	_, err = ReadZip(zipPath)
-	if err == nil || !strings.Contains(err.Error(), "duplicate path") {
-		t.Fatalf("error = %v, want duplicate path error", err)
+	if _, err := ReadZip(zipPath); err == nil || !strings.Contains(err.Error(), "duplicate path") {
+		t.Fatalf("duplicate ReadZip error = %v", err)
 	}
-}
 
-func TestReadZipRejectsSymlink(t *testing.T) {
-	zipPath := filepath.Join(t.TempDir(), "symlink.zip")
-	file, err := os.Create(zipPath)
+	symlinkPath := filepath.Join(t.TempDir(), "symlink.zip")
+	symlinkFile, err := os.Create(symlinkPath)
 	if err != nil {
 		t.Fatal(err)
 	}
-	writer := zip.NewWriter(file)
-	header := &zip.FileHeader{Name: "link"}
+	symlinkWriter := zip.NewWriter(symlinkFile)
+	header := &zip.FileHeader{Name: "SKILL.md"}
 	header.SetMode(os.ModeSymlink | 0o777)
-	entry, err := writer.CreateHeader(header)
+	entry, err := symlinkWriter.CreateHeader(header)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if _, err := entry.Write([]byte("SKILL.md")); err != nil {
+	if _, err := entry.Write([]byte("target")); err != nil {
 		t.Fatal(err)
 	}
-	if err := writer.Close(); err != nil {
+	if err := symlinkWriter.Close(); err != nil {
 		t.Fatal(err)
 	}
-	if err := file.Close(); err != nil {
+	if err := symlinkFile.Close(); err != nil {
 		t.Fatal(err)
 	}
-
-	_, err = ReadZip(zipPath)
-	if err == nil || !strings.Contains(err.Error(), "cannot contain symlink") {
-		t.Fatalf("error = %v, want symlink error", err)
+	if _, err := ReadZip(symlinkPath); err == nil || !strings.Contains(err.Error(), "symlink") {
+		t.Fatalf("symlink ReadZip error = %v", err)
 	}
 }
 
@@ -171,8 +177,8 @@ func TestWriteZipIsDeterministicAndReadable(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !bytes.Equal(read["scripts/run.py"], files["scripts/run.py"]) {
-		t.Fatalf("archive content = %q", read["scripts/run.py"])
+	if !bytes.Equal(read.Files["scripts/run.py"], files["scripts/run.py"]) {
+		t.Fatalf("archive content = %q", read.Files["scripts/run.py"])
 	}
 }
 

--- a/backend/core/skillv2/skillpatch/engine.go
+++ b/backend/core/skillv2/skillpatch/engine.go
@@ -15,6 +15,7 @@ type Result struct {
 	Files          map[string][]byte
 	AppliedPatches []AppliedPatch
 	PatchSetSHA256 string
+	SkillMDPatched bool
 }
 
 func Apply(target Target, files map[string][]byte, catalog Catalog) (Result, error) {
@@ -29,6 +30,9 @@ func Apply(target Target, files map[string][]byte, catalog Catalog) (Result, err
 		for _, operation := range patch.Operations {
 			if err := applyOperation(result.Files, patch.ID, operation); err != nil {
 				return Result{}, err
+			}
+			if operation.Path == "SKILL.md" {
+				result.SkillMDPatched = true
 			}
 		}
 		result.AppliedPatches = append(result.AppliedPatches, AppliedPatch{ID: patch.ID, SHA256: patch.SHA256})


### PR DESCRIPTION
## Summary

按评论改为运行时元数据兜底，移除人工确认方案。

## Changes

- 统一 ZIP 读取并返回包根；外部 ZIP/URL 在缺少元数据时自动生成身份字段。
- RemoteFS 为外部 Skill 提供严格有效的 `SKILL.md` 运行时视图，原始归档与 revision 字节保持不变。
- 覆盖完整 Monkey Patch、替换、草稿提交、回滚、市场安装及 ZIP 安全校验。

## Notes

- 已通过相关 Go 测试、`make skills-materialize`、`make featured-check` 与 `git diff --check`。
