### PR TITLE
feat(agent): add no-progress runtime notices

### DIFF
--- a/algorithm/lazymind/chat/engine/agent_runtime/executor.py
+++ b/algorithm/lazymind/chat/engine/agent_runtime/executor.py
@@ -20,7 +20,11 @@ from .telemetry import (
     sid,
     telemetry_enabled,
 )
-from .tool_call_guard import ToolCallGuard
+from .tool_call_guard import (
+    ExactRepeatMonitor,
+    FailureRetryPolicy,
+    ToolExecutionMiddleware,
+)
 from .tool_limit_control import tool_limit_decision_coordinator
 
 
@@ -102,6 +106,7 @@ class AgentExecutor:
             )
             if telemetry_enabled() else None
         )
+        repeat_monitor = ExactRepeatMonitor()
         kwargs = {
             'stream': True,
             'max_retries': options.max_retries or _cfg['max_retries'],
@@ -122,6 +127,7 @@ class AgentExecutor:
             'skills_dir': options.skills_dir,
             'extra_stop_condition': options.extra_stop_condition,
             'runtime_observer': observer,
+            'runtime_extensions': [repeat_monitor],
         }
         kwargs.update({key: value for key, value in optional.items() if value is not None})
         tools = _sanitize_tools(_deduplicate_tools(plan.tools))
@@ -132,8 +138,9 @@ class AgentExecutor:
             prompt=plan.prompt.system_prompt,
             **kwargs,
         )
-        agent._tools_manager = ToolCallGuard(
+        agent._tools_manager = ToolExecutionMiddleware(
             CitationResultMiddleware(agent._tools_manager),
+            failure_policy=FailureRetryPolicy(options.tool_failure_limits),
             expanded_round_limit=max(2, int(_cfg['agentic_expanded_max_rounds'])),
             cancel_check=options.extra_stop_condition,
         )

--- a/algorithm/lazymind/chat/engine/agent_runtime/executor.py
+++ b/algorithm/lazymind/chat/engine/agent_runtime/executor.py
@@ -23,6 +23,7 @@ from .telemetry import (
 from .tool_call_guard import (
     ExactRepeatMonitor,
     FailureRetryPolicy,
+    OneShotNoticeBuffer,
     ToolExecutionMiddleware,
 )
 from .tool_limit_control import tool_limit_decision_coordinator
@@ -107,6 +108,7 @@ class AgentExecutor:
             if telemetry_enabled() else None
         )
         repeat_monitor = ExactRepeatMonitor()
+        notice_buffer = OneShotNoticeBuffer()
         kwargs = {
             'stream': True,
             'max_retries': options.max_retries or _cfg['max_retries'],
@@ -127,7 +129,7 @@ class AgentExecutor:
             'skills_dir': options.skills_dir,
             'extra_stop_condition': options.extra_stop_condition,
             'runtime_observer': observer,
-            'runtime_extensions': [repeat_monitor],
+            'model_context_provider': notice_buffer.take,
         }
         kwargs.update({key: value for key, value in optional.items() if value is not None})
         tools = _sanitize_tools(_deduplicate_tools(plan.tools))
@@ -143,8 +145,12 @@ class AgentExecutor:
             failure_policy=FailureRetryPolicy(options.tool_failure_limits),
             expanded_round_limit=max(2, int(_cfg['agentic_expanded_max_rounds'])),
             cancel_check=options.extra_stop_condition,
+            repeat_monitor=repeat_monitor,
+            notice_buffer=notice_buffer,
         )
         agent._agent_lab_run_id = run_id
+        agent._exact_repeat_monitor = repeat_monitor
+        agent._runtime_notice_buffer = notice_buffer
         # Restore lazy Toolkit activation before the streaming helper takes over.
         # Relying only on ReactAgent._pre_process makes restoration dependent on
         # llm_chat_history surviving the helper/framework call path.
@@ -182,6 +188,12 @@ class AgentExecutor:
     ) -> AsyncIterator[Tuple[str, Any]]:
         history = plan.history if plan.history else None
         run_id = getattr(agent, '_agent_lab_run_id', '')
