### PR TITLE
enhance ai fix in chat

### DIFF
--- a/algorithm/lazymind/rewrite/__init__.py
+++ b/algorithm/lazymind/rewrite/__init__.py
@@ -12,10 +12,12 @@ from .base import (
 # Import business modules to register their prompt builders and edit dispatch.
 from . import skill  # noqa: F401
 from . import polish  # noqa: F401
+from .polish import rewrite_editable_selection
 
 __all__ = [
     'BadRequestError',
     'RewriteTaskType',
     'UnprocessableContentError',
     'rewrite_content',
+    'rewrite_editable_selection',
 ]

--- a/algorithm/lazymind/rewrite/api/rewrite_routes.py
+++ b/algorithm/lazymind/rewrite/api/rewrite_routes.py
@@ -14,6 +14,7 @@ from lazymind.rewrite import (
     RewriteTaskType,
     UnprocessableContentError,
     rewrite_content,
+    rewrite_editable_selection,
 )
 
 router = APIRouter()
@@ -29,6 +30,9 @@ class RewritePayload(BaseModel):
         ...,
         description='Per-request model configuration loaded by core for the current user',
     )
+    full_content: str | None = None
+    selection_start: int | None = None
+    selection_end: int | None = None
 
     @model_validator(mode='after')
     def validate_inputs(self) -> 'RewritePayload':
@@ -49,6 +53,16 @@ def _init_session(task_type: RewriteTaskType, model_config: Dict[str, Any]) -> N
 async def rewrite(payload: RewritePayload):
     try:
         _init_session(payload.task_type, payload.llm_config)
