### PR TITLE
[Feature] support local bundled sources for Featured Skills

### DIFF
--- a/backend/core/cmd/builtin-skill-bundle/main.go
+++ b/backend/core/cmd/builtin-skill-bundle/main.go
@@ -131,9 +131,11 @@ func run(ctx context.Context, opts options, client *http.Client) error {
 		}
 	}
 	sources := make([]sourceInput, 0, len(ordinarySources.Skills)+len(ordinarySources.BundledSkills))
-	seenSources := make(map[string]struct{}, len(ordinarySources.Skills))
+	seenSources := make(map[string]struct{}, len(ordinarySources.Skills)+len(ordinarySources.BundledSkills))
 	for index := range ordinarySources.BundledSkills {
-		sources = append(sources, sourceInput{Bundled: &ordinarySources.BundledSkills[index], MarketVisible: true})
+		source := &ordinarySources.BundledSkills[index]
+		sources = append(sources, sourceInput{Bundled: source, MarketVisible: true})
+		seenSources[bundledSourceURL(source.Path)] = struct{}{}
 	}
 	for _, source := range ordinarySources.Skills {
 		sources = append(sources, sourceInput{URL: source, MarketVisible: true})
@@ -146,16 +148,21 @@ func run(ctx context.Context, opts options, client *http.Client) error {
 		if err != nil {
 			return err
 		}
-		for _, definition := range featuredDefinitions {
+		for index := range featuredDefinitions {
+			definition := &featuredDefinitions[index]
 			if definition.Status != showcase.StatusPublished {
 				continue
 			}
-			source := strings.TrimSpace(definition.Skill.SourceURL)
+			input, source, err := featuredSourceInput(definition.Skill.SourceURL, definition.Skill.RequiredVersion)
+			if err != nil {
+				return bundleFailure("featured Skill %s: %v", definition.ID, err)
+			}
 			if _, exists := seenSources[source]; exists {
 				return bundleFailure("source %s cannot be both a market Skill and a featured-only Skill", source)
 			}
 			seenSources[source] = struct{}{}
-			sources = append(sources, sourceInput{URL: source})
+			definition.Skill.SourceURL = source
+			sources = append(sources, input)
 		}
 	}
 	var lockedBySource map[string]skillbuiltin.CatalogSkill
@@ -366,6 +373,19 @@ func resolveSourceInput(source sourceInput, sourcesRoot string) (sourceSpec, err
 		Category: source.Bundled.Category, Version: source.Bundled.Version,
 		LocalPath: localPath,
 	}, nil
+}
+
+func featuredSourceInput(raw, requiredVersion string) (sourceInput, string, error) {
+	source := strings.TrimSpace(raw)
+	if _, err := resolveSource(source); err == nil {
+		return sourceInput{URL: source}, source, nil
+	}
+	cleaned, err := skillpackage.CleanPath(source)
+	if err != nil {
+		return sourceInput{}, "", bundleFailure("invalid local Skill path %q", source)
+	}
+	bundled := &bundledSource{Path: cleaned, Version: strings.TrimSpace(requiredVersion)}
+	return sourceInput{Bundled: bundled}, bundledSourceURL(cleaned), nil
 }
 
 func bundledSourceURL(relativePath string) string {

--- a/backend/core/cmd/builtin-skill-bundle/main_test.go
+++ b/backend/core/cmd/builtin-skill-bundle/main_test.go
@@ -14,6 +14,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"lazymind/core/showcase"
@@ -295,15 +296,187 @@ func TestRunBuildsFeaturedCatalogAndKeepsSkillOutOfMarket(t *testing.T) {
 	if err := os.WriteFile(sources, []byte("schema_version: 1\nskills: []\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	definition := `schema_version: 2
+	definition := testFeaturedDefinition("https://example.test/demo.zip", "1.2.3")
+	if err := os.WriteFile(filepath.Join(featuredDir, "featured.yaml"), []byte(definition), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	opts := options{
+		Sources:         sources,
+		Lock:            filepath.Join(root, "lock.json"),
+		Cache:           filepath.Join(root, "cache"),
+		Output:          filepath.Join(root, "runtime", "builtin-skills"),
+		FeaturedSources: featuredSources,
+		FeaturedOutput:  filepath.Join(root, "runtime", "featured-skills"),
+	}
+	if err := run(context.Background(), opts, client); err != nil {
+		t.Fatal(err)
+	}
+	builtinCatalog := readCatalog(t, filepath.Join(opts.Output, "catalog.json"))
+	if len(builtinCatalog.Skills) != 1 || skillbuiltin.CatalogSkillMarketVisible(builtinCatalog.Skills[0]) {
+		t.Fatalf("builtin catalog = %#v", builtinCatalog)
+	}
+	body, err := os.ReadFile(filepath.Join(opts.FeaturedOutput, "catalog.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var featuredCatalog showcase.Catalog
+	if err := json.Unmarshal(body, &featuredCatalog); err != nil {
+		t.Fatal(err)
+	}
+	if len(featuredCatalog.Cases) != 1 || featuredCatalog.Cases[0].Skill.BuiltinSkillUID != builtinCatalog.Skills[0].UID {
+		t.Fatalf("featured catalog = %#v", featuredCatalog)
+	}
+	asset := featuredCatalog.Cases[0].Assets["cover"]
+	if asset.URL == "" || asset.SHA256 == "" {
+		t.Fatalf("compiled asset = %#v", asset)
+	}
+}
+
+func TestRunBuildsFeaturedCatalogFromLocalDirectory(t *testing.T) {
+	root := t.TempDir()
+	featuredSources := filepath.Join(root, "featured")
+	featuredDir := filepath.Join(featuredSources, "demo-featured")
+	skillDir := filepath.Join(featuredDir, "skill")
+	if err := os.MkdirAll(filepath.Join(skillDir, "references"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(skillDir, "SKILL.md"), []byte("---\nname: local-featured\ndescription: local featured skill\nversion: 1.2.3\n---\n# Local Featured\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	referencePath := filepath.Join(skillDir, "references", "guide.md")
+	if err := os.WriteFile(referencePath, []byte("guide\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	writeTestPNG(t, filepath.Join(featuredDir, "assets", "cover.png"))
+	if err := os.WriteFile(filepath.Join(featuredDir, "featured.yaml"), []byte(testFeaturedDefinition("featured/demo-featured/skill", "1.2.3")), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	sources := filepath.Join(root, "sources.yaml")
+	if err := os.WriteFile(sources, []byte("schema_version: 1\nskills: []\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	opts := options{
+		Sources:         sources,
+		Lock:            filepath.Join(root, "lock.json"),
+		Cache:           filepath.Join(root, "cache"),
+		Output:          filepath.Join(root, "runtime", "builtin-skills"),
+		FeaturedSources: featuredSources,
+		FeaturedOutput:  filepath.Join(root, "runtime", "featured-skills"),
+	}
+	if err := run(context.Background(), opts, http.DefaultClient); err != nil {
+		t.Fatal(err)
+	}
+	builtinCatalog := readCatalog(t, filepath.Join(opts.Output, "catalog.json"))
+	if len(builtinCatalog.Skills) != 1 {
+		t.Fatalf("builtin catalog = %#v", builtinCatalog)
+	}
+	entry := builtinCatalog.Skills[0]
+	if entry.SourceURL != "builtin://featured/demo-featured/skill" || skillbuiltin.CatalogSkillMarketVisible(entry) {
+		t.Fatalf("local featured entry = %#v", entry)
+	}
+	packageFiles, err := skillpackage.ReadZip(filepath.Join(opts.Output, filepath.FromSlash(entry.PackageFile)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(packageFiles["references/guide.md"]) != "guide\n" {
+		t.Fatalf("package files = %#v", packageFiles)
+	}
+	featuredCatalog := readFeaturedCatalog(t, filepath.Join(opts.FeaturedOutput, "catalog.json"))
+	if len(featuredCatalog.Cases) != 1 || featuredCatalog.Cases[0].Skill.SourceURL != entry.SourceURL || featuredCatalog.Cases[0].Skill.BuiltinSkillUID != entry.UID {
+		t.Fatalf("featured catalog = %#v", featuredCatalog)
+	}
+
+	opts.Output = filepath.Join(root, "runtime-frozen", "builtin-skills")
+	opts.FeaturedOutput = filepath.Join(root, "runtime-frozen", "featured-skills")
+	opts.FrozenLockfile = true
+	if err := run(context.Background(), opts, http.DefaultClient); err != nil {
+		t.Fatalf("frozen local featured build failed: %v", err)
+	}
+	if err := os.WriteFile(referencePath, []byte("changed\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	opts.Output = filepath.Join(root, "runtime-changed", "builtin-skills")
+	opts.FeaturedOutput = filepath.Join(root, "runtime-changed", "featured-skills")
+	if err := run(context.Background(), opts, http.DefaultClient); err == nil {
+		t.Fatal("frozen build accepted a changed local Featured Skill")
+	}
+}
+
+func TestRunRejectsFeaturedSourceAssignedToSkillMarket(t *testing.T) {
+	root := t.TempDir()
+	featuredSources := filepath.Join(root, "featured")
+	featuredDir := filepath.Join(featuredSources, "demo-featured")
+	skillDir := filepath.Join(featuredDir, "skill")
+	if err := os.MkdirAll(skillDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(skillDir, "SKILL.md"), []byte("---\nname: local-featured\ndescription: local featured skill\nversion: 1.2.3\n---\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	writeTestPNG(t, filepath.Join(featuredDir, "assets", "cover.png"))
+	if err := os.WriteFile(filepath.Join(featuredDir, "featured.yaml"), []byte(testFeaturedDefinition("featured/demo-featured/skill", "1.2.3")), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	sources := filepath.Join(root, "sources.yaml")
+	if err := os.WriteFile(sources, []byte(`schema_version: 1
+bundled_skills:
+  - uid: bsk_market_demo
+    path: featured/demo-featured/skill
+    category: demo
+    version: 1.2.3
+skills: []
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	opts := options{
+		Sources: sources, Lock: filepath.Join(root, "lock.json"), Cache: filepath.Join(root, "cache"),
+		Output: filepath.Join(root, "runtime", "builtin-skills"), FeaturedSources: featuredSources,
+		FeaturedOutput: filepath.Join(root, "runtime", "featured-skills"),
+	}
+	err := run(context.Background(), opts, http.DefaultClient)
+	if err == nil || !strings.Contains(err.Error(), "cannot be both a market Skill and a featured-only Skill") {
+		t.Fatalf("error = %v", err)
+	}
+}
+
+func TestRunRejectsMissingLocalFeaturedDirectory(t *testing.T) {
+	root := t.TempDir()
+	featuredSources := filepath.Join(root, "featured")
+	featuredDir := filepath.Join(featuredSources, "demo-featured")
+	writeTestPNG(t, filepath.Join(featuredDir, "assets", "cover.png"))
+	if err := os.WriteFile(filepath.Join(featuredDir, "featured.yaml"), []byte(testFeaturedDefinition("featured/demo-featured/missing", "1.2.3")), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	sources := filepath.Join(root, "sources.yaml")
+	if err := os.WriteFile(sources, []byte("schema_version: 1\nskills: []\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	err := run(context.Background(), options{
+		Sources: sources, Lock: filepath.Join(root, "lock.json"), Cache: filepath.Join(root, "cache"),
+		Output: filepath.Join(root, "runtime", "builtin-skills"), FeaturedSources: featuredSources,
+		FeaturedOutput: filepath.Join(root, "runtime", "featured-skills"),
+	}, http.DefaultClient)
+	if err == nil || !strings.Contains(err.Error(), "bundled skill directory not found") {
+		t.Fatalf("error = %v", err)
+	}
+}
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(request *http.Request) (*http.Response, error) {
+	return f(request)
+}
+
+func testFeaturedDefinition(source, requiredVersion string) string {
+	return `schema_version: 2
 id: demo-featured
 type: work
 version: 1.0.0
 status: published
 default_locale: zh-CN
 skill:
-  source_url: https://example.test/demo.zip
-  required_version: 1.2.3
+  source_url: ` + source + `
+  required_version: ` + requiredVersion + `
 placement:
   home: true
   gallery: true
@@ -345,45 +518,19 @@ tasks:
       summary: Result
       highlights: [One]
 `
-	if err := os.WriteFile(filepath.Join(featuredDir, "featured.yaml"), []byte(definition), 0o644); err != nil {
-		t.Fatal(err)
-	}
-	opts := options{
-		Sources:         sources,
-		Lock:            filepath.Join(root, "lock.json"),
-		Cache:           filepath.Join(root, "cache"),
-		Output:          filepath.Join(root, "runtime", "builtin-skills"),
-		FeaturedSources: featuredSources,
-		FeaturedOutput:  filepath.Join(root, "runtime", "featured-skills"),
-	}
-	if err := run(context.Background(), opts, client); err != nil {
-		t.Fatal(err)
-	}
-	builtinCatalog := readCatalog(t, filepath.Join(opts.Output, "catalog.json"))
-	if len(builtinCatalog.Skills) != 1 || skillbuiltin.CatalogSkillMarketVisible(builtinCatalog.Skills[0]) {
-		t.Fatalf("builtin catalog = %#v", builtinCatalog)
-	}
-	body, err := os.ReadFile(filepath.Join(opts.FeaturedOutput, "catalog.json"))
+}
+
+func readFeaturedCatalog(t *testing.T, path string) showcase.Catalog {
+	t.Helper()
+	body, err := os.ReadFile(path)
 	if err != nil {
 		t.Fatal(err)
 	}
-	var featuredCatalog showcase.Catalog
-	if err := json.Unmarshal(body, &featuredCatalog); err != nil {
+	var catalog showcase.Catalog
+	if err := json.Unmarshal(body, &catalog); err != nil {
 		t.Fatal(err)
 	}
-	if len(featuredCatalog.Cases) != 1 || featuredCatalog.Cases[0].Skill.BuiltinSkillUID != builtinCatalog.Skills[0].UID {
-		t.Fatalf("featured catalog = %#v", featuredCatalog)
-	}
-	asset := featuredCatalog.Cases[0].Assets["cover"]
-	if asset.URL == "" || asset.SHA256 == "" {
-		t.Fatalf("compiled asset = %#v", asset)
-	}
-}
-
-type roundTripFunc func(*http.Request) (*http.Response, error)
-
-func (f roundTripFunc) RoundTrip(request *http.Request) (*http.Response, error) {
-	return f(request)
+	return catalog
 }
 
 func makeSkillZip(t *testing.T) []byte {

--- a/backend/core/showcase/catalog.go
+++ b/backend/core/showcase/catalog.go
@@ -21,6 +21,8 @@ import (
 
 	_ "golang.org/x/image/webp"
 	"gopkg.in/yaml.v3"
+
+	skillpackage "lazymind/core/skillv2/skillpackage"
 )
 
 const (
@@ -536,9 +538,8 @@ func validateDefinition(definition FeaturedDefinition, compiled bool) error {
 	if (definition.Placement.Home || definition.Placement.Gallery) && definition.Placement.Order <= 0 {
 		return definitionFailure("placement.order must be positive")
 	}
-	parsedSource, err := url.Parse(strings.TrimSpace(definition.Skill.SourceURL))
-	if err != nil || parsedSource.Host == "" || parsedSource.Scheme != "https" && parsedSource.Scheme != "http" {
-		return definitionFailure("skill.source_url must be an HTTP(S) URL")
+	if err := validateSkillSource(definition.Skill.SourceURL, compiled); err != nil {
+		return err
 	}
 	if compiled {
 		if definition.Skill.BuiltinSkillUID == "" || definition.Skill.Version == "" || len(definition.Skill.ArchiveSHA256) != sha256.Size*2 {
@@ -603,6 +604,26 @@ func validateDefinition(definition FeaturedDefinition, compiled bool) error {
 	}
 	if err := validateAssetUsage(definition); err != nil {
 		return err
+	}
+	return nil
+}
+
+func validateSkillSource(raw string, compiled bool) error {
+	source := strings.TrimSpace(raw)
+	parsed, err := url.Parse(source)
+	if err == nil && parsed.Host != "" && (parsed.Scheme == "https" || parsed.Scheme == "http") {
+		return nil
+	}
+	if compiled && strings.HasPrefix(source, "builtin://") {
+		if _, err := skillpackage.CleanPath(strings.TrimPrefix(source, "builtin://")); err == nil {
+			return nil
+		}
+	}
+	if parsed != nil && (parsed.Scheme != "" || parsed.Host != "") {
+		return definitionFailure("skill.source_url must be an HTTP(S) URL or a relative path under skills")
+	}
+	if _, err := skillpackage.CleanPath(source); err != nil {
+		return definitionFailure("skill.source_url must be an HTTP(S) URL or a relative path under skills")
 	}
 	return nil
 }

--- a/backend/core/showcase/catalog_test.go
+++ b/backend/core/showcase/catalog_test.go
@@ -168,6 +168,45 @@ func TestLoadSourceDirectoryRejectsUnknownFieldsAndInvalidAssets(t *testing.T) {
 			t.Fatalf("error = %v", err)
 		}
 	})
+	t.Run("unsafe local Skill source", func(t *testing.T) {
+		root := t.TempDir()
+		body := strings.Replace(validFeaturedYAML("demo", false), "https://example.test/demo.zip", "../private-skill", 1)
+		writeFeaturedSource(t, root, "demo", body)
+		_, err := LoadSourceDirectory(root)
+		if err == nil || !strings.Contains(err.Error(), "HTTP(S) URL or a relative path") {
+			t.Fatalf("error = %v", err)
+		}
+	})
+}
+
+func TestLoadSourceDirectoryAcceptsLocalSkillSource(t *testing.T) {
+	root := t.TempDir()
+	body := strings.Replace(validFeaturedYAML("demo", false), "https://example.test/demo.zip", "featured/demo/skill", 1)
+	writeFeaturedSource(t, root, "demo", body)
+	definitions, err := LoadSourceDirectory(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(definitions) != 1 || definitions[0].Skill.SourceURL != "featured/demo/skill" {
+		t.Fatalf("definitions = %#v", definitions)
+	}
+}
+
+func TestCompileCatalogAcceptsNormalizedBuiltinSkillSource(t *testing.T) {
+	root := t.TempDir()
+	body := strings.Replace(validFeaturedYAML("demo", false), "https://example.test/demo.zip", "featured/demo/skill", 1)
+	writeFeaturedSource(t, root, "demo", body)
+	definitions, err := LoadSourceDirectory(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	definitions[0].Skill.SourceURL = "builtin://featured/demo/skill"
+	definitions[0].Skill.BuiltinSkillUID = "bsk_demo"
+	definitions[0].Skill.Version = "1.0.0"
+	definitions[0].Skill.ArchiveSHA256 = strings.Repeat("a", 64)
+	if _, err := CompileCatalog(definitions, filepath.Join(t.TempDir(), "featured-skills")); err != nil {
+		t.Fatal(err)
+	}
 }
 
 func TestLoadSourceDirectoryRejectsLocaleTaskDrift(t *testing.T) {


### PR DESCRIPTION
## 背景

现有「精选能力」只支持通过 HTTP(S) `source_url` 配置远程 Skill。部分 Skill 尚未发布到 SkillHub，只能以文件目录形式随仓库内置，因此需要补充本地 Skill 来源支持。

本 PR 在不改变现有配置方式的前提下，让 Featured Skill 的 `source_url` 同时支持：

- HTTP(S) 远程地址：打包时下载 ZIP；
- `skills/` 下的本地相对目录：打包时自动压缩成 ZIP。

两种来源最终进入同一套 lock、Catalog、ZIP 校验和 Skill V2 安装流程。

## 配置方式

### 现有远程 Featured

配置保持不变：

```yaml
skill:
  source_url: https://skillhub.cn/skills/user_xxx/example
  required_version: 1.0.0
```

### 本地 Featured

本地路径相对仓库的 `skills/` 目录：

```yaml
skill:
  source_url: featured/local-advisor/skill
  required_version: 1.0.0
```

推荐目录结构：

```text
skills/featured/local-advisor/
├── featured.yaml
├── assets/
│   └── cover.png
├── locales/
│   └── en-US.yaml
└── skill/
    ├── SKILL.md
    ├── scripts/
    └── references/
```

## 主要改动

- 保留现有远程 `source_url` 行为。
- Featured `source_url` 新增本地相对目录解析。
- 本地 Skill 目录在构建时自动生成确定性 ZIP。
- 本地来源编译后统一规范化为：

```text
builtin://featured/local-advisor/skill
```

- 根据规范化本地路径生成稳定 builtin UID，不使用 Skill 名称作为身份。
- `required_version` 可继续作为本地 Featured 的发布版本。
- 本地 Featured 自动设置为 `market_visible=false`。
- 用户点击“试一试”时继续调用现有 builtin enable API。
- 重复安装继续按 builtin UID 保持幂等。
- 不修改 Skill V2、Revision、Blob、安装接口或前端展示模型。

## 展示归属

Skill 的展示位置严格互斥：

- 配置在 `builtin-sources.yaml`：进入技能广场；
- 配置在 `skills/featured/<id>/featured.yaml`：进入精选能力。

同一个远程 URL 或本地目录不能同时配置到两个区域，构建时会直接失败。

## 安全校验

本地来源复用现有 Skill Package 安全能力，包括：

- 拒绝绝对路径；
- 拒绝 `../` 路径穿越