### PR TITLE
fix(skills): route gaokao volunteer advisor to work entry

### DIFF
--- a/skills/featured/gaokao-volunteer-advisor/featured.yaml
+++ b/skills/featured/gaokao-volunteer-advisor/featured.yaml
@@ -1,6 +1,6 @@
 schema_version: 2
 id: gaokao-volunteer-advisor
-type: chat
+type: work
 version: 1.0.0
 status: published
 default_locale: zh-CN


### PR DESCRIPTION
## Summary

将 gaokao-volunteer-advisor 精选能力从 Chat 类型调整为 Work 类型，使其进入“新建任务”入口，符合其以志愿方案和分析报告为主要交付物的使用场景。

## Changes

- 将 `gaokao-volunteer-advisor` Featured 配置的 `type` 从 `chat` 调整为 `work`。
- 保持 SkillHub 来源、版本、任务配置、多语言文案和素材不变。
- 未修改原始 Skill ZIP 或 `SKILL.md`。

## Notes

- 已通过 Featured 配置校验：`Validated 2 featured Skills`。
- 本 PR 仅涉及 Featured 入口类型调整。
- 不涉及高考数据源、脚本兼容性或 Skill 运行逻辑调整。