+        if payload.task_type == 'polish' and payload.full_content is not None:
+            start = payload.selection_start
+            end = payload.selection_end
+            if start is None or end is None or not (0 <= start < end <= len(payload.full_content)):
+                raise BadRequestError('valid selection_start and selection_end are required')
+            if payload.full_content[start:end] != payload.content:
+                raise BadRequestError('selection offsets do not match content')
+            return rewrite_editable_selection(
+                payload.full_content, start, end, payload.user_instruct,
+            )
         generated = rewrite_content(
             task_type=payload.task_type,
             content=payload.content,

--- a/algorithm/lazymind/rewrite/polish.py
+++ b/algorithm/lazymind/rewrite/polish.py
@@ -2,13 +2,63 @@
 
 from __future__ import annotations
 
-from typing import Optional
+from typing import Any, Dict, Optional
+
+from lazyllm import AutoModel
 
 from .base import (
     _COMMON_OUTPUT_SPEC,
     _PROMPT_BUILDERS,
     _format_prompt_tail,
 )
+
+
+def rewrite_editable_selection(
+    full_content: str,
+    selection_start: int,
+    selection_end: int,
+    user_instruct: str,
+) -> Dict[str, Any]:
+    """Rewrite one exact range while treating the complete editable block as read-only context."""
+    selected = full_content[selection_start:selection_end]
+    block_start = full_content.rfind('\n\n', 0, selection_start)
+    block_start = 0 if block_start < 0 else block_start + 2
+    block_end = full_content.find('\n\n', selection_end)
+    block_end = len(full_content) if block_end < 0 else block_end
+    containing_block = full_content[block_start:block_end]
+    prompt = (
+        'You edit one authorized Markdown block inside a complete document. '
+        'The user quote is an attention anchor, not a modification boundary.\n'
+        'Return only one JSON object with this shape:\n'
+        '{"content":"complete replacement for the authorized Markdown block"}\n'
+        'Focus first on the quoted text and the user instruction, then inspect the entire authorized block and modify '
+        'as much or as little of that block as needed for a coherent result. '
+        'You may change text before or after the quote '
+        'inside the block. Do not change anything outside the authorized block.\n'
+        'Preserve the block type, Markdown structure, facts, intent, and unaffected wording '
+        'unless the instruction requires otherwise. Review the replacement in the context '
+        'of the complete document and introduce no new language, logic, '
+        'factual, structural, formatting, or boundary-coherence problems.\n\n'
+        f'Complete Markdown document:\n<document>\n{full_content}\n</document>\n\n'
+        f'User quote (attention anchor only):\n<quote>{selected}</quote>\n'
+        f'Cited location (zero-based, end-exclusive): [{selection_start}, {selection_end})\n'
+        'The location identifies the quote when the same text appears more than once; do not recalculate it.\n'
+        f'Complete containing Markdown block:\n<containing_block>\n{containing_block}\n</containing_block>\n'
+        f'Quote location inside containing block: [{selection_start - block_start}, {selection_end - block_start})\n'
+        f'User instruction: {user_instruct}\n'
+    )
+    raw = AutoModel(model='llm')(prompt)
+    # Keep parsing deliberately strict: callers must never apply prose as a patch.
+    from .base import _extract_json_object  # local import keeps the public API small
+    parsed = _extract_json_object(raw)
+    content = parsed.get('content')
+    if not isinstance(content, str):
+        raise ValueError("Generated field 'content' must be a string.")
+    return {
+        'content': content,
+        'target_start': block_start,
+        'target_end': block_end,
+    }
 
 
 def _build_polish_prompt(

--- a/backend/core/algo/generate_client.go
+++ b/backend/core/algo/generate_client.go
@@ -26,6 +26,17 @@ func GeneratePolish(ctx context.Context, req PolishGenerateRequest) (string, err
 	return generate(ctx, rewritePayload("polish", req.Content, req.UserInstruct, req.LLMConfig))
 }
 
+func GenerateEditablePolish(ctx context.Context, req RewriteRequest) (map[string]any, error) {
+	var response map[string]any
+	if err := common.ApiPost(ctx, generateURL(rewritePath), req, nil, &response, generateTimeout); err != nil {
+		return nil, err
+	}
+	if _, ok := response["content"].(string); !ok {
+		return nil, fmt.Errorf("generate endpoint returned invalid editable polish content")
+	}
+	return response, nil
+}
+
 func generateURL(path string) string {
 	return common.ChatServiceEndpoint() + path
 }

--- a/backend/core/algo/types.go
+++ b/backend/core/algo/types.go
@@ -1,10 +1,13 @@
 package algo
 
 type RewriteRequest struct {
-	TaskType     string         `json:"task_type"`
-	Content      string         `json:"content"`
-	UserInstruct string         `json:"user_instruct"`
-	LLMConfig    map[string]any `json:"llm_config"`
+	TaskType       string         `json:"task_type"`
+	Content        string         `json:"content"`
+	UserInstruct   string         `json:"user_instruct"`
+	LLMConfig      map[string]any `json:"llm_config"`
+	FullContent    string         `json:"full_content,omitempty"`
+	SelectionStart *int           `json:"selection_start,omitempty"`
+	SelectionEnd   *int           `json:"selection_end,omitempty"`
 }
 
 type SkillGenerateRequest struct {

--- a/backend/core/chat/prompt.go
+++ b/backend/core/chat/prompt.go
@@ -345,9 +345,12 @@ func normalizeEditablePolishResult(polished string, allowEmpty bool) string {
 
 func PolishPrompt(w http.ResponseWriter, r *http.Request) {
 	var body struct {
-		Content      string `json:"content"`
-		UserInstruct string `json:"user_instruct"`
-		AllowEmpty   bool   `json:"allow_empty"`
+		Content        string  `json:"content"`
+		UserInstruct   string  `json:"user_instruct"`
+		AllowEmpty     bool    `json:"allow_empty"`
+		FullContent    *string `json:"full_content"`
+		SelectionStart *int    `json:"selection_start"`
+		SelectionEnd   *int    `json:"selection_end"`
 	}
 	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
 		common.ReplyErr(w, fmt.Sprintf("%s: %v", "invalid body", err), http.StatusBadRequest)
@@ -375,6 +378,29 @@ func PolishPrompt(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	userInstruct = editablePolishInstruction(userInstruct, body.AllowEmpty)
+	if body.FullContent != nil {
+		fullRunes := []rune(*body.FullContent)
+		if body.SelectionStart == nil || body.SelectionEnd == nil ||
+			*body.SelectionStart < 0 || *body.SelectionEnd <= *body.SelectionStart ||
+			*body.SelectionEnd > len(fullRunes) ||
+			string(fullRunes[*body.SelectionStart:*body.SelectionEnd]) != content {
+			common.ReplyErr(w, "selection offsets do not match content", http.StatusBadRequest)
+			return
+		}
+		result, generateErr := algo.GenerateEditablePolish(r.Context(), algo.RewriteRequest{
+			TaskType: "polish", Content: content, UserInstruct: userInstruct, LLMConfig: llmConfig,
+			FullContent: *body.FullContent, SelectionStart: body.SelectionStart, SelectionEnd: body.SelectionEnd,
+		})
+		if generateErr != nil {
+			common.ReplyErr(w, "prompt polish failed: "+generateErr.Error(), http.StatusBadGateway)
+			return
+		}
+		if value, _ := result["content"].(string); body.AllowEmpty {
+			result["content"] = normalizeEditablePolishResult(value, true)
+		}
+		writePromptJSON(w, http.StatusOK, result)
+		return
+	}
 	polished, err := algo.GeneratePolish(r.Context(), algo.PolishGenerateRequest{
 		Content:      content,
 		UserInstruct: userInstruct,

--- a/backend/core/common/error_catalog_additional.go
+++ b/backend/core/common/error_catalog_additional.go
@@ -601,6 +601,8 @@ func init() {
 	registerAdditionalError("model free_auto_select_base_urls requires a positive free_auto_select_priority", http.StatusInternalServerError, 2002313)
 	registerAdditionalError("model free_auto_select_base_urls must not contain an empty URL", http.StatusInternalServerError, 2002314)
 	registerAdditionalError("marshal model free_auto_select_base_urls", http.StatusInternalServerError, 2002315)
+	registerAdditionalError("selection offsets do not match content", http.StatusBadRequest, 2002316)
+	registerAdditionalError("generate endpoint returned invalid editable polish content", http.StatusBadGateway, 2002317)
 }
 
 func registerAdditionalError(message string, status, code int) {

--- a/frontend/src/modules/chat/components/MarkdownViewer/EditableBlock.tsx
+++ b/frontend/src/modules/chat/components/MarkdownViewer/EditableBlock.tsx
@@ -30,10 +30,36 @@ interface EditableBlockProps {
   onCiteSelection?: (text: string) => void;
 }
 
-function replaceSelectedText(markdown: string, selectedText: string, replacement: string) {
-  const index = markdown.indexOf(selectedText);
-  if (index < 0) throw new Error("selected text is no longer present");
-  return markdown.slice(0, index) + replacement + markdown.slice(index + selectedText.length);
+function resolveSelectionRange(markdown: string, selection: ArtifactRewriteSelection) {
+  const selectedText = selection.selectedText;
+  const paragraphText = selection.paragraph?.textContent ?? "";
+  const paragraphStart = paragraphText ? markdown.indexOf(paragraphText) : -1;
+  if (paragraphStart >= 0 && markdown.indexOf(paragraphText, paragraphStart + paragraphText.length) < 0) {
+    const localStart = selection.startOffset;
+    if (typeof localStart === "number") {
+      const start = paragraphStart + localStart;
+      if (markdown.slice(start, start + selectedText.length) === selectedText) {
+        return { start, end: start + selectedText.length, paragraphStart };
+      }
+    }
+  }
+  const start = markdown.indexOf(selectedText);
+  if (start < 0 || markdown.indexOf(selectedText, start + selectedText.length) >= 0) {
+    throw new Error("selected text is missing or ambiguous");
+  }
+  return { start, end: start + selectedText.length, paragraphStart: start };
+}
+
+function codePointOffset(value: string, jsOffset: number) {
+  return Array.from(value.slice(0, jsOffset)).length;
+}
+
+function jsOffsetFromCodePoints(value: string, offset: number) {
+  return Array.from(value).slice(0, offset).join("").length;
+}
+
+function replaceRange(markdown: string, start: number, end: number, replacement: string) {
+  return markdown.slice(0, start) + replacement + markdown.slice(end);
 }
 
 /** A persisted chat writing surface backed by the shared Workflow editor and diff controls. */
@@ -93,23 +119,36 @@ export default function EditableBlock({
     instruction: string,
     selection: ArtifactRewriteSelection,
   ): Promise<RewriteSelectionPreview> => {
+    const range = resolveSelectionRange(markdown, selection);
     const response = await PromptServiceApi().polishEditableSelection({
       content: selection.selectedText,
-      user_instruct: `${instruction}\nOnly return the revised selected text. Do not add explanations or Markdown fences.`,
+      user_instruct: instruction,
       allow_empty: true,
+      full_content: markdown,
+      selection_start: codePointOffset(markdown, range.start),
+      selection_end: codePointOffset(markdown, range.end),
     }, {
       timeout: 10 * 60 * 1_000,
       silentError: true,
     } as never);
     const newText = response.data.content ?? "";
-    const nextMarkdown = replaceSelectedText(markdown, selection.selectedText, newText);
+    const targetStart = typeof response.data.target_start === "number"
+      ? jsOffsetFromCodePoints(markdown, response.data.target_start) : -1;
+    const targetEnd = typeof response.data.target_end === "number"
+      ? jsOffsetFromCodePoints(markdown, response.data.target_end) : -1;
+    if (targetStart < 0 || targetEnd <= targetStart
+      || targetStart > range.start || targetEnd < range.end) {
+      throw new Error("invalid authorized block range");
+    }
+    const oldText = markdown.slice(targetStart, targetEnd);
+    const nextMarkdown = replaceRange(markdown, targetStart, targetEnd, newText);
     return {
       status: "ready",
       action: "rewrite_selection",
       base_revision: revision,
       representation: "markdown",
       target: { type: "block", block_type: "paragraph" },
-      preview: { old_text: selection.selectedText, new_text: newText },
+      preview: { old_text: oldText, new_text: newText },
       patch: { type: "string_replace_set", payload: {} },
       artifact: { content_type: "text/markdown", value: nextMarkdown },
     };
@@ -121,7 +160,7 @@ export default function EditableBlock({
     const nextMarkdown = String(preview.artifact.value);
     setRewritePreview({
       paragraph: selection.paragraph,
-      startOffset: selection.startOffset,
+      startOffset: 0,
       sessionId: "",
       slotId: "",
       listIndex: 0,

--- a/frontend/src/modules/chat/utils/request.ts
+++ b/frontend/src/modules/chat/utils/request.ts
@@ -888,10 +888,16 @@ export function PromptServiceApi() {
         content: string;
         user_instruct: string;
         allow_empty: true;
+        full_content?: string;
+        selection_start?: number;
+        selection_end?: number;
       },
       options?: RawAxiosRequestConfig,
     ) {
-      return axiosInstance.post<PromptPolishOpenAPIResponse>(
+      return axiosInstance.post<PromptPolishOpenAPIResponse & {
+        target_start?: number;
+        target_end?: number;
+      }>(
         `${coreApiBaseUrl}/prompts:polish`,
         payload,
         withJsonOptions(options),

--- a/i18n/errors/core.json
+++ b/i18n/errors/core.json
@@ -1450,5 +1450,7 @@
   "2002312": { "en-US": "Free-model auto-selection priority cannot be negative", "zh-CN": "免费模型自动选择优先级不能为负数" },
   "2002313": { "en-US": "Free-model endpoint scope requires a positive auto-selection priority", "zh-CN": "免费模型端点范围要求配置正数自动选择优先级" },
   "2002314": { "en-US": "Free-model endpoint scope cannot contain an empty URL", "zh-CN": "免费模型端点范围不能包含空 URL" },
-  "2002315": { "en-US": "Failed to encode free-model endpoint scope", "zh-CN": "编码免费模型端点范围失败" }
+  "2002315": { "en-US": "Failed to encode free-model endpoint scope", "zh-CN": "编码免费模型端点范围失败" },
+  "2002316": { "en-US": "The selected range no longer matches the editable content", "zh-CN": "所选范围与可编辑内容不一致" },
+  "2002317": { "en-US": "The AI returned invalid editable content", "zh-CN": "AI 返回的可编辑内容无效" }
 }

--- a/tests/algorithm/test_rewrite.py
+++ b/tests/algorithm/test_rewrite.py
@@ -41,6 +41,7 @@ def _load_rewrite_module():
         sys.modules['lazymind.model_config'] = fake_load_config
 
         from algorithm.lazymind.rewrite import base
+        from algorithm.lazymind.rewrite.polish import rewrite_editable_selection
 
         ns = ModuleType('test_rewrite_module')
         ns.BadRequestError = base.BadRequestError
@@ -50,6 +51,7 @@ def _load_rewrite_module():
         ns._format_inputs_block = base._format_inputs_block
         ns._validate_generated_content = base._validate_generated_content
         ns.rewrite_content = base.rewrite_content
+        ns.rewrite_editable_selection = rewrite_editable_selection
         return ns
     finally:
         for name, original in original_modules.items():
@@ -65,6 +67,7 @@ _PROMPT_BUILDERS = rewrite._PROMPT_BUILDERS
 _format_inputs_block = rewrite._format_inputs_block
 _validate_generated_content = rewrite._validate_generated_content
 rewrite_content = rewrite.rewrite_content
+rewrite_editable_selection = rewrite.rewrite_editable_selection
 
 
 def _load_rewrite_routes_module():
@@ -186,6 +189,46 @@ def test_polish_prompt_asks_model_to_rewrite_without_answering():
     assert '{"content": "<new complete text>"}' in prompt
 
 
+def test_editable_selection_authorizes_the_complete_containing_block(monkeypatch):
+    document = '结论：以为AI Agent为核心核心，向上支撑内容创作。'
+    selected = '核心'
+    selection_start = document.index(selected)
+    selection_end = selection_start + len(selected)
+
+    class FakeModel:
+        def __call__(self, _prompt):
+            return '{"content":"结论：以AI Agent为核心，向上支撑内容创作。"}'
+
+    monkeypatch.setitem(rewrite_editable_selection.__globals__, 'AutoModel', lambda **_kwargs: FakeModel())
+    result = rewrite_editable_selection(
+        document, selection_start, selection_end, '找出并修正语病',
+    )
+
+    assert result == {
+        'content': '结论：以AI Agent为核心，向上支撑内容创作。',
+        'target_start': 0,
+        'target_end': len(document),
+    }
+
+
+def test_editable_selection_prompt_includes_complete_containing_block(monkeypatch):
+    document = '上一段。\n\n问题段落：以为AI Agent为核心。\n\n下一段。'
+    selected = 'I Agent为'
+    start = document.index(selected)
+    captured = {}
+
+    class FakeModel:
+        def __call__(self, prompt):
+            captured['prompt'] = prompt
+            return '{"content":"问题段落：以AI Agent为核心。"}'
+
+    monkeypatch.setitem(rewrite_editable_selection.__globals__, 'AutoModel', lambda **_kwargs: FakeModel())
+    rewrite_editable_selection(document, start, start + len(selected), '按要求检查并修改')
+
+    assert '<containing_block>\n问题段落：以为AI Agent为核心。\n</containing_block>' in captured['prompt']
+    assert 'attention anchor, not a modification boundary' in captured['prompt']
+
+
 def test_rewrite_route_requires_user_instruct_and_llm_config(monkeypatch):
     rewrite_routes = _load_rewrite_routes_module()
     app = FastAPI()
@@ -215,6 +258,54 @@ def test_rewrite_route_requires_user_instruct_and_llm_config(monkeypatch):
 
     assert response.status_code == 200
     assert response.json() == {'content': 'new content'}
+
+
+def test_rewrite_route_forwards_complete_editable_context(monkeypatch):
+    rewrite_routes = _load_rewrite_routes_module()
+    app = FastAPI()
+    app.include_router(rewrite_routes.router)
+    client = TestClient(app)
+
+    def fake_selection_rewrite(full_content, start, end, instruction):
+        assert full_content == 'asdfghjkl123'
+        assert (start, end) == (4, 9)
+        assert instruction == 'make it clear'
+        return {
+            'content': 'ASDFGHJKL123',
+            'target_start': 0,
+            'target_end': 12,
+        }
+
+    monkeypatch.setattr(rewrite_routes, 'rewrite_editable_selection', fake_selection_rewrite)
+    response = client.post('/api/chat/rewrite', json={
+        'task_type': 'polish',
+        'content': 'ghjkl',
+        'user_instruct': 'make it clear',
+        'llm_config': {},
+        'full_content': 'asdfghjkl123',
+        'selection_start': 4,
+        'selection_end': 9,
+    })
+
+    assert response.status_code == 200
+    assert response.json()['target_start'] == 0
+
+
+def test_rewrite_route_rejects_mismatched_editable_offsets():
+    rewrite_routes = _load_rewrite_routes_module()
+    app = FastAPI()
+    app.include_router(rewrite_routes.router)
+    client = TestClient(app)
+    response = client.post('/api/chat/rewrite', json={
+        'task_type': 'polish',
+        'content': 'wrong',
+        'user_instruct': 'fix it',
+        'llm_config': {},
+        'full_content': 'asdfghjkl123',
+        'selection_start': 4,
+        'selection_end': 9,
+    })
+    assert response.status_code == 400
 
 
 def test_rewrite_route_rejects_missing_user_instruct_or_llm_config():


### PR DESCRIPTION
## Summary

Improve AI editing for completed Chat editable blocks by treating the user selection as an attention anchor while authorizing the model to revise the complete containing Markdown paragraph.

This prevents partial English words, numbers, identifiers, or other character-level selections from forcing an incoherent replacement at the exact selection boundary. The model can use the whole editable document as read-only context and make the smallest coherent change within the selected paragraph.

## Changes

- Send the complete editable Markdown, exact selected text, and Unicode code-point offsets through Core to Algorithm.
- Validate that the submitted offsets still identify the selected text before invoking the model.
- Add a dedicated editable-selection rewrite path without changing ordinary prompt polishing.
- Resolve the Markdown paragraph containing the quote and make that paragraph the only authorized modification range.
- Tell the model that the quote is an attention anchor rather than a modification boundary.
- Return the rewritten paragraph together with its exact target range.
- Apply and preview the paragraph replacement in Chat while preserving all other editable content.
- Reject missing, stale, ambiguous, or invalid selection ranges instead of replacing the first matching string.
- Handle frontend JavaScript offsets and backend Unicode code-point offsets safely, including Chinese and emoji content.

## Behavior

Before this change, selecting a partial token such as I Agent inside AI Agent could make the model return text that duplicated neighboring characters when the result was spliced back into the document.

After this change:

1. The exact browser selection identifies the area of interest.
2. The full editable document is available as context.
3. The containing Markdown paragraph is the bounded edit scope.
4. The model returns one complete replacement paragraph.
5. The user reviews the paragraph diff and can accept or reject it.

Conversation history is not included in this rewrite request.

## Validation

- make lint
- Algorithm rewrite tests: 15 passed
- Frontend TypeScript typecheck
- Frontend editable block tests: 6 passed
- Core chat and algo Go tests