+        repeat_monitor = getattr(agent, '_exact_repeat_monitor', None)
+        notice_buffer = getattr(agent, '_runtime_notice_buffer', None)
+        if repeat_monitor is not None:
+            repeat_monitor.reset()
+        if notice_buffer is not None:
+            notice_buffer.clear()
         if telemetry_enabled():
             append_event(
                 'run_start',
@@ -222,6 +234,10 @@ class AgentExecutor:
                 raise
             yield 'final', result
         finally:
+            if repeat_monitor is not None:
+                repeat_monitor.reset()
+            if notice_buffer is not None:
+                notice_buffer.clear()
             if telemetry_enabled():
                 append_event(
                     'run_end',

--- a/algorithm/lazymind/chat/engine/agent_runtime/executor.py
+++ b/algorithm/lazymind/chat/engine/agent_runtime/executor.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-import json
-import time
 import types
 import uuid
 from typing import Any, AsyncIterator, Optional, Tuple
@@ -9,126 +7,21 @@ from typing import Any, AsyncIterator, Optional, Tuple
 import lazyllm
 import lazyllm.module.stream_helper as _sh
 import lazyllm.tools.agent as _agent_mod
-from lazyllm.tools.agent.toolError import tool_failure
-from lazymind.config import config as _cfg
+
 from lazymind.chat.engine.tools.infra import CitationResultMiddleware
-from lazymind.chat.engine.tools.session_env import redact_session_env_arguments
+from lazymind.config import config as _cfg
 
 from .context_estimator import estimate_non_history_tokens
 from .models import AgentRole, AgentRunPlan
 from .pruner import estimate_history_tokens, make_history_compactor
 from .telemetry import (
     append_event,
-    emit_tool_call,
-    emit_tool_result,
     make_runtime_observer,
     sid,
     telemetry_enabled,
 )
+from .tool_call_guard import ToolCallGuard
 from .tool_limit_control import tool_limit_decision_coordinator
-
-
-_EXPANDED_BUDGET_TOOLS = {
-    'advance_step',
-    'advance_step_and_hand_off',
-    'create_workflow_draft',
-    'create_subagent',
-}
-_MAX_TOOL_LOG_CHARS = 800
-_RESULT_LOG_KEYS = (
-    'target', 'display_name', 'kind', 'file_id', 'offset', 'end_line',
-    'total_lines', 'eof', 'next_offset', 'limit', 'pattern', 'total',
-    'truncated', 'status', 'filename', 'corpus', 'skipped', 'channels',
-)
-
-
-def _requires_expanded_budget(tool_name: str) -> bool:
-    """Return whether invoking this tool starts workflow or SubAgent work."""
-    return tool_name in _EXPANDED_BUDGET_TOOLS or tool_name.startswith('trigger_')
-
-
-def _tool_call_session_id() -> str:
-    cfg = lazyllm.globals.get('agentic_config') or {}
-    if isinstance(cfg, dict) and cfg.get('session_id'):
-        return str(cfg['session_id'])
-    try:
-        return str(getattr(lazyllm.globals, '_sid', '') or '')
-    except Exception:
-        return ''
-
-
-def _compact_json(value: Any, limit: int = _MAX_TOOL_LOG_CHARS) -> str:
-    try:
-        text = json.dumps(value, ensure_ascii=False, default=str)
-    except Exception:
-        text = str(value)
-    if len(text) > limit:
-        return text[:limit] + f'...<{len(text) - limit} more chars>'
-    return text
-
-
-def _parse_tool_arguments(function: dict[str, Any]) -> Any:
-    arguments = function.get('arguments', {})
-    if isinstance(arguments, str):
-        try:
-            return json.loads(arguments)
-        except Exception:
-            return arguments
-    return arguments
-
-
-def _summarize_tool_result(result: Any) -> dict[str, Any]:
-    summary: dict[str, Any] = {}
-    if not isinstance(result, dict):
-        summary['result_type'] = type(result).__name__
-        return summary
-    if 'ok' in result:
-        summary['ok'] = result.get('ok')
-    msg = result.get('msg')
-    if msg:
-        summary['msg'] = str(msg)[:240]
-    value = result.get('value') if 'value' in result else result
-    if not isinstance(value, dict):
-        return summary
-    if 'success' in value:
-        summary['success'] = value.get('success')
-    error = value.get('error')
-    if isinstance(error, dict) and error.get('reason'):
-        summary['error'] = str(error.get('reason'))[:240]
-    payload = value.get('result') if isinstance(value.get('result'), dict) else value
-    if not isinstance(payload, dict):
-        return summary
-    for key in _RESULT_LOG_KEYS:
-        if key in payload and payload[key] is not None:
-            summary[key] = payload[key]
-    matches = payload.get('matches')
-    if isinstance(matches, list):
-        summary['match_count'] = len(matches)
-    footer = payload.get('footer')
-    if isinstance(footer, str) and footer.strip():
-        summary['footer'] = footer.strip()[:240]
-    return summary
-
-
-def _format_log_fields(fields: dict[str, Any]) -> str:
-    parts: list[str] = []
-    for key, value in fields.items():
-        if value is None:
-            continue
-        if isinstance(value, (dict, list)):
-            rendered = _compact_json(value, 240)
-        else:
-            rendered = str(value)
-        parts.append(f'[{key}={rendered}]')
-    return ' '.join(parts)
-
-
-def _log_tool_call(event: str, name: str, **fields: Any) -> None:
-    extras = _format_log_fields(fields)
-    suffix = f' {extras}' if extras else ''
-    lazyllm.LOG.info(
-        f'[ToolCall] [sid={_tool_call_session_id()}] [event={event}] [name={name}]{suffix}'
-    )
 
 
 def _sanitize_tools(tools: list[Any]) -> list[Any]:
@@ -157,185 +50,6 @@ def _sanitize_tools(tools: list[Any]) -> list[Any]:
                 tool = {**tool, 'tools': kept}
         cleaned.append(tool)
     return cleaned
-
-
-class ToolCallGuard:
-    """Stop selected tools from looping after failures without limiting successful work."""
-
-    def __init__(
-        self,
-        manager: Any,
-        failure_limits: dict[str, int] | None = None,
-        expanded_round_limit: int | None = None,
-        repeated_call_limit: int = 3,
-        cancel_check: Any = None,
-    ):
-        self._manager = manager
-        self._failure_limits = dict(failure_limits or {})
-        self._consecutive_failures: dict[str, int] = {}
-        self._expanded_round_limit = expanded_round_limit
-        self._repeated_call_limit = max(2, int(repeated_call_limit))
-        self._signature_calls: dict[str, int] = {}
-        self._failed_signatures: set[str] = set()
-        self._cancel_check = cancel_check
-
-    def __getattr__(self, name: str) -> Any:
-        return getattr(self._manager, name)
-
-    @staticmethod
-    def _signature(tool_call: dict[str, Any]) -> str:
-        function = tool_call.get('function') or {}
-        arguments = function.get('arguments', {})
-        if isinstance(arguments, str):
-            try:
-                arguments = json.loads(arguments)
-            except Exception:
-                arguments = arguments.strip()
-        try:
-            normalized = json.dumps(
-                arguments, ensure_ascii=False, sort_keys=True, separators=(',', ':'),
-            )
-        except (TypeError, ValueError):
-            normalized = str(arguments)
-        return f"{function.get('name', '')}:{normalized}"
-
-    @staticmethod
-    def _failed(result: Any) -> bool:
-        return isinstance(result, dict) and result.get('ok') is False
-
-    @staticmethod
-    def _blocked(name: str, message: str) -> dict[str, Any]:
-        message = f'[Repeated Tool Failure] {name}: {message}'
-        return tool_failure(message)
-
-    @staticmethod
-    def _loop_blocked(name: str, message: str) -> dict[str, Any]:
-        message = f'[Repeated Tool Call] {name}: {message}'
-        return tool_failure(message)
-
-    def __call__(self, tools: Any, verbose: bool = False,
-                 allowed_tool_names: set[str] | None = None) -> Any:
-        if self._cancel_check is not None:
-            self._cancel_check(None)
-        tool_calls = [tools] if isinstance(tools, dict) else list(tools or [])
-        results: list[Any] = [None] * len(tool_calls)
-        pending: list[dict[str, Any]] = []
-        pending_indices: list[int] = []
-        pending_signatures: dict[str, int] = {}
-        duplicate_indices: dict[int, int] = {}
-        for index, tool_call in enumerate(tool_calls):
-            function = tool_call.get('function') or {}
-            name = str(function.get('name') or '')
-            if _requires_expanded_budget(name):
-                workspace = lazyllm.locals.get('_lazyllm_agent', {}).get('workspace')
-                if (
-                    isinstance(workspace, dict)
-                    and self._expanded_round_limit is not None
-                    and workspace.get('_react_round_limit') != self._expanded_round_limit
-                ):
-                    workspace['_react_round_limit'] = self._expanded_round_limit
-                    lazyllm.LOG.info(
-                        f'ChatAgent used tool={name}; automatically expanding '
-                        f'tool round limit to {self._expanded_round_limit}.'
-                    )
-            signature = self._signature(tool_call)
-            arguments = _parse_tool_arguments(function)
-            signature_calls = self._signature_calls.get(signature, 0)
-            if signature_calls >= self._repeated_call_limit:
-                results[index] = self._loop_blocked(
-                    name,
-                    f'the exact same call was already made {self._repeated_call_limit} times; '
-                    'stop retrying it and synthesize from existing results or choose another tool.',
-                )
-                _log_tool_call(
-                    'blocked', name, reason='repeated_call',
-                    args=redact_session_env_arguments(name, arguments),
-                )
-                continue
-            guarded = name in self._failure_limits
-            if guarded and signature in self._failed_signatures:
-                results[index] = self._blocked(
-                    name, 'this exact call already failed; do not retry it with the same arguments.',
-                )
-                emit_tool_call(tool_call, blocked=True, reason='repeated_failed_signature')
-                emit_tool_result(tool_call, results[index])
-                _log_tool_call(
-                    'blocked', name, reason='repeated_failure',
-                    args=redact_session_env_arguments(name, arguments),
-                )
-                continue
-            if guarded and signature in pending_signatures:
-                duplicate_indices[index] = pending_signatures[signature]
-                emit_tool_call(tool_call, blocked=True, reason='duplicate_merged')
-                _log_tool_call(
-                    'merged', name, reason='duplicate_in_batch',
-                    args=redact_session_env_arguments(name, arguments),
-                )
-                continue
-            failures = self._consecutive_failures.get(name, 0)
-            limit = self._failure_limits.get(name)
-            if limit is not None and failures >= limit:
-                results[index] = self._blocked(
-                    name,
-                    f'{failures} consecutive attempts failed. Stop changing parameters and use '
-                    'another grounded source or explain that the evidence is unavailable.',
-                )
-                emit_tool_call(tool_call, blocked=True, reason='consecutive_failure_limit')
-                emit_tool_result(tool_call, results[index])
-                _log_tool_call(
-                    'blocked', name, reason='consecutive_failures',
-                    failures=failures,
-                    args=redact_session_env_arguments(name, arguments),
-                )
-                continue
-            emit_tool_call(tool_call)
-            self._signature_calls[signature] = signature_calls + 1
-            pending.append(tool_call)
-            pending_indices.append(index)
-            if guarded:
-                pending_signatures[signature] = index
-        if pending:
-            for tool_call in pending:
-                function = tool_call.get('function') or {}
-                _log_tool_call(
-                    'start',
-                    str(function.get('name') or ''),
-                    args=redact_session_env_arguments(
-                        str(function.get('name') or ''),
-                        _parse_tool_arguments(function),
-                    ),
-                )
-            started_at = time.perf_counter()
-            pending_results = self._manager(
-                pending,
-                verbose=verbose,
-                allowed_tool_names=allowed_tool_names,
-            )
-            elapsed = time.perf_counter() - started_at
-            for index, tool_call, result in zip(pending_indices, pending, pending_results):
-                results[index] = result
-                emit_tool_result(tool_call, result)
-                name = str((tool_call.get('function') or {}).get('name') or '')
-                _log_tool_call(
-                    'done', name, elapsed=f'{elapsed:.3f}s', **_summarize_tool_result(result),
-                )
-                if name in self._failure_limits:
-                    if self._failed(result):
-                        self._consecutive_failures[name] = (
-                            self._consecutive_failures.get(name, 0) + 1
-                        )
-                        self._failed_signatures.add(self._signature(tool_call))
-                    else:
-                        self._consecutive_failures[name] = 0
-                        prefix = f'{name}:'
-                        self._failed_signatures = {
-                            item for item in self._failed_signatures if not item.startswith(prefix)
-                        }
-        for duplicate_index, original_index in duplicate_indices.items():
-            results[duplicate_index] = results[original_index]
-            if results[duplicate_index] is not None:
-                emit_tool_result(tool_calls[duplicate_index], results[duplicate_index])
-        return results
 
 
 def _tool_name(tool: Any) -> str:
@@ -420,8 +134,7 @@ class AgentExecutor:
         )
         agent._tools_manager = ToolCallGuard(
             CitationResultMiddleware(agent._tools_manager),
-            options.tool_failure_limits,
-            max(2, int(_cfg['agentic_expanded_max_rounds'])),
+            expanded_round_limit=max(2, int(_cfg['agentic_expanded_max_rounds'])),
             cancel_check=options.extra_stop_condition,
         )
         agent._agent_lab_run_id = run_id

--- a/algorithm/lazymind/chat/engine/agent_runtime/models.py
+++ b/algorithm/lazymind/chat/engine/agent_runtime/models.py
@@ -47,7 +47,6 @@ class AgentExecutionOptions:
     skills_dir: Optional[str] = None
     extra_stop_condition: Optional[Callable[..., Any]] = None
     max_retries: Optional[int] = None
-    tool_failure_limits: Optional[dict[str, int]] = None
     llm_config: Optional[dict[str, Any]] = None
     max_input_tokens: Optional[Any] = None
     history_compactor: Optional[Callable[..., list[dict[str, Any]]]] = None

--- a/algorithm/lazymind/chat/engine/agent_runtime/models.py
+++ b/algorithm/lazymind/chat/engine/agent_runtime/models.py
@@ -47,6 +47,7 @@ class AgentExecutionOptions:
     skills_dir: Optional[str] = None
     extra_stop_condition: Optional[Callable[..., Any]] = None
     max_retries: Optional[int] = None
+    tool_failure_limits: Optional[dict[str, int]] = None
     llm_config: Optional[dict[str, Any]] = None
     max_input_tokens: Optional[Any] = None
     history_compactor: Optional[Callable[..., list[dict[str, Any]]]] = None

--- a/algorithm/lazymind/chat/engine/agent_runtime/pruner.py
+++ b/algorithm/lazymind/chat/engine/agent_runtime/pruner.py
@@ -427,6 +427,10 @@ def make_history_compactor(
             kwargs.get('prefix') or {},
             kwargs.get('current_input'),
         )
+        non_history_tokens += max(
+            0,
+            int(kwargs.get('reserved_runtime_context_tokens') or 0),
+        )
         state, _rebuilt = reconcile_projection(combined, kwargs.get('runtime_state'))
         stable = state['entries']
         before_total = non_history_tokens + projection_tokens(stable)

--- a/algorithm/lazymind/chat/engine/agent_runtime/telemetry.py
+++ b/algorithm/lazymind/chat/engine/agent_runtime/telemetry.py
@@ -140,6 +140,8 @@ def make_runtime_observer(*, role: str = '', run_id: str = '') -> Any:
 
 
 def emit_tool_call(tool_call: dict[str, Any], *, blocked: bool = False, reason: str = '') -> None:
+    if not telemetry_enabled():
+        return
     function = tool_call.get('function') or {}
     name = str(function.get('name') or '')
     arguments = function.get('arguments', {})
@@ -178,6 +180,8 @@ def emit_tool_call(tool_call: dict[str, Any], *, blocked: bool = False, reason: 
 
 
 def emit_tool_result(tool_call: dict[str, Any], result: Any) -> None:
+    if not telemetry_enabled():
+        return
     function = tool_call.get('function') or {}
     name = str(function.get('name') or '')
     category = classify_tool(name)

--- a/algorithm/lazymind/chat/engine/agent_runtime/tool_call_guard.py
+++ b/algorithm/lazymind/chat/engine/agent_runtime/tool_call_guard.py
@@ -3,13 +3,22 @@ from __future__ import annotations
 import hashlib
 import json
 import time
+from collections import Counter
 from dataclasses import dataclass
 from typing import Any
 
 import lazyllm
+from lazyllm.tools.agent import (
+    PreparedToolCall,
+    RuntimeContext,
+    RuntimeDelta,
+    ToolExecutionBatch,
+    ToolExecutionRecord,
+)
+from lazyllm.tools.agent.toolError import tool_failure
 
 from lazymind.chat.engine.tools.session_env import redact_session_env_arguments
-from .telemetry import emit_tool_call, emit_tool_result
+from .telemetry import append_event, emit_tool_call, emit_tool_result
 
 
 _EXPANDED_BUDGET_TOOLS = {
@@ -25,14 +34,6 @@ _RESULT_LOG_KEYS = (
     'truncated', 'status', 'filename', 'corpus', 'skipped', 'channels',
 )
 _REPEATED_CALL_THRESHOLD = 3
-
-
-@dataclass
-class _RepeatedCallState:
-    tool_name: str
-    arguments_digest: str
-    result_digest: str
-    count: int
 
 
 def _requires_expanded_budget(tool_name: str) -> bool:
@@ -59,27 +60,16 @@ def _compact_json(value: Any, limit: int = _MAX_TOOL_LOG_CHARS) -> str:
     return text
 
 
-def _parse_tool_arguments(function: dict[str, Any]) -> Any:
-    arguments = function.get('arguments', {})
-    if isinstance(arguments, str):
-        try:
-            return json.loads(arguments)
-        except Exception:
-            return arguments
-    return arguments
-
-
-def _stable_digest(value: Any) -> str:
+def _stable_digest(value: Any) -> str | None:
     try:
         normalized = json.dumps(
             value,
             ensure_ascii=False,
             sort_keys=True,
             separators=(',', ':'),
-            default=str,
         )
-    except Exception:
-        normalized = str(value)
+    except (TypeError, ValueError):
+        return None
     return hashlib.sha256(normalized.encode('utf-8')).hexdigest()
 
 
@@ -134,32 +124,185 @@ def _log_tool_call(event: str, name: str, **fields: Any) -> None:
     )
 
 
-class ToolCallGuard:
-    """Monitor tool calls and queue internal runtime notices without changing results."""
+@dataclass(frozen=True)
+class _FailureBatchDecision:
+    pending_indices: tuple[int, ...]
+    blocked_results: dict[int, Any]
+    duplicate_sources: dict[int, int]
 
-    def __init__(self, manager: Any, expanded_round_limit: int | None = None, cancel_check: Any = None):
+
+class FailureRetryPolicy:
+    """Preserve configured hard failure budgets independently of repeat notices."""
+
+    def __init__(self, failure_limits: dict[str, int] | None = None):
+        self._failure_limits = dict(failure_limits or {})
+        self._consecutive_failures: dict[str, int] = {}
+        self._failed_signatures: set[str] = set()
+
+    @staticmethod
+    def _failed(result: Any) -> bool:
+        return isinstance(result, dict) and result.get('ok') is False
+
+    @staticmethod
+    def _signature(prepared: PreparedToolCall) -> str:
+        arguments = prepared.validated_arguments
+        if arguments is None:
+            arguments = prepared.arguments
+        digest = _stable_digest(arguments) or str(arguments)
+        return f'{prepared.tool_name}:{digest}'
+
+    @staticmethod
+    def _blocked(name: str, message: str) -> dict[str, Any]:
+        return tool_failure(f'[Repeated Tool Failure] {name}: {message}')
+
+    def decide(self, prepared_calls: list[PreparedToolCall]) -> _FailureBatchDecision:
+        pending_indices = []
+        blocked_results: dict[int, Any] = {}
+        duplicate_sources: dict[int, int] = {}
+        pending_signatures: dict[str, int] = {}
+        for index, prepared in enumerate(prepared_calls):
+            name = prepared.tool_name
+            limit = self._failure_limits.get(name)
+            if limit is None or not prepared.ready:
+                pending_indices.append(index)
+                continue
+            signature = self._signature(prepared)
+            if signature in self._failed_signatures:
+                blocked_results[index] = self._blocked(
+                    name,
+                    'this exact call already failed; do not retry it with the same arguments.',
+                )
+                continue
+            failures = self._consecutive_failures.get(name, 0)
+            if failures >= limit:
+                blocked_results[index] = self._blocked(
+                    name,
+                    f'{failures} consecutive attempts failed. Use another grounded source or '
+                    'explain that the evidence is unavailable.',
+                )
+                continue
+            if signature in pending_signatures:
+                duplicate_sources[index] = pending_signatures[signature]
+                continue
+            pending_signatures[signature] = index
+            pending_indices.append(index)
+        return _FailureBatchDecision(
+            pending_indices=tuple(pending_indices),
+            blocked_results=blocked_results,
+            duplicate_sources=duplicate_sources,
+        )
+
+    def observe(self, records: list[ToolExecutionRecord]) -> None:
+        for record in records:
+            name = record.tool_name
+            if name not in self._failure_limits or not record.executed:
+                continue
+            signature = self._signature(record.prepared)
+            if self._failed(record.result):
+                self._consecutive_failures[name] = self._consecutive_failures.get(name, 0) + 1
+                self._failed_signatures.add(signature)
+            else:
+                self._consecutive_failures[name] = 0
+                prefix = f'{name}:'
+                self._failed_signatures = {
+                    item for item in self._failed_signatures if not item.startswith(prefix)
+                }
+
+
+class ExactRepeatMonitor:
+    """Emit soft runtime context for exact repeated observations."""
+
+    def __init__(self, threshold: int = _REPEATED_CALL_THRESHOLD):
+        self._threshold = max(2, int(threshold))
+        self._previous_batch_digest: str | None = None
+        self._batch_count = 0
+        self._pending_notice = False
+
+    def _reset(self) -> None:
+        self._previous_batch_digest = None
+        self._batch_count = 0
+        self._pending_notice = False
+
+    def begin_run(self, context: dict[str, Any]) -> None:
+        del context
+        self._reset()
+
+    def end_run(self, reason: str) -> None:
+        del reason
+        self._reset()
+
+    def runtime_context_delivered(self, batch_ids) -> None:
+        if self._pending_notice:
+            append_event('repeat_notice_delivered', batch_ids=list(batch_ids))
+            self._pending_notice = False
+
+    @staticmethod
+    def _record_fingerprint(record: ToolExecutionRecord):
+        arguments = record.validated_arguments
+        if arguments is None:
+            arguments = record.arguments
+        arguments_digest = _stable_digest(arguments)
+        result_digest = _stable_digest(record.result)
+        if arguments_digest is None or result_digest is None:
+            return None
+        return record.tool_name, arguments_digest, result_digest
+
+    def after_tool_batch(self, records) -> RuntimeDelta:
+        self._pending_notice = False
+        eligible = [
+            record for record in records
+            if record.executed and not record.access.polling
+        ]
+        if not eligible:
+            self._reset()
+            return RuntimeDelta()
+        fingerprints = [self._record_fingerprint(record) for record in eligible]
+        if any(item is None for item in fingerprints):
+            self._reset()
+            return RuntimeDelta()
+        batch_digest = _stable_digest(fingerprints)
+        if batch_digest is None:
+            self._reset()
+            return RuntimeDelta()
+        previous_count = self._batch_count
+        if batch_digest == self._previous_batch_digest:
+            self._batch_count += 1
+        else:
+            if previous_count >= self._threshold:
+                append_event('post_notice_strategy_changed', previous_streak=previous_count)
+            self._previous_batch_digest = batch_digest
+            self._batch_count = 1
+        intra_batch_count = max(Counter(fingerprints).values(), default=0)
+        repeat_count = max(self._batch_count, intra_batch_count)
+        if repeat_count < self._threshold:
+            return RuntimeDelta()
+        batch_ids = [record.call_id for record in records]
+        append_event(
+            'exact_repeat_detected',
+            streak=repeat_count,
+            batch_ids=batch_ids,
+            tool_names=[record.tool_name for record in eligible],
+        )
+        self._pending_notice = True
+        return RuntimeDelta(model_context=(RuntimeContext(
+            '[Internal runtime notice]\n'
+            f'The same tool call batch has returned the same result {repeat_count} consecutive times. '
+            'Review the result and change the approach or arguments instead of repeating it unchanged.'
+        ),))
+
+
+class ToolExecutionMiddleware:
+    """Coordinate cancellation, failure policy, telemetry, and one prepared execution."""
+
+    def __init__(self, manager: Any, failure_policy: FailureRetryPolicy | None = None,
+                 expanded_round_limit: int | None = None, cancel_check: Any = None):
         self._manager = manager
+        self._failure_policy = failure_policy or FailureRetryPolicy()
         self._expanded_round_limit = expanded_round_limit
         self._cancel_check = cancel_check
-        self._repeated_call_state: _RepeatedCallState | None = None
-        self._internal_runtime_notices: dict[tuple[str, ...], str] = {}
 
     def __getattr__(self, name: str) -> Any:
         return getattr(self._manager, name)
-
-    def reset_internal_runtime_notice_state(self) -> None:
-        self._repeated_call_state = None
-        self._internal_runtime_notices.clear()
-
-    def consume_internal_runtime_notices(self, batch_tool_call_ids) -> list[str]:
-        ids = tuple(str(item) for item in batch_tool_call_ids)
-        if not self._internal_runtime_notices:
-            return []
-        if ids not in self._internal_runtime_notices:
-            self.reset_internal_runtime_notice_state()
-            return []
-        notice = self._internal_runtime_notices.pop(ids)
-        return [notice]
 
     def _expand_round_limit(self, tool_name: str) -> None:
         if not _requires_expanded_budget(tool_name):
@@ -176,73 +319,70 @@ class ToolCallGuard:
                 f'tool round limit to {self._expanded_round_limit}.'
             )
 
-    def _update_repeated_state(self, tool_call: dict[str, Any], result: Any, access: Any) -> int:
-        if bool(getattr(access, 'polling', False)) or bool(getattr(access, 'counts_as_progress', False)):
-            self._repeated_call_state = None
-            return 0
-        function = tool_call.get('function') or {}
-        name = str(function.get('name') or '')
-        arguments_digest = _stable_digest(_parse_tool_arguments(function))
-        result_digest = _stable_digest(result)
-        previous = self._repeated_call_state
-        if (
-            previous is not None
-            and previous.tool_name == name
-            and previous.arguments_digest == arguments_digest
-            and previous.result_digest == result_digest
+    def execute_prepared_calls(self, prepared_calls):
+        if self._cancel_check is not None:
+            self._cancel_check(None)
+        prepared_calls = list(prepared_calls or [])
+        if not prepared_calls:
+            return ToolExecutionBatch(results=[], records=())
+        decision = self._failure_policy.decide(prepared_calls)
+        pending = [prepared_calls[index] for index in decision.pending_indices]
+        for index, prepared in enumerate(prepared_calls):
+            self._expand_round_limit(prepared.tool_name)
+            arguments = redact_session_env_arguments(prepared.tool_name, prepared.arguments)
+            if index in decision.blocked_results:
+                emit_tool_call(prepared.tool_call, blocked=True, reason='failure_retry_policy')
+                _log_tool_call('blocked', prepared.tool_name, reason='failure_retry_policy', args=arguments)
+                append_event('failure_retry_blocked', name=prepared.tool_name, call_id=prepared.call_id)
+            elif index in decision.duplicate_sources:
+                emit_tool_call(prepared.tool_call, blocked=True, reason='duplicate_merged')
+                _log_tool_call('merged', prepared.tool_name, reason='duplicate_in_batch', args=arguments)
+            else:
+                emit_tool_call(prepared.tool_call)
+                _log_tool_call('start', prepared.tool_name, args=arguments)
+        started_at = time.perf_counter()
+        executed_batch = self._manager.execute_prepared_calls(pending)
+        elapsed = time.perf_counter() - started_at
+        results: list[Any] = [None] * len(prepared_calls)
+        records: list[ToolExecutionRecord | None] = [None] * len(prepared_calls)
+        for original_index, result, record in zip(
+            decision.pending_indices, executed_batch.results, executed_batch.records,
         ):
-            count = previous.count + 1
-        else:
-            count = 1
-        self._repeated_call_state = _RepeatedCallState(name, arguments_digest, result_digest, count)
-        return count
+            results[original_index] = result
+            records[original_index] = record
+            emit_tool_result(prepared_calls[original_index].tool_call, result)
+            _log_tool_call(
+                'done',
+                prepared_calls[original_index].tool_name,
+                elapsed=f'{elapsed:.3f}s',
+                **_summarize_tool_result(result),
+            )
+        for index, result in decision.blocked_results.items():
+            results[index] = result
+            records[index] = ToolExecutionRecord(prepared_calls[index], result, executed=False)
+            emit_tool_result(prepared_calls[index].tool_call, result)
+        for index, source_index in decision.duplicate_sources.items():
+            result = results[source_index]
+            results[index] = result
+            records[index] = ToolExecutionRecord(prepared_calls[index], result, executed=False)
+            emit_tool_result(prepared_calls[index].tool_call, result)
+        completed_records = [record for record in records if record is not None]
+        self._failure_policy.observe(completed_records)
+        return ToolExecutionBatch(
+            results=lazyllm.package(results),
+            records=tuple(completed_records),
+        )
+
+    def execute_with_records(self, tools: Any, verbose: bool = False,
+                             allowed_tool_names: set[str] | None = None):
+        del verbose
+        prepared = self._manager.prepare_tool_calls(tools, allowed_tool_names)
+        return self.execute_prepared_calls(prepared)
 
     def __call__(self, tools: Any, verbose: bool = False,
                  allowed_tool_names: set[str] | None = None) -> Any:
-        try:
-            if self._cancel_check is not None:
-                self._cancel_check(None)
-            tool_calls = [tools] if isinstance(tools, dict) else list(tools or [])
-            normalizer = getattr(self._manager, 'normalize_tool_calls', None)
-            if callable(normalizer):
-                normalizer(tool_calls)
-            for tool_call in tool_calls:
-                function = tool_call.get('function') or {}
-                name = str(function.get('name') or '')
-                self._expand_round_limit(name)
-                _log_tool_call(
-                    'start', name,
-                    args=redact_session_env_arguments(name, _parse_tool_arguments(function)),
-                )
-                emit_tool_call(tool_call)
-            resolver = getattr(self._manager, 'resolve_tool_accesses', None)
-            accesses = resolver(tool_calls, allowed_tool_names) if callable(resolver) else [None] * len(tool_calls)
-            started_at = time.perf_counter()
-            results = self._manager(
-                tool_calls,
-                verbose=verbose,
-                allowed_tool_names=allowed_tool_names,
-            )
-            elapsed = time.perf_counter() - started_at
-        except Exception:
-            self.reset_internal_runtime_notice_state()
-            raise
-
-        highest_count = 0
-        result_items = list(results)
-        if len(result_items) != len(tool_calls) or len(accesses) != len(tool_calls):
-            self.reset_internal_runtime_notice_state()
-            return results
-        for tool_call, result, access in zip(tool_calls, result_items, accesses):
-            emit_tool_result(tool_call, result)
-            name = str((tool_call.get('function') or {}).get('name') or '')
-            _log_tool_call('done', name, elapsed=f'{elapsed:.3f}s', **_summarize_tool_result(result))
-            highest_count = max(highest_count, self._update_repeated_state(tool_call, result, access))
-        if highest_count >= _REPEATED_CALL_THRESHOLD:
-            ids = tuple(str(tool_call.get('id') or '') for tool_call in tool_calls)
-            self._internal_runtime_notices[ids] = (
-                '[Internal runtime notice]\n'
-                f'The same tool call has returned the same result {highest_count} consecutive times. '
-                'Review the result and change the approach or arguments instead of repeating it unchanged.'
-            )
-        return results
+        return self.execute_with_records(
+            tools,
+            verbose=verbose,
+            allowed_tool_names=allowed_tool_names,
+        ).results

--- a/algorithm/lazymind/chat/engine/agent_runtime/tool_call_guard.py
+++ b/algorithm/lazymind/chat/engine/agent_runtime/tool_call_guard.py
@@ -9,10 +9,7 @@ from typing import Any
 
 import lazyllm
 from lazyllm.tools.agent import (
-    PreparedToolBatch,
     PreparedToolCall,
-    RuntimeContext,
-    RuntimeDelta,
     ToolExecutionBatch,
     ToolExecutionDisposition,
     ToolExecutionRecord,
@@ -221,25 +218,10 @@ class ExactRepeatMonitor:
         self._threshold = max(2, int(threshold))
         self._previous_batch_digest: str | None = None
         self._batch_count = 0
-        self._pending_notice = False
 
-    def _reset(self) -> None:
+    def reset(self) -> None:
         self._previous_batch_digest = None
         self._batch_count = 0
-        self._pending_notice = False
-
-    def begin_run(self, context: dict[str, Any]) -> None:
-        del context
-        self._reset()
-
-    def end_run(self, reason: str) -> None:
-        del reason
-        self._reset()
-
-    def runtime_context_delivered(self, batch_ids) -> None:
-        if self._pending_notice:
-            append_event('repeat_notice_delivered', batch_ids=list(batch_ids))
-            self._pending_notice = False
 
     @staticmethod
     def _record_fingerprint(record: ToolExecutionRecord):
@@ -252,27 +234,25 @@ class ExactRepeatMonitor:
             return None
         return record.tool_name, arguments_digest, result_digest
 
-    def after_tool_batch(self, records) -> RuntimeDelta:
-        self._pending_notice = False
+    def after_tool_batch(self, records) -> str | None:
         eligible = [
             record for record in records
             if record.disposition in {
                 ToolExecutionDisposition.EXECUTED,
                 ToolExecutionDisposition.PREPARATION_FAILED,
-                ToolExecutionDisposition.DISPATCH_FAILED,
-            } and not record.access.polling
+            } and not record.polling
         ]
         if not eligible:
-            self._reset()
-            return RuntimeDelta()
+            self.reset()
+            return None
         fingerprints = [self._record_fingerprint(record) for record in eligible]
         if any(item is None for item in fingerprints):
-            self._reset()
-            return RuntimeDelta()
+            self.reset()
+            return None
         batch_digest = _stable_digest(fingerprints)
         if batch_digest is None:
-            self._reset()
-            return RuntimeDelta()
+            self.reset()
+            return None
         previous_count = self._batch_count
         if batch_digest == self._previous_batch_digest:
             self._batch_count += 1
@@ -284,7 +264,7 @@ class ExactRepeatMonitor:
         intra_batch_count = max(Counter(fingerprints).values(), default=0)
         repeat_count = max(self._batch_count, intra_batch_count)
         if repeat_count < self._threshold:
-            return RuntimeDelta()
+            return None
         batch_ids = [record.call_id for record in records]
         append_event(
             'exact_repeat_detected',
@@ -292,23 +272,49 @@ class ExactRepeatMonitor:
             batch_ids=batch_ids,
             tool_names=[record.tool_name for record in eligible],
         )
-        self._pending_notice = True
-        return RuntimeDelta(model_context=(RuntimeContext(
+        return (
             '[Internal runtime notice]\n'
             f'The same tool call batch has returned the same result {repeat_count} consecutive times. '
             'Review the result and change the approach or arguments instead of repeating it unchanged.'
-        ),))
+        )
+
+
+class OneShotNoticeBuffer:
+    """Hold at most one model-only notice until the next tool-result turn."""
+
+    def __init__(self):
+        self.clear()
+
+    def publish(self, notice: str | None, batch_ids=()) -> None:
+        self._notice = notice.strip() if isinstance(notice, str) else ''
+        self._batch_ids = tuple(str(item) for item in batch_ids) if self._notice else ()
+
+    def take(self) -> str | None:
+        notice, batch_ids = self._notice, self._batch_ids
+        self.clear()
+        if not notice:
+            return None
+        append_event('repeat_notice_delivered', batch_ids=list(batch_ids))
+        return notice
+
+    def clear(self) -> None:
+        self._notice = ''
+        self._batch_ids = ()
 
 
 class ToolExecutionMiddleware:
     """Coordinate cancellation, failure policy, telemetry, and one prepared execution."""
 
     def __init__(self, manager: Any, failure_policy: FailureRetryPolicy | None = None,
-                 expanded_round_limit: int | None = None, cancel_check: Any = None):
+                 expanded_round_limit: int | None = None, cancel_check: Any = None,
+                 repeat_monitor: ExactRepeatMonitor | None = None,
+                 notice_buffer: OneShotNoticeBuffer | None = None):
         self._manager = manager
         self._failure_policy = failure_policy or FailureRetryPolicy()
         self._expanded_round_limit = expanded_round_limit
         self._cancel_check = cancel_check
+        self._repeat_monitor = repeat_monitor
+        self._notice_buffer = notice_buffer
 
     def __getattr__(self, name: str) -> Any:
         return getattr(self._manager, name)
@@ -328,46 +334,56 @@ class ToolExecutionMiddleware:
                 f'tool round limit to {self._expanded_round_limit}.'
             )
 
