### PR TITLE
Fix product workflow chapter publishing and document layout

### DIFF
--- a/tests/algorithm/chat/test_product_workflow_delivery_contract.py
+++ b/tests/algorithm/chat/test_product_workflow_delivery_contract.py
@@ -1,0 +1,193 @@
+import importlib.util
+import tempfile
+from pathlib import Path
+from unittest import mock
+
+import lazyllm
+import yaml
+
+from lazymind.chat.engine.subagent.context import SubAgentContext, set_context
+
+
+ROOT = Path(__file__).resolve().parents[3]
+WORKFLOW_ROOT = ROOT / 'workflows' / 'product_solution_delivery'
+
+
+def _load_writer_bridge():
+    path = WORKFLOW_ROOT / 'scripts' / 'writer_bridge.py'
+    spec = importlib.util.spec_from_file_location('product_writer_bridge_contract_test', path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_chapter_publisher_emits_stable_file_items():
+    bridge = _load_writer_bridge()
+    saved = []
+
+    def fake_save_artifact(**kwargs):
+        saved.append(kwargs)
+        return {'status': 'ok'}
+
+    with mock.patch.object(bridge, '_save_artifact', side_effect=fake_save_artifact):
+        result = bridge._publish_chapter_artifacts(
+            'review', ['/workspace/chapter-1.md', '/workspace/chapter-2.md'],
+        )
+
+    assert result == {
+        'slot': 'review_chapters',
+        'expected_count': 2,
+        'published_count': 2,
+        'complete': True,
+        'warnings': [],
+    }
+    assert [item['key'] for item in saved] == ['review_chapters', 'review_chapters']
+    assert [item['value'] for item in saved] == [
+        '/workspace/chapter-1.md', '/workspace/chapter-2.md',
+    ]
+    assert [item['content_type'] for item in saved] == ['file', 'file']
+    assert [item['publisher_list_index'] for item in saved] == [0, 1]
+    assert all(item['internal_publish'] for item in saved)
+
+
+def test_chapter_publisher_matches_real_subagent_artifact_contract():
+    bridge = _load_writer_bridge()
+    events = []
+
+    class FakeDB:
+        @staticmethod
+        def next_artifact_seq(_task_id, _key):
+            return 1
+
+    previous = lazyllm.globals.get('subagent_ctx')
+    with tempfile.TemporaryDirectory() as directory:
+        workspace = Path(directory)
+        chapters = []
+        for index in range(2):
+            chapter = workspace / f'chapter-{index + 1}.md'
+            chapter.write_text(f'# chapter {index + 1}\n', encoding='utf-8')
+            chapters.append(str(chapter))
+        context = SubAgentContext(
+            task_id='task-product-chapters',
+            conversation_id='conversation-product',
+            agent_type='workflow_step',
+            objective='publish chapters',
+            params={'output_slot_types': {'review_chapters': 'file'}},
+            workspace_path=str(workspace),
+            input_slots=[],
+            output_slots=['review_chapters'],
+            db=FakeDB(),
+            emit=events.append,
+        )
+        set_context(context)
+        try:
+            result = bridge._publish_chapter_artifacts('review', chapters)
+        finally:
+            if previous is None:
+                lazyllm.globals.pop('subagent_ctx', None)
+            else:
+                lazyllm.globals['subagent_ctx'] = previous
+
+    assert result['complete'] is True
+    assert [event['content_type'] for event in events] == ['file', 'file']
+    assert [event['seq'] for event in events] == [1, 2]
+    assert [event['value']['list_index'] for event in events] == [0, 1]
+    assert all('path' in event['value'] for event in events)
+
+
+def test_chapter_publish_failure_is_reported_but_does_not_abort_remaining_items():
+    bridge = _load_writer_bridge()
+    calls = []
+
+    def fake_save_artifact(**kwargs):
+        calls.append(kwargs['publisher_list_index'])
+        if kwargs['publisher_list_index'] == 0:
+            raise RuntimeError('temporary artifact sink failure')
+        return {'status': 'ok'}
+
+    with mock.patch.object(bridge, '_save_artifact', side_effect=fake_save_artifact):
+        result = bridge._publish_chapter_artifacts(
+            'prd', ['/workspace/chapter-1.md', '/workspace/chapter-2.md'],
+        )
+
+    assert calls == [0, 1]
+    assert result['published_count'] == 1
+    assert result['complete'] is False
+    assert result['warnings'] == [
+        'prd_chapters[1] publish failed: temporary artifact sink failure',
+    ]
+
+
+def test_document_bridge_keeps_required_paths_and_hides_raw_chapter_list():
+    bridge = _load_writer_bridge()
+    chapters = ['/workspace/chapter-1.md', '/workspace/chapter-2.md']
+    publish_result = {
+        'slot': 'design_chapters',
+        'expected_count': 2,
+        'published_count': 1,
+        'complete': False,
+        'warnings': ['one optional chapter was not published'],
+    }
+
+    with (
+        mock.patch.object(bridge, '_runtime_stage', return_value='design'),
+        mock.patch.object(bridge, '_stage_contract'),
+        mock.patch.object(bridge, '_required_bound_file', side_effect=[
+            '/workspace/task.json', '/workspace/outline.md', '/workspace/context.json',
+        ]),
+        mock.patch.object(bridge, 'product_writer_plan_sections', return_value={
+            'section_instructions': '/workspace/plan.json',
+            'warnings': ['planning warning'],
+        }),
+        mock.patch.object(bridge, 'product_writer_write_sections', return_value=chapters),
+        mock.patch.object(
+            bridge, 'product_writer_assemble_draft', return_value='/workspace/document.md',
+        ),
+        mock.patch.object(
+            bridge, 'product_writer_update_context', return_value='/workspace/final-context.json',
+        ),
+        mock.patch.object(
+            bridge, '_publish_chapter_artifacts', return_value=publish_result,
+        ),
+    ):
+        result = bridge.product_writer_generate_document_from_inputs('design')
+
+    assert result['section_plan'] == '/workspace/plan.json'
+    assert result['document'] == '/workspace/document.md'
+    assert result['writing_context'] == '/workspace/final-context.json'
+    assert result['chapter_count'] == 2
+    assert result['chapter_publish'] == publish_result
+    assert result['warnings'] == [
+        'planning warning', 'one optional chapter was not published',
+    ]
+    assert 'chapter_files' not in result
+
+
+def test_product_document_tabs_use_non_composite_collapsed_chapter_lists():
+    workflow = yaml.safe_load(
+        (WORKFLOW_ROOT / 'workflow.yaml').read_text(encoding='utf-8'),
+    )
+    state = yaml.safe_load(
+        (WORKFLOW_ROOT / 'scenario' / 'state.yml').read_text(encoding='utf-8'),
+    )
+    tabs = {tab['id']: tab for tab in workflow['ui']['tabs']}
+
+    for stage in ('direction', 'design', 'prd', 'review', 'handoff'):
+        chapter_slot = f'{stage}_chapters'
+        document_tab = tabs[f'{stage}_document']
+        assert document_tab['layout'] == 'list'
+        assert 'composite_layout' not in document_tab
+        assert [slot['id'] for slot in document_tab['slots']] == [
+            f'{stage}_document', chapter_slot,
+        ]
+        assert workflow['ui']['slots'][chapter_slot]['collapsed'] is True
+
+        prompt = ' '.join(
+            state['steps'][f'write_{stage}_document']['prompt'].split()
+        )
+        assert f'directly to {chapter_slot}' in prompt
+        assert 'do not save that slot again' in prompt
+        assert 'Chapter publish warnings are non-blocking' in prompt
+        assert 'do not retry generation or call another tool for them' in prompt
+        assert 'chapter_files' not in prompt

--- a/tests/algorithm/chat/test_product_workflow_delivery_contract.py
+++ b/tests/algorithm/chat/test_product_workflow_delivery_contract.py
@@ -62,7 +62,7 @@ def test_chapter_publisher_matches_real_subagent_artifact_contract():
 
     previous = lazyllm.globals.get('subagent_ctx')
     with tempfile.TemporaryDirectory() as directory:
-        workspace = Path(directory)
+        workspace = Path(directory).resolve()
         chapters = []
         for index in range(2):
             chapter = workspace / f'chapter-{index + 1}.md'

--- a/workflows/product_solution_delivery/scenario/state.yml
+++ b/workflows/product_solution_delivery/scenario/state.yml
@@ -124,10 +124,11 @@ steps:
       Use the latest approved direction_outline as the only structure. On first generation call
       product_writer_generate_document_from_inputs(stage_id="direction"). The business bridge reads
       immutable bound inputs, plans sections, streams/resumes Writer checkpoints, assembles the
-      draft and refreshes context. Do not call generic file/Artifact lookup tools or reconstruct
-      intermediate paths. Save its section_plan, chapter_files, document and writing_context paths
-      respectively as direction_section_plan, direction_chapters, direction_document and
-      direction_context_final. On rerun use targeted revision only with
+      draft and refreshes context. It publishes each optional chapter directly to direction_chapters;
+      do not save that slot again. Do not call generic file/Artifact lookup tools or reconstruct
+      intermediate paths. Save its section_plan, document and writing_context paths respectively as
+      direction_section_plan, direction_document and direction_context_final. Chapter publish
+      warnings are non-blocking; do not retry generation or call another tool for them. On rerun use targeted revision only with
       document_slot="direction_document". Stop for user editing and Continue approval.
     tools: [product_writer_generate_document_from_inputs, product_writer_revise_markdown]
     inputs:
@@ -215,9 +216,11 @@ steps:
       {{runtime_instruction}}
 
       Use the latest approved design_outline as the only structure. On first generation call
-      product_writer_generate_document_from_inputs(stage_id="design"). Save its section_plan,
-      chapter_files, document and writing_context paths respectively as design_section_plan,
-      design_chapters, design_document and design_context_final. The bridge owns file binding,
+      product_writer_generate_document_from_inputs(stage_id="design"). It publishes each optional
+      chapter directly to design_chapters; do not save that slot again. Save its section_plan,
+      document and writing_context paths respectively as design_section_plan, design_document and
+      design_context_final. Chapter publish warnings are non-blocking; do not retry generation or
+      call another tool for them. The bridge owns file binding,
       section planning, checkpoint streaming, assembly and context refresh; do not call generic
       file/Artifact tools or reconstruct intermediate paths. On rerun use targeted revision only
       with document_slot="design_document". Stop for user editing and Continue approval.
@@ -272,9 +275,11 @@ steps:
       {{runtime_instruction}}
 
       Use the latest approved prd_outline as the only structure. On first generation call
-      product_writer_generate_document_from_inputs(stage_id="prd"). Save its section_plan,
-      chapter_files, document and writing_context paths respectively as prd_section_plan,
-      prd_chapters, prd_document and prd_context_final. The bridge owns file binding, section
+      product_writer_generate_document_from_inputs(stage_id="prd"). It publishes each optional
+      chapter directly to prd_chapters; do not save that slot again. Save its section_plan, document
+      and writing_context paths respectively as prd_section_plan, prd_document and prd_context_final.
+      Chapter publish warnings are non-blocking; do not retry generation or call another tool for
+      them. The bridge owns file binding, section
       planning, checkpoint streaming, assembly and context refresh; do not call generic
       file/Artifact tools. Do not turn unknown product rules into facts. On rerun use targeted
       revision only with document_slot="prd_document". Stop for user editing and Continue approval.
@@ -362,9 +367,11 @@ steps:
       {{runtime_instruction}}
 
       Use the latest approved review_outline as the only structure. On first generation call
-      product_writer_generate_document_from_inputs(stage_id="review"). Save its section_plan,
-      chapter_files, document and writing_context paths respectively as review_section_plan,
-      review_chapters, review_document and review_context_final. The bridge owns file binding,
+      product_writer_generate_document_from_inputs(stage_id="review"). It publishes each optional
+      chapter directly to review_chapters; do not save that slot again. Save its section_plan,
+      document and writing_context paths respectively as review_section_plan, review_document and
+      review_context_final. Chapter publish warnings are non-blocking; do not retry generation or
+      call another tool for them. The bridge owns file binding,
       section planning, checkpoint streaming, assembly and context refresh; do not call generic
       file/Artifact tools. Preserve severity, evidence, affected layer and recommended action, and
       never silently modify reviewed upstream artifacts. On rerun use targeted revision only with
@@ -424,9 +431,11 @@ steps:
       {{runtime_instruction}}
 
       Use the latest approved handoff_outline as the only structure. On first generation call
-      product_writer_generate_document_from_inputs(stage_id="handoff"). Save its section_plan,
-      chapter_files, document and writing_context paths respectively as handoff_section_plan,
-      handoff_chapters, handoff_document and handoff_context_final. The bridge owns file binding,
+      product_writer_generate_document_from_inputs(stage_id="handoff"). It publishes each optional
+      chapter directly to handoff_chapters; do not save that slot again. Save its section_plan,
+      document and writing_context paths respectively as handoff_section_plan, handoff_document and
+      handoff_context_final. Chapter publish warnings are non-blocking; do not retry generation or
+      call another tool for them. The bridge owns file binding,
       section planning, checkpoint streaming, assembly and context refresh; do not call generic
       file/Artifact tools. On rerun use targeted revision only with
       document_slot="handoff_document". Readiness

--- a/workflows/product_solution_delivery/scripts/writer_bridge.py
+++ b/workflows/product_solution_delivery/scripts/writer_bridge.py
@@ -13,6 +13,7 @@ from lazyllm import AutoModel
 from lazyllm.tools.writer.data_models import StringReplaceSet
 from lazyllm.tools.writer.tools import WriterRevisionTools
 from lazymind.chat.engine.subagent.context import require_context
+from lazymind.chat.engine.subagent.tools import _save_artifact
 from lazymind.chat.engine.tools.writer import (
     DraftMarkdownStreamEventEmitter,
     WriterCreateToolkit,
@@ -816,12 +817,47 @@ def product_writer_generate_document_from_inputs(stage_id: str) -> dict[str, Any
     chapters = product_writer_write_sections(task_path, section_plan, context_path)
     document = product_writer_assemble_draft(chapters[0], context_path, outline_path)
     final_context = product_writer_update_context(document, context_path)
+    chapter_publish = _publish_chapter_artifacts(stage, chapters)
     return {
         'section_plan': section_plan,
-        'chapter_files': chapters,
+        'chapter_count': len(chapters),
+        'chapter_publish': chapter_publish,
         'document': document,
         'writing_context': final_context,
-        'warnings': list(plan.get('warnings') or []),
+        'warnings': [
+            *list(plan.get('warnings') or []),
+            *list(chapter_publish.get('warnings') or []),
+        ],
+    }
+
+
+def _publish_chapter_artifacts(stage: str, chapters: list[str]) -> dict[str, Any]:
+    """Publish optional chapter files as deterministic items without blocking the draft."""
+    slot = f'{stage}_chapters'
+    published = 0
+    warnings: list[str] = []
+    for list_index, chapter in enumerate(chapters):
+        try:
+            _save_artifact(
+                key=slot,
+                value=chapter,
+                content_type='file',
+                source_tool='product_writer_generate_document_from_inputs',
+                caption=f'{ARTIFACT_TITLES[stage]} · 第 {list_index + 1} 章',
+                internal_publish=True,
+                publisher_list_index=list_index,
+            )
+            published += 1
+        except Exception as exc:
+            warnings.append(
+                f'{slot}[{list_index + 1}] publish failed: {str(exc)[:300]}'
+            )
+    return {
+        'slot': slot,
+        'expected_count': len(chapters),
+        'published_count': published,
+        'complete': published == len(chapters),
+        'warnings': warnings,
     }
 
 

--- a/workflows/product_solution_delivery/workflow.yaml
+++ b/workflows/product_solution_delivery/workflow.yaml
@@ -183,25 +183,25 @@ ui:
     material_digest: {widgetType: text-markdown, readOnly: true, maxHeight: 680}
     direction_outline: {widgetType: file-card, readOnly: false}
     direction_outline_report: {widgetType: text-markdown, readOnly: true}
-    direction_chapters: {widgetType: file-card, readOnly: true}
+    direction_chapters: {widgetType: file-card, readOnly: true, collapsed: true}
     direction_document: {widgetType: file-card, readOnly: false}
     competitive_analysis: {widgetType: html-preview, readOnly: true}
     design_outline: {widgetType: file-card, readOnly: false}
     design_outline_report: {widgetType: text-markdown, readOnly: true}
-    design_chapters: {widgetType: file-card, readOnly: true}
+    design_chapters: {widgetType: file-card, readOnly: true, collapsed: true}
     design_document: {widgetType: file-card, readOnly: false}
     prd_outline: {widgetType: file-card, readOnly: false}
     prd_outline_report: {widgetType: text-markdown, readOnly: true}
-    prd_chapters: {widgetType: file-card, readOnly: true}
+    prd_chapters: {widgetType: file-card, readOnly: true, collapsed: true}
     prd_document: {widgetType: file-card, readOnly: false}
     prototype: {widgetType: html-preview, readOnly: true}
     review_outline: {widgetType: file-card, readOnly: false}
     review_outline_report: {widgetType: text-markdown, readOnly: true}
-    review_chapters: {widgetType: file-card, readOnly: true}
+    review_chapters: {widgetType: file-card, readOnly: true, collapsed: true}
     review_document: {widgetType: file-card, readOnly: false}
     handoff_outline: {widgetType: file-card, readOnly: false}
     handoff_outline_report: {widgetType: text-markdown, readOnly: true}
-    handoff_chapters: {widgetType: file-card, readOnly: true}
+    handoff_chapters: {widgetType: file-card, readOnly: true, collapsed: true}
     handoff_document: {widgetType: file-card, readOnly: false}
     delivery_summary: {widgetType: text-markdown, readOnly: true}
   tabs:
@@ -226,7 +226,7 @@ ui:
       layout: composite
       slots: [{id: direction_outline}, {id: direction_outline_report}]
       composite_layout: {direction: row, children: [{slot: direction_outline, weight: 2}, {slot: direction_outline_report, weight: 1}]}
-    - {id: direction_document, step_id: write_direction_document, label: 产品方向, hide_when_material: skip_direction, layout: composite, slots: [{id: direction_document}, {id: direction_chapters}], composite_layout: {direction: column, children: [{slot: direction_document, weight: 3}, {slot: direction_chapters, weight: 1}]}}
+    - {id: direction_document, step_id: write_direction_document, label: 产品方向, hide_when_material: skip_direction, layout: list, slots: [{id: direction_document}, {id: direction_chapters}]}
     - {id: competitive, step_id: analyze_competitive_position, label: 竞品生态位, hide_when_material: skip_competitive, layout: list, slots: [{id: competitive_analysis}]}
     - id: design_outline
       step_id: build_design_outline
@@ -235,7 +235,7 @@ ui:
       layout: composite
       slots: [{id: design_outline}, {id: design_outline_report}]
       composite_layout: {direction: row, children: [{slot: design_outline, weight: 2}, {slot: design_outline_report, weight: 1}]}
-    - {id: design_document, step_id: write_design_document, label: 产品方案, hide_when_material: skip_design, layout: composite, slots: [{id: design_document}, {id: design_chapters}], composite_layout: {direction: column, children: [{slot: design_document, weight: 3}, {slot: design_chapters, weight: 1}]}}
+    - {id: design_document, step_id: write_design_document, label: 产品方案, hide_when_material: skip_design, layout: list, slots: [{id: design_document}, {id: design_chapters}]}
     - id: prd_outline
       step_id: build_prd_outline
       label: PRD 大纲
@@ -243,7 +243,7 @@ ui:
       layout: composite
       slots: [{id: prd_outline}, {id: prd_outline_report}]
       composite_layout: {direction: row, children: [{slot: prd_outline, weight: 2}, {slot: prd_outline_report, weight: 1}]}
-    - {id: prd_document, step_id: write_prd_document, label: PRD, hide_when_material: skip_prd, layout: composite, slots: [{id: prd_document}, {id: prd_chapters}], composite_layout: {direction: column, children: [{slot: prd_document, weight: 3}, {slot: prd_chapters, weight: 1}]}}
+    - {id: prd_document, step_id: write_prd_document, label: PRD, hide_when_material: skip_prd, layout: list, slots: [{id: prd_document}, {id: prd_chapters}]}
     - {id: prototype, step_id: build_interactive_prototype, label: 交互原型, hide_when_material: skip_prototype, layout: list, slots: [{id: prototype}]}
     - id: review_outline
       step_id: build_review_outline
@@ -252,7 +252,7 @@ ui:
       layout: composite
       slots: [{id: review_outline}, {id: review_outline_report}]
       composite_layout: {direction: row, children: [{slot: review_outline, weight: 2}, {slot: review_outline_report, weight: 1}]}
-    - {id: review_document, step_id: write_review_document, label: 方案评审, hide_when_material: skip_review, layout: composite, slots: [{id: review_document}, {id: review_chapters}], composite_layout: {direction: column, children: [{slot: review_document, weight: 3}, {slot: review_chapters, weight: 1}]}}
+    - {id: review_document, step_id: write_review_document, label: 方案评审, hide_when_material: skip_review, layout: list, slots: [{id: review_document}, {id: review_chapters}]}
     - id: handoff_outline
       step_id: build_handoff_outline
       label: 交付大纲
@@ -260,7 +260,7 @@ ui:
       layout: composite
       slots: [{id: handoff_outline}, {id: handoff_outline_report}]
       composite_layout: {direction: row, children: [{slot: handoff_outline, weight: 2}, {slot: handoff_outline_report, weight: 1}]}
-    - {id: handoff_document, step_id: write_handoff_document, label: 研发交付, hide_when_material: skip_handoff, layout: composite, slots: [{id: handoff_document}, {id: handoff_chapters}], composite_layout: {direction: column, children: [{slot: handoff_document, weight: 3}, {slot: handoff_chapters, weight: 1}]}}
+    - {id: handoff_document, step_id: write_handoff_document, label: 研发交付, hide_when_material: skip_handoff, layout: list, slots: [{id: handoff_document}, {id: handoff_chapters}]}
     - {id: delivery, step_id: finalize_product_delivery, label: 交付总结, layout: list, slots: [{id: delivery_summary}]}
 
 i18n:


### PR DESCRIPTION
## Summary

- Publish chapters as deterministic file artifacts with stable list indexes.
- Keep chapter publishing failures non-blocking and prevent redundant retries.
- Replace composite document layouts with collapsed list views.
- Add contract tests for publishing, fallback behavior, and UI configuration.

## Testing

<img width="1912" height="914" alt="04afc57a-77b2-49f4-9b90-429cc2a2b058" src="https://github.com/user-attachments/assets/0fa0b8ca-3295-4a10-ad82-cd626b6a89ea" />
