### PR TITLE
fix(ppt): allow outline generation without material images

### DIFF
--- a/backend/core/config/model_catalog.yaml
+++ b/backend/core/config/model_catalog.yaml
@@ -1212,6 +1212,7 @@ model_providers:
         - name: deepseek-ai/DeepSeek-V4-Flash
           type: llm
           max_input_tokens: "1M"
+          free_auto_select_priority: 1
         - name: THUDM/GLM-Z1-9B-0414
           type: llm
         - name: Pro/moonshotai/Kimi-K2.6
@@ -1281,7 +1282,6 @@ model_providers:
         - name: deepseek-ai/DeepSeek-V3
           type: llm
           max_input_tokens: "128K"
-          free_auto_select_priority: 1
         - name: Pro/deepseek-ai/DeepSeek-V3
           type: llm
           max_input_tokens: "128K"

--- a/backend/core/modelprovider/auto_selection_test.go
+++ b/backend/core/modelprovider/auto_selection_test.go
@@ -79,8 +79,8 @@ func TestAutoSelectUnconfiguredProviderModelsPrefersVerifiedFreeModels(t *testin
 	}
 
 	models := []orm.UserModelProviderGroupModel{
-		{ID: "paid-llm", Name: "deepseek-ai/DeepSeek-V4-Flash", ModelType: "llm"},
-		{ID: "free-llm", Name: "deepseek-ai/DeepSeek-V3", ModelType: "llm", FreeAutoSelectPriority: 1},
+		{ID: "free-llm", Name: "deepseek-ai/DeepSeek-V4-Flash", ModelType: "llm", FreeAutoSelectPriority: 1},
+		{ID: "paid-llm", Name: "deepseek-ai/DeepSeek-V3", ModelType: "llm"},
 		{ID: "paid-vlm", Name: "Pro/moonshotai/Kimi-K2.6", ModelType: "vlm"},
 		{ID: "free-vlm", Name: "Qwen/Qwen3.5-4B", ModelType: "vlm", FreeAutoSelectPriority: 1},
 		{ID: "paid-embed", Name: "Qwen/Qwen3-Embedding-8B", ModelType: "embed"},
@@ -95,7 +95,7 @@ func TestAutoSelectUnconfiguredProviderModelsPrefersVerifiedFreeModels(t *testin
 		t.Fatalf("auto select: %v", err)
 	}
 	wantConfigured := []autoSelectedModel{
-		{ModelKey: "llm", Name: "deepseek-ai/DeepSeek-V3"},
+		{ModelKey: "llm", Name: "deepseek-ai/DeepSeek-V4-Flash"},
 		{ModelKey: "vlm", Name: "Qwen/Qwen3.5-4B"},
 		{ModelKey: "embed_main", Name: "BAAI/bge-m3"},
 		{ModelKey: "image_generator", Name: "Kwai-Kolors/Kolors"},

--- a/backend/core/modelprovider/list_test.go
+++ b/backend/core/modelprovider/list_test.go
@@ -113,7 +113,7 @@ func TestListUserProvidersReturnsCatalogDescriptionForRequestedLanguage(t *testi
 		t.Fatalf("expected 19 catalog providers, got %d", providerCount)
 	}
 	var freeModel orm.DefaultModel
-	if err := db.Where("provider_name = ? AND name = ?", "SiliconFlow", "deepseek-ai/DeepSeek-V3").
+	if err := db.Where("provider_name = ? AND name = ?", "SiliconFlow", "deepseek-ai/DeepSeek-V4-Flash").
 		Take(&freeModel).Error; err != nil {
 		t.Fatalf("load catalog free model: %v", err)
 	}

--- a/workflows/ppt-workflow/runtime/scripts/tests/test_run_stage_fast_prompt.py
+++ b/workflows/ppt-workflow/runtime/scripts/tests/test_run_stage_fast_prompt.py
@@ -80,6 +80,17 @@ class StyleRenderingRecipeTest(unittest.TestCase):
 
 
 class OutlineReferenceImageRepairTest(unittest.TestCase):
+    def test_empty_image_pool_clears_hallucinated_binding_without_failing(self) -> None:
+        pages = [
+            {"page_no": 1, "use_image": {"reference_image_index": 0}},
+            {"page_no": 2, "use_image": None},
+        ]
+
+        repaired = run_stage._ensure_outline_reference_images(pages, [])
+
+        self.assertEqual(repaired, 1)
+        self.assertEqual([page["use_image"] for page in pages], [None, None])
+
     def test_repairs_prose_only_material_reference_and_fills_other_pages(self) -> None:
         pages = [
             {"page_no": 1, "visual_hints": "封面", "use_image": None},

--- a/workflows/ppt-workflow/scripts/tests/test_partial_edit.py
+++ b/workflows/ppt-workflow/scripts/tests/test_partial_edit.py
@@ -166,7 +166,7 @@ class PartialEditTests(unittest.TestCase):
             'sys.modules',
             {'lazyllm': lazyllm_module, 'lazyllm.components': components_module},
         ), mock.patch.dict(
-            TOOLS.os.environ, {'LAZYMIND_PPT_LLM_TIMEOUT': '300'}, clear=False,
+            TOOLS.os.environ, {'LAZYMIND_PPT_LLM_TIMEOUT': '90'}, clear=False,
         ):
             self.assertEqual(TOOLS._agent_llm_call('system', 'user'), 'generated')
             self.assertEqual(
@@ -176,12 +176,16 @@ class PartialEditTests(unittest.TestCase):
 
         self.assertEqual(
             shared.call_args_list[0],
-            mock.call('user', timeout=300.0, max_retries=1),
+            mock.call('user', timeout=90.0, max_retries=1),
         )
         self.assertEqual(
             shared.call_args_list[1],
             mock.call('user', timeout=75.0, max_retries=1),
         )
+        self.assertEqual(model.share.call_count, 2)
+        self.assertTrue(all(
+            call.kwargs['stream'] is True for call in model.share.call_args_list
+        ))
 
     def test_add_item_below_clones_structure_and_assigns_fresh_ids(self):
         selection = {
@@ -750,6 +754,43 @@ class PartialEditTests(unittest.TestCase):
             self.assertEqual(result['retry_count'], 1)
             self.assertEqual(result['retries'][0]['page'], 1)
             self.assertTrue(result['retries'][0]['ok'])
+
+    def test_batch_page_html_does_not_retry_timed_out_page(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            deck, _page = make_deck(Path(tmp))
+            attempts = 0
+
+            def capture(*_args, **_kwargs):
+                nonlocal attempts
+                attempts += 1
+                raise TOOLS._PPTModelTimeoutError(
+                    'LLM timed out after 90s without receiving progress [page-html:1]'
+                )
+
+            fake_model_client = mock.Mock()
+            fake_runtime = mock.Mock()
+            fake_runtime._capture_cmd.side_effect = capture
+            fake_runtime.cmd_page_html = mock.Mock()
+            with mock.patch.object(
+                TOOLS, '_load_sn_ppt_modules',
+                return_value=(fake_model_client, fake_runtime),
+            ), mock.patch.object(
+                TOOLS, '_load_slide_outline_briefs', return_value={},
+            ), mock.patch.object(
+                TOOLS, '_ui_slot_order_list', return_value=[],
+            ), mock.patch.object(
+                TOOLS.time, 'sleep', return_value=None,
+            ), mock.patch.dict(
+                TOOLS.os.environ, {'LAZYMIND_PPT_PAGE_RETRIES': '1'}, clear=False,
+            ):
+                result = TOOLS._batch_page_html_publish_progressive(
+                    deck, concurrency=1,
+                )
+
+            self.assertEqual(attempts, 1)
+            self.assertEqual(result['status'], 'failed')
+            self.assertEqual(result['retry_count'], 0)
+            self.assertIn('timed out after 90s', result['failed_detail'][0]['error'])
 
 
 if __name__ == '__main__':

--- a/workflows/ppt-workflow/scripts/tests/test_partial_edit.py
+++ b/workflows/ppt-workflow/scripts/tests/test_partial_edit.py
@@ -96,6 +96,61 @@ class DeckInitializationTests(unittest.TestCase):
             )
             self.assertEqual(task_pack['params']['page_count'], 25)
 
+    def test_attach_material_images_is_successful_noop_for_empty_pool(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            deck = Path(tmp)
+            with (
+                mock.patch.object(TOOLS, '_resolve_deck_dir', return_value=deck),
+                mock.patch.object(
+                    TOOLS,
+                    '_attach_material_images_to_deck',
+                    return_value={
+                        'attached': 0,
+                        'reference_images': [],
+                        'captions': {},
+                    },
+                ),
+            ):
+                result = TOOLS.ppt_attach_material_images(str(deck))
+
+        self.assertEqual(result['attached'], 0)
+        self.assertEqual(result['reference_image_count'], 0)
+        self.assertIn('continuing', result['note'])
+
+    def test_build_outline_continues_when_no_material_images_exist(self):
+        stages: list[str] = []
+
+        def run_stage(_deck_dir, *, stage):
+            stages.append(stage)
+            return {'status': 'ok', 'pages': 4}
+
+        with mock.patch.object(TOOLS, 'ppt_init_deck', return_value={
+            'deck_dir': '/tmp/deck-without-images',
+            'deck_id': 'deck-without-images',
+            'page_count': 4,
+            'ppt_mode': 'fast',
+            'material_images_attached': 0,
+        }), mock.patch.object(TOOLS, 'ppt_attach_material_images', return_value={
+            'deck_dir': '/tmp/deck-without-images',
+            'attached': 0,
+            'reference_image_count': 0,
+            'reference_images': [],
+        }) as attach, mock.patch.object(
+            TOOLS, 'ppt_run_stage', side_effect=run_stage,
+        ), mock.patch.object(TOOLS, 'ppt_publish_outline', return_value={
+            'published_count': 4,
+            'published': [1, 2, 3, 4],
+        }):
+            result = TOOLS.ppt_build_outline(
+                user_query='生成四页无图汇报',
+                page_count=4,
+            )
+
+        attach.assert_not_called()
+        self.assertEqual(stages, ['preflight', 'style', 'outline'])
+        self.assertEqual(result['material_images_attached'], 0)
+        self.assertEqual(result['published_count'], 4)
+
 
 class PartialEditTests(unittest.TestCase):
     def test_agent_llm_call_propagates_default_and_explicit_timeout(self):

--- a/workflows/ppt-workflow/scripts/tools.py
+++ b/workflows/ppt-workflow/scripts/tools.py
@@ -93,6 +93,41 @@ _model_client_mod: Any = None
 _LOG = logging.getLogger(__name__)
 
 
+class _PPTModelTimeoutError(RuntimeError):
+    """A page model call made no progress before its inactivity timeout."""
+
+
+def _is_model_timeout_exception(exc: BaseException) -> bool:
+    """Recognize provider timeout wrappers without coupling to LazyLLM internals."""
+    seen: set[int] = set()
+    current: BaseException | None = exc
+    while current is not None and id(current) not in seen:
+        seen.add(id(current))
+        if isinstance(current, (TimeoutError, requests.exceptions.Timeout)):
+            return True
+        if type(current).__name__ in {
+            'ConnectTimeout', 'ReadTimeout', 'TimeoutException',
+        }:
+            return True
+        terminal = getattr(current, 'terminal', None)
+        failure = getattr(terminal, 'failure', None)
+        code = getattr(getattr(failure, 'code', None), 'value', None)
+        if code == 'request_timeout':
+            return True
+        current = current.__cause__ or current.__context__
+    return False
+
+
+def _page_result_timed_out(result: dict[str, Any] | None) -> bool:
+    payload = (result or {}).get('payload') or {}
+    if payload.get('failure_kind') == 'timeout':
+        return True
+    error = str(payload.get('error') or '').lower()
+    return any(marker in error for marker in (
+        'timed out', 'timeout', 'readtimeout', 'connecttimeout',
+    ))
+
+
 def _tool_success(_tool_name: str, result: Any, meta: dict[str, Any] | None = None) -> Any:
     """Return a successful tool value using the canonical LazyLLM contract.
 
@@ -2421,7 +2456,13 @@ def _batch_page_html_publish_progressive(
                 try:
                     code, payload = fut.result()
                 except Exception as exc:
-                    code, payload = 1, {'status': 'failed', 'error': str(exc)}
+                    code, payload = 1, {
+                        'status': 'failed',
+                        'error': str(exc),
+                        'failure_kind': (
+                            'timeout' if _is_model_timeout_exception(exc) else 'error'
+                        ),
+                    }
                 if not isinstance(payload, dict):
                     payload = {'status': 'failed', 'error': 'empty page payload'}
                 ok = code == 0 and payload.get('status', 'ok' if code == 0 else 'failed') == 'ok'
@@ -2443,7 +2484,14 @@ def _batch_page_html_publish_progressive(
             os.environ.get('LAZYMIND_PPT_PAGE_RETRIES'), 1, lo=0, hi=3,
         )
         for retry_no in range(1, retry_limit + 1):
-            pending = [pno for pno in page_nos if not ready_ok.get(pno, False)]
+            # A timed-out page has already spent the full inactivity window in
+            # the provider call. Retrying it serially can block the workflow
+            # for several more minutes without adding useful information.
+            pending = [
+                pno for pno in page_nos
+                if not ready_ok.get(pno, False)
+                and not _page_result_timed_out(results.get(pno))
+            ]
             if not pending:
                 break
             time.sleep(min(2 ** (retry_no - 1), 4))
@@ -2453,7 +2501,13 @@ def _batch_page_html_publish_progressive(
                 try:
                     code, payload = _run_one(pno)
                 except Exception as exc:
-                    code, payload = 1, {'status': 'failed', 'error': str(exc)}
+                    code, payload = 1, {
+                        'status': 'failed',
+                        'error': str(exc),
+                        'failure_kind': (
+                            'timeout' if _is_model_timeout_exception(exc) else 'error'
+                        ),
+                    }
                 if not isinstance(payload, dict):
                     payload = {'status': 'failed', 'error': 'empty page payload'}
                 ok = code == 0 and payload.get(
@@ -2531,21 +2585,32 @@ def _agent_llm_call(
     effective_timeout = float(
         timeout
         if timeout is not None
-        else os.environ.get('LAZYMIND_PPT_LLM_TIMEOUT', '300')
+        else os.environ.get('LAZYMIND_PPT_LLM_TIMEOUT', '90')
     )
     llm = AutoModel(model='llm').share(
         prompt=ChatPrompter(instruction=instruction),
-        stream=False,
+        # Keep consuming provider chunks so timeout measures inactivity rather
+        # than the total time needed to generate a complete HTML document.
+        # AutoModel still merges the chunks and returns one final string here.
+        stream=True,
     )
     # model_client deliberately forwards its per-request timeout to this
     # adapter. The adapter previously discarded it, so AutoModel fell back to
     # the provider configuration's 120-second timeout. Page HTML commonly
     # needs longer than that; pass the effective timeout into the actual call.
-    out = llm(
-        prompt_input,
-        timeout=effective_timeout,
-        max_retries=max(1, int(retries) + 1),
-    )
+    try:
+        out = llm(
+            prompt_input,
+            timeout=effective_timeout,
+            max_retries=max(1, int(retries) + 1),
+        )
+    except Exception as exc:
+        if _is_model_timeout_exception(exc):
+            raise _PPTModelTimeoutError(
+                f'LLM timed out after {effective_timeout:g}s without receiving progress '
+                f'[{request_name}]'
+            ) from exc
+        raise
     text = str(out).strip() if out is not None else ''
     if not text:
         raise RuntimeError(f'AutoModel llm returned empty text [{request_name}]')

--- a/workflows/ppt-workflow/scripts/tools.py
+++ b/workflows/ppt-workflow/scripts/tools.py
@@ -3276,23 +3276,24 @@ def ppt_attach_material_images(deck_dir: str) -> dict:
         deck_dir (str): Absolute deck directory from ppt_init_deck / ppt_find_deck.
 
     Returns:
-        On success: attached count and reference_images paths.
+        Attached count and reference_images paths. Zero attached images is a
+        successful no-op because material_images is optional for PPT decks.
     """
     try:
         deck = _resolve_deck_dir(deck_dir)
     except FileNotFoundError as exc:
         return _tool_error('ppt_attach_material_images', str(exc))
     result = _attach_material_images_to_deck(deck)
-    if result['attached'] <= 0:
-        return _tool_error(
-            'ppt_attach_material_images',
-            'no material images registered — call ppt_register_material_images in collect_materials first',
-        )
     return _tool_success('ppt_attach_material_images', {
         'deck_dir': str(deck.resolve()),
         'attached': result['attached'],
         'reference_image_count': len(result['reference_images']),
         'reference_images': result['reference_images'],
+        'note': (
+            'No material images were registered; continuing with CSS/SVG/ECharts visuals.'
+            if result['attached'] <= 0 else
+            'Material images attached as Pool B reference images.'
+        ),
     })
 
 
@@ -3550,17 +3551,6 @@ def ppt_build_outline(
     stages: list[dict[str, Any]] = [
         {'step': 'init', 'ok': True, 'deck_id': init_payload.get('deck_id')},
     ]
-
-    # Late register recovery: init attaches automatically, but retry once if empty.
-    if int(init_payload.get('material_images_attached') or 0) <= 0:
-        attach_res = ppt_attach_material_images(deck_dir)
-        if not _tool_failed(attach_res):
-            stages.append({
-                'step': 'attach_material_images',
-                'ok': True,
-                **{k: v for k, v in _tool_payload(attach_res).items()
-                   if k in ('attached', 'reference_image_count')},
-            })
 
     for stage_name in ('preflight', 'style', 'outline'):
         stage_res = ppt_run_stage(deck_dir, stage=stage_name)


### PR DESCRIPTION
# 取消构建大纲强制要图片

> 无图片依旧生成

<img width="2310" height="1158" alt="image" src="https://github.com/user-attachments/assets/f4575cbc-85ee-4856-8fdf-9bc45e8d1f96" />

# 流式输出ppt_html 避免因为供应商返回过慢导致被误杀