-    def execute_prepared_calls(self, prepared_batch: PreparedToolBatch):
+    def execute_with_records(self, tools: Any, verbose: bool = False,
+                             allowed_tool_names: set[str] | None = None):
+        del verbose
         if self._cancel_check is not None:
             self._cancel_check(None)
-        if not isinstance(prepared_batch, PreparedToolBatch):
-            raise TypeError('execute_prepared_calls requires a PreparedToolBatch')
-        prepared_calls = list(prepared_batch.calls)
-        if not prepared_calls:
-            return self._manager.execute_prepared_calls(prepared_batch)
-        decision = self._failure_policy.decide(prepared_calls)
-        for index, prepared in enumerate(prepared_calls):
-            if index in decision.pending_indices and prepared.ready:
-                self._expand_round_limit(prepared.tool_name)
-            arguments = redact_session_env_arguments(prepared.tool_name, prepared.arguments)
-            if index in decision.blocked_results:
-                emit_tool_call(prepared.tool_call, blocked=True, reason='failure_retry_policy')
-                _log_tool_call('blocked', prepared.tool_name, reason='failure_retry_policy', args=arguments)
-                append_event('failure_retry_blocked', name=prepared.tool_name, call_id=prepared.call_id)
-            elif index in decision.duplicate_sources:
-                emit_tool_call(prepared.tool_call, blocked=True, reason='duplicate_merged')
-                _log_tool_call('merged', prepared.tool_name, reason='duplicate_in_batch', args=arguments)
-            else:
-                emit_tool_call(prepared.tool_call)
-                _log_tool_call('start', prepared.tool_name, args=arguments)
-        started_at = time.perf_counter()
-        executed_batch = self._manager.execute_prepared_calls(
-            prepared_batch,
-            selected_indices=decision.pending_indices,
+        prepared_calls: list[PreparedToolCall] = []
+        decision: _FailureBatchDecision | None = None
+        started_at = 0.0
+
+        def select(prepared):
+            nonlocal prepared_calls, decision, started_at
+            prepared_calls = list(prepared)
+            decision = self._failure_policy.decide(prepared_calls)
+            for index, item in enumerate(prepared_calls):
+                if index in decision.pending_indices and item.ready:
+                    self._expand_round_limit(item.tool_name)
+                arguments = redact_session_env_arguments(item.tool_name, item.arguments)
+                if index in decision.blocked_results:
+                    emit_tool_call(item.tool_call, blocked=True, reason='failure_retry_policy')
+                    _log_tool_call(
+                        'blocked', item.tool_name,
+                        reason='failure_retry_policy', args=arguments,
+                    )
+                    append_event('failure_retry_blocked', name=item.tool_name, call_id=item.call_id)
+                elif index in decision.duplicate_sources:
+                    emit_tool_call(item.tool_call, blocked=True, reason='duplicate_merged')
+                    _log_tool_call('merged', item.tool_name, reason='duplicate_in_batch', args=arguments)
+                else:
+                    emit_tool_call(item.tool_call)
+                    _log_tool_call('start', item.tool_name, args=arguments)
+            started_at = time.perf_counter()
+            return decision.pending_indices
+
+        executed_batch = self._manager.execute_with_records(
+            tools,
+            allowed_tool_names=allowed_tool_names,
+            dispatch_selector=select,
         )
+        if decision is None:
+            return executed_batch
         elapsed = time.perf_counter() - started_at
         results: list[Any] = [None] * len(prepared_calls)
         records: list[ToolExecutionRecord | None] = [None] * len(prepared_calls)
-        for original_index, result, record in zip(
-            decision.pending_indices, executed_batch.results, executed_batch.records,
-        ):
-            results[original_index] = result
-            records[original_index] = record
-            emit_tool_result(prepared_calls[original_index].tool_call, result)
+        for result, record in zip(executed_batch.results, executed_batch.records):
+            results[record.index] = result
+            records[record.index] = record
+            emit_tool_result(prepared_calls[record.index].tool_call, result)
             _log_tool_call(
                 'done',
-                prepared_calls[original_index].tool_name,
+                prepared_calls[record.index].tool_name,
                 elapsed=f'{elapsed:.3f}s',
                 **_summarize_tool_result(result),
             )
@@ -376,7 +392,8 @@ class ToolExecutionMiddleware:
             records[index] = ToolExecutionRecord(
                 prepared_calls[index],
                 result,
-                disposition=ToolExecutionDisposition.POLICY_BLOCKED,
+                disposition=ToolExecutionDisposition.SKIPPED,
+                reason='policy_blocked',
             )
             emit_tool_result(prepared_calls[index].tool_call, result)
         for index, source_index in decision.duplicate_sources.items():
@@ -385,21 +402,20 @@ class ToolExecutionMiddleware:
             records[index] = ToolExecutionRecord(
                 prepared_calls[index],
                 result,
-                disposition=ToolExecutionDisposition.DEDUPLICATED,
+                disposition=ToolExecutionDisposition.SKIPPED,
+                reason='deduplicated',
             )
             emit_tool_result(prepared_calls[index].tool_call, result)
         completed_records = [record for record in records if record is not None]
         self._failure_policy.observe(completed_records)
-        return ToolExecutionBatch(
+        batch = ToolExecutionBatch(
             results=lazyllm.package(results),
             records=tuple(completed_records),
         )
-
-    def execute_with_records(self, tools: Any, verbose: bool = False,
-                             allowed_tool_names: set[str] | None = None):
-        del verbose
-        prepared_batch = self._manager.prepare_tool_calls(tools, allowed_tool_names)
-        return self.execute_prepared_calls(prepared_batch)
+        if self._repeat_monitor is not None and self._notice_buffer is not None:
+            notice = self._repeat_monitor.after_tool_batch(completed_records)
+            self._notice_buffer.publish(notice, [record.call_id for record in completed_records])
+        return batch
 
     def __call__(self, tools: Any, verbose: bool = False,
                  allowed_tool_names: set[str] | None = None) -> Any:

--- a/algorithm/lazymind/chat/engine/agent_runtime/tool_call_guard.py
+++ b/algorithm/lazymind/chat/engine/agent_runtime/tool_call_guard.py
@@ -1,0 +1,248 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import time
+from dataclasses import dataclass
+from typing import Any
+
+import lazyllm
+
+from lazymind.chat.engine.tools.session_env import redact_session_env_arguments
+from .telemetry import emit_tool_call, emit_tool_result
+
+
+_EXPANDED_BUDGET_TOOLS = {
+    'advance_step',
+    'advance_step_and_hand_off',
+    'create_workflow_draft',
+    'create_subagent',
+}
+_MAX_TOOL_LOG_CHARS = 800
+_RESULT_LOG_KEYS = (
+    'target', 'display_name', 'kind', 'file_id', 'offset', 'end_line',
+    'total_lines', 'eof', 'next_offset', 'limit', 'pattern', 'total',
+    'truncated', 'status', 'filename', 'corpus', 'skipped', 'channels',
+)
+_REPEATED_CALL_THRESHOLD = 3
+
+
+@dataclass
+class _RepeatedCallState:
+    tool_name: str
+    arguments_digest: str
+    result_digest: str
+    count: int
+
+
+def _requires_expanded_budget(tool_name: str) -> bool:
+    return tool_name in _EXPANDED_BUDGET_TOOLS or tool_name.startswith('trigger_')
+
+
+def _tool_call_session_id() -> str:
+    cfg = lazyllm.globals.get('agentic_config') or {}
+    if isinstance(cfg, dict) and cfg.get('session_id'):
+        return str(cfg['session_id'])
+    try:
+        return str(getattr(lazyllm.globals, '_sid', '') or '')
+    except Exception:
+        return ''
+
+
+def _compact_json(value: Any, limit: int = _MAX_TOOL_LOG_CHARS) -> str:
+    try:
+        text = json.dumps(value, ensure_ascii=False, default=str)
+    except Exception:
+        text = str(value)
+    if len(text) > limit:
+        return text[:limit] + f'...<{len(text) - limit} more chars>'
+    return text
+
+
+def _parse_tool_arguments(function: dict[str, Any]) -> Any:
+    arguments = function.get('arguments', {})
+    if isinstance(arguments, str):
+        try:
+            return json.loads(arguments)
+        except Exception:
+            return arguments
+    return arguments
+
+
+def _stable_digest(value: Any) -> str:
+    try:
+        normalized = json.dumps(
+            value,
+            ensure_ascii=False,
+            sort_keys=True,
+            separators=(',', ':'),
+            default=str,
+        )
+    except Exception:
+        normalized = str(value)
+    return hashlib.sha256(normalized.encode('utf-8')).hexdigest()
+
+
+def _summarize_tool_result(result: Any) -> dict[str, Any]:
+    summary: dict[str, Any] = {}
+    if not isinstance(result, dict):
+        summary['result_type'] = type(result).__name__
+        return summary
+    if 'ok' in result:
+        summary['ok'] = result.get('ok')
+    msg = result.get('msg')
+    if msg:
+        summary['msg'] = str(msg)[:240]
+    value = result.get('value') if 'value' in result else result
+    if not isinstance(value, dict):
+        return summary
+    if 'success' in value:
+        summary['success'] = value.get('success')
+    error = value.get('error')
+    if isinstance(error, dict) and error.get('reason'):
+        summary['error'] = str(error.get('reason'))[:240]
+    payload = value.get('result') if isinstance(value.get('result'), dict) else value
+    if not isinstance(payload, dict):
+        return summary
+    for key in _RESULT_LOG_KEYS:
+        if key in payload and payload[key] is not None:
+            summary[key] = payload[key]
+    matches = payload.get('matches')
+    if isinstance(matches, list):
+        summary['match_count'] = len(matches)
+    footer = payload.get('footer')
+    if isinstance(footer, str) and footer.strip():
+        summary['footer'] = footer.strip()[:240]
+    return summary
+
+
+def _format_log_fields(fields: dict[str, Any]) -> str:
+    parts: list[str] = []
+    for key, value in fields.items():
+        if value is None:
+            continue
+        rendered = _compact_json(value, 240) if isinstance(value, (dict, list)) else str(value)
+        parts.append(f'[{key}={rendered}]')
+    return ' '.join(parts)
+
+
+def _log_tool_call(event: str, name: str, **fields: Any) -> None:
+    extras = _format_log_fields(fields)
+    suffix = f' {extras}' if extras else ''
+    lazyllm.LOG.info(
+        f'[ToolCall] [sid={_tool_call_session_id()}] [event={event}] [name={name}]{suffix}'
+    )
+
+
+class ToolCallGuard:
+    """Monitor tool calls and queue internal runtime notices without changing results."""
+
+    def __init__(self, manager: Any, expanded_round_limit: int | None = None, cancel_check: Any = None):
+        self._manager = manager
+        self._expanded_round_limit = expanded_round_limit
+        self._cancel_check = cancel_check
+        self._repeated_call_state: _RepeatedCallState | None = None
+        self._internal_runtime_notices: dict[tuple[str, ...], str] = {}
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._manager, name)
+
+    def reset_internal_runtime_notice_state(self) -> None:
+        self._repeated_call_state = None
+        self._internal_runtime_notices.clear()
+
+    def consume_internal_runtime_notices(self, batch_tool_call_ids) -> list[str]:
+        ids = tuple(str(item) for item in batch_tool_call_ids)
+        if not self._internal_runtime_notices:
+            return []
+        if ids not in self._internal_runtime_notices:
+            self.reset_internal_runtime_notice_state()
+            return []
+        notice = self._internal_runtime_notices.pop(ids)
+        return [notice]
+
+    def _expand_round_limit(self, tool_name: str) -> None:
+        if not _requires_expanded_budget(tool_name):
+            return
+        workspace = lazyllm.locals.get('_lazyllm_agent', {}).get('workspace')
+        if (
+            isinstance(workspace, dict)
+            and self._expanded_round_limit is not None
+            and workspace.get('_react_round_limit') != self._expanded_round_limit
+        ):
+            workspace['_react_round_limit'] = self._expanded_round_limit
+            lazyllm.LOG.info(
+                f'ChatAgent used tool={tool_name}; automatically expanding '
+                f'tool round limit to {self._expanded_round_limit}.'
+            )
+
+    def _update_repeated_state(self, tool_call: dict[str, Any], result: Any, access: Any) -> int:
+        if bool(getattr(access, 'polling', False)) or bool(getattr(access, 'counts_as_progress', False)):
+            self._repeated_call_state = None
+            return 0
+        function = tool_call.get('function') or {}
+        name = str(function.get('name') or '')
+        arguments_digest = _stable_digest(_parse_tool_arguments(function))
+        result_digest = _stable_digest(result)
+        previous = self._repeated_call_state
+        if (
+            previous is not None
+            and previous.tool_name == name
+            and previous.arguments_digest == arguments_digest
+            and previous.result_digest == result_digest
+        ):
+            count = previous.count + 1
+        else:
+            count = 1
+        self._repeated_call_state = _RepeatedCallState(name, arguments_digest, result_digest, count)
+        return count
+
+    def __call__(self, tools: Any, verbose: bool = False,
+                 allowed_tool_names: set[str] | None = None) -> Any:
+        try:
+            if self._cancel_check is not None:
+                self._cancel_check(None)
+            tool_calls = [tools] if isinstance(tools, dict) else list(tools or [])
+            normalizer = getattr(self._manager, 'normalize_tool_calls', None)
+            if callable(normalizer):
+                normalizer(tool_calls)
+            for tool_call in tool_calls:
+                function = tool_call.get('function') or {}
+                name = str(function.get('name') or '')
+                self._expand_round_limit(name)
+                _log_tool_call(
+                    'start', name,
+                    args=redact_session_env_arguments(name, _parse_tool_arguments(function)),
+                )
+                emit_tool_call(tool_call)
+            resolver = getattr(self._manager, 'resolve_tool_accesses', None)
+            accesses = resolver(tool_calls, allowed_tool_names) if callable(resolver) else [None] * len(tool_calls)
+            started_at = time.perf_counter()
+            results = self._manager(
+                tool_calls,
+                verbose=verbose,
+                allowed_tool_names=allowed_tool_names,
+            )
+            elapsed = time.perf_counter() - started_at
+        except Exception:
+            self.reset_internal_runtime_notice_state()
+            raise
+
+        highest_count = 0
+        result_items = list(results)
+        if len(result_items) != len(tool_calls) or len(accesses) != len(tool_calls):
+            self.reset_internal_runtime_notice_state()
+            return results
+        for tool_call, result, access in zip(tool_calls, result_items, accesses):
+            emit_tool_result(tool_call, result)
+            name = str((tool_call.get('function') or {}).get('name') or '')
+            _log_tool_call('done', name, elapsed=f'{elapsed:.3f}s', **_summarize_tool_result(result))
+            highest_count = max(highest_count, self._update_repeated_state(tool_call, result, access))
+        if highest_count >= _REPEATED_CALL_THRESHOLD:
+            ids = tuple(str(tool_call.get('id') or '') for tool_call in tool_calls)
+            self._internal_runtime_notices[ids] = (
+                '[Internal runtime notice]\n'
+                f'The same tool call has returned the same result {highest_count} consecutive times. '
+                'Review the result and change the approach or arguments instead of repeating it unchanged.'
+            )
+        return results

--- a/algorithm/lazymind/chat/engine/agent_runtime/tool_call_guard.py
+++ b/algorithm/lazymind/chat/engine/agent_runtime/tool_call_guard.py
@@ -9,10 +9,12 @@ from typing import Any
 
 import lazyllm
 from lazyllm.tools.agent import (
+    PreparedToolBatch,
     PreparedToolCall,
     RuntimeContext,
     RuntimeDelta,
     ToolExecutionBatch,
+    ToolExecutionDisposition,
     ToolExecutionRecord,
 )
 from lazyllm.tools.agent.toolError import tool_failure
@@ -195,7 +197,10 @@ class FailureRetryPolicy:
     def observe(self, records: list[ToolExecutionRecord]) -> None:
         for record in records:
             name = record.tool_name
-            if name not in self._failure_limits or not record.executed:
+            if (
+                name not in self._failure_limits
+                or record.disposition is not ToolExecutionDisposition.EXECUTED
+            ):
                 continue
             signature = self._signature(record.prepared)
             if self._failed(record.result):
@@ -251,7 +256,11 @@ class ExactRepeatMonitor:
         self._pending_notice = False
         eligible = [
             record for record in records
-            if record.executed and not record.access.polling
+            if record.disposition in {
+                ToolExecutionDisposition.EXECUTED,
+                ToolExecutionDisposition.PREPARATION_FAILED,
+                ToolExecutionDisposition.DISPATCH_FAILED,
+            } and not record.access.polling
         ]
         if not eligible:
             self._reset()
@@ -319,16 +328,18 @@ class ToolExecutionMiddleware:
                 f'tool round limit to {self._expanded_round_limit}.'
             )
 
