### PR TITLE
fix(desktop): avoid hidden renderer startup timeout

### DIFF
--- a/desktop/electron/src/main.js
+++ b/desktop/electron/src/main.js
@@ -1669,6 +1669,7 @@ function browserWindowOptions(show = true) {
       contextIsolation: true,
       nodeIntegration: false,
       sandbox: false,
+      backgroundThrottling: false,
     },
   };
 }

--- a/desktop/scripts/desktop-build.test.mjs
+++ b/desktop/scripts/desktop-build.test.mjs
@@ -619,6 +619,11 @@ test("Desktop renderer keeps Node disabled behind an isolated preload bridge", (
   assert.match(source, /contextIsolation:\s*true/);
   assert.match(source, /nodeIntegration:\s*false/);
   assert.match(source, /preload:\s*path\.join\(__dirname, "preload\.js"\)/);
+  assert.match(
+    source,
+    /backgroundThrottling:\s*false/,
+    "hidden Chat windows must keep running until they report renderer readiness",
+  );
 });
 
 test("Desktop clears stale frontend caches before opening a renderer", () => {

--- a/frontend/src/modules/chat/pages/home/index.test.tsx
+++ b/frontend/src/modules/chat/pages/home/index.test.tsx
@@ -1,0 +1,38 @@
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import Home from "./index";
+
+vi.mock("../newChat", () => ({
+  default: () => <div>New chat</div>,
+}));
+
+describe("Home", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    Object.defineProperty(window, "lazymindDesktop", {
+      configurable: true,
+      value: undefined,
+    });
+  });
+
+  it("notifies the desktop as soon as the Chat home mounts", () => {
+    const notifyAppReady = vi.fn();
+    const requestAnimationFrame = vi.spyOn(window, "requestAnimationFrame");
+    Object.defineProperty(window, "lazymindDesktop", {
+      configurable: true,
+      value: { notifyAppReady },
+    });
+
+    render(<Home />);
+
+    expect(screen.getByText("New chat")).toBeInTheDocument();
+    expect(notifyAppReady).toHaveBeenCalledOnce();
+    expect(requestAnimationFrame).not.toHaveBeenCalled();
+  });
+
+  it("still renders outside the desktop shell", () => {
+    expect(() => render(<Home />)).not.toThrow();
+    expect(screen.getByText("New chat")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/modules/chat/pages/home/index.tsx
+++ b/frontend/src/modules/chat/pages/home/index.tsx
@@ -4,18 +4,7 @@ import "./index.scss";
 
 function Home() {
   useEffect(() => {
-    let secondFrame: number | undefined;
-    const firstFrame = window.requestAnimationFrame(() => {
-      secondFrame = window.requestAnimationFrame(() => {
-        window.lazymindDesktop?.notifyAppReady?.();
-      });
-    });
-    return () => {
-      window.cancelAnimationFrame(firstFrame);
-      if (secondFrame !== undefined) {
-        window.cancelAnimationFrame(secondFrame);
-      }
-    };
+    window.lazymindDesktop?.notifyAppReady?.();
   }, []);
 
   return (


### PR DESCRIPTION
# 即使正常启动所有服务 依旧显示启动失败

<img width="1788" height="1020" alt="img_v3_02152_a5dbe809-e794-481a-86f4-2c3e25739d7g" src="https://github.com/user-attachments/assets/36b7615e-a4d6-4da9-b762-e08ed754dd18" />

# 修复


渲染问题修复
根因是一个循环等待：
主窗口隐藏
  → 隐藏窗口中的 requestAnimationFrame 不执行/被节流
  → 前端无法发送 renderer-ready
  → 主进程收不到 ready，所以不显示窗口
  → 120 秒后超时
当前主窗口以 show: false 创建，而聊天首页要经过连续两次 requestAnimationFrame 才调用：
window.lazymindDesktop?.notifyAppReady?.()
最小修复
在 [main.js](/mnt/c/Users/cuishaoting/AppData/Local/Programs/LazyMind/resources/runtime/app/desktop/electron/src/main.js) 的 webPreferences 中加入：
webPreferences: {
  preload: path.join(__dirname, "preload.js"),
  contextIsolation: true,
  nodeIntegration: false,
  sandbox: false,
  backgroundThrottling: false,
},
这样隐藏窗口中的定时器和 requestAnimationFrame 不会被 Chromium 暂停。
更可靠的修复
前端聊天首页组件不应依赖两次动画帧发送就绪信号。React 的 useEffect 本身已经代表组件完成挂载，可以直接发送：
useEffect(() => {
  window.lazymindDesktop?.notifyAppReady?.()
}, [])
将当前类似下面的代码删除：
useEffect(() => {
  let secondFrame

  const firstFrame = window.requestAnimationFrame(() => {
    secondFrame = window.requestAnimationFrame(() => {
      window.lazymindDesktop?.notifyAppReady?.()
    })
  })

  return () => {
    window.cancelAnimationFrame(firstFrame)
    if (secondFrame !== undefined) {
      window.cancelAnimationFrame(secondFrame)
    }
  }
}, [])
推荐两项一起修改：
Electron 设置 backgroundThrottling: false
前端挂载后直接发送 notifyAppReady()
此外建议给主窗口增加诊断日志：
nextMainWindow.webContents.on("did-fail-load", (_event, code, description, url) => {
  appendStartupLog(
    "error",
    `frontend load failed: code=${code}, description=${description}, url=${url}`,
  )
})

nextMainWindow.webContents.on("render-process-gone", (_event, details) => {
  appendStartupLog("error", `renderer process gone: ${JSON.stringify(details)}`)
})

nextMainWindow.webContents.on("console-message", (_event, level, message) => {
  appendStartupLog("renderer", `[${level}] ${message}`)
})
这样即使将来再失败，日志也能区分页面脚本异常、资源加载失败和渲染进程崩溃。当前最关键的修复是去掉 renderer-ready 对隐藏窗口双重 requestAnimationFrame 的依赖。