### PR TITLE
fix(frontend): add active state for chat mode buttons

### DIFF
--- a/frontend/src/layouts/MainLayout.tsx
+++ b/frontend/src/layouts/MainLayout.tsx
@@ -43,6 +43,9 @@ import {
 } from "@/utils/developerMode";
 import RecordList from "@/modules/chat/components/RecordList";
 import {
+  CHAT_CONVERSATION_FILTER_EVENT,
+  CHAT_CONVERSATION_FILTER_KEY,
+  type ChatConversationFilter,
   CHAT_NEW_RUN_IN_BACKGROUND_KEY,
   CHAT_RESUME_CONVERSATION_KEY,
   CHAT_SELECT_CONVERSATION_EVENT,
@@ -99,6 +102,16 @@ function canScrollVertically(element: HTMLElement, deltaY: number) {
   return deltaY < 0 ? element.scrollTop > 0 : element.scrollTop < maxScrollTop;
 }
 
+function readChatConversationMode(): ChatConversationFilter {
+  try {
+    return sessionStorage.getItem(CHAT_CONVERSATION_FILTER_KEY) === "task"
+      ? "task"
+      : "normal";
+  } catch {
+    return "normal";
+  }
+}
+
 interface ProfileFormValues {
   username: string;
   displayName?: string;
@@ -146,6 +159,8 @@ export default function MainLayout() {
   const [settingsOpen, setSettingsOpen] = useState(false);
   const [terminalConnectionOpen, setTerminalConnectionOpen] = useState(false);
   const [sidebarSearchText, setSidebarSearchText] = useState("");
+  const [chatConversationMode, setChatConversationMode] =
+    useState<ChatConversationFilter>(readChatConversationMode);
   const [isMenuCollapsed, setIsMenuCollapsed] = useState(readStoredMainMenuCollapsed);
   const [shouldRenderMenuContent, setShouldRenderMenuContent] = useState(
     () => !readStoredMainMenuCollapsed(),
@@ -378,6 +393,29 @@ export default function MainLayout() {
   }, [isMenuCollapsed]);
 
   useEffect(() => {
+    const handleFilterChange = (event: Event) => {
+      const filter = (
+        event as CustomEvent<{ filter?: ChatConversationFilter }>
+      ).detail?.filter;
+      if (filter !== "normal" && filter !== "task") {
+        return;
+      }
+      setChatConversationMode(filter);
+    };
+
+    window.addEventListener(
+      CHAT_CONVERSATION_FILTER_EVENT,
+      handleFilterChange,
+    );
+    return () => {
+      window.removeEventListener(
+        CHAT_CONVERSATION_FILTER_EVENT,
+        handleFilterChange,
+      );
+    };
+  }, []);
+
+  useEffect(() => {
     const handleConversationSelect = (event: Event) => {
       const conversationId =
         (event as CustomEvent<{ conversationId?: string }>).detail
@@ -461,6 +499,8 @@ export default function MainLayout() {
     setCurrentSidebarConversationId("");
     navigate(targetPath);
   };
+
+  const isTaskMode = chatConversationMode === "task";
 
   const renderModulePopover = (
     items: Array<{ key: string; label: string; icon: ReactNode }>,
@@ -801,17 +841,19 @@ export default function MainLayout() {
               <div className="sider-primary-action">
                 <Button
                   type="text"
-                  className="sider-new-chat-button"
+                  className={`sider-new-chat-button${!isTaskMode ? " is-active" : ""}`}
                   icon={<PlusOutlined />}
                   onClick={() => handleNewChat(false)}
+                  aria-pressed={!isTaskMode}
                 >
                   {t("layout.newChat")}
                 </Button>
                 <Button
-                  type="primary"
-                  className="sider-new-chat-button sider-new-task-button"
+                  type="text"
+                  className={`sider-new-chat-button${isTaskMode ? " is-active" : ""}`}
                   icon={<PlusOutlined />}
                   onClick={() => handleNewChat(true)}
+                  aria-pressed={isTaskMode}
                 >
                   {t("layout.newTask")}
                 </Button>

--- a/frontend/src/layouts/index.scss
+++ b/frontend/src/layouts/index.scss
@@ -214,15 +214,15 @@
         inset 0 0 0 1px rgba(22, 119, 255, 0.18),
         0 4px 14px rgba(15, 23, 42, 0.06);
     }
-  }
 
-  .sider-new-task-button.ant-btn {
-    background: #eaf3ff;
-    color: #0958d9;
-    box-shadow: inset 0 0 0 1px rgba(22, 119, 255, 0.14);
+    &.is-active {
+      background: #eaf3ff;
+      color: #0958d9;
+      box-shadow: inset 0 0 0 1px rgba(22, 119, 255, 0.14);
+    }
 
-    &:hover,
-    &:focus-visible {
+    &.is-active:hover,
+    &.is-active:focus-visible {
       background: #dbeafe !important;
       color: #0958d9 !important;
       box-shadow: inset 0 0 0 1px rgba(22, 119, 255, 0.24);


### PR DESCRIPTION
原有“快速问答”没有选中态，“新建任务”因为用了蓝色样式，视觉上更像当前选中项，易误导当前模式：

<img width="524" height="520" alt="image" src="https://github.com/user-attachments/assets/d789687d-f832-44a3-8afa-7c224b7147fb" />


修复后（默认“快速问答”为浅蓝色选中态，“新建任务”默认白色；点击“新建任务”后，它变成浅蓝色，“快速问答”变白；再点“快速问答”会切回来）：

<img width="1156" height="556" alt="image" src="https://github.com/user-attachments/assets/31c190f5-150a-4a83-8d1c-89c91d673f21" />