-    def execute_prepared_calls(self, prepared_calls):
+    def execute_prepared_calls(self, prepared_batch: PreparedToolBatch):
         if self._cancel_check is not None:
             self._cancel_check(None)
-        prepared_calls = list(prepared_calls or [])
+        if not isinstance(prepared_batch, PreparedToolBatch):
+            raise TypeError('execute_prepared_calls requires a PreparedToolBatch')
+        prepared_calls = list(prepared_batch.calls)
         if not prepared_calls:
-            return ToolExecutionBatch(results=[], records=())
+            return self._manager.execute_prepared_calls(prepared_batch)
         decision = self._failure_policy.decide(prepared_calls)
-        pending = [prepared_calls[index] for index in decision.pending_indices]
         for index, prepared in enumerate(prepared_calls):
-            self._expand_round_limit(prepared.tool_name)
+            if index in decision.pending_indices and prepared.ready:
+                self._expand_round_limit(prepared.tool_name)
             arguments = redact_session_env_arguments(prepared.tool_name, prepared.arguments)
             if index in decision.blocked_results:
                 emit_tool_call(prepared.tool_call, blocked=True, reason='failure_retry_policy')
@@ -341,7 +352,10 @@ class ToolExecutionMiddleware:
                 emit_tool_call(prepared.tool_call)
                 _log_tool_call('start', prepared.tool_name, args=arguments)
         started_at = time.perf_counter()
-        executed_batch = self._manager.execute_prepared_calls(pending)
+        executed_batch = self._manager.execute_prepared_calls(
+            prepared_batch,
+            selected_indices=decision.pending_indices,
+        )
         elapsed = time.perf_counter() - started_at
         results: list[Any] = [None] * len(prepared_calls)
         records: list[ToolExecutionRecord | None] = [None] * len(prepared_calls)
@@ -359,12 +373,20 @@ class ToolExecutionMiddleware:
             )
         for index, result in decision.blocked_results.items():
             results[index] = result
-            records[index] = ToolExecutionRecord(prepared_calls[index], result, executed=False)
+            records[index] = ToolExecutionRecord(
+                prepared_calls[index],
+                result,
+                disposition=ToolExecutionDisposition.POLICY_BLOCKED,
+            )
             emit_tool_result(prepared_calls[index].tool_call, result)
         for index, source_index in decision.duplicate_sources.items():
             result = results[source_index]
             results[index] = result
-            records[index] = ToolExecutionRecord(prepared_calls[index], result, executed=False)
+            records[index] = ToolExecutionRecord(
+                prepared_calls[index],
+                result,
+                disposition=ToolExecutionDisposition.DEDUPLICATED,
+            )
             emit_tool_result(prepared_calls[index].tool_call, result)
         completed_records = [record for record in records if record is not None]
         self._failure_policy.observe(completed_records)
@@ -376,8 +398,8 @@ class ToolExecutionMiddleware:
     def execute_with_records(self, tools: Any, verbose: bool = False,
                              allowed_tool_names: set[str] | None = None):
         del verbose
-        prepared = self._manager.prepare_tool_calls(tools, allowed_tool_names)
-        return self.execute_prepared_calls(prepared)
+        prepared_batch = self._manager.prepare_tool_calls(tools, allowed_tool_names)
+        return self.execute_prepared_calls(prepared_batch)
 
     def __call__(self, tools: Any, verbose: bool = False,
                  allowed_tool_names: set[str] | None = None) -> Any:

--- a/algorithm/lazymind/chat/engine/tools/infra/tool_result_citations.py
+++ b/algorithm/lazymind/chat/engine/tools/infra/tool_result_citations.py
@@ -7,7 +7,7 @@ from dataclasses import replace
 from typing import Any
 
 import lazyllm
-from lazyllm.tools.agent import PreparedToolBatch, ToolExecutionBatch
+from lazyllm.tools.agent import ToolExecutionBatch
 from lazyllm.tools.tools.search import SearchBase
 
 from lazymind.chat.engine.tools.lazy_kb import KBToolkit
@@ -119,7 +119,7 @@ class CitationResultMiddleware:
             return result
         return {**result, 'value': processed}
 
-    def _process_batch(self, batch: ToolExecutionBatch, tool_calls: list[dict[str, Any]]):
+    def _process_batch(self, batch: ToolExecutionBatch):
         results = list(batch.results)
         state = _citation_state()
         if not state:
@@ -128,9 +128,9 @@ class CitationResultMiddleware:
         collect_only = agentic_config.get('citation_mode') == 'collect_only'
         processed = [
             self._process_result(
-                tool_call, result, state, collect_only=collect_only,
+                record.prepared.tool_call, result, state, collect_only=collect_only,
             )
-            for tool_call, result in zip(tool_calls, results)
+            for record, result in zip(batch.records, results)
         ]
         records = tuple(
             replace(record, result=result)
@@ -138,25 +138,16 @@ class CitationResultMiddleware:
         )
         return ToolExecutionBatch(results=processed, records=records)
 
-    def execute_prepared_calls(
-        self,
-        prepared_batch: PreparedToolBatch,
-        selected_indices=None,
-    ):
-        batch = self._manager.execute_prepared_calls(
-            prepared_batch,
-            selected_indices=selected_indices,
-        )
-        return self._process_batch(
-            batch,
-            [record.prepared.tool_call for record in batch.records],
-        )
-
     def execute_with_records(self, tools: Any, verbose: bool = False,
-                             allowed_tool_names: set[str] | None = None):
+                             allowed_tool_names: set[str] | None = None,
+                             *, dispatch_selector=None):
         del verbose
-        prepared = self._manager.prepare_tool_calls(tools, allowed_tool_names)
-        return self.execute_prepared_calls(prepared)
+        batch = self._manager.execute_with_records(
+            tools,
+            allowed_tool_names=allowed_tool_names,
+            dispatch_selector=dispatch_selector,
+        )
+        return self._process_batch(batch)
 
     def __call__(self, tools: Any, verbose: bool = False,
                  allowed_tool_names: set[str] | None = None) -> Any:

--- a/algorithm/lazymind/chat/engine/tools/infra/tool_result_citations.py
+++ b/algorithm/lazymind/chat/engine/tools/infra/tool_result_citations.py
@@ -7,7 +7,7 @@ from dataclasses import replace
 from typing import Any
 
 import lazyllm
-from lazyllm.tools.agent import ToolExecutionBatch
+from lazyllm.tools.agent import PreparedToolBatch, ToolExecutionBatch
 from lazyllm.tools.tools.search import SearchBase
 
 from lazymind.chat.engine.tools.lazy_kb import KBToolkit
@@ -138,10 +138,19 @@ class CitationResultMiddleware:
         )
         return ToolExecutionBatch(results=processed, records=records)
 
-    def execute_prepared_calls(self, prepared_calls):
-        prepared_calls = list(prepared_calls or [])
-        batch = self._manager.execute_prepared_calls(prepared_calls)
-        return self._process_batch(batch, [item.tool_call for item in prepared_calls])
+    def execute_prepared_calls(
+        self,
+        prepared_batch: PreparedToolBatch,
+        selected_indices=None,
+    ):
+        batch = self._manager.execute_prepared_calls(
+            prepared_batch,
+            selected_indices=selected_indices,
+        )
+        return self._process_batch(
+            batch,
+            [record.prepared.tool_call for record in batch.records],
+        )
 
     def execute_with_records(self, tools: Any, verbose: bool = False,
                              allowed_tool_names: set[str] | None = None):

--- a/algorithm/lazymind/chat/engine/tools/infra/tool_result_citations.py
+++ b/algorithm/lazymind/chat/engine/tools/infra/tool_result_citations.py
@@ -3,9 +3,11 @@
 from __future__ import annotations
 
 import copy
+from dataclasses import replace
 from typing import Any
 
 import lazyllm
+from lazyllm.tools.agent import ToolExecutionBatch
 from lazyllm.tools.tools.search import SearchBase
 
 from lazymind.chat.engine.tools.lazy_kb import KBToolkit
@@ -117,22 +119,40 @@ class CitationResultMiddleware:
             return result
         return {**result, 'value': processed}
 
-    def __call__(self, tools: Any, verbose: bool = False,
-                 allowed_tool_names: set[str] | None = None) -> Any:
-        tool_calls = [tools] if isinstance(tools, dict) else list(tools or [])
-        results = list(self._manager(
-            tools,
-            verbose=verbose,
-            allowed_tool_names=allowed_tool_names,
-        ))
+    def _process_batch(self, batch: ToolExecutionBatch, tool_calls: list[dict[str, Any]]):
+        results = list(batch.results)
         state = _citation_state()
         if not state:
-            return results
+            return ToolExecutionBatch(results=results, records=batch.records)
         agentic_config = lazyllm.globals.get('agentic_config') or {}
         collect_only = agentic_config.get('citation_mode') == 'collect_only'
