### PR TITLE
feat(chat): add hybrid semantic skill retrieval

### DIFF
--- a/algorithm/lazymind/chat/engine/agent_runtime/executor.py
+++ b/algorithm/lazymind/chat/engine/agent_runtime/executor.py
@@ -224,6 +224,7 @@ class AgentExecutor:
         }
         optional = {
             'skills': options.skills,
+            'skill_manager': options.skill_manager,
             'workspace': options.workspace,
             'keep_full_turns': options.keep_full_turns,
             'fs': options.fs,

--- a/algorithm/lazymind/chat/engine/agent_runtime/models.py
+++ b/algorithm/lazymind/chat/engine/agent_runtime/models.py
@@ -41,6 +41,7 @@ class PromptBundle:
 @dataclass(frozen=True)
 class AgentExecutionOptions:
     skills: Any = None
+    skill_manager: Any = None
     workspace: Optional[str] = None
     keep_full_turns: Optional[int] = None
     fs: Any = None

--- a/algorithm/lazymind/chat/engine/prompts/__init__.py
+++ b/algorithm/lazymind/chat/engine/prompts/__init__.py
@@ -13,7 +13,6 @@ from .task_profile import (
     TaskProfile,
     fallback_task_profile,
     resolve_task_profile,
-    select_skill_candidates,
     selected_prompt_modules,
 )
 
@@ -29,6 +28,5 @@ __all__ = [
     'TaskProfile',
     'fallback_task_profile',
     'resolve_task_profile',
-    'select_skill_candidates',
     'selected_prompt_modules',
 ]

--- a/algorithm/lazymind/chat/engine/prompts/task_profile.py
+++ b/algorithm/lazymind/chat/engine/prompts/task_profile.py
@@ -1046,28 +1046,6 @@ def selected_prompt_modules(profile: TaskProfile) -> list[str]:
     return list(dict.fromkeys(modules))
 
 
-_SKILL_OUTCOME_TERMS: dict[Outcome, tuple[str, ...]] = {
-    'research': ('research', 'review', 'search', '调研', '研究'),
-    'analyze': ('analysis', 'review', 'critique', '分析', '审查'),
-    'transform': ('transform', 'rewrite', 'translate', 'summary', '转换', '改写'),
-    'decide': ('decision', 'comparison', 'compare', '决策', '对比'),
-    'plan': ('planning', 'plan', 'roadmap', '规划', '计划'),
-    'create': ('create', 'writing', 'generation', '创作', '生成'),
-    'execute': ('automation', 'operation', 'deploy', '执行', '自动化'),
-    'diagnose': ('diagnose', 'debug', 'review', '排障', '诊断'),
-    'answer': ('answer',),
-    'learn': ('learning', 'tutorial'),
-}
-
-
-def _selection_tokens(value: str) -> set[str]:
-    text = str(value or '').lower()
-    latin = re.findall(r'[a-z0-9][a-z0-9_-]{1,}', text)
-    cjk = re.findall(r'[\u3400-\u9fff]{2,}', text)
-    bigrams = [token[index:index + 2] for token in cjk for index in range(len(token) - 1)]
-    return set(latin + cjk + bigrams)
-
-
 def select_skill_candidates(
     available_skills: list[str] | None,
     query: str,
@@ -1083,12 +1061,9 @@ def select_skill_candidates(
             return available_skills
         available = set(available_skills or [])
         return [skill for skill in selected if skill in available]
-    available = [str(item) for item in (available_skills or []) if str(item).strip()]
-    query_tokens = _selection_tokens(query)
-    query_tokens.update(_SKILL_OUTCOME_TERMS[profile.primary_outcome])
-    ranked = []
-    for index, skill in enumerate(available):
-        score = len(query_tokens & _selection_tokens(skill))
-        ranked.append((score, index, skill))
-    ranked.sort(key=lambda item: (-item[0], item[1]))
-    return [skill for score, _, skill in ranked if score > 0][:max(1, min(limit, 5))]
+    # Skill references are identifiers, not semantic metadata. Filtering them by
+    # lexical overlap can discard a relevant skill before LazyLLM's SkillManager
+    # reads its SKILL.md description and lets the model decide whether to use it.
+    # Keep query/limit in the interface for existing callers, but delegate
+    # candidate relevance to the downstream skill mechanism.
+    return [str(item) for item in (available_skills or []) if str(item).strip()]

--- a/algorithm/lazymind/chat/engine/prompts/task_profile.py
+++ b/algorithm/lazymind/chat/engine/prompts/task_profile.py
@@ -531,7 +531,8 @@ def _rule_profile(query: str, *, has_attachments: bool = False) -> tuple[TaskPro
     secondary_deliverables = tuple(_DELIVERABLE_BY_OUTCOME[item] for item in secondary)
     research_required = current or 'research' in matches
     skill_mode: SkillMode = 'explicit' if explicit_skill else (
-        'suppress' if primary in {'learn', 'transform'} or is_simple_fact else 'candidates'
+        'suppress' if is_simple_fact or bool(_TRIVIAL_CHAT_INPUT.fullmatch(text.strip()))
+        else 'candidates'
     )
     subject_kind, input_mode = _subject_and_input(text, has_attachments)
     source_strategy = (
@@ -877,8 +878,10 @@ def _validate_llm_profile(
     # Explicit freshness and skill wording are authoritative deterministic signals.
     if rule.freshness == 'current':
         freshness = 'current'
-    if rule.skill_mode == 'explicit':
-        skill_mode = 'explicit'
+    if rule.skill_mode in {'explicit', 'suppress'}:
+        skill_mode = rule.skill_mode
+    else:
+        skill_mode = 'candidates'
     primary_subtype = (
         rule.outcome_subtype if primary == rule.primary_outcome else _outcome_subtype(primary, query)
     )
@@ -988,7 +991,7 @@ def resolve_task_profile(
     except Exception as exc:
         return replace(
             rule,
-            skill_mode='explicit' if rule.skill_mode == 'explicit' else 'suppress',
+            skill_mode=rule.skill_mode,
             source='fallback',
             router_latency_ms=int((time.monotonic() - started) * 1000),
             router_error=f'{type(exc).__name__}: {exc}'[:240],
@@ -1044,26 +1047,3 @@ def selected_prompt_modules(profile: TaskProfile) -> list[str]:
     if assessment.interaction_need == 'blocking':
         modules.append('clarification')
     return list(dict.fromkeys(modules))
-
-
-def select_skill_candidates(
-    available_skills: list[str] | None,
-    query: str,
-    profile: TaskProfile,
-    *,
-    limit: int = 5,
-) -> list[str] | None:
-    if profile.skill_mode == 'suppress':
-        return []
-    if profile.skill_mode == 'explicit':
-        selected = profile.explicit_resources.skill_names
-        if not selected:
-            return available_skills
-        available = set(available_skills or [])
-        return [skill for skill in selected if skill in available]
-    # Skill references are identifiers, not semantic metadata. Filtering them by
-    # lexical overlap can discard a relevant skill before LazyLLM's SkillManager
-    # reads its SKILL.md description and lets the model decide whether to use it.
-    # Keep query/limit in the interface for existing callers, but delegate
-    # candidate relevance to the downstream skill mechanism.
-    return [str(item) for item in (available_skills or []) if str(item).strip()]

--- a/algorithm/lazymind/chat/engine/skills/__init__.py
+++ b/algorithm/lazymind/chat/engine/skills/__init__.py
@@ -1,0 +1,13 @@
+from .retriever import (
+    SkillDescriptor,
+    SkillRetrievalHit,
+    SkillRetrievalResult,
+    SkillRetriever,
+)
+
+__all__ = [
+    'SkillDescriptor',
+    'SkillRetrievalHit',
+    'SkillRetrievalResult',
+    'SkillRetriever',
+]

--- a/algorithm/lazymind/chat/engine/skills/retriever.py
+++ b/algorithm/lazymind/chat/engine/skills/retriever.py
@@ -1,0 +1,359 @@
+from __future__ import annotations
+
+import hashlib
+import math
+import re
+import threading
+import time
+from collections import Counter, OrderedDict
+from concurrent.futures import ThreadPoolExecutor, TimeoutError as FutureTimeoutError
+from contextvars import copy_context
+from dataclasses import dataclass
+from typing import Any, Iterable, Mapping, Sequence
+
+
+_LATIN_TOKEN = re.compile(r'[a-z0-9]+', re.I)
+_CJK_RUN = re.compile(r'[\u3400-\u4dbf\u4e00-\u9fff]+')
+
+
+@dataclass(frozen=True)
+class SkillDescriptor:
+    skill_id: str
+    name: str
+    description: str
+    aliases: tuple[str, ...] = ()
+    tags: tuple[str, ...] = ()
+    revision: str = ''
+
+    @classmethod
+    def from_mapping(cls, value: Mapping[str, Any]) -> 'SkillDescriptor':
+        def strings(raw: Any) -> tuple[str, ...]:
+            if isinstance(raw, str):
+                items = raw.split(',')
+            elif isinstance(raw, (list, tuple, set)):
+                items = raw
+            else:
+                items = ()
+            return tuple(dict.fromkeys(str(item).strip() for item in items if str(item).strip()))
+
+        skill_id = str(value.get('id') or value.get('key') or '').strip()
+        return cls(
+            skill_id=skill_id,
+            name=str(value.get('name') or skill_id).strip(),
+            description=str(value.get('description') or '').strip(),
+            aliases=strings(value.get('aliases')),
+            tags=strings(value.get('tags')),
+            revision=str(value.get('revision') or '').strip(),
+        )
+
+    @property
+    def search_text(self) -> str:
+        return '\n'.join(filter(None, [
+            self.skill_id,
+            self.name,
+            self.description,
+            ' '.join(self.aliases),
+            ' '.join(self.tags),
+        ]))
+
+    @property
+    def fingerprint(self) -> str:
+        payload = '\0'.join([
+            self.skill_id,
+            self.name,
+            self.description,
+            *self.aliases,
+            *self.tags,
+            self.revision,
+        ])
+        return hashlib.sha256(payload.encode('utf-8')).hexdigest()
+
+
+@dataclass(frozen=True)
+class SkillRetrievalHit:
+    descriptor: SkillDescriptor
+    score: float
+    channels: tuple[str, ...]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            'id': self.descriptor.skill_id,
+            'name': self.descriptor.name,
+            'description': self.descriptor.description,
+            'aliases': list(self.descriptor.aliases),
+            'tags': list(self.descriptor.tags),
+            'score': round(float(self.score), 8),
+            'channels': list(self.channels),
+        }
+
+
+@dataclass(frozen=True)
+class SkillRetrievalResult:
+    hits: tuple[SkillRetrievalHit, ...]
+    strategy: str
+    catalog_size: int
+    latency_ms: int
+    embedding_error: str = ''
+
+    @property
+    def skill_ids(self) -> list[str]:
+        return [hit.descriptor.skill_id for hit in self.hits]
+
+    def to_trace_dict(self) -> dict[str, Any]:
+        return {
+            'strategy': self.strategy,
+            'catalog_size': self.catalog_size,
+            'latency_ms': self.latency_ms,
+            'embedding_error': self.embedding_error,
+            'hits': [hit.to_dict() for hit in self.hits],
+        }
+
+
+class SkillRetriever:
+    _embedding_cache: OrderedDict[tuple[str, str], tuple[float, ...]] = OrderedDict()
+    _embedding_cache_lock = threading.Lock()
+    _embedding_executor = ThreadPoolExecutor(max_workers=4)
+    _embedding_cache_limit = 4096
+
+    def __init__(
+        self,
+        *,
+        embedder: Any = None,
+        cache_namespace: str = 'default',
+        small_catalog_threshold: int = 20,
+        embedding_timeout_seconds: float = 3.0,
+        rrf_constant: int = 60,
+    ) -> None:
+        self._embedder = embedder
+        self._cache_namespace = str(cache_namespace or 'default')
+        self._small_catalog_threshold = max(0, int(small_catalog_threshold))
+        self._embedding_timeout_seconds = max(0.1, float(embedding_timeout_seconds))
+        self._rrf_constant = max(1, int(rrf_constant))
+
+    def retrieve(
+        self,
+        query_context: str,
+        descriptors: Iterable[SkillDescriptor | Mapping[str, Any]],
+        limit: int = 8,
+    ) -> SkillRetrievalResult:
+        started = time.monotonic()
+        catalog = self._normalize_descriptors(descriptors)
+        if not catalog:
+            return self._result((), 'empty', 0, started)
+        if len(catalog) <= self._small_catalog_threshold:
+            hits = tuple(SkillRetrievalHit(item, 1.0, ('all',)) for item in catalog)
+            return self._result(hits, 'all', len(catalog), started)
+
+        limit = max(1, min(int(limit), len(catalog)))
+        pool_size = min(len(catalog), max(limit * 2, 12))
+        lexical = self._lexical_ranking(str(query_context or ''), catalog)[:pool_size]
+        dense, embedding_error = self._dense_ranking(str(query_context or ''), catalog)
+        if dense:
+            lexical_matches = [item for item in lexical if item[1] > 0]
+            hits = self._fuse_rankings(
+                catalog,
+                lexical_matches,
+                dense[:pool_size],
+                limit,
+            )
+            strategy = 'hybrid'
+        else:
+            hits = tuple(
+                SkillRetrievalHit(catalog[index], score, ('lexical',))
+                for index, score in lexical
+                if score > 0
+            )
+            hits = hits[:limit]
+            strategy = 'lexical'
+        return self._result(hits, strategy, len(catalog), started, embedding_error)
+
+    @staticmethod
+    def _normalize_descriptors(
+        descriptors: Iterable[SkillDescriptor | Mapping[str, Any]],
+    ) -> list[SkillDescriptor]:
+        result, seen = [], set()
+        for value in descriptors:
+            descriptor = value if isinstance(value, SkillDescriptor) else SkillDescriptor.from_mapping(value)
+            if not descriptor.skill_id or descriptor.skill_id in seen:
+                continue
+            seen.add(descriptor.skill_id)
+            result.append(descriptor)
+        return result
+
+    def _result(
+        self,
+        hits: Sequence[SkillRetrievalHit],
+        strategy: str,
+        catalog_size: int,
+        started: float,
+        embedding_error: str = '',
+    ) -> SkillRetrievalResult:
+        return SkillRetrievalResult(
+            hits=tuple(hits),
+            strategy=strategy,
+            catalog_size=catalog_size,
+            latency_ms=max(0, int((time.monotonic() - started) * 1000)),
+            embedding_error=str(embedding_error or '')[:240],
+        )
+
+    @classmethod
+    def _tokens(cls, text: str) -> list[str]:
+        lowered = str(text or '').lower()
+        tokens = _LATIN_TOKEN.findall(lowered)
+        for run in _CJK_RUN.findall(lowered):
+            tokens.extend(run)
+            tokens.extend(run[index:index + 2] for index in range(len(run) - 1))
+        return tokens
+
+    def _lexical_ranking(
+        self,
+        query: str,
+        catalog: Sequence[SkillDescriptor],
+    ) -> list[tuple[int, float]]:
+        query_terms = self._tokens(query)
+        documents = [self._tokens(item.search_text) for item in catalog]
+        if not query_terms:
+            return [(index, 0.0) for index in range(len(catalog))]
+        document_frequency = Counter(
+            term for document in documents for term in set(document)
+        )
+        average_length = sum(map(len, documents)) / max(1, len(documents))
+        query_frequency = Counter(query_terms)
+        normalized_query = re.sub(r'\s+', '', query.lower())
+        ranking = []
+        for index, (descriptor, document) in enumerate(zip(catalog, documents)):
+            term_frequency = Counter(document)
+            score = 0.0
+            for term, query_count in query_frequency.items():
+                frequency = term_frequency.get(term, 0)
+                if not frequency:
+                    continue
+                inverse_frequency = math.log(
+                    1 + (len(documents) - document_frequency[term] + 0.5)
+                    / (document_frequency[term] + 0.5)
+                )
+                length_factor = 1 - 0.75 + 0.75 * len(document) / max(1.0, average_length)
+                score += query_count * inverse_frequency * (
+                    frequency * 2.2 / (frequency + 1.2 * length_factor)
+                )
+            exact_labels = [descriptor.name, *descriptor.aliases]
+            if any(
+                (normalized := re.sub(r'\s+', '', label.lower()))
+                and (normalized in normalized_query or normalized_query in normalized)
+                for label in exact_labels
+            ):
+                score += 4.0
+            exact_latin_terms = {
+                term for term in query_frequency
+                if len(term) >= 2 and term.isascii() and term in term_frequency
+            }
+            score += 5.0 * len(exact_latin_terms)
+            ranking.append((index, score))
+        return sorted(ranking, key=lambda item: (-item[1], item[0]))
+
+    def _dense_ranking(
+        self,
+        query: str,
+        catalog: Sequence[SkillDescriptor],
+    ) -> tuple[list[tuple[int, float]], str]:
+        if self._embedder is None or not query.strip():
+            return [], 'embedding model unavailable' if self._embedder is None else ''
+        cached: dict[int, tuple[float, ...]] = {}
+        missing_indices = []
+        with self._embedding_cache_lock:
+            for index, descriptor in enumerate(catalog):
+                key = (self._cache_namespace, descriptor.fingerprint)
+                vector = self._embedding_cache.get(key)
+                if vector is None:
+                    missing_indices.append(index)
+                else:
+                    self._embedding_cache.move_to_end(key)
+                    cached[index] = vector
+        texts = [query, *(catalog[index].search_text for index in missing_indices)]
+        try:
+            vectors = self._embed_batch(texts)
+            query_vector = vectors[0]
+            if len(vectors) != len(texts):
+                raise ValueError('embedding model returned an unexpected batch size')
+            with self._embedding_cache_lock:
+                for index, vector in zip(missing_indices, vectors[1:]):
+                    cached[index] = vector
+                    descriptor = catalog[index]
+                    key = (self._cache_namespace, descriptor.fingerprint)
+                    self._embedding_cache[key] = vector
+                    self._embedding_cache.move_to_end(key)
+                while len(self._embedding_cache) > self._embedding_cache_limit:
+                    self._embedding_cache.popitem(last=False)
+            dimensions = {len(query_vector), *(len(vector) for vector in cached.values())}
+            if len(dimensions) != 1:
+                raise ValueError('embedding dimensions do not match')
+        except Exception as exc:
+            return [], f'{type(exc).__name__}: {exc}'
+        ranking = [
+            (index, self._cosine(query_vector, cached[index]))
+            for index in range(len(catalog))
+        ]
+        return sorted(ranking, key=lambda item: (-item[1], item[0])), ''
+
+    def _embed_batch(self, texts: list[str]) -> list[tuple[float, ...]]:
+        context = copy_context()
+        future = self._embedding_executor.submit(context.run, self._embedder, texts)
+        try:
+            raw = future.result(timeout=self._embedding_timeout_seconds)
+        except FutureTimeoutError as exc:
+            future.cancel()
+            raise TimeoutError(
+                f'embedding exceeded {self._embedding_timeout_seconds:.1f}s'
+            ) from exc
+        if not isinstance(raw, (list, tuple)) or len(raw) != len(texts):
+            raise ValueError('embedding model must return one vector per input')
+        vectors = []
+        for value in raw:
+            if not isinstance(value, (list, tuple)) or not value:
+                raise ValueError('embedding vector is empty or invalid')
+            vector = tuple(float(item) for item in value)
+            if not all(math.isfinite(item) for item in vector):
+                raise ValueError('embedding vector contains non-finite values')
+            vectors.append(vector)
+        return vectors
+
+    @staticmethod
+    def _cosine(left: Sequence[float], right: Sequence[float]) -> float:
+        left_norm = math.sqrt(sum(value * value for value in left))
+        right_norm = math.sqrt(sum(value * value for value in right))
+        if not left_norm or not right_norm:
+            return 0.0
+        return sum(a * b for a, b in zip(left, right)) / (left_norm * right_norm)
+
+    def _fuse_rankings(
+        self,
+        catalog: Sequence[SkillDescriptor],
+        lexical: Sequence[tuple[int, float]],
+        dense: Sequence[tuple[int, float]],
+        limit: int,
+    ) -> tuple[SkillRetrievalHit, ...]:
+        scores: dict[int, float] = {}
+        channels: dict[int, list[str]] = {}
+        for channel, ranking in (('lexical', lexical), ('dense', dense)):
+            for rank, (index, _) in enumerate(ranking, start=1):
+                scores[index] = scores.get(index, 0.0) + 1.0 / (self._rrf_constant + rank)
+                channels.setdefault(index, []).append(channel)
+        ranked = sorted(scores, key=lambda index: (-scores[index], index))
+        selected = ranked[:limit]
+        if limit >= 2:
+            channel_leaders = [ranking[0][0] for ranking in (dense, lexical) if ranking]
+            for leader in channel_leaders:
+                if leader in selected:
+                    continue
+                replace_at = next(
+                    (
+                        index for index in range(len(selected) - 1, -1, -1)
+                        if selected[index] not in channel_leaders
+                    ),
+                    len(selected) - 1,
+                )
+                selected[replace_at] = leader
+        return tuple(
+            SkillRetrievalHit(catalog[index], scores[index], tuple(channels[index]))
+            for index in selected
+        )

--- a/algorithm/lazymind/chat/engine/tools/skill_search.py
+++ b/algorithm/lazymind/chat/engine/tools/skill_search.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+from typing import Any
+
+from lazymind.chat.engine.skills import SkillRetriever
+
+
+def build_search_skills_tool(skill_manager: Any, retriever: SkillRetriever) -> Any:
+    def search_skills(query: str, limit: int = 8) -> dict[str, Any]:
+        '''Search enabled skills by meaning and keywords, then expose matching skills.
+
+        Use this when the initially shown skills do not cover the task, the task changes
+        during the conversation, or a compound request may need another skill. Call this
+        tool first, inspect the returned name and description, then call get_skill in a
+        later action only for a relevant result.
+
+        Args:
+            query (str): A concise description of the capability or workflow needed.
+            limit (int, optional): Maximum number of matching skills. Defaults to 8.
+        '''
+        result = retriever.retrieve(
+            query,
+            skill_manager.list_skill_metadata('allowed'),
+            limit=max(1, min(int(limit), 20)),
+        )
+        exposed = skill_manager.expose_skills(result.skill_ids)
+        exposed_by_id = {
+            str(item.get('id')): item for item in exposed.get('skills', [])
+        }
+        hits = []
+        for hit in result.hits:
+            item = exposed_by_id.get(hit.descriptor.skill_id)
+            if item:
+                hits.append({
+                    **item,
+                    'score': round(hit.score, 8),
+                    'channels': list(hit.channels),
+                })
+        return {
+            'status': exposed.get('status', 'ok'),
+            'query': query,
+            'count': len(hits),
+            'strategy': result.strategy,
+            'latency_ms': result.latency_ms,
+            'embedding_error': result.embedding_error,
+            'skills': hits,
+            'errors': exposed.get('errors', []),
+        }
+
+    return search_skills

--- a/algorithm/lazymind/chat/service/chat_service.py
+++ b/algorithm/lazymind/chat/service/chat_service.py
@@ -25,9 +25,9 @@ from lazymind.chat.config import (
 from lazymind.chat.engine.prompts import (
     add_standard_system_sections,
     resolve_task_profile,
-    select_skill_candidates,
     selected_prompt_modules,
 )
+from lazymind.chat.engine.skills import SkillRetriever
 from lazymind.common.memory import (
     EpisodeReadError,
     EpisodeType,
@@ -65,6 +65,7 @@ from lazymind.chat.engine.tools.intent_writer import (
     render_intent_section,
 )
 from lazymind.chat.engine.tools.skill_listing import build_list_skills_tool
+from lazymind.chat.engine.tools.skill_search import build_search_skills_tool
 from lazymind.chat.service.utils import (
     SensitiveFilter,
     SensitiveMatch,
@@ -76,10 +77,15 @@ from lazymind.chat.service.utils import (
     validate_and_resolve_files,
 )
 from lazyllm.tools.fs.client import FS
-from lazymind.model_config import inject_model_config, summarize_model_config_for_log
+from lazymind.model_config import (
+    inject_model_config,
+    is_model_role_available,
+    summarize_model_config_for_log,
+)
 from lazyllm.tools.tool_config_inject import inject_tool_config
 from lazyllm import AutoModel
 from lazyllm.tools.mcp.client import MCPClient
+from lazyllm.tools.agent.skill_manager import SkillManager as LazySkillManager
 from lazymind.config import config as _cfg
 
 rag_sem = asyncio.Semaphore(MAX_CONCURRENCY)
@@ -109,6 +115,34 @@ _TASK_PROFILE_ROUTER_TIMEOUT_SECONDS = 20
 _SENSITIVE_MATCH_UNSET = object()
 _mcp_tool_cache: dict[str, tuple[float, list[Any]]] = {}
 _mcp_tool_cache_lock = threading.Lock()
+
+
+def _skill_embedding_cache_namespace(model_config: dict[str, Any] | None) -> str:
+    role_config = (model_config or {}).get('embed_main') or {}
+
+    def safe(value: Any) -> Any:
+        if isinstance(value, dict):
+            return {
+                str(key): safe(item)
+                for key, item in value.items()
+                if not any(secret in str(key).lower() for secret in ('key', 'token', 'secret'))
+            }
+        if isinstance(value, (list, tuple)):
+            return [safe(item) for item in value]
+        return value if isinstance(value, (str, int, float, bool)) or value is None else str(value)
+
+    payload = json.dumps(safe(role_config), ensure_ascii=False, sort_keys=True, separators=(',', ':'))
+    return hashlib.sha256(payload.encode('utf-8')).hexdigest()[:16]
+
+
+def _build_skill_retriever(model_config: dict[str, Any] | None) -> SkillRetriever:
+    embedder = AutoModel(model='embed_main') if is_model_role_available('embed_main') else None
+    return SkillRetriever(
+        embedder=embedder,
+        cache_namespace=_skill_embedding_cache_namespace(model_config),
+        small_catalog_threshold=_cfg['skill_retrieval_small_catalog_threshold'],
+        embedding_timeout_seconds=_cfg['skill_retrieval_embedding_timeout'],
+    )
 
 
 def _select_episode_reference_items(
@@ -828,8 +862,63 @@ async def _handle_chat_impl(
     artifact_tools = _build_chat_artifact_tools()
     workspace = chat_agent_workspace(user_id or '0', conversation_id)
     skill_listing_tools = [build_list_skills_tool(agent.available_skills)]
+    workflow_skill_dir = ''
+    workflow_skill_name = ''
+    if agentic_config.get('enable_workflow', True):
+        from lazymind.workflow_toolkit import WORKFLOW_SKILL_NAME, workflow_skills_dir
+        workflow_skill_name = WORKFLOW_SKILL_NAME
+        workflow_skill_dir = workflow_skills_dir()
+
+    allowed_skill_ids = list(dict.fromkeys([
+        *(agent.available_skills or []),
+        *([workflow_skill_name] if workflow_skill_name else []),
+    ]))
+    active_skill_ids = _active_skills_from_history(agent_history, agent.available_skills)
+    if task_profile is None:
+        initial_skill_ids = list(allowed_skill_ids)
+    elif task_profile.skill_mode == 'explicit':
+        initial_skill_ids = list(dict.fromkeys([
+            *active_skill_ids,
+            *task_profile.explicit_resources.skill_names,
+        ]))
+    else:
+        initial_skill_ids = list(active_skill_ids)
+    if workflow_skill_name:
+        initial_skill_ids = list(dict.fromkeys([*initial_skill_ids, workflow_skill_name]))
+
+    skill_manager = None
+    skill_retriever = None
+    skill_retrieval_result = None
+    if allowed_skill_ids:
+        skill_manager = LazySkillManager(
+            dir=','.join(filter(None, [_cfg['skill_fs_url'], workflow_skill_dir])),
+            skills=initial_skill_ids,
+            allowed_skills=allowed_skill_ids,
+            fs=FS,
+        )
+        if task_profile is not None:
+            skill_retriever = _build_skill_retriever(runtime.llm_config)
+        if task_profile is not None and task_profile.skill_mode == 'candidates':
+            skill_catalog = await asyncio.to_thread(
+                skill_manager.list_skill_metadata, 'allowed',
+            )
+            skill_retrieval_result = await asyncio.to_thread(
+                skill_retriever.retrieve,
+                language_query,
+                skill_catalog,
+                _cfg['skill_retrieval_topk'],
+            )
+            skill_manager.expose_skills(skill_retrieval_result.skill_ids)
+
+    skill_search_tools = (
+        [build_search_skills_tool(skill_manager, skill_retriever)]
+        if skill_manager is not None and skill_retriever is not None else []
+    )
+    selected_skills = [
+        item['id'] for item in skill_manager.list_skill_metadata('visible')
+    ] if skill_manager is not None else []
     all_tools = ([intentwriter] + agent_tools + artifact_tools + subagent_tools + attachment_tools
-                 + skill_listing_tools + ask_user_tools + workflow_tools + mcp_tools)
+                 + skill_listing_tools + skill_search_tools + ask_user_tools + workflow_tools + mcp_tools)
     active_workflow_tool_isolation = bool(
         isinstance(effective_workflow_context, dict)
         and effective_workflow_context.get('session_id')
@@ -853,21 +942,6 @@ async def _handle_chat_impl(
             task_profile.primary_outcome,
             [getattr(tool, '__name__', str(tool)) for tool in all_tools],
         )
-    skill_config = agent.available_skills
-    selected_skills = agent.available_skills
-    if task_profile is not None:
-        selected_skills = select_skill_candidates(agent.available_skills, language_query, task_profile)
-        selected_skills = list(dict.fromkeys([
-            *_active_skills_from_history(agent_history, agent.available_skills),
-            *(selected_skills or []),
-        ]))
-        skill_config = selected_skills or False
-    workflow_skill_dir = ''
-    if agentic_config.get('enable_workflow', True):
-        from lazymind.workflow_toolkit import WORKFLOW_SKILL_NAME, workflow_skills_dir
-        selected_skills = list(dict.fromkeys([*(selected_skills or []), WORKFLOW_SKILL_NAME]))
-        skill_config = selected_skills
-        workflow_skill_dir = workflow_skills_dir()
     set_trace_context({
         'trace_id': conversation.session_id, 'session_id': conversation.session_id, 'sampled': True,
         'module_trace': {
@@ -887,6 +961,9 @@ async def _handle_chat_impl(
             'router_error': task_profile.router_error if task_profile else '',
             'prompt_modules': selected_prompt_modules(task_profile) if task_profile else [],
             'skills_exposed': list(selected_skills or []),
+            'skill_retrieval': (
+                skill_retrieval_result.to_trace_dict() if skill_retrieval_result else {}
+            ),
         },
     })
     episode_store = None
@@ -1093,11 +1170,9 @@ async def _handle_chat_impl(
         stop_tools=stop_tools,
         force_summarize_context=query,
         execution_options=AgentExecutionOptions(
-            skills=skill_config,
+            skill_manager=skill_manager,
             workspace=workspace,
             keep_full_turns=_cfg['agentic_keep_full_turns'],
-            fs=FS,
-            skills_dir=','.join(filter(None, [_cfg['skill_fs_url'], workflow_skill_dir])),
             max_retries={
                 'low': _cfg['agentic_max_rounds_low'],
                 'medium': _cfg['agentic_max_rounds_medium'],

--- a/algorithm/lazymind/config.py
+++ b/algorithm/lazymind/config.py
@@ -178,6 +178,12 @@ config.add('core_internal_token', str, '', 'AUTH_SERVICE_INTERNAL_TOKEN',
 config.add('agentic_kb_name', str, 'general_algo', 'AGENTIC_KB_NAME',
            description='Default knowledge base name for agentic.')
 config.add('skill_fs_url', str, 'remote://skills', 'SKILL_FS_URL', description='Skill filesystem URL.')
+config.add('skill_retrieval_topk', int, 8, 'SKILL_RETRIEVAL_TOPK',
+           description='Maximum number of Skill metadata candidates exposed by initial retrieval.')
+config.add('skill_retrieval_small_catalog_threshold', int, 20, 'SKILL_RETRIEVAL_SMALL_CATALOG_THRESHOLD',
+           description='Expose all allowed Skill metadata when the catalog is no larger than this value.')
+config.add('skill_retrieval_embedding_timeout', float, 3.0, 'SKILL_RETRIEVAL_EMBEDDING_TIMEOUT',
+           description='Seconds before Skill dense retrieval falls back to lexical retrieval.')
 _validate_positive_integer_env('LAZYMIND_PREFERENCE_INDEX_MAX_ITEMS')
 config.add(
     'preference_index_max_items',

--- a/tests/algorithm/chat/test_agent_executor.py
+++ b/tests/algorithm/chat/test_agent_executor.py
@@ -60,6 +60,17 @@ def test_executor_passes_cancel_condition_to_chat_agent(monkeypatch) -> None:
     assert constructor.call_args.kwargs['extra_stop_condition'] is stop_condition
 
 
+def test_executor_passes_prebuilt_skill_manager(monkeypatch) -> None:
+    agent = MagicMock()
+    constructor = MagicMock(return_value=agent)
+    monkeypatch.setattr(executor_mod._agent_mod, 'ReactAgent', constructor)
+    skill_manager = object()
+
+    AgentExecutor().create_agent('llm', _plan(skill_manager=skill_manager))
+
+    assert constructor.call_args.kwargs['skill_manager'] is skill_manager
+
+
 def test_tool_guard_checks_cancellation_before_dispatch(monkeypatch) -> None:
     manager = MagicMock(return_value=[{'ok': True}])
     cancel_check = MagicMock(side_effect=CancelledError('stopped by user'))

--- a/tests/algorithm/chat/test_pipeline_agentic.py
+++ b/tests/algorithm/chat/test_pipeline_agentic.py
@@ -109,11 +109,14 @@ def test_handle_chat_constructs_react_agent_from_runtime_context(monkeypatch):
     assert agent_calls
     assert agent_calls[0]['llm'].startswith('llm:')
     assert agent_calls[0]['tools']
-    assert agent_calls[0]['kwargs']['skills'] is False
+    skill_manager = agent_calls[0]['kwargs']['skill_manager']
+    assert skill_manager is not None
+    assert skill_manager.list_skill_metadata('allowed') == []
     assert callable(agent_calls[0]['kwargs']['extra_stop_condition'])
     assert agent_calls[0]['kwargs']['stream'] is True
     tool_names = {getattr(tool, '__name__', '') for tool in agent_calls[0]['tools']}
     assert {'read_file', 'write_file', 'list_dir'} <= tool_names
+    assert 'search_skills' in tool_names
     workspace = chat_service.chat_agent_workspace('user-1', 'conversation-1')
     assert agent_calls[0]['kwargs']['workspace'] == workspace
     assert f'Use `{workspace}` as the single working directory' in agent_calls[0]['kwargs']['prompt']

--- a/tests/algorithm/chat/test_skill_retriever.py
+++ b/tests/algorithm/chat/test_skill_retriever.py
@@ -1,0 +1,506 @@
+from __future__ import annotations
+
+import os
+import time
+from contextvars import ContextVar
+
+import pytest
+
+from lazymind.chat.engine.skills import SkillRetriever
+from lazymind.chat.engine.tools.skill_search import build_search_skills_tool
+
+
+CATALOG = [
+    {
+        'id': 'resume-assistant',
+        'name': 'Resume Assistant',
+        'description': 'Turn scattered experience into a professional resume or CV.',
+        'aliases': ['简历', '履历'],
+        'tags': ['career'],
+    },
+    {
+        'id': 'hot-news-summary',
+        'name': 'Hot News Summary',
+        'description': '抓取并整理今日热点、热门话题和新闻热搜。',
+        'aliases': ['每日热点'],
+        'tags': ['news'],
+    },
+    {
+        'id': 'spreadsheet-cleaner',
+        'name': 'Spreadsheet Cleaner',
+        'description': 'Normalize and clean spreadsheet rows.',
+        'tags': ['data'],
+    },
+]
+
+
+def _descriptor(skill_id: str, description: str, *aliases: str) -> dict:
+    return {
+        'id': skill_id,
+        'name': skill_id.replace('-', ' ').title(),
+        'description': description,
+        'aliases': list(aliases),
+    }
+
+
+LARGE_CATALOG = [
+    _descriptor(
+        'resume-assistant',
+        'Turn scattered work experience into a professional resume, CV, curriculum vitae, 求职材料或个人履历。',
+        '简历', '履历',
+    ),
+    _descriptor(
+        'hot-news-summary',
+        "Fetch and summarize today's trending news, breaking stories, 今日热点、新闻热搜和热门话题。",
+        '每日热点', '今日新闻',
+    ),
+    _descriptor('academic-writer', '撰写学术论文、摘要、研究方法和实验结论。'),
+    _descriptor('arxiv-search', 'Search arXiv preprints and retrieve papers by topic or author.'),
+    _descriptor('bibliography-manager', '整理参考文献、BibTeX 和论文书目。'),
+    _descriptor('spreadsheet-cleaner', '清洗 Excel 或 CSV，处理缺失值、重复行和格式错误。'),
+    _descriptor('csv-profiler', 'Profile CSV columns, distributions, types, and anomalies.'),
+    _descriptor('sql-analyst', '编写 SQL 查询并分析数据库表、指标和聚合结果。'),
+    _descriptor('market-research', '研究市场规模、行业趋势、客户与商业机会。'),
+    _descriptor('competitor-analysis', '分析竞品功能、定价、定位、优缺点和竞争格局。'),
+    _descriptor('prd-writer', '生成产品需求文档 PRD、用户故事和验收标准。'),
+    _descriptor('meeting-minutes', '把会议讨论整理成会议纪要、决策和待办事项。'),
+    _descriptor('ppt-generator', '根据提纲和材料生成 PowerPoint 演示文稿。'),
+    _descriptor('pdf-exporter', '把文档或简历导出为排版稳定的 PDF 文件。'),
+    _descriptor('diagram-maker', '绘制流程图、架构图、时序图和 Mermaid 图表。'),
+    _descriptor('image-generator', '根据文字描述生成创意图片、插画和海报。'),
+    _descriptor('image-editor', '编辑已有图片，移除元素、标注亮点或修改风格。'),
+    _descriptor('translator', '在中文、英文及其他语言之间翻译文本。'),
+    _descriptor('code-reviewer', '审查代码缺陷、可维护性、安全性和测试覆盖。'),
+    _descriptor('python-debugger', '诊断 Python 异常、脚本错误和性能问题。'),
+    _descriptor('api-docs', '生成和维护 API 文档、参数说明与调用示例。'),
+    _descriptor('legal-contract-review', '审阅合同条款、法律风险与权利义务。'),
+    _descriptor('travel-planner', '规划旅行路线、住宿、交通和景点日程。'),
+    _descriptor('weather-forecast', '查询天气预报、温度、降雨和空气质量。'),
+    _descriptor('email-drafter', '起草、润色和回复工作邮件。'),
+    _descriptor('social-copywriter', '创作社交媒体文案、标题和营销帖子。'),
+    _descriptor('interview-coach', '准备面试问题、模拟问答和反馈。'),
+    _descriptor('job-search', '搜索职位、筛选招聘信息并规划求职。'),
+    _descriptor('cover-letter', '撰写求职信和岗位申请信。'),
+    _descriptor('personal-bio', '撰写个人简介、自我介绍和作者介绍。'),
+    _descriptor('knowledge-base-qa', '基于内部知识库文档回答问题并引用来源。'),
+    _descriptor('web-research', '在网页上检索资料、核验来源并汇总结论。'),
+    _descriptor('literature-review', '综述多篇论文的研究脉络、方法与不足。'),
+    _descriptor('data-visualization', '把数据制作成图表、仪表盘和可视化报告。'),
+    _descriptor('finance-model', '建立财务预测、现金流、预算和估值模型。'),
+    _descriptor('stock-monitor', '监控股票行情、公告、价格异动和投资组合。'),
+    _descriptor('product-roadmap', '制定产品路线图、版本目标和里程碑。'),
+    _descriptor('user-research', '设计用户访谈、可用性测试并提炼需求。'),
+    _descriptor('survey-analysis', '分析问卷结果、交叉统计和开放题反馈。'),
+    _descriptor('sentiment-analysis', '识别评论或舆情中的情绪与观点倾向。'),
+    _descriptor('calendar-planner', '安排日历、会议时间和个人日程。'),
+    _descriptor('task-manager', '拆解任务、跟踪进度、优先级和负责人。'),
+    _descriptor('invoice-parser', '从发票中提取金额、税号、日期和开票方。'),
+    _descriptor('receipt-ocr', 'OCR 识别小票图片中的商品、金额和时间。'),
+    _descriptor('audio-transcriber', '把访谈、会议或录音转写成文字。'),
+    _descriptor('video-summary', '总结视频内容、时间点和主要观点。'),
+    _descriptor('citation-checker', '检查论文引用、引文一致性和来源真实性。'),
+    _descriptor('grammar-editor', '校对语法、拼写、表达和文章风格。'),
+    _descriptor('presentation-design', '优化演示稿版式、视觉层级和配色。'),
+    _descriptor(
+        'computer-vision-explainer',
+        'Explain CV as computer vision, image recognition, detection, and visual models.',
+        'CV',
+    ),
+]
+
+
+LEXICAL_RECALL_CASES = [
+    ('把这些零散经历整理成一份专业求职履历', 'resume-assistant'),
+    ('帮我优化 CV 简历', 'resume-assistant'),
+    ('polish my curriculum vitae for a job application', 'resume-assistant'),
+    ('今天有什么新闻热搜', 'hot-news-summary'),
+    ("what's trending in the news today", 'hot-news-summary'),
+    ('把这个 CSV 的缺失值和重复行清理掉', 'spreadsheet-cleaner'),
+    ('分析竞品的功能和定价', 'competitor-analysis'),
+    ('把访谈录音转成文字', 'audio-transcriber'),
+    ('检查论文引用是否真实一致', 'citation-checker'),
+    ('把会议讨论整理成纪要和待办', 'meeting-minutes'),
+    ('从一堆发票里提取金额和税号', 'invoice-parser'),
+    ('生成一个包含用户故事和验收标准的 PRD', 'prd-writer'),
+    ('帮我审查这份合同的法律风险', 'legal-contract-review'),
+    ('把销售数据做成图表和仪表盘', 'data-visualization'),
+    ('分析问卷里的开放题反馈', 'survey-analysis'),
+    ('CV 在 computer vision 里是什么意思', 'computer-vision-explainer'),
+]
+
+SEMANTIC_RECALL_CASES = [
+    ('把过往职业背景变成一份应聘档案', 'resume-assistant'),
+    ('给我一份今天外界发生了什么的速览', 'hot-news-summary'),
+    ('这份表里脏数据太多，帮我收拾一下', 'spreadsheet-cleaner'),
+    ('我想知道同类产品都是怎么卖的', 'competitor-analysis'),
+    ('把这段访谈变成可读文本', 'audio-transcriber'),
+    ('这些出处靠不靠谱', 'citation-checker'),
+    ('这里的 CV 指图像识别方向', 'computer-vision-explainer'),
+]
+
+_CONCEPT_SKILLS = {
+    'resume-assistant': 0,
+    'hot-news-summary': 1,
+    'spreadsheet-cleaner': 2,
+    'competitor-analysis': 3,
+    'audio-transcriber': 4,
+    'citation-checker': 5,
+    'computer-vision-explainer': 6,
+}
+_CONCEPT_QUERIES = {query: _CONCEPT_SKILLS[skill_id] for query, skill_id in SEMANTIC_RECALL_CASES}
+
+
+def _fixture_semantic_embedder(texts: list[str]) -> list[list[float]]:
+    vectors = []
+    for text in texts:
+        concept = _CONCEPT_QUERIES.get(text)
+        if concept is None:
+            concept = _CONCEPT_SKILLS.get(text.split('\n', 1)[0])
+        vector = [0.0] * 8
+        if concept is None:
+            vector[7] = 1.0
+        else:
+            vector[concept] = 1.0
+        vectors.append(vector)
+    return vectors
+
+
+def test_small_catalog_exposes_all_metadata_without_embedding() -> None:
+    retriever = SkillRetriever(
+        embedder=lambda _: (_ for _ in ()).throw(AssertionError('embedding must not run')),
+        small_catalog_threshold=3,
+    )
+
+    result = retriever.retrieve('帮我整理简历', CATALOG, limit=1)
+
+    assert result.strategy == 'all'
+    assert result.skill_ids == [item['id'] for item in CATALOG]
+
+
+def test_catalog_threshold_switches_from_full_metadata_to_hybrid_top_k() -> None:
+    retriever = SkillRetriever(
+        embedder=_fixture_semantic_embedder,
+        cache_namespace='catalog-threshold',
+        small_catalog_threshold=20,
+    )
+
+    small_result = retriever.retrieve(
+        '把过往职业背景变成一份应聘档案',
+        LARGE_CATALOG[:20],
+        limit=3,
+    )
+    large_result = retriever.retrieve(
+        '把过往职业背景变成一份应聘档案',
+        LARGE_CATALOG[:21],
+        limit=3,
+    )
+
+    assert small_result.strategy == 'all'
+    assert len(small_result.hits) == 20
+    assert large_result.strategy == 'hybrid'
+    assert len(large_result.hits) == 3
+    assert 'resume-assistant' in large_result.skill_ids
+
+
+def test_lexical_fallback_recalls_natural_news_wording() -> None:
+    retriever = SkillRetriever(embedder=None, small_catalog_threshold=0)
+
+    result = retriever.retrieve('用投资视角看看今天的新闻热搜', CATALOG, limit=2)
+
+    assert result.strategy == 'lexical'
+    assert result.skill_ids[0] == 'hot-news-summary'
+    assert result.embedding_error == 'embedding model unavailable'
+
+
+def test_lexical_fallback_does_not_pad_results_with_zero_score_decoys() -> None:
+    catalog = [
+        _descriptor('resume-assistant', 'Build a professional curriculum vitae.'),
+        _descriptor('weather-forecast', 'Forecast temperature and rain.'),
+        _descriptor('invoice-parser', 'Extract totals and tax numbers from invoices.'),
+        _descriptor('diagram-maker', 'Draw architecture diagrams.'),
+    ]
+    retriever = SkillRetriever(embedder=None, small_catalog_threshold=0)
+
+    result = retriever.retrieve('curriculum vitae', catalog, limit=3)
+
+    assert result.skill_ids == ['resume-assistant']
+    assert result.hits[0].score > 0
+
+
+def test_large_catalog_lexical_fallback_meets_recall_at_three_target() -> None:
+    assert len(LARGE_CATALOG) == 50
+    retriever = SkillRetriever(embedder=None, small_catalog_threshold=20)
+    misses = []
+
+    for index, (query, expected_skill) in enumerate(LEXICAL_RECALL_CASES):
+        catalog = LARGE_CATALOG if index % 2 == 0 else list(reversed(LARGE_CATALOG))
+        result = retriever.retrieve(query, catalog, limit=3)
+        if expected_skill not in result.skill_ids:
+            misses.append((query, expected_skill, result.skill_ids))
+
+    assert len(misses) <= 1, f'Recall@3 below 15/16: {misses}'
+
+
+def test_large_catalog_compound_request_recalls_both_workflows() -> None:
+    retriever = SkillRetriever(embedder=None, small_catalog_threshold=20)
+
+    result = retriever.retrieve(
+        '先汇总今天的新闻热搜，再把我的零散经历整理成 CV 简历',
+        list(reversed(LARGE_CATALOG)),
+        limit=5,
+    )
+
+    assert {'hot-news-summary', 'resume-assistant'} <= set(result.skill_ids)
+
+
+def test_dense_and_lexical_rankings_are_fused() -> None:
+    def embed(texts: list[str]) -> list[list[float]]:
+        vectors = []
+        for text in texts:
+            lowered = text.lower()
+            if '求职材料' in text or 'resume' in lowered or 'cv' in lowered:
+                vectors.append([1.0, 0.0])
+            elif '新闻' in text or 'news' in lowered:
+                vectors.append([0.0, 1.0])
+            else:
+                vectors.append([0.2, 0.2])
+        return vectors
+
+    retriever = SkillRetriever(
+        embedder=embed,
+        cache_namespace='dense-test',
+        small_catalog_threshold=0,
+    )
+
+    result = retriever.retrieve('把零散经历变成求职材料', CATALOG, limit=2)
+
+    assert result.strategy == 'hybrid'
+    assert result.skill_ids[0] == 'resume-assistant'
+    assert 'dense' in result.hits[0].channels
+
+
+def test_large_catalog_hybrid_retrieval_recalls_semantic_paraphrases() -> None:
+    retriever = SkillRetriever(
+        embedder=_fixture_semantic_embedder,
+        cache_namespace='large-semantic-matrix',
+        small_catalog_threshold=20,
+    )
+    misses = []
+
+    for catalog_order, catalog in (
+        ('forward', LARGE_CATALOG),
+        ('reversed', list(reversed(LARGE_CATALOG))),
+    ):
+        for query, expected_skill in SEMANTIC_RECALL_CASES:
+            result = retriever.retrieve(query, catalog, limit=3)
+            if expected_skill not in result.skill_ids:
+                misses.append((catalog_order, query, expected_skill, result.skill_ids))
+                continue
+            expected_hit = next(hit for hit in result.hits if hit.descriptor.skill_id == expected_skill)
+            assert 'dense' in expected_hit.channels
+            assert result.strategy == 'hybrid'
+            assert len(result.skill_ids) == len(set(result.skill_ids)) == 3
+
+    assert misses == []
+
+
+def test_hybrid_retrieval_disambiguates_cv_with_semantics_and_keywords() -> None:
+    query = '这里的 CV 指图像识别方向'
+    retriever = SkillRetriever(
+        embedder=_fixture_semantic_embedder,
+        cache_namespace='cv-disambiguation',
+        small_catalog_threshold=20,
+    )
+
+    result = retriever.retrieve(query, LARGE_CATALOG, limit=3)
+
+    assert result.skill_ids[0] == 'computer-vision-explainer'
+    assert result.hits[0].channels == ('lexical', 'dense')
+
+
+def test_fusion_keeps_a_strong_dense_leader_amid_lexical_collisions() -> None:
+    catalog = [
+        _descriptor('records-organizer', '整理职业背景、应聘档案和历史材料。'),
+        _descriptor('career-planner', '规划职业背景和长期发展方向。'),
+        _descriptor('application-tracker', '跟踪应聘档案和申请状态。'),
+        _descriptor('resume-assistant', 'Create a polished resume or CV from work experience.'),
+    ]
+    query = '把过往职业背景变成一份应聘档案'
+
+    def embed(texts: list[str]) -> list[list[float]]:
+        vectors = []
+        for text in texts:
+            skill_id = text.split('\n', 1)[0]
+            if text == query or skill_id == 'resume-assistant':
+                vectors.append([1.0, 0.0])
+            else:
+                vectors.append([0.1, 0.995])
+        return vectors
+
+    retriever = SkillRetriever(
+        embedder=embed,
+        cache_namespace='dense-leader-coverage',
+        small_catalog_threshold=0,
+    )
+
+    result = retriever.retrieve(query, catalog, limit=3)
+
+    assert 'resume-assistant' in result.skill_ids
+    resume_hit = next(hit for hit in result.hits if hit.descriptor.skill_id == 'resume-assistant')
+    assert resume_hit.channels == ('dense',)
+
+
+def test_embedding_failure_falls_back_without_dropping_candidates() -> None:
+    def broken_embed(_: list[str]) -> list[list[float]]:
+        raise RuntimeError('provider unavailable')
+
+    retriever = SkillRetriever(
+        embedder=broken_embed,
+        cache_namespace='failure-test',
+        small_catalog_threshold=0,
+    )
+
+    result = retriever.retrieve('今天有什么热点', CATALOG, limit=2)
+
+    assert result.strategy == 'lexical'
+    assert result.skill_ids[0] == 'hot-news-summary'
+    assert 'provider unavailable' in result.embedding_error
+
+
+def test_embedding_timeout_falls_back_to_lexical_results() -> None:
+    def slow_embed(texts: list[str]) -> list[list[float]]:
+        time.sleep(0.25)
+        return [[1.0, 0.0] for _ in texts]
+
+    retriever = SkillRetriever(
+        embedder=slow_embed,
+        cache_namespace='timeout-test',
+        small_catalog_threshold=0,
+        embedding_timeout_seconds=0.01,
+    )
+
+    result = retriever.retrieve('今天有什么新闻热搜', LARGE_CATALOG, limit=3)
+
+    assert result.strategy == 'lexical'
+    assert result.skill_ids[0] == 'hot-news-summary'
+    assert 'embedding exceeded' in result.embedding_error
+
+
+def test_embedding_worker_inherits_request_context() -> None:
+    request_model = ContextVar('request_model', default='missing')
+    request_model.set('configured-embed-model')
+
+    def contextual_embed(texts: list[str]) -> list[list[float]]:
+        if request_model.get() != 'configured-embed-model':
+            raise RuntimeError('request model context was lost')
+        return [[1.0, float(index)] for index, _ in enumerate(texts)]
+
+    retriever = SkillRetriever(
+        embedder=contextual_embed,
+        cache_namespace='context-test',
+        small_catalog_threshold=0,
+    )
+
+    result = retriever.retrieve('整理求职材料', CATALOG, limit=2)
+
+    assert result.strategy == 'hybrid'
+    assert result.embedding_error == ''
+
+
+def test_catalog_embeddings_are_batched_reused_and_selectively_refreshed() -> None:
+    batches = []
+
+    def recording_embedder(texts: list[str]) -> list[list[float]]:
+        batches.append(list(texts))
+        return _fixture_semantic_embedder(texts)
+
+    catalog = [dict(item) for item in LARGE_CATALOG]
+    retriever = SkillRetriever(
+        embedder=recording_embedder,
+        cache_namespace='batch-and-refresh-contract',
+        small_catalog_threshold=20,
+    )
+
+    retriever.retrieve(SEMANTIC_RECALL_CASES[0][0], catalog, limit=5)
+    retriever.retrieve(SEMANTIC_RECALL_CASES[1][0], catalog, limit=5)
+    changed_catalog = [dict(item) for item in catalog]
+    changed_catalog[10]['description'] += ' Updated metadata.'
+    retriever.retrieve(SEMANTIC_RECALL_CASES[2][0], changed_catalog, limit=5)
+
+    assert [len(batch) for batch in batches] == [51, 1, 2]
+
+
+def test_search_tool_exposes_only_retrieved_allowed_skills() -> None:
+    class Manager:
+        def __init__(self) -> None:
+            self.exposed = []
+
+        def list_skill_metadata(self, scope: str):
+            assert scope == 'allowed'
+            return CATALOG
+
+        def expose_skills(self, names):
+            self.exposed.extend(names)
+            by_id = {item['id']: item for item in CATALOG}
+            return {
+                'status': 'ok',
+                'skills': [by_id[name] for name in names if name in by_id],
+                'errors': [],
+            }
+
+    manager = Manager()
+    tool = build_search_skills_tool(
+        manager,
+        SkillRetriever(embedder=None, small_catalog_threshold=0),
+    )
+
+    result = tool('我需要整理 CV', limit=1)
+
+    assert result['skills'][0]['id'] == 'resume-assistant'
+    assert manager.exposed == ['resume-assistant']
+
+
+@pytest.mark.skipif(
+    os.environ.get('RUN_LIVE_SKILL_RETRIEVAL') != '1'
+    or not os.environ.get('LIVE_SKILL_EMBED_API_KEY'),
+    reason='requires explicit live retrieval opt-in and an embedding API key',
+)
+def test_live_embedding_meets_large_catalog_semantic_recall_target() -> None:
+    import lazyllm
+
+    source = os.environ.get('LIVE_SKILL_EMBED_SOURCE', 'siliconflow')
+    model = os.environ.get('LIVE_SKILL_EMBED_MODEL', 'BAAI/bge-m3')
+    embedder = lazyllm.OnlineEmbeddingModule(
+        source=source,
+        model=model,
+        type='embed',
+        api_key=os.environ['LIVE_SKILL_EMBED_API_KEY'],
+        timeout=15,
+    )
+    retriever = SkillRetriever(
+        embedder=embedder,
+        cache_namespace=f'{source}-{model}-live-eval',
+        small_catalog_threshold=20,
+        embedding_timeout_seconds=3.0,
+    )
+    misses = []
+    provider_errors = []
+
+    for query, expected_skill in SEMANTIC_RECALL_CASES:
+        result = retriever.retrieve(query, LARGE_CATALOG, limit=5)
+        if result.embedding_error:
+            provider_errors.append({
+                'query': query,
+                'error': result.embedding_error,
+            })
+        if expected_skill not in result.skill_ids:
+            misses.append({
+                'query': query,
+                'expected': expected_skill,
+                'actual': result.skill_ids,
+                'strategy': result.strategy,
+                'embedding_error': result.embedding_error,
+            })
+
+    assert not provider_errors, f'live embedding provider unavailable: {provider_errors}'
+    assert len(misses) <= 1, f'live Recall@5 below 6/7: {misses}'

--- a/tests/algorithm/chat/test_skill_retriever.py
+++ b/tests/algorithm/chat/test_skill_retriever.py
@@ -460,6 +460,35 @@ def test_search_tool_exposes_only_retrieved_allowed_skills() -> None:
     assert manager.exposed == ['resume-assistant']
 
 
+def test_duplicate_descriptors_are_deduplicated() -> None:
+    retriever = SkillRetriever(embedder=None, small_catalog_threshold=20)
+    duplicated = [*CATALOG, dict(CATALOG[0])]
+
+    result = retriever.retrieve('整理简历', duplicated, limit=10)
+
+    assert result.strategy == 'all'
+    assert result.skill_ids == [item['id'] for item in CATALOG]
+    assert len(result.hits) == len(CATALOG)
+
+
+def test_limit_is_clamped_to_catalog_size() -> None:
+    retriever = SkillRetriever(embedder=None, small_catalog_threshold=0)
+
+    result = retriever.retrieve('curriculum vitae', CATALOG, limit=100)
+
+    assert len(result.hits) <= len(CATALOG)
+
+
+def test_empty_query_returns_no_lexical_hits() -> None:
+    retriever = SkillRetriever(embedder=None, small_catalog_threshold=0)
+
+    result = retriever.retrieve('', CATALOG, limit=3)
+
+    assert result.strategy == 'lexical'
+    assert result.skill_ids == []
+    assert result.embedding_error == 'embedding model unavailable'
+
+
 @pytest.mark.skipif(
     os.environ.get('RUN_LIVE_SKILL_RETRIEVAL') != '1'
     or not os.environ.get('LIVE_SKILL_EMBED_API_KEY'),

--- a/tests/algorithm/chat/test_skill_runtime_integration.py
+++ b/tests/algorithm/chat/test_skill_runtime_integration.py
@@ -1,0 +1,226 @@
+from __future__ import annotations
+
+import copy
+import json
+
+import lazyllm
+from lazyllm.common import new_session
+from lazyllm.tools import ReactAgent
+from lazyllm.tools.agent.skill_manager import SkillManager
+
+from lazymind.chat.engine.skills import SkillRetriever
+from lazymind.chat.engine.tools.skill_search import build_search_skills_tool
+
+
+def _write_skill(root, skill_id: str, description: str, aliases=()) -> None:
+    directory = root / skill_id
+    directory.mkdir()
+    alias_yaml = '[' + ', '.join(aliases) + ']'
+    (directory / 'SKILL.md').write_text(
+        '---\n'
+        f'name: {skill_id}\n'
+        f'description: {description}\n'
+        f'aliases: {alias_yaml}\n'
+        '---\n'
+        f'# {skill_id}\n',
+        encoding='utf-8',
+    )
+
+
+class _DiscoveryLoopLLM:
+    def __init__(self) -> None:
+        self._module_id = f'discovery-loop-{id(self)}'
+        self._state = {'round': 0}
+
+    def share(self, **_kwargs):
+        return copy.copy(self)
+
+    def used_by(self, _module_id):
+        return self
+
+    def __call__(self, _input, **_kwargs):
+        history = lazyllm.locals.get('chat_history', {}).get(self._module_id, [])
+        current_messages = _input.get('input', []) if isinstance(_input, dict) else []
+        observations = [*history, *current_messages]
+        current_round = self._state['round']
+        self._state['round'] += 1
+        if current_round == 0:
+            return {
+                'role': 'assistant',
+                'content': 'I need to discover a relevant workflow.',
+                'tool_calls': [{
+                    'id': 'search-1',
+                    'type': 'function',
+                    'function': {
+                        'name': 'search_skills',
+                        'arguments': json.dumps({'query': 'build a resume or CV', 'limit': 3}),
+                    },
+                }],
+            }
+        if current_round == 1:
+            assert any(
+                item.get('role') == 'tool' and 'resume-assistant' in str(item.get('content'))
+                for item in observations
+            ), 'the model did not receive search_skills results'
+            return {
+                'role': 'assistant',
+                'content': 'The resume workflow is relevant; I will load it.',
+                'tool_calls': [{
+                    'id': 'get-1',
+                    'type': 'function',
+                    'function': {
+                        'name': 'get_skill',
+                        'arguments': json.dumps({'name': 'resume-assistant'}),
+                    },
+                }],
+            }
+        assert any(
+            item.get('role') == 'tool' and 'RESUME_WORKFLOW_MARKER' in str(item.get('content'))
+            for item in observations
+        ), 'the model did not receive the loaded SKILL.md'
+        return {'role': 'assistant', 'content': 'Loaded and used RESUME_WORKFLOW_MARKER.'}
+
+
+class _RetryingDiscoveryLoopLLM:
+    def __init__(self) -> None:
+        self._module_id = f'retrying-discovery-loop-{id(self)}'
+        self._state = {'round': 0}
+
+    def share(self, **_kwargs):
+        return copy.copy(self)
+
+    def used_by(self, _module_id):
+        return self
+
+    def __call__(self, current_input, **_kwargs):
+        current_messages = current_input.get('input', []) if isinstance(current_input, dict) else []
+        observation = '\n'.join(str(item.get('content', '')) for item in current_messages)
+        current_round = self._state['round']
+        self._state['round'] += 1
+        if current_round == 0:
+            return _tool_call(
+                'search-vague',
+                'search_skills',
+                {'query': '把过往背景变成应聘档案', 'limit': 3},
+            )
+        if current_round == 1:
+            assert "'count': 0" in observation
+            assert 'embedding model unavailable' in observation
+            return _tool_call(
+                'search-specific',
+                'search_skills',
+                {'query': 'professional resume CV', 'limit': 3},
+            )
+        if current_round == 2:
+            assert 'resume-assistant' in observation
+            return _tool_call('get-after-retry', 'get_skill', {'name': 'resume-assistant'})
+        assert 'RESUME_WORKFLOW_MARKER' in observation
+        return {'role': 'assistant', 'content': 'Recovered after refining the Skill search.'}
+
+
+def _tool_call(call_id: str, name: str, arguments: dict) -> dict:
+    return {
+        'role': 'assistant',
+        'content': '',
+        'tool_calls': [{
+            'id': call_id,
+            'type': 'function',
+            'function': {'name': name, 'arguments': json.dumps(arguments)},
+        }],
+    }
+
+
+def test_search_skills_expands_get_skill_visibility_in_same_agent_session(tmp_path) -> None:
+    _write_skill(
+        tmp_path,
+        'resume-assistant',
+        'Turn scattered experience into a professional resume or CV.',
+        aliases=('简历', '履历'),
+    )
+    _write_skill(
+        tmp_path,
+        'hot-news-summary',
+        '抓取并整理今日热点、热门话题和新闻热搜。',
+        aliases=('每日热点',),
+    )
+    for index in range(23):
+        _write_skill(tmp_path, f'filler-{index}', f'Unrelated capability number {index}.')
+
+    allowed = ['resume-assistant', 'hot-news-summary', *(f'filler-{index}' for index in range(23))]
+    manager = SkillManager(dir=str(tmp_path), skills=[], allowed_skills=allowed)
+    search_skills = build_search_skills_tool(
+        manager,
+        SkillRetriever(embedder=None, small_catalog_threshold=20),
+    )
+
+    with new_session('skill-runtime-integration'):
+        assert manager.get_skill('resume-assistant')['status'] == 'missing'
+
+        result = search_skills('把这些零散经历整理成 CV', limit=3)
+
+        assert result['skills'][0]['id'] == 'resume-assistant'
+        assert manager.get_skill('resume-assistant')['status'] == 'ok'
+        assert manager.get_skill('not-allowed')['status'] == 'missing'
+
+
+def test_react_agent_can_discover_and_load_a_skill_after_the_first_round(tmp_path) -> None:
+    _write_skill(
+        tmp_path,
+        'resume-assistant',
+        'Turn scattered experience into a professional resume or CV. RESUME_WORKFLOW_MARKER',
+        aliases=('简历', '履历'),
+    )
+    for index in range(49):
+        _write_skill(tmp_path, f'decoy-{index}', f'Unrelated workflow number {index}.')
+
+    allowed = ['resume-assistant', *(f'decoy-{index}' for index in range(49))]
+    manager = SkillManager(dir=str(tmp_path), skills=[], allowed_skills=allowed)
+    search_skills = build_search_skills_tool(
+        manager,
+        SkillRetriever(embedder=None, small_catalog_threshold=20),
+    )
+    agent = ReactAgent(
+        llm=_DiscoveryLoopLLM(),
+        tools=[search_skills],
+        skill_manager=manager,
+        max_retries=3,
+        stream=False,
+        enable_builtin_tools=False,
+    )
+
+    with new_session('skill-discovery-agent-loop'):
+        assert manager.get_skill('resume-assistant')['status'] == 'missing'
+
+        result = agent('Turn my scattered experience into a professional CV.')
+
+        assert result == 'Loaded and used RESUME_WORKFLOW_MARKER.'
+        assert manager.get_skill('resume-assistant')['status'] == 'missing'
+
+
+def test_react_agent_can_refine_an_empty_skill_search_inside_the_loop(tmp_path) -> None:
+    _write_skill(
+        tmp_path,
+        'resume-assistant',
+        'Turn scattered experience into a professional resume or CV. RESUME_WORKFLOW_MARKER',
+    )
+    for index in range(49):
+        _write_skill(tmp_path, f'decoy-{index}', f'Unrelated workflow number {index}.')
+
+    allowed = ['resume-assistant', *(f'decoy-{index}' for index in range(49))]
+    manager = SkillManager(dir=str(tmp_path), skills=[], allowed_skills=allowed)
+    agent = ReactAgent(
+        llm=_RetryingDiscoveryLoopLLM(),
+        tools=[build_search_skills_tool(
+            manager,
+            SkillRetriever(embedder=None, small_catalog_threshold=20),
+        )],
+        skill_manager=manager,
+        max_retries=4,
+        stream=False,
+        enable_builtin_tools=False,
+    )
+
+    with new_session('skill-search-refinement-agent-loop'):
+        result = agent('把过往背景变成应聘档案。')
+
+    assert result == 'Recovered after refining the Skill search.'

--- a/tests/algorithm/chat/test_skill_runtime_integration.py
+++ b/tests/algorithm/chat/test_skill_runtime_integration.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import copy
 import json
+import threading
 
 import lazyllm
 from lazyllm.common import new_session
@@ -130,6 +131,40 @@ def _tool_call(call_id: str, name: str, arguments: dict) -> dict:
     }
 
 
+class _DirectGetSkillLLM:
+    '''Fake LLM that calls get_skill immediately, without searching first.
+
+    Mirrors the production flow where chat_service exposes the initial
+    retrieval hits before the agent loop starts, so the loop's first action
+    can already be get_skill rather than search_skills.
+    '''
+
+    def __init__(self, skill_name: str) -> None:
+        self._module_id = f'direct-get-{id(self)}'
+        self._skill_name = skill_name
+        self._state = {'round': 0}
+
+    def share(self, **_kwargs):
+        return copy.copy(self)
+
+    def used_by(self, _module_id):
+        return self
+
+    def __call__(self, _input, **_kwargs):
+        history = lazyllm.locals.get('chat_history', {}).get(self._module_id, [])
+        current_messages = _input.get('input', []) if isinstance(_input, dict) else []
+        observations = [*history, *current_messages]
+        current_round = self._state['round']
+        self._state['round'] += 1
+        if current_round == 0:
+            return _tool_call('get-direct', 'get_skill', {'name': self._skill_name})
+        assert any(
+            item.get('role') == 'tool' and 'RESUME_WORKFLOW_MARKER' in str(item.get('content'))
+            for item in observations
+        ), 'the model did not receive the loaded SKILL.md via get_skill'
+        return {'role': 'assistant', 'content': 'Loaded RESUME_WORKFLOW_MARKER.'}
+
+
 def test_search_skills_expands_get_skill_visibility_in_same_agent_session(tmp_path) -> None:
     _write_skill(
         tmp_path,
@@ -224,3 +259,75 @@ def test_react_agent_can_refine_an_empty_skill_search_inside_the_loop(tmp_path) 
         result = agent('把过往背景变成应聘档案。')
 
     assert result == 'Recovered after refining the Skill search.'
+
+
+def test_initial_retrieval_exposure_is_visible_in_agent_loop(tmp_path) -> None:
+    _write_skill(
+        tmp_path,
+        'resume-assistant',
+        'Turn scattered experience into a professional resume or CV. RESUME_WORKFLOW_MARKER',
+        aliases=('简历', '履历'),
+    )
+    for index in range(49):
+        _write_skill(tmp_path, f'decoy-{index}', f'Unrelated workflow number {index}.')
+
+    allowed = ['resume-assistant', *(f'decoy-{index}' for index in range(49))]
+    manager = SkillManager(dir=str(tmp_path), skills=[], allowed_skills=allowed)
+    agent = ReactAgent(
+        llm=_DirectGetSkillLLM('resume-assistant'),
+        tools=[],
+        skill_manager=manager,
+        max_retries=2,
+        stream=False,
+        enable_builtin_tools=False,
+    )
+
+    with new_session('initial-exposure-agent-loop'):
+        assert manager.get_skill('resume-assistant')['status'] == 'missing'
+        manager.expose_skills(['resume-assistant'])
+        result = agent('Turn my scattered experience into a professional CV.')
+
+    assert result == 'Loaded RESUME_WORKFLOW_MARKER.'
+
+
+def test_concurrent_sessions_do_not_share_exposed_skills(tmp_path) -> None:
+    _write_skill(tmp_path, 'resume-assistant', 'resume workflow', aliases=('简历',))
+    _write_skill(tmp_path, 'hot-news-summary', 'news workflow', aliases=('热点',))
+    manager = SkillManager(
+        dir=str(tmp_path),
+        skills=[],
+        allowed_skills=['resume-assistant', 'hot-news-summary'],
+    )
+
+    results: dict[str, tuple[str, str]] = {}
+    barrier = threading.Barrier(2)
+
+    def run_resume_session() -> None:
+        with new_session('concurrent-resume-session'):
+            barrier.wait()
+            manager.expose_skills(['resume-assistant'])
+            results['resume'] = (
+                manager.get_skill('resume-assistant')['status'],
+                manager.get_skill('hot-news-summary')['status'],
+            )
+
+    def run_news_session() -> None:
+        with new_session('concurrent-news-session'):
+            barrier.wait()
+            manager.expose_skills(['hot-news-summary'])
+            results['news'] = (
+                manager.get_skill('hot-news-summary')['status'],
+                manager.get_skill('resume-assistant')['status'],
+            )
+
+    resume_thread = threading.Thread(target=run_resume_session)
+    news_thread = threading.Thread(target=run_news_session)
+    resume_thread.start()
+    news_thread.start()
+    resume_thread.join(timeout=30)
+    news_thread.join(timeout=30)
+
+    assert not resume_thread.is_alive()
+    assert not news_thread.is_alive()
+    assert results['resume'] == ('ok', 'missing')
+    assert results['news'] == ('ok', 'missing')

--- a/tests/algorithm/chat/test_task_profile.py
+++ b/tests/algorithm/chat/test_task_profile.py
@@ -8,7 +8,6 @@ import pytest
 from lazymind.chat.engine.prompts.system_prompt import add_standard_system_sections
 from lazymind.chat.engine.prompts.task_profile import (
     resolve_task_profile,
-    select_skill_candidates,
     selected_prompt_modules,
 )
 from lazymind.chat.engine.agent_runtime import AgentRole, PromptBuilder
@@ -407,7 +406,7 @@ def test_classifier_failure_scenarios_are_safe(query: str) -> None:
     profile = resolve_task_profile(query, classifier=lambda _: 'invalid')
     assert profile.source == 'fallback'
     assert profile.primary_outcome == 'answer'
-    assert profile.skill_mode == 'suppress'
+    assert profile.skill_mode == 'candidates'
 
 
 @pytest.mark.parametrize('scenario', RESOURCE_BINDING_SCENARIOS, ids=lambda item: item['id'])
@@ -420,8 +419,7 @@ def test_explicit_resource_binding_scenarios(scenario: dict) -> None:
     bindings = scenario['bindings']
     if bindings.get('skill_names') and not scenario.get('expected_excluded'):
         assert profile.skill_mode == 'explicit'
-        available = ['default/enabled-skill', *bindings['skill_names']]
-        assert select_skill_candidates(available, scenario['query'], profile) == bindings['skill_names']
+        assert profile.explicit_resources.skill_names == tuple(bindings['skill_names'])
     if bindings.get('knowledge_base_ids') and not scenario.get('expected_excluded'):
         assert profile.source_strategy == 'knowledge_base'
         assert profile.explicit_resources.knowledge_base_ids == tuple(bindings['knowledge_base_ids'])
@@ -443,12 +441,7 @@ def test_explicit_resource_binding_scenarios(scenario: dict) -> None:
     if scenario.get('expected_not_explicit'):
         assert profile.skill_mode != 'explicit'
     if 'expected_selected_skills' in scenario:
-        available = scenario.get('available_skills') or [
-            'default/enabled-skill', *bindings.get('skill_names', []),
-        ]
-        assert select_skill_candidates(available, scenario['query'], profile) == scenario[
-            'expected_selected_skills'
-        ]
+        assert list(profile.explicit_resources.skill_names) == scenario['expected_selected_skills']
 
 
 @pytest.mark.parametrize(('query', 'expected'), SCENARIOS)
@@ -457,7 +450,7 @@ def test_one_hundred_divergent_scenarios_route_by_user_outcome(query: str, expec
     assert profile.primary_outcome == expected
 
 
-def test_ai_video_learning_uses_research_tutorial_and_suppresses_skills() -> None:
+def test_ai_video_learning_keeps_skill_discovery_available() -> None:
     profile = resolve_task_profile('如何制作AI视频', enable_llm_fallback=False)
 
     assert profile.primary_outcome == 'learn'
@@ -466,7 +459,7 @@ def test_ai_video_learning_uses_research_tutorial_and_suppresses_skills() -> Non
     assert profile.freshness == 'current'
     assert profile.research_required is True
     assert profile.deliverable_kind == 'tutorial'
-    assert profile.skill_mode == 'suppress'
+    assert profile.skill_mode == 'candidates'
     assert selected_prompt_modules(profile) == [
         'learning', 'fresh_research', 'tutorial', 'skill_restraint',
     ]
@@ -502,7 +495,7 @@ def test_invalid_classifier_response_falls_back_without_raising() -> None:
     )
     assert profile.source == 'fallback'
     assert profile.primary_outcome == 'answer'
-    assert profile.skill_mode == 'suppress'
+    assert profile.skill_mode == 'candidates'
     assert profile.router_error
 
 
@@ -634,11 +627,9 @@ def test_optional_issue_uses_assumption_without_forcing_clarification() -> None:
     assert 'clarification' not in selected_prompt_modules(profile)
 
 
-def test_skill_candidates_delegate_semantic_selection_to_skill_manager() -> None:
+def test_nontrivial_request_enables_skill_retrieval() -> None:
     profile = resolve_task_profile('调研AI视频行业', enable_llm_fallback=False)
-    available = [f'research/video-{index}' for index in range(8)] + ['writing/poetry']
-    visible = select_skill_candidates(available, '调研AI视频行业', profile)
-    assert visible == available
+    assert profile.skill_mode == 'candidates'
 
 
 def test_skill_candidates_do_not_drop_semantically_relevant_cross_language_skill() -> None:
@@ -646,12 +637,9 @@ def test_skill_candidates_do_not_drop_semantically_relevant_cross_language_skill
     profile = resolve_task_profile(query, enable_llm_fallback=False)
 
     assert profile.skill_mode == 'candidates'
-    assert select_skill_candidates(
-        ['external/hot-news-summary'], query, profile,
-    ) == ['external/hot-news-summary']
 
 
-def test_explicit_skill_selection_overrides_learning_suppression() -> None:
+def test_explicit_skill_selection_overrides_semantic_retrieval() -> None:
     profile = resolve_task_profile(
         '教我制作AI视频',
         enable_llm_fallback=False,
@@ -659,9 +647,7 @@ def test_explicit_skill_selection_overrides_learning_suppression() -> None:
     )
     assert profile.primary_outcome == 'learn'
     assert profile.skill_mode == 'explicit'
-    assert select_skill_candidates(
-        ['research/deep-research', 'video/ai-production'], '教我制作AI视频', profile,
-    ) == ['video/ai-production']
+    assert profile.explicit_resources.skill_names == ('video/ai-production',)
 
 
 def test_explicit_knowledge_base_overrides_inferred_web_source() -> None:

--- a/tests/algorithm/chat/test_task_profile.py
+++ b/tests/algorithm/chat/test_task_profile.py
@@ -634,13 +634,21 @@ def test_optional_issue_uses_assumption_without_forcing_clarification() -> None:
     assert 'clarification' not in selected_prompt_modules(profile)
 
 
-def test_skill_candidates_are_relevance_ranked_and_capped_at_five() -> None:
+def test_skill_candidates_delegate_semantic_selection_to_skill_manager() -> None:
     profile = resolve_task_profile('调研AI视频行业', enable_llm_fallback=False)
     available = [f'research/video-{index}' for index in range(8)] + ['writing/poetry']
     visible = select_skill_candidates(available, '调研AI视频行业', profile)
-    assert visible is not None
-    assert len(visible) == 5
-    assert all(item.startswith('research/video-') for item in visible)
+    assert visible == available
+
+
+def test_skill_candidates_do_not_drop_semantically_relevant_cross_language_skill() -> None:
+    query = '用投资视角看看热点'
+    profile = resolve_task_profile(query, enable_llm_fallback=False)
+
+    assert profile.skill_mode == 'candidates'
+    assert select_skill_candidates(
+        ['external/hot-news-summary'], query, profile,
+    ) == ['external/hot-news-summary']
 
 
 def test_explicit_skill_selection_overrides_learning_suppression() -> None:


### PR DESCRIPTION
## What
- 新 `SkillRetriever`：目录 ≤20 全量元数据；>20 走 lexical（BM25 风格，中英）+ dense（embed_main）两路 RRF 融合 TopK=8；embedding 缺失/报错/超时自动降级 lexical
- 新 `search_skills` 工具：Loop 内二次发现，命中后动态 expose，下一轮 get_skill 可用
- chat_service：显式选择绕过召回；candidates 模式召回后 expose；suppress 只表示「初始不预载」
- 依赖 https://github.com/LazyAGI/LazyLLM/pull/1285

## Why
原实现用 query 与 skill 路径名字面打分截 Top5，语义相近但字面不近的表达会在模型判断前被过滤；首轮漏召回后也没有二次发现入口。

## Tests
- `test_skill_retriever.py`：50 descriptor，中英/复合/CV 歧义/正逆序/降级/缓存/线程池
- `test_skill_runtime_integration.py`：真实 ReactAgent + fake LLM，初始 expose→Loop get_skill、并发 session 隔离、Loop 内二次发现/纠错
- 邻接回归 1223 passed, 1 skipped（live embedding 默认关闭）
- live embedding：SiliconFlow bge-m3 7 条语义用例 Recall@5=7/7（小型 sanity check，非系统准确率）
- 真实模型 smoke：DeepSeek-V4-Flash 5 场景，模型会主动 search/get，无关请求不滥用

## 边界（诚实声明）
- 真实模型行为仅 5 条 smoke，非大规模评测
- 完整 HTTP /chat E2E 未跑（Docker 环境受限）
- 100/500/1000 规模 Recall 曲线未测
- TopK=8 / 阈值=20 是实验起点，非调优最优
