### PR TITLE
fix(showcase): remove non-featured skills from home

### DIFF
--- a/skills/featured/interview-simulator/featured.yaml
+++ b/skills/featured/interview-simulator/featured.yaml
@@ -12,7 +12,7 @@ skill:
   required_version: 1.0.0
 
 placement:
-  home: true
+  home: false
   gallery: true
   order: 16
 

--- a/skills/featured/ordering.yaml
+++ b/skills/featured/ordering.yaml
@@ -7,9 +7,7 @@ home:
   chat:
     - novel-generator
     - chat-eq-reply
-    - interview-simulator
     - xiaohongshu-copywriter
-    - poster-design
   work:
     - ppt-workflow
     - image-workflow

--- a/skills/featured/poster-design/featured.yaml
+++ b/skills/featured/poster-design/featured.yaml
@@ -12,7 +12,7 @@ skill:
   required_version: 1.0.0
 
 placement:
-  home: true
+  home: false
   gallery: true
   order: 17
 


### PR DESCRIPTION
## Summary

- remove `interview-simulator` and `poster-design` from the homepage featured ordering
- set `placement.home: false` for both capabilities
- keep `placement.gallery: true`, so both remain available in the capability center
- retain their SkillHub provider and source attribution

## Verification

- `make featured-check`: validated 21 featured capabilities
- Docker E2E: neither capability appears in the homepage “精选能力” section
- Docker E2E: both capabilities remain visible in the capability center
- merge simulation against the latest `main`: clean