-        return [
+        processed = [
             self._process_result(
                 tool_call, result, state, collect_only=collect_only,
             )
             for tool_call, result in zip(tool_calls, results)
         ]
+        records = tuple(
+            replace(record, result=result)
+            for record, result in zip(batch.records, processed)
+        )
+        return ToolExecutionBatch(results=processed, records=records)
+
+    def execute_prepared_calls(self, prepared_calls):
+        prepared_calls = list(prepared_calls or [])
+        batch = self._manager.execute_prepared_calls(prepared_calls)
+        return self._process_batch(batch, [item.tool_call for item in prepared_calls])
+
+    def execute_with_records(self, tools: Any, verbose: bool = False,
+                             allowed_tool_names: set[str] | None = None):
+        del verbose
+        prepared = self._manager.prepare_tool_calls(tools, allowed_tool_names)
+        return self.execute_prepared_calls(prepared)
+
+    def __call__(self, tools: Any, verbose: bool = False,
+                 allowed_tool_names: set[str] | None = None) -> Any:
+        return self.execute_with_records(
+            tools,
+            verbose=verbose,
+            allowed_tool_names=allowed_tool_names,
+        ).results

--- a/algorithm/lazymind/chat/engine/tools/local_file/workspace.py
+++ b/algorithm/lazymind/chat/engine/tools/local_file/workspace.py
@@ -130,6 +130,12 @@ def _resolve_workspace_path(path: str, user_id: str, conversation_id: str) -> tu
     return workspace, resolved
 
 
+def _workspace_file_resource(arguments: Dict[str, Any], key: str = 'path'):
+    user_id, conversation_id = _current_artifact_scope()
+    _, resolved = _resolve_workspace_path(str(arguments[key]), user_id, conversation_id)
+    return 'file', resolved
+
+
 def _file_tool_root(workspace: str) -> Optional[str]:
     return None if _cfg['trusted_local_mode'] else workspace
 
@@ -267,7 +273,7 @@ def save_chat_file(
     }
 
 
-@fc_register(write_keys=lambda args: ('file', args['path']))
+@fc_register(write_keys=_workspace_file_resource)
 def write_file(
     path: str,
     content: str,
@@ -317,6 +323,7 @@ def _resolve_text_target_for_tool(
         raise ToolExecutionError(str(exc)) from exc
 
 
+@fc_register(exclusive=True)
 def read_file(
     target: str,
     offset: int = 1,
@@ -351,6 +358,7 @@ def read_file(
     return payload
 
 
+@fc_register(exclusive=True)
 def grep(
     target: str,
     pattern: str,
@@ -438,6 +446,7 @@ def grep(
     }
 
 
+@fc_register(read_keys=_workspace_file_resource)
 def list_dir(path: str = '.', recursive: bool = False, max_depth: int = 5) -> Dict[str, Any]:
     """List files in the current chat workspace or an allowed host path.
 

--- a/algorithm/lazymind/chat/engine/tools/local_file/workspace.py
+++ b/algorithm/lazymind/chat/engine/tools/local_file/workspace.py
@@ -9,6 +9,7 @@ import uuid
 from typing import Any, Dict, Literal, Optional
 
 import lazyllm
+from lazyllm.tools import fc_register
 from lazyllm.tools.agent import (
     ToolExecutionError,
 )
@@ -19,6 +20,7 @@ from lazyllm.tools.agent.file_tool import (
 )
 
 from lazymind.config import config as _cfg
+
 from .resolver import resolve_text_target
 from .window import (
     RESULT_BYTE_BUDGET,
@@ -265,6 +267,7 @@ def save_chat_file(
     }
 
 
+@fc_register(write_keys=lambda args: ('file', args['path']))
 def write_file(
     path: str,
     content: str,

--- a/algorithm/lazymind/chat/engine/tools/memory.py
+++ b/algorithm/lazymind/chat/engine/tools/memory.py
@@ -5,7 +5,7 @@ from typing import Any, Dict, List, Literal, Union
 import lazyllm
 import requests
 from lazyllm.tools.agent import ToolExecutionError
-from lazyllm.tools import tool_concurrency
+from lazyllm.tools import fc_register
 from pydantic import ValidationError
 
 from lazymind.common.memory import (
@@ -272,7 +272,7 @@ class MemoryTools:
     def __lazy_source__(self) -> bool:
         return False
 
-    @tool_concurrency(read_keys=_read_memory_keys)
+    @fc_register(read_keys=_read_memory_keys)
     def read_memory(
         self,
         target: Literal['soul', 'profile', 'preference'],
@@ -350,7 +350,7 @@ class MemoryTools:
             },
         )
 
-    @tool_concurrency(read_keys=_read_memory_reference_keys)
+    @fc_register(read_keys=_read_memory_reference_keys)
     def read_memory_reference(self, refs: Union[str, List[str]]) -> Dict[str, Any]:
         """Read detailed user-preference reference files on demand.
 
@@ -440,7 +440,7 @@ class MemoryTools:
             },
         )
 
-    @tool_concurrency(write_keys=('memory', SOUL_PATH))
+    @fc_register(write_keys=('memory', SOUL_PATH))
     def soul_editor(self, operations: List[Dict[str, Any]]) -> Dict[str, Any]:
         """Apply one atomic batch of operations to the agent Soul.
 
@@ -484,7 +484,7 @@ class MemoryTools:
             ledger_result={'status': 'applied'},
         )
 
-    @tool_concurrency(write_keys=('memory', PROFILE_PATH))
+    @fc_register(write_keys=('memory', PROFILE_PATH))
     def profile_editor(self, operations: List[Dict[str, Any]]) -> Dict[str, Any]:
         """Apply one atomic batch of operations to the user Profile.
 
@@ -531,7 +531,7 @@ class MemoryTools:
             ledger_result={'status': 'applied'},
         )
 
-    @tool_concurrency(write_keys=[
+    @fc_register(write_keys=[
         ('memory', PREFERENCE_PATH),
         _REFERENCE_COLLECTION_KEY,
     ])

--- a/algorithm/lazymind/chat/engine/tools/subagent_chat_tools.py
+++ b/algorithm/lazymind/chat/engine/tools/subagent_chat_tools.py
@@ -5,6 +5,7 @@ import uuid
 from typing import Any, Dict, List, Optional
 
 import lazyllm
+from lazyllm.tools import fc_register
 
 from lazymind.chat.engine.subagent import SUBAGENT_ATTACHMENT_CONTEXT_KEY
 from lazymind.chat.engine.subagent.db import TaskQueryDB
@@ -321,6 +322,7 @@ def _resolve_task(task_ref: str, tasks: List[Dict[str, Any]]) -> Optional[Dict[s
     return None
 
 
+@fc_register(polling=True)
 def list_subagents(status: Optional[str] = None) -> Dict[str, Any]:
     """List SubAgent tasks in the current conversation, optionally filtered by status.
 
@@ -344,6 +346,7 @@ def list_subagents(status: Optional[str] = None) -> Dict[str, Any]:
     return {'status': 'ok', 'message': msg, 'tasks': tasks}
 
 
+@fc_register(polling=True)
 def get_subagent_status(task_ref: str) -> Dict[str, Any]:
     """Get the status of a SubAgent task.
 

--- a/algorithm/lazymind/chat/service/chat_service.py
+++ b/algorithm/lazymind/chat/service/chat_service.py
@@ -1567,6 +1567,16 @@ async def _handle_chat_impl(
                 'high': _cfg['agentic_max_rounds_high'],
                 'max': max(1, int(_cfg['agentic_expanded_max_rounds']) - 1),
             }.get(thinking_depth, _cfg['agentic_max_rounds_medium']),
+            tool_failure_limits={
+                'url_fetch': 2,
+                'grep': 2,
+                'read_file': 2,
+                'kb_tmp_search': 2,
+                'kb_search': 2,
+                'list_knowledge_bases': 2,
+                'list_knowledge_base_documents': 2,
+                'aggregate_knowledge_base_documents': 2,
+            },
             extra_stop_condition=make_cancel_stop_condition(),
         ),
     )

--- a/algorithm/lazymind/chat/service/chat_service.py
+++ b/algorithm/lazymind/chat/service/chat_service.py
@@ -1567,16 +1567,6 @@ async def _handle_chat_impl(
                 'high': _cfg['agentic_max_rounds_high'],
                 'max': max(1, int(_cfg['agentic_expanded_max_rounds']) - 1),
             }.get(thinking_depth, _cfg['agentic_max_rounds_medium']),
-            tool_failure_limits={
-                'url_fetch': 2,
-                'grep': 2,
-                'read_file': 2,
-                'kb_tmp_search': 2,
-                'kb_search': 2,
-                'list_knowledge_bases': 2,
-                'list_knowledge_base_documents': 2,
-                'aggregate_knowledge_base_documents': 2,
-            },
             extra_stop_condition=make_cancel_stop_condition(),
         ),
     )

--- a/algorithm/tests/chat/engine/test_tool_call_guard.py
+++ b/algorithm/tests/chat/engine/test_tool_call_guard.py
@@ -1,38 +1,29 @@
-from dataclasses import dataclass
-
-from lazymind.chat.engine.agent_runtime.tool_call_guard import ToolCallGuard
-
-
-@dataclass(frozen=True)
-class _Access:
-    counts_as_progress: bool = False
-    polling: bool = False
+from lazyllm.tools.agent import PreparedToolCall, ToolExecutionRecord
+from lazymind.chat.engine.agent_runtime.tool_call_guard import ExactRepeatMonitor
 
 
-class _Manager:
-    def __init__(self):
-        self.call_count = 0
+def _record(call_id: str):
+    arguments = {'query': 'same'}
+    prepared = PreparedToolCall(
+        tool_call={'id': call_id, 'function': {'name': 'search', 'arguments': arguments}},
+        call_id=call_id,
+        tool_name='search',
+        arguments=arguments,
+        validated_arguments=arguments,
+    )
+    return ToolExecutionRecord(
+        prepared,
+        {'ok': True, 'value': {'results': ['grounded']}},
+    )
 
-    def resolve_tool_accesses(self, calls, allowed_tool_names=None):
-        return [_Access() for _ in calls]
 
-    def __call__(self, calls, verbose=False, allowed_tool_names=None):
-        self.call_count += len(calls)
-        return [{'ok': True, 'value': {'results': ['grounded']}} for _ in calls]
+def test_identical_records_emit_a_fresh_notice_from_the_third_batch():
+    monitor = ExactRepeatMonitor()
+    notices = []
 
+    for index in range(4):
+        notices.append(monitor.after_tool_batch([_record(f'call-{index}')]).model_context)
 
-def _call(call_id: str):
-    return {'id': call_id, 'function': {'name': 'search', 'arguments': {'query': 'same'}}}
-
-
-def test_identical_calls_are_executed_and_notice_is_consumed_once():
-    manager = _Manager()
-    guard = ToolCallGuard(manager)
-
-    for index in range(3):
-        result = guard([_call(f'call-{index}')])
-        assert result[0]['ok'] is True
-
-    assert manager.call_count == 3
-    assert guard.consume_internal_runtime_notices(['call-2'])
-    assert guard.consume_internal_runtime_notices(['call-2']) == []
+    assert notices[:2] == [(), ()]
+    assert len(notices[2]) == 1
+    assert len(notices[3]) == 1

--- a/algorithm/tests/chat/engine/test_tool_call_guard.py
+++ b/algorithm/tests/chat/engine/test_tool_call_guard.py
@@ -1,33 +1,38 @@
-from unittest.mock import MagicMock
+from dataclasses import dataclass
 
-from lazymind.chat.engine.agent_runtime.executor import ToolCallGuard
-
-
-def _call(name: str = 'search', query: str = 'same'):
-    return {'function': {'name': name, 'arguments': {'query': query}}}
+from lazymind.chat.engine.agent_runtime.tool_call_guard import ToolCallGuard
 
 
-def test_exact_successful_call_is_blocked_after_limit_even_when_interleaved():
-    manager = MagicMock(side_effect=lambda calls, verbose=False: [
-        {'ok': True, 'value': {'results': ['grounded']}} for _ in calls
-    ])
-    guard = ToolCallGuard(manager, repeated_call_limit=3)
-
-    for _ in range(3):
-        assert guard([_call()])[0]['ok'] is True
-        assert guard([_call(query='different')])[0]['ok'] is True
-
-    blocked = guard([_call()])[0]
-    assert blocked['ok'] is False
-    assert 'exact same call was already made 3 times' in blocked['msg']
-    assert manager.call_count == 6
+@dataclass(frozen=True)
+class _Access:
+    counts_as_progress: bool = False
+    polling: bool = False
 
 
-def test_distinct_arguments_remain_allowed():
-    manager = MagicMock(side_effect=lambda calls, verbose=False: [
-        {'ok': True, 'value': {}} for _ in calls
-    ])
-    guard = ToolCallGuard(manager, repeated_call_limit=3)
+class _Manager:
+    def __init__(self):
+        self.call_count = 0
 
-    for index in range(10):
-        assert guard([_call(query=f'query-{index}')])[0]['ok'] is True
+    def resolve_tool_accesses(self, calls, allowed_tool_names=None):
+        return [_Access() for _ in calls]
+
+    def __call__(self, calls, verbose=False, allowed_tool_names=None):
+        self.call_count += len(calls)
+        return [{'ok': True, 'value': {'results': ['grounded']}} for _ in calls]
+
+
+def _call(call_id: str):
+    return {'id': call_id, 'function': {'name': 'search', 'arguments': {'query': 'same'}}}
+
+
+def test_identical_calls_are_executed_and_notice_is_consumed_once():
+    manager = _Manager()
+    guard = ToolCallGuard(manager)
+
+    for index in range(3):
+        result = guard([_call(f'call-{index}')])
+        assert result[0]['ok'] is True
+
+    assert manager.call_count == 3
+    assert guard.consume_internal_runtime_notices(['call-2'])
+    assert guard.consume_internal_runtime_notices(['call-2']) == []

--- a/tests/algorithm/chat/test_agent_executor.py
+++ b/tests/algorithm/chat/test_agent_executor.py
@@ -6,7 +6,11 @@ from asyncio import CancelledError
 from unittest.mock import MagicMock
 
 import pytest
-
+from lazyllm.tools.agent import (
+    PreparedToolCall,
+    ToolExecutionBatch,
+    ToolExecutionRecord,
+)
 from lazymind.chat.engine.agent_runtime import (
     AgentExecutionOptions,
     AgentExecutor,
@@ -31,6 +35,7 @@ def _plan(**options) -> AgentRunPlan:
 
 def test_executor_creates_agent_with_shared_defaults(monkeypatch) -> None:
     agent = MagicMock()
+    original_manager = agent._tools_manager
     constructor = MagicMock(return_value=agent)
     monkeypatch.setattr(executor_mod._agent_mod, 'ReactAgent', constructor)
 
@@ -43,6 +48,10 @@ def test_executor_creates_agent_with_shared_defaults(monkeypatch) -> None:
     assert kwargs['enable_builtin_tools'] is False
     assert callable(kwargs['on_max_retries'])
     assert kwargs['workspace'] == '/tmp/work'
+    assert len(kwargs['runtime_extensions']) == 1
+    assert isinstance(kwargs['runtime_extensions'][0], executor_mod.ExactRepeatMonitor)
+    assert isinstance(agent._tools_manager, executor_mod.ToolExecutionMiddleware)
+    assert agent._tools_manager._manager._manager is original_manager
     agent._prepare_tool_context.assert_called_once_with(
         '### User Instruction\n\nhello', [],
     )
@@ -61,14 +70,14 @@ def test_executor_passes_cancel_condition_to_chat_agent(monkeypatch) -> None:
 
 
 def test_tool_guard_checks_cancellation_before_dispatch(monkeypatch) -> None:
-    manager = MagicMock(return_value=[{'ok': True}])
+    manager = MagicMock()
     cancel_check = MagicMock(side_effect=CancelledError('stopped by user'))
-    guard = executor_mod.ToolCallGuard(manager, cancel_check=cancel_check)
+    middleware = executor_mod.ToolExecutionMiddleware(manager, cancel_check=cancel_check)
 
     with pytest.raises(CancelledError, match='stopped by user'):
-        guard([{'function': {'name': 'prepare_workflow', 'arguments': '{}'}}])
+        middleware.execute_prepared_calls([])
 
-    manager.assert_not_called()
+    manager.execute_prepared_calls.assert_not_called()
 
 
 def test_cancel_condition_stops_the_sid_scoped_agent(monkeypatch) -> None:
@@ -105,7 +114,24 @@ def test_executor_enables_builtin_tools_in_trusted_local_mode(monkeypatch) -> No
 
 def test_executor_auto_expands_after_plugin_or_subagent_tool(monkeypatch) -> None:
     agent = MagicMock()
-    agent._tools_manager = MagicMock(return_value=[{'ok': True}])
+    manager = MagicMock()
+    prepared = PreparedToolCall(
+        tool_call={
+            'id': 'create',
+            'function': {'name': 'create_subagent', 'arguments': '{}'},
+        },
+        call_id='create',
+        tool_name='create_subagent',
+        arguments={},
+        validated_arguments={},
+    )
+    result = {'ok': True, 'value': 'created'}
+    manager.prepare_tool_calls.return_value = [prepared]
+    manager.execute_prepared_calls.return_value = ToolExecutionBatch(
+        results=[result],
+        records=(ToolExecutionRecord(prepared, result),),
+    )
+    agent._tools_manager = manager
     constructor = MagicMock(return_value=agent)
     monkeypatch.setattr(executor_mod._agent_mod, 'ReactAgent', constructor)
     workspace = {}

--- a/tests/algorithm/chat/test_agent_executor.py
+++ b/tests/algorithm/chat/test_agent_executor.py
@@ -44,10 +44,11 @@ def test_executor_creates_agent_with_shared_defaults(monkeypatch) -> None:
     assert kwargs['enable_builtin_tools'] is False
     assert callable(kwargs['on_max_retries'])
     assert kwargs['workspace'] == '/tmp/work'
-    assert len(kwargs['runtime_extensions']) == 1
-    assert isinstance(kwargs['runtime_extensions'][0], executor_mod.ExactRepeatMonitor)
+    assert callable(kwargs['model_context_provider'])
     assert isinstance(agent._tools_manager, executor_mod.ToolExecutionMiddleware)
     assert agent._tools_manager._manager._manager is original_manager
+    assert isinstance(agent._exact_repeat_monitor, executor_mod.ExactRepeatMonitor)
+    assert isinstance(agent._runtime_notice_buffer, executor_mod.OneShotNoticeBuffer)
     agent._prepare_tool_context.assert_called_once_with(
         '### User Instruction\n\nhello', [],
     )
@@ -73,7 +74,7 @@ def test_tool_guard_checks_cancellation_before_dispatch(monkeypatch) -> None:
     with pytest.raises(CancelledError, match='stopped by user'):
         middleware.execute_with_records([])
 
-    manager.execute_prepared_calls.assert_not_called()
+    manager.execute_with_records.assert_not_called()
 
 
 def test_cancel_condition_stops_the_sid_scoped_agent(monkeypatch) -> None:
@@ -180,3 +181,48 @@ def test_executor_stream_passes_history_and_returns_final(monkeypatch) -> None:
         ('event', {'tag': 'text', 'delta': 'working'}),
         ('final', 'done'),
     ]
+
+
+@pytest.mark.parametrize('mode', ['success', 'exception', 'cancellation'])
+def test_stream_agent_clears_repeat_state_on_every_exit(monkeypatch, mode) -> None:
+    monitor = MagicMock()
+    buffer = MagicMock()
+
+    class Agent:
+        _agent_lab_run_id = 'run-id'
+        _exact_repeat_monitor = monitor
+        _runtime_notice_buffer = buffer
+
+    class Future:
+        def result(self):
+            if mode == 'exception':
+                raise RuntimeError('failed')
+            return 'done'
+
+    class Helper:
+        future = Future()
+
+        def __init__(self, _agent, init_sid):
+            assert init_sid is False
+
+        async def astream(self, _query, **_kwargs):
+            if mode == 'cancellation':
+                raise CancelledError('cancelled')
+            if False:
+                yield None
+
+    monkeypatch.setattr(executor_mod._sh, 'StreamCallHelper', Helper)
+
+    async def collect():
+        return [item async for item in AgentExecutor().stream_agent(Agent(), _plan())]
+
+    if mode == 'exception':
+        with pytest.raises(RuntimeError, match='failed'):
+            asyncio.run(collect())
+    elif mode == 'cancellation':
+        with pytest.raises(CancelledError, match='cancelled'):
+            asyncio.run(collect())
+    else:
+        assert asyncio.run(collect()) == [('final', 'done')]
+    assert monitor.reset.call_count == 2
+    assert buffer.clear.call_count == 2

--- a/tests/algorithm/chat/test_agent_executor.py
+++ b/tests/algorithm/chat/test_agent_executor.py
@@ -6,11 +6,7 @@ from asyncio import CancelledError
 from unittest.mock import MagicMock
 
 import pytest
-from lazyllm.tools.agent import (
-    PreparedToolCall,
-    ToolExecutionBatch,
-    ToolExecutionRecord,
-)
+from lazyllm.tools.agent import ToolManager
 from lazymind.chat.engine.agent_runtime import (
     AgentExecutionOptions,
     AgentExecutor,
@@ -75,7 +71,7 @@ def test_tool_guard_checks_cancellation_before_dispatch(monkeypatch) -> None:
     middleware = executor_mod.ToolExecutionMiddleware(manager, cancel_check=cancel_check)
 
     with pytest.raises(CancelledError, match='stopped by user'):
-        middleware.execute_prepared_calls([])
+        middleware.execute_with_records([])
 
     manager.execute_prepared_calls.assert_not_called()
 
@@ -114,23 +110,12 @@ def test_executor_enables_builtin_tools_in_trusted_local_mode(monkeypatch) -> No
 
 def test_executor_auto_expands_after_plugin_or_subagent_tool(monkeypatch) -> None:
     agent = MagicMock()
-    manager = MagicMock()
-    prepared = PreparedToolCall(
-        tool_call={
-            'id': 'create',
-            'function': {'name': 'create_subagent', 'arguments': '{}'},
-        },
-        call_id='create',
-        tool_name='create_subagent',
-        arguments={},
-        validated_arguments={},
-    )
-    result = {'ok': True, 'value': 'created'}
-    manager.prepare_tool_calls.return_value = [prepared]
-    manager.execute_prepared_calls.return_value = ToolExecutionBatch(
-        results=[result],
-        records=(ToolExecutionRecord(prepared, result),),
-    )
+
+    def create_subagent():
+        '''Create a subagent.'''
+        return 'created'
+
+    manager = ToolManager([create_subagent])
     agent._tools_manager = manager
     constructor = MagicMock(return_value=agent)
     monkeypatch.setattr(executor_mod._agent_mod, 'ReactAgent', constructor)

--- a/tests/algorithm/chat/test_agent_runtime_telemetry.py
+++ b/tests/algorithm/chat/test_agent_runtime_telemetry.py
@@ -1,0 +1,55 @@
+from lazymind.chat.engine.agent_runtime import telemetry
+
+
+def _unexpected_call(*_args, **_kwargs):
+    raise AssertionError('disabled telemetry must not process event payloads')
+
+
+def test_disabled_tool_call_telemetry_does_not_process_arguments(monkeypatch):
+    monkeypatch.setattr(telemetry, 'telemetry_enabled', lambda: False)
+    monkeypatch.setattr(telemetry.json, 'loads', _unexpected_call)
+    monkeypatch.setattr(telemetry, 'redact_session_env_arguments', _unexpected_call)
+    monkeypatch.setattr(telemetry, 'classify_tool', _unexpected_call)
+    monkeypatch.setattr(telemetry, '_size_bytes', _unexpected_call)
+    monkeypatch.setattr(telemetry, '_preview', _unexpected_call)
+    monkeypatch.setattr(telemetry, 'append_event', _unexpected_call)
+
+    telemetry.emit_tool_call({
+        'id': 'call-1',
+        'function': {'name': 'search', 'arguments': '{"query":"secret"}'},
+    })
+
+
+def test_disabled_tool_result_telemetry_does_not_serialize_result(monkeypatch):
+    monkeypatch.setattr(telemetry, 'telemetry_enabled', lambda: False)
+    monkeypatch.setattr(telemetry, 'classify_tool', _unexpected_call)
+    monkeypatch.setattr(telemetry, '_size_bytes', _unexpected_call)
+    monkeypatch.setattr(telemetry, '_preview', _unexpected_call)
+    monkeypatch.setattr(telemetry, 'append_event', _unexpected_call)
+
+    telemetry.emit_tool_result(
+        {'id': 'call-1', 'function': {'name': 'search'}},
+        {'ok': True, 'value': {'secret': 'must not be serialized'}},
+    )
+
+
+def test_enabled_tool_result_telemetry_still_emits_event(monkeypatch):
+    events = []
+    monkeypatch.setattr(telemetry, 'telemetry_enabled', lambda: True)
+    monkeypatch.setattr(
+        telemetry,
+        'append_event',
+        lambda kind, **payload: events.append((kind, payload)),
+    )
+
+    telemetry.emit_tool_result(
+        {'id': 'call-1', 'function': {'name': 'search'}},
+        {'ok': True, 'value': ['result']},
+    )
+
+    assert len(events) == 1
+    kind, payload = events[0]
+    assert kind == 'tool_result'
+    assert payload['tool_call_id'] == 'call-1'
+    assert payload['ok'] is True
+    assert payload['result_preview']

--- a/tests/algorithm/chat/test_external_search_citations.py
+++ b/tests/algorithm/chat/test_external_search_citations.py
@@ -3,9 +3,11 @@ import time
 import lazyllm
 from lazyllm.tools.agent.toolsManager import ToolManager
 from lazyllm.tools.tools.search import SearchBase
-
 from lazymind.chat.engine.tools.infra import CitationResultMiddleware
-from lazymind.chat.service.utils.citations import CITATION_REFS_KEY, reset_citation_state
+from lazymind.chat.service.utils.citations import (
+    CITATION_REFS_KEY,
+    reset_citation_state,
+)
 
 
 class FakeSearch(SearchBase):
@@ -75,6 +77,19 @@ def test_search_and_meta_search_register_without_changing_envelopes_or_provider_
     assert results[0]['ref'] == meta['items'][0]['ref'] == '[[1.1]]'
     assert 'ref' not in raw_results[0]
     assert state[CITATION_REFS_KEY]['1.1']['content'] == 'Snippet for agents'
+
+
+def test_citation_transformation_updates_execution_record_result():
+    _state, provider, manager = _setup_manager()
+
+    batch = manager.execute_with_records({
+        'id': 'search-call',
+        'function': {'name': 'FakeSearch_search', 'arguments': {'query': 'records'}},
+    })
+
+    assert batch.records[0].result == batch.results[0]
+    assert batch.records[0].result['value'][0]['ref'] == '[[1.1]]'
+    assert 'ref' not in provider.last_results[0]
 
 
 def test_collect_only_registers_sources_without_exposing_citation_refs():

--- a/tests/algorithm/chat/test_tool_call_guard.py
+++ b/tests/algorithm/chat/test_tool_call_guard.py
@@ -1,174 +1,106 @@
+from dataclasses import dataclass
+
+import pytest
+
 from lazymind.chat.engine.agent_runtime.executor import ToolCallGuard
+from lazymind.chat.engine.agent_runtime.tool_call_guard import ToolCallGuard as ExtractedToolCallGuard
 
 
-def _call(name, arguments):
-    return {'function': {'name': name, 'arguments': arguments}}
+@dataclass(frozen=True)
+class _Access:
+    counts_as_progress: bool = False
+    polling: bool = False
 
 
-def _failure(tool='search'):
-    return {'ok': False, 'value': f'{tool} failed'}
+def _call(name='search', arguments=None, call_id='call-1'):
+    return {
+        'id': call_id,
+        'function': {'name': name, 'arguments': arguments or {'query': 'same'}},
+    }
 
 
 class _RecordingToolManager:
-    def __init__(self, result_factory=None):
+    def __init__(self, result=None, accesses=None):
         self.calls = []
-        self.allowed_tool_names = []
-        self.result_factory = result_factory or (
-            lambda call: {'ok': True, 'value': call['function']['arguments']}
-        )
+        self.result = result if result is not None else {'ok': True, 'value': {'items': ['same']}}
+        self.accesses = accesses
+
+    def normalize_tool_calls(self, calls):
+        return calls
+
+    def resolve_tool_accesses(self, calls, allowed_tool_names=None):
+        if self.accesses is not None:
+            return self.accesses[:len(calls)]
+        return [_Access() for _ in calls]
 
     def __call__(self, calls, verbose=False, allowed_tool_names=None):
         self.calls.extend(calls)
-        self.allowed_tool_names.append(allowed_tool_names)
-        return [self.result_factory(call) for call in calls]
+        return [self.result for _ in calls]
 
 
-def test_successful_calls_are_never_limited_or_cached():
-    manager = _RecordingToolManager()
-    guard = ToolCallGuard(manager, {'url_fetch': 2})
+@pytest.mark.parametrize('result', [
+    {'ok': True, 'value': {'items': ['same']}},
+    {'ok': False, 'msg': 'same failure'},
+])
+def test_third_identical_result_queues_soft_notice_without_changing_results(result):
+    assert ToolCallGuard is ExtractedToolCallGuard
+    manager = _RecordingToolManager(result=result)
+    guard = ToolCallGuard(manager)
+    call = _call()
 
-    for index in range(20):
-        guard([_call('url_fetch', {'url': f'https://example.com/{index}'})])
-    guard([_call('url_fetch', {'url': 'https://example.com/0'})])
+    returned = [guard([call]) for _ in range(3)]
 
-    assert len(manager.calls) == 21
-
-
-def test_exact_duplicate_tool_calls_in_one_batch_are_merged():
-    manager = _RecordingToolManager()
-    guard = ToolCallGuard(manager, {'url_fetch': 2})
-
-    results = guard([
-        _call('url_fetch', {'url': 'https://example.com'}),
-        _call('url_fetch', {'url': 'https://example.com'}),
-    ])
-
-    assert results[0] == results[1]
-    assert len(manager.calls) == 1
+    assert returned == [[result], [result], [result]]
+    assert len(manager.calls) == 3
+    notice = guard.consume_internal_runtime_notices(['call-1'])
+    assert len(notice) == 1
+    assert '3 consecutive times' in notice[0]
 
 
-def test_same_batch_duplicates_do_not_consume_repeated_call_budget():
-    manager = _RecordingToolManager()
-    guard = ToolCallGuard(manager, {'url_fetch': 2}, repeated_call_limit=2)
-    call = _call('url_fetch', {'url': 'https://example.com'})
-
-    first = guard([call, call, call])
-    second = guard([call])
-
-    assert first[0] == first[1] == first[2]
-    assert second[0]['ok'] is True
-    assert len(manager.calls) == 2
-
-
-def test_allowed_tool_names_are_forwarded_to_pending_calls():
+def test_all_batch_duplicates_execute_and_notice_binds_to_ordered_batch_ids():
     manager = _RecordingToolManager()
     guard = ToolCallGuard(manager)
-    allowed = {'url_fetch'}
+    calls = [
+        _call(call_id='first'),
+        _call(call_id='second'),
+        _call(call_id='third'),
+    ]
 
-    guard([_call('url_fetch', {'url': 'https://example.com'})], allowed_tool_names=allowed)
-
-    assert manager.allowed_tool_names == [allowed]
-
-
-def test_repeated_exact_failure_respects_consecutive_failure_limit():
-    manager = _RecordingToolManager(
-        lambda _: _failure('url_fetch'),
-    )
-    guard = ToolCallGuard(manager, {'url_fetch': 2})
-
-    guard([_call('url_fetch', {'url': 'https://one.example'})])
-    blocked = guard([_call('url_fetch', {'url': 'https://one.example'})])
-
-    assert len(manager.calls) == 1
-    assert blocked[0]['ok'] is False
-    assert '[Repeated Tool Failure]' in blocked[0]['value']
-    assert 'already failed' in blocked[0]['value']
-
-
-def test_different_parameter_guesses_are_blocked_after_consecutive_failures():
-    manager = _RecordingToolManager(
-        lambda _: _failure('url_fetch'),
-    )
-    guard = ToolCallGuard(manager, {'url_fetch': 2})
-
-    guard([_call('url_fetch', {'url': 'https://one.example'})])
-    guard([_call('url_fetch', {'url': 'https://two.example'})])
-    blocked = guard([_call('url_fetch', {'url': 'https://three.example'})])
-
-    assert len(manager.calls) == 2
-    assert '[Repeated Tool Failure]' in blocked[0]['value']
-
-
-def test_success_resets_consecutive_failure_count():
-    outcomes = iter([False, True, False, False])
-    manager = _RecordingToolManager(
-        lambda _: {'ok': next(outcomes), 'value': None},
-    )
-    guard = ToolCallGuard(manager, {'url_fetch': 2})
-
-    for index in range(4):
-        guard([_call('url_fetch', {'url': f'https://example.com/{index}'})])
-
-    assert len(manager.calls) == 4
-
-
-def test_success_for_other_arguments_resets_consecutive_failure_count():
-    def result(call):
-        if call['function']['arguments']['url'].endswith('/failed'):
-            return _failure('url_fetch')
-        return {'ok': True, 'value': 'loaded'}
-
-    manager = _RecordingToolManager(result)
-    guard = ToolCallGuard(manager, {'url_fetch': 3})
-    failed_call = _call('url_fetch', {'url': 'https://example.com/failed'})
-
-    guard([failed_call])
-    guard([_call('url_fetch', {'url': 'https://example.com/success'})])
-    result = guard([failed_call])
+    results = guard(calls)
 
     assert len(manager.calls) == 3
-    assert result == [_failure('url_fetch')]
+    assert len(results) == 3
+    assert guard.consume_internal_runtime_notices(['first', 'second', 'third'])
 
 
-def test_failure_can_be_retried_by_agent_until_failure_limit():
-    failure = _failure('url_fetch')
-    manager = _RecordingToolManager(lambda _: failure)
-    guard = ToolCallGuard(manager, {'url_fetch': 2})
-    call = _call('url_fetch', {'url': 'https://example.com'})
-
-    first = guard([call])
-
-    assert first == [failure]
-    assert len(manager.calls) == 1
-
-    blocked = guard([call])
-
-    assert '[Repeated Tool Failure]' in blocked[0]['value']
-    assert 'already failed' in blocked[0]['value']
-    assert len(manager.calls) == 1
-
-
-def test_guard_preserves_failure_message():
-    cases = (
-        (_call('search', {'limit': 'many'}), _call('search', {'limit': []})),
-        (_call('seach', {}), _call('serch', {})),
-    )
-    for first_call, second_call in cases:
-        manager = _RecordingToolManager(lambda _: _failure())
-        guard = ToolCallGuard(manager)
-
-        first = guard([first_call])[0]
-        second = guard([second_call])[0]
-
-        assert first == _failure()
-        assert second == _failure()
-
-
-def test_unconfigured_stateful_tool_is_not_deduplicated():
+@pytest.mark.parametrize('change_result', [False, True])
+def test_result_or_arguments_change_resets_consecutive_state(change_result):
     manager = _RecordingToolManager()
-    guard = ToolCallGuard(manager, {'url_fetch': 2})
+    guard = ToolCallGuard(manager)
 
-    guard([_call('get_task_status', {'task_id': 'task-1'})])
-    guard([_call('get_task_status', {'task_id': 'task-1'})])
+    guard([_call(call_id='one')])
+    guard([_call(call_id='two')])
+    arguments = {'query': 'same'}
+    if change_result:
+        manager.result = {'ok': True, 'value': {'items': ['changed']}}
+    else:
+        arguments = {'query': 'changed'}
+    guard([_call(arguments=arguments, call_id='changed-1')])
+    guard([_call(arguments=arguments, call_id='changed-2')])
 
-    assert len(manager.calls) == 2
+    assert guard.consume_internal_runtime_notices(['changed-2']) == []
+
+
+@pytest.mark.parametrize('access', [
+    _Access(counts_as_progress=True),
+    _Access(polling=True),
+])
+def test_progress_and_polling_calls_are_exempt(access):
+    manager = _RecordingToolManager(accesses=[access])
+    guard = ToolCallGuard(manager)
+
+    for index in range(4):
+        guard([_call(call_id=f'call-{index}')])
+
+    assert len(manager.calls) == 4
+    assert guard.consume_internal_runtime_notices(['call-3']) == []

--- a/tests/algorithm/chat/test_tool_call_guard.py
+++ b/tests/algorithm/chat/test_tool_call_guard.py
@@ -1,10 +1,12 @@
+import copy
 import json
 
+import lazyllm
 import pytest
 from lazyllm.tools.agent import (
     PreparedToolCall,
     ResolvedToolAccess,
-    ToolExecutionBatch,
+    ToolExecutionDisposition,
     ToolExecutionRecord,
 )
 from lazymind.chat.engine.agent_runtime.tool_call_guard import (
@@ -29,11 +31,11 @@ def _prepared(name='search', arguments=None, call_id='call-1', access=None):
     )
 
 
-def _record(*, result=None, executed=True, **kwargs):
+def _record(*, result=None, disposition=ToolExecutionDisposition.EXECUTED, **kwargs):
     return ToolExecutionRecord(
         _prepared(**kwargs),
         result if result is not None else {'ok': True, 'value': {'items': ['same']}},
-        executed=executed,
+        disposition=disposition,
     )
 
 
@@ -122,7 +124,7 @@ def test_polling_records_are_excluded_and_hard_blocked_records_are_ignored():
     polling = ResolvedToolAccess(polling=True)
     assert not _notice(monitor.after_tool_batch([
         _record(access=polling),
-        _record(name='blocked', executed=False),
+        _record(name='blocked', disposition=ToolExecutionDisposition.POLICY_BLOCKED),
     ]))
 
     for index in range(3):
@@ -133,64 +135,126 @@ def test_polling_records_are_excluded_and_hard_blocked_records_are_ignored():
     assert _notice(delta)
 
 
-class _PreparedManager:
-    def __init__(self, results):
-        self.results = list(results)
-        self.executed = []
+def _failing_manager(calls):
+    from lazyllm.tools import ToolManager
 
-    def execute_prepared_calls(self, prepared):
-        prepared = list(prepared)
-        self.executed.extend(prepared)
-        results = self.results[:len(prepared)]
-        return ToolExecutionBatch(
-            results=results,
-            records=tuple(
-                ToolExecutionRecord(item, result)
-                for item, result in zip(prepared, results)
-            ),
-        )
+    def search(query: str):
+        '''Fail a search.
+
+        Args:
+            query: Search query.
+        '''
+        calls.append(query)
+        raise RuntimeError('failed')
+
+    return ToolManager([search])
+
+
+def _call(query, call_id):
+    return {
+        'id': call_id,
+        'function': {'name': 'search', 'arguments': {'query': query}},
+    }
 
 
 def test_failure_policy_blocks_same_failed_signature_without_monitoring_block():
-    failure = {'ok': False, 'msg': 'failed'}
-    manager = _PreparedManager([failure])
+    calls = []
+    manager = _failing_manager(calls)
     middleware = ToolExecutionMiddleware(
         manager,
         failure_policy=FailureRetryPolicy({'search': 2}),
     )
-    prepared = _prepared()
 
-    first = middleware.execute_prepared_calls([prepared])
-    second = middleware.execute_prepared_calls([prepared])
+    first = middleware.execute_with_records(_call('same', 'first'))
+    second = middleware.execute_with_records(_call('same', 'second'))
 
     assert first.records[0].executed is True
     assert second.records[0].executed is False
+    assert second.records[0].disposition is ToolExecutionDisposition.POLICY_BLOCKED
     assert second.results[0]['ok'] is False
-    assert len(manager.executed) == 1
+    assert calls == ['same']
     assert not _notice(ExactRepeatMonitor().after_tool_batch(second.records))
 
 
 def test_failure_policy_preserves_consecutive_budget_and_batch_merge():
-    failure = {'ok': False, 'msg': 'failed'}
-    manager = _PreparedManager([failure, failure])
+    calls = []
+    manager = _failing_manager(calls)
     middleware = ToolExecutionMiddleware(
         manager,
         failure_policy=FailureRetryPolicy({'search': 2}),
     )
 
-    first = middleware.execute_prepared_calls([
-        _prepared(arguments={'query': 'one'}, call_id='one'),
-        _prepared(arguments={'query': 'one'}, call_id='duplicate'),
+    first = middleware.execute_with_records([
+        _call('one', 'one'),
+        _call('one', 'duplicate'),
     ])
-    second = middleware.execute_prepared_calls([
-        _prepared(arguments={'query': 'two'}, call_id='two'),
+    second = middleware.execute_with_records([
+        _call('two', 'two'),
     ])
-    third = middleware.execute_prepared_calls([
-        _prepared(arguments={'query': 'three'}, call_id='three'),
+    third = middleware.execute_with_records([
+        _call('three', 'three'),
     ])
 
     assert [record.executed for record in first.records] == [True, False]
+    assert first.records[1].disposition is ToolExecutionDisposition.DEDUPLICATED
     assert first.results[0] == first.results[1]
     assert second.records[0].executed is True
     assert third.records[0].executed is False
-    assert len(manager.executed) == 2
+    assert calls == ['one', 'two']
+
+
+@pytest.mark.parametrize(('function', 'allowed_names'), [
+    ({'name': 'search', 'arguments': {}}, None),
+    ({'name': 'search', 'arguments': '{"query":'}, None),
+    ({'name': 'missing', 'arguments': {}}, None),
+    ({'name': 'search', 'arguments': {'query': 'hidden'}}, set()),
+])
+def test_identical_preparation_failures_trigger_repeat_notice(function, allowed_names):
+    calls = []
+    middleware = ToolExecutionMiddleware(_failing_manager(calls))
+    monitor = ExactRepeatMonitor()
+    notices = []
+
+    for index in range(4):
+        batch = middleware.execute_with_records({
+            'id': f'bad-{index}',
+            'function': copy.deepcopy(function),
+        }, allowed_tool_names=allowed_names)
+        assert batch.records[0].disposition is ToolExecutionDisposition.PREPARATION_FAILED
+        notices.append(_notice(monitor.after_tool_batch(batch.records)))
+
+    assert notices[:2] == [[], []]
+    assert len(notices[2]) == len(notices[3]) == 1
+    assert calls == []
+
+
+def test_round_expansion_only_applies_to_ready_scheduled_calls(monkeypatch):
+    from lazyllm.tools import ToolManager
+
+    def create_subagent(task: str):
+        '''Create a subagent.
+
+        Args:
+            task: Task description.
+        '''
+        return task
+
+    workspace = {}
+    monkeypatch.setitem(lazyllm.locals, '_lazyllm_agent', {'workspace': workspace})
+    middleware = ToolExecutionMiddleware(
+        ToolManager([create_subagent]),
+        expanded_round_limit=200,
+    )
+
+    invalid = middleware.execute_with_records({
+        'id': 'invalid',
+        'function': {'name': 'create_subagent', 'arguments': {}},
+    })
+    assert invalid.records[0].disposition is ToolExecutionDisposition.PREPARATION_FAILED
+    assert '_react_round_limit' not in workspace
+
+    middleware.execute_with_records({
+        'id': 'ready',
+        'function': {'name': 'create_subagent', 'arguments': {'task': 'inspect'}},
+    })
+    assert workspace['_react_round_limit'] == 200

--- a/tests/algorithm/chat/test_tool_call_guard.py
+++ b/tests/algorithm/chat/test_tool_call_guard.py
@@ -1,106 +1,196 @@
-from dataclasses import dataclass
+import json
 
 import pytest
-
-from lazymind.chat.engine.agent_runtime.executor import ToolCallGuard
-from lazymind.chat.engine.agent_runtime.tool_call_guard import ToolCallGuard as ExtractedToolCallGuard
-
-
-@dataclass(frozen=True)
-class _Access:
-    counts_as_progress: bool = False
-    polling: bool = False
-
-
-def _call(name='search', arguments=None, call_id='call-1'):
-    return {
-        'id': call_id,
-        'function': {'name': name, 'arguments': arguments or {'query': 'same'}},
-    }
+from lazyllm.tools.agent import (
+    PreparedToolCall,
+    ResolvedToolAccess,
+    ToolExecutionBatch,
+    ToolExecutionRecord,
+)
+from lazymind.chat.engine.agent_runtime.tool_call_guard import (
+    ExactRepeatMonitor,
+    FailureRetryPolicy,
+    ToolExecutionMiddleware,
+)
 
 
-class _RecordingToolManager:
-    def __init__(self, result=None, accesses=None):
-        self.calls = []
-        self.result = result if result is not None else {'ok': True, 'value': {'items': ['same']}}
-        self.accesses = accesses
+def _prepared(name='search', arguments=None, call_id='call-1', access=None):
+    arguments = {'query': 'same'} if arguments is None else arguments
+    return PreparedToolCall(
+        tool_call={
+            'id': call_id,
+            'function': {'name': name, 'arguments': json.dumps(arguments)},
+        },
+        call_id=call_id,
+        tool_name=name,
+        arguments=arguments,
+        validated_arguments=arguments,
+        access=access or ResolvedToolAccess(),
+    )
 
-    def normalize_tool_calls(self, calls):
-        return calls
 
-    def resolve_tool_accesses(self, calls, allowed_tool_names=None):
-        if self.accesses is not None:
-            return self.accesses[:len(calls)]
-        return [_Access() for _ in calls]
+def _record(*, result=None, executed=True, **kwargs):
+    return ToolExecutionRecord(
+        _prepared(**kwargs),
+        result if result is not None else {'ok': True, 'value': {'items': ['same']}},
+        executed=executed,
+    )
 
-    def __call__(self, calls, verbose=False, allowed_tool_names=None):
-        self.calls.extend(calls)
-        return [self.result for _ in calls]
+
+def _notice(delta):
+    return [item.content for item in delta.model_context]
 
 
 @pytest.mark.parametrize('result', [
     {'ok': True, 'value': {'items': ['same']}},
     {'ok': False, 'msg': 'same failure'},
 ])
-def test_third_identical_result_queues_soft_notice_without_changing_results(result):
-    assert ToolCallGuard is ExtractedToolCallGuard
-    manager = _RecordingToolManager(result=result)
-    guard = ToolCallGuard(manager)
-    call = _call()
+def test_third_identical_observation_emits_soft_notice_without_mutating_result(result):
+    monitor = ExactRepeatMonitor()
+    monitor.begin_run({})
+    notices = []
+    for index in range(5):
+        record = _record(call_id=f'call-{index}', result=result)
+        assert record.result is result
+        notices.append(_notice(monitor.after_tool_batch([record])))
 
-    returned = [guard([call]) for _ in range(3)]
-
-    assert returned == [[result], [result], [result]]
-    assert len(manager.calls) == 3
-    notice = guard.consume_internal_runtime_notices(['call-1'])
-    assert len(notice) == 1
-    assert '3 consecutive times' in notice[0]
+    assert notices[:2] == [[], []]
+    assert all(
+        f'{count} consecutive times' in notices[count - 1][0]
+        for count in (3, 4, 5)
+    )
 
 
-def test_all_batch_duplicates_execute_and_notice_binds_to_ordered_batch_ids():
-    manager = _RecordingToolManager()
-    guard = ToolCallGuard(manager)
-    calls = [
-        _call(call_id='first'),
-        _call(call_id='second'),
-        _call(call_id='third'),
+def test_ordered_multi_tool_batch_repeats_and_order_change_resets_streak():
+    monitor = ExactRepeatMonitor()
+    batch = [
+        _record(name='a', arguments={'value': 1}, call_id='a'),
+        _record(name='b', arguments={'value': 2}, call_id='b'),
     ]
 
-    results = guard(calls)
+    assert not _notice(monitor.after_tool_batch(batch))
+    assert not _notice(monitor.after_tool_batch(batch))
+    assert _notice(monitor.after_tool_batch(batch))
+    assert not _notice(monitor.after_tool_batch(list(reversed(batch))))
 
-    assert len(manager.calls) == 3
-    assert len(results) == 3
-    assert guard.consume_internal_runtime_notices(['first', 'second', 'third'])
+
+def test_three_identical_calls_in_one_batch_emit_one_notice():
+    monitor = ExactRepeatMonitor()
+    records = [_record(call_id=f'call-{index}') for index in range(3)]
+
+    notices = _notice(monitor.after_tool_batch(records))
+
+    assert len(notices) == 1
+    assert '3 consecutive times' in notices[0]
 
 
-@pytest.mark.parametrize('change_result', [False, True])
-def test_result_or_arguments_change_resets_consecutive_state(change_result):
-    manager = _RecordingToolManager()
-    guard = ToolCallGuard(manager)
+@pytest.mark.parametrize('change', ['arguments', 'result'])
+def test_arguments_or_result_change_resets_streak(change):
+    monitor = ExactRepeatMonitor()
+    base = _record(call_id='one')
+    monitor.after_tool_batch([base])
+    monitor.after_tool_batch([base])
+    changed = _record(
+        call_id='changed',
+        arguments={'query': 'changed'} if change == 'arguments' else None,
+        result={'ok': True, 'value': {'items': ['changed']}} if change == 'result' else None,
+    )
 
-    guard([_call(call_id='one')])
-    guard([_call(call_id='two')])
-    arguments = {'query': 'same'}
-    if change_result:
-        manager.result = {'ok': True, 'value': {'items': ['changed']}}
-    else:
-        arguments = {'query': 'changed'}
-    guard([_call(arguments=arguments, call_id='changed-1')])
-    guard([_call(arguments=arguments, call_id='changed-2')])
-
-    assert guard.consume_internal_runtime_notices(['changed-2']) == []
+    assert not _notice(monitor.after_tool_batch([changed]))
+    assert not _notice(monitor.after_tool_batch([changed]))
 
 
 @pytest.mark.parametrize('access', [
-    _Access(counts_as_progress=True),
-    _Access(polling=True),
+    ResolvedToolAccess(write_keys=frozenset({('exact', 'shared')})),
+    ResolvedToolAccess(exclusive=True),
 ])
-def test_progress_and_polling_calls_are_exempt(access):
-    manager = _RecordingToolManager(accesses=[access])
-    guard = ToolCallGuard(manager)
+def test_write_and_exclusive_failures_are_not_exempt(access):
+    monitor = ExactRepeatMonitor()
+    failure = {'ok': False, 'msg': 'approval_required'}
 
-    for index in range(4):
-        guard([_call(call_id=f'call-{index}')])
+    for index in range(2):
+        assert not _notice(monitor.after_tool_batch([
+            _record(call_id=f'call-{index}', access=access, result=failure),
+        ]))
+    assert _notice(monitor.after_tool_batch([
+        _record(call_id='call-3', access=access, result=failure),
+    ]))
 
-    assert len(manager.calls) == 4
-    assert guard.consume_internal_runtime_notices(['call-3']) == []
+
+def test_polling_records_are_excluded_and_hard_blocked_records_are_ignored():
+    monitor = ExactRepeatMonitor()
+    polling = ResolvedToolAccess(polling=True)
+    assert not _notice(monitor.after_tool_batch([
+        _record(access=polling),
+        _record(name='blocked', executed=False),
+    ]))
+
+    for index in range(3):
+        delta = monitor.after_tool_batch([
+            _record(name='stable', call_id=f'stable-{index}'),
+            _record(name='poll', call_id=f'poll-{index}', access=polling),
+        ])
+    assert _notice(delta)
+
+
+class _PreparedManager:
+    def __init__(self, results):
+        self.results = list(results)
+        self.executed = []
+
+    def execute_prepared_calls(self, prepared):
+        prepared = list(prepared)
+        self.executed.extend(prepared)
+        results = self.results[:len(prepared)]
+        return ToolExecutionBatch(
+            results=results,
+            records=tuple(
+                ToolExecutionRecord(item, result)
+                for item, result in zip(prepared, results)
+            ),
+        )
+
+
+def test_failure_policy_blocks_same_failed_signature_without_monitoring_block():
+    failure = {'ok': False, 'msg': 'failed'}
+    manager = _PreparedManager([failure])
+    middleware = ToolExecutionMiddleware(
+        manager,
+        failure_policy=FailureRetryPolicy({'search': 2}),
+    )
+    prepared = _prepared()
+
+    first = middleware.execute_prepared_calls([prepared])
+    second = middleware.execute_prepared_calls([prepared])
+
+    assert first.records[0].executed is True
+    assert second.records[0].executed is False
+    assert second.results[0]['ok'] is False
+    assert len(manager.executed) == 1
+    assert not _notice(ExactRepeatMonitor().after_tool_batch(second.records))
+
+
+def test_failure_policy_preserves_consecutive_budget_and_batch_merge():
+    failure = {'ok': False, 'msg': 'failed'}
+    manager = _PreparedManager([failure, failure])
+    middleware = ToolExecutionMiddleware(
+        manager,
+        failure_policy=FailureRetryPolicy({'search': 2}),
+    )
+
+    first = middleware.execute_prepared_calls([
+        _prepared(arguments={'query': 'one'}, call_id='one'),
+        _prepared(arguments={'query': 'one'}, call_id='duplicate'),
+    ])
+    second = middleware.execute_prepared_calls([
+        _prepared(arguments={'query': 'two'}, call_id='two'),
+    ])
+    third = middleware.execute_prepared_calls([
+        _prepared(arguments={'query': 'three'}, call_id='three'),
+    ])
+
+    assert [record.executed for record in first.records] == [True, False]
+    assert first.results[0] == first.results[1]
+    assert second.records[0].executed is True
+    assert third.records[0].executed is False
+    assert len(manager.executed) == 2

--- a/tests/algorithm/chat/test_tool_call_guard.py
+++ b/tests/algorithm/chat/test_tool_call_guard.py
@@ -12,13 +12,16 @@ from lazyllm.tools.agent import (
 from lazymind.chat.engine.agent_runtime.tool_call_guard import (
     ExactRepeatMonitor,
     FailureRetryPolicy,
+    OneShotNoticeBuffer,
     ToolExecutionMiddleware,
 )
 
 
-def _prepared(name='search', arguments=None, call_id='call-1', access=None):
+def _prepared(name='search', arguments=None, call_id='call-1', access=None,
+              index=0, polling=False):
     arguments = {'query': 'same'} if arguments is None else arguments
     return PreparedToolCall(
+        index=index,
         tool_call={
             'id': call_id,
             'function': {'name': name, 'arguments': json.dumps(arguments)},
@@ -28,19 +31,22 @@ def _prepared(name='search', arguments=None, call_id='call-1', access=None):
         arguments=arguments,
         validated_arguments=arguments,
         access=access or ResolvedToolAccess(),
+        polling=polling,
     )
 
 
-def _record(*, result=None, disposition=ToolExecutionDisposition.EXECUTED, **kwargs):
+def _record(*, result=None, disposition=ToolExecutionDisposition.EXECUTED,
+            reason='', **kwargs):
     return ToolExecutionRecord(
         _prepared(**kwargs),
         result if result is not None else {'ok': True, 'value': {'items': ['same']}},
         disposition=disposition,
+        reason=reason,
     )
 
 
-def _notice(delta):
-    return [item.content for item in delta.model_context]
+def _notice(notice):
+    return [notice] if notice else []
 
 
 @pytest.mark.parametrize('result', [
@@ -49,7 +55,6 @@ def _notice(delta):
 ])
 def test_third_identical_observation_emits_soft_notice_without_mutating_result(result):
     monitor = ExactRepeatMonitor()
-    monitor.begin_run({})
     notices = []
     for index in range(5):
         record = _record(call_id=f'call-{index}', result=result)
@@ -121,18 +126,52 @@ def test_write_and_exclusive_failures_are_not_exempt(access):
 
 def test_polling_records_are_excluded_and_hard_blocked_records_are_ignored():
     monitor = ExactRepeatMonitor()
-    polling = ResolvedToolAccess(polling=True)
     assert not _notice(monitor.after_tool_batch([
-        _record(access=polling),
-        _record(name='blocked', disposition=ToolExecutionDisposition.POLICY_BLOCKED),
+        _record(polling=True),
+        _record(
+            name='blocked',
+            disposition=ToolExecutionDisposition.SKIPPED,
+            reason='policy_blocked',
+        ),
     ]))
 
     for index in range(3):
         delta = monitor.after_tool_batch([
             _record(name='stable', call_id=f'stable-{index}'),
-            _record(name='poll', call_id=f'poll-{index}', access=polling),
+            _record(name='poll', call_id=f'poll-{index}', polling=True),
         ])
     assert _notice(delta)
+
+
+def test_middleware_publishes_only_the_current_repeat_notice():
+    from lazyllm.tools import ToolManager
+
+    def search(query: str):
+        '''Return a stable result.
+
+        Args:
+            query: Search query.
+        '''
+        return {'items': [query]}
+
+    monitor = ExactRepeatMonitor()
+    buffer = OneShotNoticeBuffer()
+    middleware = ToolExecutionMiddleware(
+        ToolManager([search]),
+        repeat_monitor=monitor,
+        notice_buffer=buffer,
+    )
+
+    for index in range(2):
+        middleware.execute_with_records(_call('same', f'call-{index}'))
+        assert buffer.take() is None
+
+    middleware.execute_with_records(_call('same', 'call-3'))
+    assert '3 consecutive times' in buffer.take()
+    assert buffer.take() is None
+
+    middleware.execute_with_records(_call('same', 'call-4'))
+    assert '4 consecutive times' in buffer.take()
 
 
 def _failing_manager(calls):
@@ -168,9 +207,9 @@ def test_failure_policy_blocks_same_failed_signature_without_monitoring_block():
     first = middleware.execute_with_records(_call('same', 'first'))
     second = middleware.execute_with_records(_call('same', 'second'))
 
-    assert first.records[0].executed is True
-    assert second.records[0].executed is False
-    assert second.records[0].disposition is ToolExecutionDisposition.POLICY_BLOCKED
+    assert first.records[0].disposition is ToolExecutionDisposition.EXECUTED
+    assert second.records[0].disposition is ToolExecutionDisposition.SKIPPED
+    assert second.records[0].reason == 'policy_blocked'
     assert second.results[0]['ok'] is False
     assert calls == ['same']
     assert not _notice(ExactRepeatMonitor().after_tool_batch(second.records))
@@ -195,11 +234,14 @@ def test_failure_policy_preserves_consecutive_budget_and_batch_merge():
         _call('three', 'three'),
     ])
 
-    assert [record.executed for record in first.records] == [True, False]
-    assert first.records[1].disposition is ToolExecutionDisposition.DEDUPLICATED
+    assert [record.disposition for record in first.records] == [
+        ToolExecutionDisposition.EXECUTED,
+        ToolExecutionDisposition.SKIPPED,
+    ]
+    assert first.records[1].reason == 'deduplicated'
     assert first.results[0] == first.results[1]
-    assert second.records[0].executed is True
-    assert third.records[0].executed is False
+    assert second.records[0].disposition is ToolExecutionDisposition.EXECUTED
+    assert third.records[0].disposition is ToolExecutionDisposition.SKIPPED
     assert calls == ['one', 'two']
 
 

--- a/tests/algorithm/chat/test_windows_tool_compatibility.py
+++ b/tests/algorithm/chat/test_windows_tool_compatibility.py
@@ -108,7 +108,8 @@ def test_chat_file_runtime_access_uses_resolved_workspace_paths(tmp_path, monkey
         chat_artifact.read_file,
         chat_artifact.grep,
     ])
-    prepared = manager.prepare_tool_calls([
+    prepared = []
+    manager.execute_with_records([
         {'function': {'name': 'write_file', 'arguments': {
             'path': 'document.md', 'content': 'relative',
         }}},
@@ -120,7 +121,7 @@ def test_chat_file_runtime_access_uses_resolved_workspace_paths(tmp_path, monkey
         {'function': {'name': 'grep', 'arguments': {
             'target': 'document.md', 'pattern': 'relative',
         }}},
-    ])
+    ], dispatch_selector=lambda calls: prepared.extend(calls) or ())
 
     assert prepared[0].access.write_keys == prepared[1].access.write_keys
     assert _accesses_conflict(prepared[2].access, prepared[0].access)

--- a/tests/algorithm/chat/test_windows_tool_compatibility.py
+++ b/tests/algorithm/chat/test_windows_tool_compatibility.py
@@ -4,7 +4,9 @@ from pathlib import Path
 
 import pytest
 
+from lazyllm.tools import ToolManager
 from lazyllm.tools.agent import ToolExecutionError
+from lazyllm.tools.agent.tool_runtime import _accesses_conflict
 from lazyllm.tools.fs import client as fs_client
 from lazymind.chat.engine.tools.local_file import workspace as chat_artifact
 
@@ -93,6 +95,37 @@ def test_chat_write_file_append_does_not_require_overwrite_approval(tmp_path, mo
     assert first['status'] == 'ok'
     assert appended['status'] == 'ok'
     assert 'first second' in chat_artifact.read_file('document.md')['text']
+
+
+def test_chat_file_runtime_access_uses_resolved_workspace_paths(tmp_path, monkeypatch):
+    monkeypatch.setattr(chat_artifact, 'chat_agent_workspace', lambda *_args: str(tmp_path))
+    monkeypatch.setattr(
+        chat_artifact, '_current_artifact_scope', lambda: ('windows-user', 'windows-conversation'),
+    )
+    manager = ToolManager([
+        chat_artifact.write_file,
+        chat_artifact.list_dir,
+        chat_artifact.read_file,
+        chat_artifact.grep,
+    ])
+    prepared = manager.prepare_tool_calls([
+        {'function': {'name': 'write_file', 'arguments': {
+            'path': 'document.md', 'content': 'relative',
+        }}},
+        {'function': {'name': 'write_file', 'arguments': {
+            'path': str(tmp_path / 'document.md'), 'content': 'absolute',
+        }}},
+        {'function': {'name': 'list_dir', 'arguments': {'path': '.'}}},
+        {'function': {'name': 'read_file', 'arguments': {'target': 'document.md'}}},
+        {'function': {'name': 'grep', 'arguments': {
+            'target': 'document.md', 'pattern': 'relative',
+        }}},
+    ])
+
+    assert prepared[0].access.write_keys == prepared[1].access.write_keys
+    assert _accesses_conflict(prepared[2].access, prepared[0].access)
+    assert prepared[3].access.exclusive is True
+    assert prepared[4].access.exclusive is True
 
 
 def test_chat_file_tools_reject_outside_workspace_by_default(tmp_path, monkeypatch):

--- a/tests/algorithm/test_episode_memory.py
+++ b/tests/algorithm/test_episode_memory.py
@@ -339,13 +339,16 @@ def test_memory_tools_registers_as_eager_container_with_episode_schema():
         'MemoryTools_preference_editor',
     }
     assert all(
-        manager.tools_info[name].concurrency_spec is not None
+        manager.tools_info[name].runtime_metadata.read_keys is not None
+        or manager.tools_info[name].runtime_metadata.write_keys is not None
         for name in resource_tools
     )
-    assert manager.tools_info['MemoryTools_episode_create'].concurrency_spec is None
+    episode_metadata = manager.tools_info['MemoryTools_episode_create'].runtime_metadata
+    assert episode_metadata.read_keys is None
+    assert episode_metadata.write_keys is None
     schema = json.dumps(manager.tools_description)
-    assert '__lazyllm_tool_concurrency__' not in schema
-    assert 'concurrency_spec' not in schema
+    assert '__lazyllm_tool_runtime_metadata__' not in schema
+    assert 'runtime_metadata' not in schema
 
 
 def test_memory_review_episode_search_is_tenant_scoped_and_capped(monkeypatch):


### PR DESCRIPTION
## Summary

- Keep exact-repeat detection, configured hard failure protection, and model-only notices while removing the general runtime-extension protocol.
- Use LazyLLM's single `execute_with_records(..., dispatch_selector=...)` entrypoint for policy decisions and execution.
- Deliver notices through an internal one-shot buffer and a narrow FunctionCall model-context provider.
- Keep file-resource scheduling and Citation result synchronization.
- Skip all tool telemetry parsing, redaction, classification, preview generation, and result serialization when Agent Lab telemetry is disabled.

## Runtime Behavior

`ToolExecutionMiddleware` supplies a selector that applies `FailureRetryPolicy`, emits enabled telemetry/logging, expands the round limit only for ready calls selected for execution, and returns the selected indices. After Citation transforms final results, the middleware rebuilds the complete ordered batch:

- executed and preparation-failed records come from ToolManager;
- hard blocks use `SKIPPED/reason=policy_blocked`;
- batch reuse uses `SKIPPED/reason=deduplicated`.

`ExactRepeatMonitor` compares only `EXECUTED` and `PREPARATION_FAILED` records and ignores every `SKIPPED` record. Successful results, tool failures, invalid JSON, missing required arguments, hidden tools, and missing tools can therefore participate in exact-repeat detection without producing a duplicate soft notice for a hard-blocked call. Polling calls remain exempt.

From the third identical ordered batch onward, the monitor publishes one current notice. `OneShotNoticeBuffer.take()` clears it immediately and emits delivery telemetry; old notices are never replayed and no notice enters workspace or public history. AgentExecutor clears monitor and buffer state at both run start and `finally`, covering normal completion, stop, max round, exception, and cancellation.

## File Resource Scheduling

- `write_file` maps equivalent relative and absolute targets to the same normalized file resource.
- `list_dir` declares a normalized directory read key, so child writes conflict correctly.
- `read_file` and `grep` remain conservative `exclusive=True` operations because attachment/PDF/resource resolution may materialize data.
- Scheduling is local to one ToolManager batch; there is no cross-session global lock.

## Telemetry

Telemetry remains opt-in through the existing Agent Lab configuration. When disabled, `emit_tool_call()` and `emit_tool_result()` return before parsing arguments or serializing/previewing results, making the disabled path effectively zero serialization overhead. Enabled event fields and output behavior are unchanged.

## Dependency

LazyAGI/LazyLLM#1302 has been merged. The submodule now points to merged `main` commit `c807e4e5`.

## Test Coverage

- Latest focused Guard, AgentExecutor, telemetry, Citation-wrapper, and Windows resource suite: **40 passed**.
- Broader Agent history, prompt cache, file-resource, Guard, AgentExecutor, Citation, KB toolkit, and compatibility run during implementation: **93 passed**.
- LazyLLM focused runtime/scheduling/FunctionCall suite: **35 passed**.
- Changed-file flake8, syntax compilation, stale-symbol search, and whitespace checks pass locally.

Coverage includes hard failure blocking, per-tool failure budgets, batch deduplication, preparation-failure repeat notices, skipped-record exclusion, final Citation result fingerprints, one-shot notice delivery, lifecycle cleanup, file conflicts, selector decisions, cancellation, and disabled-telemetry zero-work behavior.

## Compatibility and Scope

The supported policy components are `ToolExecutionMiddleware`, `ExactRepeatMonitor`, `FailureRetryPolicy`, and the internal `OneShotNoticeBuffer`. `AgentExecutionOptions.tool_failure_limits`, Chat defaults, tool `ok/value/msg`, UI ToolResult, and existing logs remain compatible.

This PR intentionally does not add a broad effect/progress model, polling backoff, a general middleware chain, cross-session concurrency control, or concurrent reuse of one Agent instance.
