### PR TITLE
fix(frontend): prevent IME Enter from sending chat message

### DIFF
--- a/frontend/src/modules/chat/components/ChatInput/MentionEditor.tsx
+++ b/frontend/src/modules/chat/components/ChatInput/MentionEditor.tsx
@@ -69,6 +69,9 @@ export interface MentionEditorRef {
   getMentions: () => ChatMention[];
 }
 
+const isImeComposingEvent = (event: React.KeyboardEvent<HTMLElement>) =>
+  event.nativeEvent.isComposing || event.nativeEvent.keyCode === 229;
+
 const groups: Array<{
   type: CandidateType;
   shortcut: string;
@@ -497,6 +500,9 @@ const MentionEditor = forwardRef<MentionEditorRef, {
         onCompositionEnd={() => { onCompositionChange(false); refreshQuery(); }}
         onPaste={onPaste}
         onKeyDown={(event) => {
+          if (isImeComposingEvent(event)) {
+            return;
+          }
           if (query) {
             if (event.key === "ArrowDown" || event.key === "ArrowUp") {
               event.preventDefault();


### PR DESCRIPTION
## 📌 PR 内容 / PR Description

- 修复中文输入法输入过程中，按 Enter 确认候选词时误触发聊天消息发送的问题。
- 在聊天输入框 `MentionEditor` 的 Enter 处理逻辑中补充 IME 组合输入判断：
  - `event.nativeEvent.isComposing`
  - `event.nativeEvent.keyCode === 229`
- 避免 macOS / Windows 不同输入法或浏览器事件顺序差异导致的误发送。

## ✅ 变更类型 / Type of Change

- [x] 修复 Bug / Bug fix
- [ ] 新功能 / New feature
- [ ] 重构 / Refactor
- [ ] 文档更新 / Documentation update