### PR TITLE
fix(chat): make user cancellation terminal authoritative

### DIFF
--- a/algorithm/lazymind/chat/engine/agent_runtime/__init__.py
+++ b/algorithm/lazymind/chat/engine/agent_runtime/__init__.py
@@ -12,7 +12,7 @@ from .models import (
     ContextUsageItem,
     ContextUsageReport,
 )
-from .cancellation import make_cancel_stop_condition
+from .cancellation import UserCancelledError, make_cancel_stop_condition
 from .prompt_builder import PromptBuilder
 from .context_estimator import (
     estimate_context_usage,
@@ -42,4 +42,5 @@ __all__ = [
     'normalize_attachments',
     'render_attachment_content',
     'make_cancel_stop_condition',
+    'UserCancelledError',
 ]

--- a/algorithm/lazymind/chat/engine/agent_runtime/cancellation.py
+++ b/algorithm/lazymind/chat/engine/agent_runtime/cancellation.py
@@ -4,6 +4,10 @@ import json
 from asyncio import CancelledError
 
 
+class UserCancelledError(CancelledError):
+    """The active Agent run was explicitly stopped by the user."""
+
+
 def make_cancel_stop_condition():
     """Stop the current Agent when its sid-scoped cancel queue is signalled."""
     def _check(_output) -> bool:
@@ -13,10 +17,10 @@ def make_cancel_stop_condition():
             for raw in messages:
                 try:
                     if json.loads(raw).get('tag') == 'cancel':
-                        raise CancelledError('stopped by user')
+                        raise UserCancelledError('stopped by user')
                 except (ValueError, TypeError):
                     continue
-        except CancelledError:
+        except UserCancelledError:
             raise
         except Exception:
             pass

--- a/algorithm/lazymind/chat/engine/agent_runtime/tool_limit_control.py
+++ b/algorithm/lazymind/chat/engine/agent_runtime/tool_limit_control.py
@@ -4,7 +4,6 @@ import json
 import threading
 import time
 import uuid
-from asyncio import CancelledError
 from typing import Any, Optional
 
 import lazyllm
@@ -12,6 +11,8 @@ from lazyllm import FileSystemQueue
 from lazyllm.tools.agent.base import _write_agent_data
 
 from lazymind.config import config
+
+from .cancellation import UserCancelledError
 
 
 class ToolLimitDecisionCoordinator:
@@ -59,7 +60,7 @@ class ToolLimitDecisionCoordinator:
             for raw in FileSystemQueue(klass='cancel').dequeue() or []:
                 try:
                     if json.loads(raw).get('tag') == 'cancel':
-                        raise CancelledError('stopped by user')
+                        raise UserCancelledError('stopped by user')
                 except (TypeError, ValueError):
                     continue
             time.sleep(min(0.2, max(0.01, deadline - time.monotonic())))

--- a/algorithm/lazymind/chat/runtime_events.py
+++ b/algorithm/lazymind/chat/runtime_events.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from enum import Enum
 from typing import Any, Dict, Optional
 from uuid import uuid4
 
@@ -12,6 +13,12 @@ INCOMPLETE_MODEL_FINISHES = frozenset({
     'insufficient_system_resource',
     'unknown',
 })
+
+
+class RunOutcome(str, Enum):
+    SUCCEEDED = 'succeeded'
+    FAILED = 'failed'
+    CANCELLED = 'cancelled'
 
 
 def runtime_event(event_type: str, run_id: str, data: Dict[str, Any], *, event_id: Optional[str] = None) -> dict:
@@ -41,11 +48,11 @@ class RunAccumulator:
             self.last_model_terminal = data
             self.semantic_output = self.semantic_output or bool(data.get('has_semantic_output'))
 
-    def finish(self, *, succeeded: bool) -> dict:
+    def finish(self, *, outcome: RunOutcome) -> dict:
         if self.terminal_emitted:
             raise RuntimeError(f'run {self.run_id} already has a terminal')
         self.terminal_emitted = True
-        status, reason, code = self._terminal_fields(succeeded)
+        status, reason, code = self._terminal_fields(outcome)
         data: Dict[str, Any] = {
             'status': status,
             'reason': reason,
@@ -61,8 +68,10 @@ class RunAccumulator:
                 data['diagnostic_id'] = failure['diagnostic_id']
         return runtime_event('run_finished', self.run_id, data)
 
-    def _terminal_fields(self, succeeded: bool) -> tuple[str, str, str]:
-        if succeeded:
+    def _terminal_fields(self, outcome: RunOutcome) -> tuple[str, str, str]:
+        if outcome == RunOutcome.CANCELLED:
+            return 'cancelled', 'user_cancelled', ''
+        if outcome == RunOutcome.SUCCEEDED:
             return 'completed', 'awaiting_user_input' if self.ask_pending else 'normal', ''
         terminal = self.last_model_terminal or {}
         if terminal.get('kind') == 'finish':

--- a/algorithm/lazymind/chat/service/chat_service.py
+++ b/algorithm/lazymind/chat/service/chat_service.py
@@ -55,6 +55,7 @@ from lazymind.chat.engine.agent_runtime import (
     AgentExecutor,
     AgentRole,
     AgentRunPlan,
+    UserCancelledError,
     make_cancel_stop_condition,
     PromptBuilder,
     normalize_attachments,
@@ -1614,7 +1615,9 @@ async def _handle_chat_impl(
 
     async def event_stream() -> Any:
         final_result: Any = None
-        succeeded = False
+        from lazymind.chat.runtime_events import RunOutcome
+
+        outcome = RunOutcome.FAILED
 
         try:
             async with rag_sem:
@@ -1644,7 +1647,7 @@ async def _handle_chat_impl(
                 cost = round(time.time() - start_time, 3)
                 yield log_and_emit_frame(frame, cost, query, conversation.session_id, tag='FINISH')
 
-            succeeded = True
+            outcome = RunOutcome.SUCCEEDED
 
             if episode_results:
                 try:
@@ -1665,6 +1668,12 @@ async def _handle_chat_impl(
                         f'error_type={type(exc).__name__} error={exc}'
                     )
 
+        except UserCancelledError:
+            outcome = RunOutcome.CANCELLED
+            LOG.info(
+                f'[ChatServer] agent cancelled by user '
+                f'[conversation_id={conversation_id}] [run_id={translator.run.run_id}]'
+            )
         except Exception:
             LOG.exception('[ChatServer] agent failed')
         finally:
@@ -1673,7 +1682,7 @@ async def _handle_chat_impl(
                 _unregister_active_session(_conv_id_key, conversation.session_id)
 
         cost = round(time.time() - start_time, 3)
-        terminal_frame = translator.finish_run(succeeded=succeeded)
+        terminal_frame = translator.finish_run(outcome=outcome)
         terminal_frame['tool_call_turns'] = translator.tool_call_turns
         yield log_and_emit_frame(terminal_frame, cost, query, conversation.session_id, tag='RUN_FINISH')
 

--- a/algorithm/lazymind/chat/service/component/event_translator.py
+++ b/algorithm/lazymind/chat/service/component/event_translator.py
@@ -4,7 +4,7 @@ import re
 from typing import Any, Optional
 
 from lazymind.config import config as _cfg
-from lazymind.chat.runtime_events import RunAccumulator
+from lazymind.chat.runtime_events import RunAccumulator, RunOutcome
 from lazymind.chat.service.utils import (
     build_stream_citation_scanner,
     materialize_source_views,
@@ -166,6 +166,7 @@ class AgentEventFrameTranslator:
         if event_type == 'tool_results':
             tool_results = [tr for tr in (event.get('tool_results', []) or []) if isinstance(tr, dict)]
             if tool_results:
+                self.run.semantic_output = True
                 parts = [
                     _tool_result_frame_text(
                         tr,
@@ -179,12 +180,13 @@ class AgentEventFrameTranslator:
         if event_type == 'subagent_think':
             think = str(event.get('think') or '')
             if think:
+                self.run.semantic_output = True
                 frames.append(_stream_frame(think=think))
 
         return frames
 
-    def finish_run(self, *, succeeded: bool) -> dict[str, Any]:
-        return _stream_frame(extra={'runtime_event': self.run.finish(succeeded=succeeded)})
+    def finish_run(self, *, outcome: RunOutcome) -> dict[str, Any]:
+        return _stream_frame(extra={'runtime_event': self.run.finish(outcome=outcome)})
 
     def flush(self) -> list[dict[str, Any]]:
         frames: list[dict[str, Any]] = []

--- a/algorithm/tests/chat/test_cancellation.py
+++ b/algorithm/tests/chat/test_cancellation.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from lazymind.chat.engine.agent_runtime.cancellation import (
+    UserCancelledError,
+    make_cancel_stop_condition,
+)
+
+
+def test_user_cancel_signal_raises_domain_cancellation(monkeypatch):
+    from lazyllm.common import queue as queue_module
+
+    class FakeQueue:
+        def __init__(self, *, klass):
+            assert klass == 'cancel'
+
+        def dequeue(self):
+            return [json.dumps({'tag': 'cancel'})]
+
+    monkeypatch.setattr(queue_module, 'FileSystemQueue', FakeQueue)
+
+    with pytest.raises(UserCancelledError, match='stopped by user'):
+        make_cancel_stop_condition()(None)
+
+
+def test_non_user_queue_failure_does_not_cancel(monkeypatch):
+    from lazyllm.common import queue as queue_module
+
+    class BrokenQueue:
+        def __init__(self, *, klass):
+            assert klass == 'cancel'
+
+        def dequeue(self):
+            raise RuntimeError('state unavailable')
+
+    monkeypatch.setattr(queue_module, 'FileSystemQueue', BrokenQueue)
+
+    assert make_cancel_stop_condition()(None) is False
+
+
+def test_user_cancel_during_tool_limit_wait_uses_domain_cancellation(monkeypatch):
+    from lazymind.chat.engine.agent_runtime import tool_limit_control
+
+    class FakeQueue:
+        def __init__(self, *, klass):
+            self.klass = klass
+
+        def dequeue(self):
+            if self.klass == 'cancel':
+                return [json.dumps({'tag': 'cancel'})]
+            return []
+
+    monkeypatch.setattr(tool_limit_control, 'FileSystemQueue', FakeQueue)
+
+    with pytest.raises(UserCancelledError, match='stopped by user'):
+        tool_limit_control.ToolLimitDecisionCoordinator()._wait_for_action('decision-1', 0.2)

--- a/algorithm/tests/chat/test_runtime_events.py
+++ b/algorithm/tests/chat/test_runtime_events.py
@@ -6,7 +6,7 @@ import lazyllm
 import pytest
 
 from lazymind.chat.engine.agent_runtime.executor import AgentExecutor
-from lazymind.chat.runtime_events import RunAccumulator
+from lazymind.chat.runtime_events import RunAccumulator, RunOutcome
 from lazymind.chat.service.component.event_translator import AgentEventFrameTranslator
 
 
@@ -62,7 +62,7 @@ def test_translator_binds_model_event_to_run():
 ])
 def test_run_accumulator_maps_model_terminal(terminal, status, reason):
     accumulator = RunAccumulator(run_id='run-1', last_model_terminal=terminal)
-    event = accumulator.finish(succeeded=False)
+    event = accumulator.finish(outcome=RunOutcome.FAILED)
 
     assert event['type'] == 'run_finished'
     assert event['data']['status'] == status
@@ -77,7 +77,7 @@ def test_successful_model_terminal_does_not_mask_downstream_runtime_failure(fini
         'has_semantic_output': True,
     })
 
-    assert accumulator.finish(succeeded=False)['data']['code'] == 'runtime_failure'
+    assert accumulator.finish(outcome=RunOutcome.FAILED)['data']['code'] == 'runtime_failure'
 
 
 def test_run_accumulator_only_propagates_public_failure_fields():
@@ -94,7 +94,7 @@ def test_run_accumulator_only_propagates_public_failure_fields():
         },
     })
 
-    data = accumulator.finish(succeeded=False)['data']
+    data = accumulator.finish(outcome=RunOutcome.FAILED)['data']
 
     assert data == {
         'status': 'failed',
@@ -108,13 +108,50 @@ def test_run_accumulator_only_propagates_public_failure_fields():
 
 def test_run_accumulator_awaiting_user_input_is_completed():
     accumulator = RunAccumulator(run_id='run-1', ask_pending=True, semantic_output=True)
-    event = accumulator.finish(succeeded=True)
+    event = accumulator.finish(outcome=RunOutcome.SUCCEEDED)
 
     assert event['data'] == {
         'status': 'completed',
         'reason': 'awaiting_user_input',
         'partial_output': True,
     }
+
+
+def test_run_accumulator_user_cancel_is_an_explicit_terminal():
+    accumulator = RunAccumulator(
+        run_id='run-1',
+        semantic_output=True,
+        last_model_terminal={
+            'model_call_id': 'call-1',
+            'kind': 'finish',
+            'finish': 'tool_calls',
+            'has_semantic_output': True,
+        },
+    )
+
+    event = accumulator.finish(outcome=RunOutcome.CANCELLED)
+
+    assert event['data'] == {
+        'status': 'cancelled',
+        'reason': 'user_cancelled',
+        'partial_output': True,
+        'model_call_id': 'call-1',
+    }
+    with pytest.raises(RuntimeError, match='already has a terminal'):
+        accumulator.finish(outcome=RunOutcome.CANCELLED)
+
+
+@pytest.mark.parametrize('event', [
+    {'tag': 'tool_results', 'tool_results': [{'id': 'tool-1', 'name': 'search', 'content': 'result'}]},
+    {'tag': 'subagent_think', 'think': 'working'},
+])
+def test_cancelled_terminal_marks_rendered_runtime_output_as_partial(event):
+    translator = AgentEventFrameTranslator(query='test', run_id='run-1')
+
+    assert translator.feed(event)
+    terminal = translator.finish_run(outcome=RunOutcome.CANCELLED)['runtime_event']['data']
+
+    assert terminal['partial_output'] is True
 
 
 @pytest.mark.asyncio

--- a/backend/core/chat/conversation.go
+++ b/backend/core/chat/conversation.go
@@ -20,6 +20,7 @@ import (
 	"lazymind/core/common"
 	"lazymind/core/common/orm"
 	"lazymind/core/evolution"
+	"lazymind/core/log"
 	"lazymind/core/modelconfig"
 	"lazymind/core/state"
 	"lazymind/core/store"
@@ -1044,6 +1045,16 @@ func StopChatGeneration(w http.ResponseWriter, r *http.Request) {
 			ids = append(ids, historyID)
 		}
 		for _, hid := range ids {
+			if status, err := getChatStatus(r.Context(), stateStore, convID, hid); err == nil &&
+				status.Status == "generating" && strings.TrimSpace(status.RunID) != "" {
+				if _, err := claimUserCancelDecision(r.Context(), stateStore, convID, hid, status.RunID); err != nil {
+					log.Logger.Warn().Err(err).
+						Str("conversation_id", convID).
+						Str("history_id", hid).
+						Str("run_id", status.RunID).
+						Msg("failed to record user cancellation decision")
+				}
+			}
 			_ = setChatCancelSignal(r.Context(), stateStore, convID, hid)
 		}
 	}

--- a/backend/core/chat/conversation_logic.go
+++ b/backend/core/chat/conversation_logic.go
@@ -1721,6 +1721,24 @@ func consumeRuntimeChunk(chunk UpstreamStreamChunk, runID string, partialOutput 
 	return decision, true
 }
 
+func resolveRuntimeChunkDecision(
+	ctx context.Context,
+	stateStore state.Store,
+	convID, historyID, runID string,
+	decision runtimeChunkDecision,
+	partialOutput bool,
+) runtimeChunkDecision {
+	if decision.Terminal == nil {
+		return decision
+	}
+	decision.Terminal = resolveRunTerminal(
+		ctx, stateStore, convID, historyID, runID,
+		decision.Terminal, partialOutput, "upstream_terminal",
+	)
+	decision.Event = runFinishedEvent(runID, *decision.Terminal)
+	return decision
+}
+
 func publishRuntimeChunk(
 	reqCtx, storeCtx context.Context,
 	w http.ResponseWriter,
@@ -1767,9 +1785,14 @@ func streamSingleAnswer(
 	if err != nil {
 		runEvent := failedRunEvent(runID, "upstream_request_failed", false)
 		terminal, _ := runEvent.Terminal()
+		terminal = resolveRunTerminal(
+			context.Background(), stateStore, convID, historyID, runID,
+			terminal, false, "upstream_request",
+		)
+		runEvent = runFinishedEvent(runID, *terminal)
 		persistImmediateRunTerminal(db, convID, historyID, query, runID, target, historyExt, terminal)
 		if stateStore != nil {
-			_ = setChatRuntimeStatus(chatCtx, stateStore, convID, historyID, terminal.Status, "", runID, terminal)
+			_ = setChatRuntimeStatus(context.Background(), stateStore, convID, historyID, terminal.Status, "", runID, terminal)
 		}
 		writeSSEChunk(w, flusher, &ChatChunkResponse{
 			ConversationID: convID,
@@ -1837,8 +1860,13 @@ func streamSingleAnswer(
 		ThinkingDurationS: 0,
 	})
 	for d := range ch {
-		decision, handled := consumeRuntimeChunk(d, runID, fullResult != "" || pendingThink != "")
+		partialOutput := fullResult != "" || pendingThink != ""
+		decision, handled := consumeRuntimeChunk(d, runID, partialOutput)
 		if handled {
+			decision = resolveRuntimeChunkDecision(
+				context.Background(), stateStore, convID, historyID, runID,
+				decision, partialOutput,
+			)
 			if decision.Terminal != nil {
 				runTerminal = decision.Terminal
 			}
@@ -2052,6 +2080,11 @@ func streamSingleAnswer(
 			runEvent = failedRunEvent(runID, "missing_run_terminal", fullResult != "" || pendingThink != "")
 		}
 		runTerminal, _ = runEvent.Terminal()
+		runTerminal = resolveRunTerminal(
+			context.Background(), stateStore, convID, historyID, runID,
+			runTerminal, fullResult != "" || pendingThink != "", "core_fallback",
+		)
+		runEvent = runFinishedEvent(runID, *runTerminal)
 		runtimeChunk := &ChatChunkResponse{ConversationID: convID, Seq: int32(seq), HistoryID: historyID, RuntimeEvent: runEvent}
 		if reqCtx.Err() == nil {
 			writeSSEChunk(w, flusher, runtimeChunk)
@@ -2078,6 +2111,12 @@ func streamSingleAnswer(
 	if externalFinalized {
 		var persistedHistory orm.ChatHistory
 		persisted = db.Where("id = ? AND conversation_id = ?", historyID, convID).Take(&persistedHistory).Error == nil
+		if persisted {
+			if err := persistResolvedExternalRunTerminal(context.Background(), db, historyID, runTerminal); err != nil {
+				log.Logger.Warn().Err(err).Str("conversation_id", convID).Str("history_id", historyID).
+					Msg("failed to persist resolved external run terminal")
+			}
+		}
 	}
 	if !externalFinalized && target.IsRegeneration && target.Existing != nil {
 		if err := db.Model(&orm.ChatHistory{}).Where("id = ?", historyID).Updates(map[string]any{
@@ -2388,7 +2427,12 @@ func streamDualAnswer(
 				primaryCh = nil
 				continue
 			}
-			if decision, handled := consumeRuntimeChunk(d, primaryRunID, primaryResult != "" || primaryPendingThink != ""); handled {
+			partialOutput := primaryResult != "" || primaryPendingThink != ""
+			if decision, handled := consumeRuntimeChunk(d, primaryRunID, partialOutput); handled {
+				decision = resolveRuntimeChunkDecision(
+					context.Background(), stateStore, convID, historyID, primaryRunID,
+					decision, partialOutput,
+				)
 				if decision.Terminal != nil {
 					primaryTerminal = decision.Terminal
 				}
@@ -2416,7 +2460,12 @@ func streamDualAnswer(
 				secondaryCh = nil
 				continue
 			}
-			if decision, handled := consumeRuntimeChunk(d, secondaryRunID, secondaryResult != "" || secondaryPendingThink != ""); handled {
+			partialOutput := secondaryResult != "" || secondaryPendingThink != ""
+			if decision, handled := consumeRuntimeChunk(d, secondaryRunID, partialOutput); handled {
+				decision = resolveRuntimeChunkDecision(
+					context.Background(), stateStore, convID, secondaryHistoryID, secondaryRunID,
+					decision, partialOutput,
+				)
 				if decision.Terminal != nil {
 					secondaryTerminal = decision.Terminal
 				}
@@ -2447,7 +2496,12 @@ func streamDualAnswer(
 						primaryDone = true
 						primaryCh = nil
 					} else {
-						if decision, handled := consumeRuntimeChunk(d, primaryRunID, primaryResult != "" || primaryPendingThink != ""); handled {
+						partialOutput := primaryResult != "" || primaryPendingThink != ""
+						if decision, handled := consumeRuntimeChunk(d, primaryRunID, partialOutput); handled {
+							decision = resolveRuntimeChunkDecision(
+								context.Background(), stateStore, convID, historyID, primaryRunID,
+								decision, partialOutput,
+							)
 							if decision.Terminal != nil {
 								primaryTerminal = decision.Terminal
 							}
@@ -2499,7 +2553,12 @@ func streamDualAnswer(
 						secondaryDone = true
 						secondaryCh = nil
 					} else {
-						if decision, handled := consumeRuntimeChunk(d, secondaryRunID, secondaryResult != "" || secondaryPendingThink != ""); handled {
+						partialOutput := secondaryResult != "" || secondaryPendingThink != ""
+						if decision, handled := consumeRuntimeChunk(d, secondaryRunID, partialOutput); handled {
+							decision = resolveRuntimeChunkDecision(
+								context.Background(), stateStore, convID, secondaryHistoryID, secondaryRunID,
+								decision, partialOutput,
+							)
 							if decision.Terminal != nil {
 								secondaryTerminal = decision.Terminal
 							}
@@ -2560,8 +2619,19 @@ dualPersist:
 		secondaryResult += "<think>" + secondaryPendingThink + "</think>"
 	}
 	if primaryTerminal == nil {
-		event := failedRunEvent(primaryRunID, "missing_run_terminal", primaryResult != "")
+		partialOutput := primaryResult != ""
+		var event *ChatRuntimeEvent
+		if chatCtx.Err() != nil {
+			event = cancelledRunEvent(primaryRunID, partialOutput)
+		} else {
+			event = failedRunEvent(primaryRunID, "missing_run_terminal", partialOutput)
+		}
 		primaryTerminal, _ = event.Terminal()
+		primaryTerminal = resolveRunTerminal(
+			context.Background(), stateStore, convID, historyID, primaryRunID,
+			primaryTerminal, partialOutput, "core_fallback",
+		)
+		event = runFinishedEvent(primaryRunID, *primaryTerminal)
 		chunk := &ChatChunkResponse{ConversationID: convID, Seq: int32(seq), HistoryID: historyID, RuntimeEvent: event}
 		if reqCtx.Err() == nil {
 			writeSSEChunk(w, flusher, chunk)
@@ -2571,8 +2641,19 @@ dualPersist:
 		}
 	}
 	if secondaryTerminal == nil {
-		event := failedRunEvent(secondaryRunID, "missing_run_terminal", secondaryResult != "")
+		partialOutput := secondaryResult != ""
+		var event *ChatRuntimeEvent
+		if chatCtx.Err() != nil {
+			event = cancelledRunEvent(secondaryRunID, partialOutput)
+		} else {
+			event = failedRunEvent(secondaryRunID, "missing_run_terminal", partialOutput)
+		}
 		secondaryTerminal, _ = event.Terminal()
+		secondaryTerminal = resolveRunTerminal(
+			context.Background(), stateStore, convID, secondaryHistoryID, secondaryRunID,
+			secondaryTerminal, partialOutput, "core_fallback",
+		)
+		event = runFinishedEvent(secondaryRunID, *secondaryTerminal)
 		chunk := &ChatChunkResponse{ConversationID: convID, Seq: int32(seq), HistoryID: secondaryHistoryID, RuntimeEvent: event}
 		if reqCtx.Err() == nil {
 			writeSSEChunk(w, flusher, chunk)

--- a/backend/core/chat/redis_cache.go
+++ b/backend/core/chat/redis_cache.go
@@ -184,6 +184,13 @@ func reconcileGeneratingExternalChatStatuses(
 		}
 		terminalEvent := externalRunTerminalEvent(run.ID, run.Status, result != "")
 		terminal, _ := terminalEvent.Terminal()
+		terminal = resolveRunTerminal(
+			ctx, stateStore, run.ConversationID, run.HistoryID, run.ID,
+			terminal, result != "", "external_durable_terminal",
+		)
+		if err := persistResolvedExternalRunTerminal(ctx, db, run.HistoryID, terminal); err != nil {
+			return ids, err
+		}
 		if err := setChatRuntimeStatus(ctx, stateStore, conversationID, historyID, terminal.Status, result, run.ID, terminal); err != nil {
 			return ids, err
 		}
@@ -215,7 +222,23 @@ func projectExternalChatRunStatus(
 	}
 	terminalEvent := externalRunTerminalEvent(run.ID, run.Status, result != "")
 	terminal, _ := terminalEvent.Terminal()
+	terminal = resolveRunTerminal(
+		ctx, stateStore, run.ConversationID, run.HistoryID, run.ID,
+		terminal, result != "", "external_durable_terminal",
+	)
+	if err := persistResolvedExternalRunTerminal(ctx, db, run.HistoryID, terminal); err != nil {
+		return err
+	}
 	return setChatRuntimeStatus(ctx, stateStore, run.ConversationID, run.HistoryID, terminal.Status, result, run.ID, terminal)
+}
+
+func persistResolvedExternalRunTerminal(ctx context.Context, db *gorm.DB, historyID string, terminal *RunTerminal) error {
+	if db == nil || terminal == nil {
+		return nil
+	}
+	return db.WithContext(ctx).Model(&orm.ChatHistory{}).Where("id = ?", historyID).Updates(map[string]any{
+		"run_status": terminal.Status, "run_terminal": terminalJSON(terminal), "update_time": time.Now(),
+	}).Error
 }
 
 func getChatStatus(ctx context.Context, stateStore state.Store, conversationID, historyID string) (*ChatStatus, error) {

--- a/backend/core/chat/redis_cancel_integration_test.go
+++ b/backend/core/chat/redis_cancel_integration_test.go
@@ -127,6 +127,47 @@ func TestRedisCancelWatcherReleasesConnections(t *testing.T) {
 		}
 	})
 
+	t.Run("run decisions are atomic and run scoped", func(t *testing.T) {
+		decisionCtx := context.Background()
+		conversationID := prefix + ":decision"
+		historyID := "history"
+		failure := &RunTerminal{Status: "failed", Reason: "model_failure", Code: "rate_limited"}
+		for _, runID := range []string{"cancel-first", "failure-first", "next-run"} {
+			key := runDecisionKey(conversationID, historyID, runID)
+			t.Cleanup(func() { _ = client.Del(context.Background(), key).Err() })
+		}
+
+		if won, err := claimUserCancelDecision(decisionCtx, stateStore, conversationID, historyID, "cancel-first"); err != nil || !won {
+			t.Fatalf("claim cancellation: won=%v err=%v", won, err)
+		}
+		cancelled := resolveRunTerminal(
+			decisionCtx, stateStore, conversationID, historyID, "cancel-first",
+			failure, false, "redis_integration_terminal",
+		)
+		if cancelled.Status != "cancelled" || cancelled.Reason != "user_cancelled" {
+			t.Fatalf("cancel-first terminal=%#v", cancelled)
+		}
+
+		acceptedFailure := resolveRunTerminal(
+			decisionCtx, stateStore, conversationID, historyID, "failure-first",
+			failure, false, "redis_integration_terminal",
+		)
+		if won, err := claimUserCancelDecision(decisionCtx, stateStore, conversationID, historyID, "failure-first"); err != nil || won {
+			t.Fatalf("late cancellation: won=%v err=%v", won, err)
+		}
+		if acceptedFailure.Status != "failed" || acceptedFailure.Reason != "model_failure" {
+			t.Fatalf("failure-first terminal=%#v", acceptedFailure)
+		}
+
+		nextRun := resolveRunTerminal(
+			decisionCtx, stateStore, conversationID, historyID, "next-run",
+			failure, false, "redis_integration_terminal",
+		)
+		if nextRun.Status != "failed" || nextRun.Reason != "model_failure" {
+			t.Fatalf("previous run decision leaked into next run: %#v", nextRun)
+		}
+	})
+
 	assertRedisPoolIdle(t, client)
 	requestCtx, requestCancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
 	defer requestCancel()

--- a/backend/core/chat/run_decision.go
+++ b/backend/core/chat/run_decision.go
@@ -1,0 +1,138 @@
+package chat
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	"lazymind/core/log"
+	"lazymind/core/state"
+)
+
+const (
+	runDecisionKeyPrefix = "rag/chat/run-decision:%s:%s:%s"
+	runDecisionTTL       = 15 * time.Minute
+
+	runDecisionUserCancel = "user_cancel"
+	runDecisionTerminal   = "terminal"
+)
+
+type runDecision struct {
+	Kind        string       `json:"kind"`
+	Terminal    *RunTerminal `json:"terminal,omitempty"`
+	Source      string       `json:"source"`
+	DecidedAtMS int64        `json:"decided_at_ms"`
+}
+
+func runDecisionKey(conversationID, historyID, runID string) string {
+	return fmt.Sprintf(runDecisionKeyPrefix, conversationID, historyID, runID)
+}
+
+func claimRunDecision(
+	ctx context.Context,
+	stateStore state.Store,
+	conversationID, historyID, runID string,
+	candidate runDecision,
+) (runDecision, bool, error) {
+	if stateStore == nil || strings.TrimSpace(conversationID) == "" ||
+		strings.TrimSpace(historyID) == "" || strings.TrimSpace(runID) == "" {
+		return candidate, true, nil
+	}
+	candidate.DecidedAtMS = time.Now().UnixMilli()
+	payload, err := json.Marshal(candidate)
+	if err != nil {
+		return runDecision{}, false, err
+	}
+	key := runDecisionKey(conversationID, historyID, runID)
+	won, err := stateStore.SetNX(ctx, key, payload, runDecisionTTL)
+	if err != nil {
+		return runDecision{}, false, err
+	}
+	if won {
+		logRunDecision("chat run decision accepted", conversationID, historyID, runID, candidate, "")
+		return candidate, true, nil
+	}
+	existingPayload, err := stateStore.Get(ctx, key)
+	if err != nil {
+		return runDecision{}, false, err
+	}
+	var existing runDecision
+	if err := json.Unmarshal(existingPayload, &existing); err != nil {
+		return runDecision{}, false, err
+	}
+	logRunDecision("chat run decision ignored", conversationID, historyID, runID, existing, candidate.Source)
+	return existing, false, nil
+}
+
+func logRunDecision(message, conversationID, historyID, runID string, winner runDecision, ignoredSource string) {
+	event := log.Logger.Info().
+		Str("conversation_id", conversationID).
+		Str("history_id", historyID).
+		Str("run_id", runID).
+		Str("decision_kind", winner.Kind).
+		Str("decision_source", winner.Source)
+	if winner.Terminal != nil {
+		event = event.
+			Str("terminal_status", winner.Terminal.Status).
+			Str("terminal_reason", winner.Terminal.Reason).
+			Str("terminal_code", winner.Terminal.Code)
+	}
+	if ignoredSource != "" {
+		event = event.Str("ignored_source", ignoredSource)
+	}
+	event.Msg(message)
+}
+
+func claimUserCancelDecision(
+	ctx context.Context,
+	stateStore state.Store,
+	conversationID, historyID, runID string,
+) (bool, error) {
+	winner, _, err := claimRunDecision(ctx, stateStore, conversationID, historyID, runID, runDecision{
+		Kind:   runDecisionUserCancel,
+		Source: "user_stop",
+	})
+	return err == nil && winner.Kind == runDecisionUserCancel, err
+}
+
+func resolveRunTerminal(
+	ctx context.Context,
+	stateStore state.Store,
+	conversationID, historyID, runID string,
+	candidate *RunTerminal,
+	partialOutput bool,
+	source string,
+) *RunTerminal {
+	if candidate == nil {
+		fallback := RunTerminal{
+			Status: "failed", Reason: "runtime_failure", Code: "missing_run_terminal",
+			PartialOutput: partialOutput,
+		}
+		candidate = &fallback
+	}
+	winner, _, err := claimRunDecision(ctx, stateStore, conversationID, historyID, runID, runDecision{
+		Kind:     runDecisionTerminal,
+		Terminal: candidate,
+		Source:   source,
+	})
+	if err != nil {
+		log.Logger.Warn().Err(err).
+			Str("conversation_id", conversationID).
+			Str("history_id", historyID).
+			Str("run_id", runID).
+			Str("decision_source", source).
+			Msg("chat run decision state unavailable; using candidate terminal")
+		return candidate
+	}
+	if winner.Kind == runDecisionUserCancel {
+		return &RunTerminal{
+			Status: "cancelled", Reason: "user_cancelled", PartialOutput: partialOutput,
+		}
+	}
+	if winner.Kind == runDecisionTerminal && winner.Terminal != nil {
+		return winner.Terminal
+	}
+	return candidate
+}

--- a/backend/core/chat/run_decision_stream_test.go
+++ b/backend/core/chat/run_decision_stream_test.go
@@ -1,0 +1,124 @@
+package chat
+
+import (
+	"context"
+	"encoding/json"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"gorm.io/gorm"
+
+	"lazymind/core/common/orm"
+	"lazymind/core/state"
+)
+
+func newRunDecisionStreamHarness(t *testing.T) (*gorm.DB, state.Store) {
+	t.Helper()
+	database, err := orm.Connect(orm.DriverSQLite, filepath.Join(t.TempDir(), "chat.db"))
+	if err != nil {
+		t.Fatalf("connect chat database: %v", err)
+	}
+	if err := database.AutoMigrate(&orm.Conversation{}, &orm.ChatHistory{}, &orm.TaskCenterTask{}); err != nil {
+		t.Fatalf("migrate chat database: %v", err)
+	}
+	now := time.Now().UTC()
+	if err := database.Create(&orm.Conversation{
+		ID: "conv-stream-decision",
+		BaseModel: orm.BaseModel{
+			CreateUserID: "user-1", CreateUserName: "user-1", CreatedAt: now, UpdatedAt: now,
+		},
+	}).Error; err != nil {
+		t.Fatalf("create conversation: %v", err)
+	}
+	stateStore, err := state.NewSQLiteStore(filepath.Join(t.TempDir(), "state.db"))
+	if err != nil {
+		t.Fatalf("create state store: %v", err)
+	}
+	t.Cleanup(func() { _ = stateStore.Close() })
+	return database.DB, stateStore
+}
+
+func TestStreamSingleAnswerUserCancelWinsOverCancellationEOF(t *testing.T) {
+	db, stateStore := newRunDecisionStreamHarness(t)
+	const historyID = "history-cancel-first"
+	const runID = "run-cancel-first"
+	server := streamServer(t, runID, algorithmFrame(t, map[string]any{"text": "partial answer"}))
+	defer server.Close()
+
+	if won, err := claimUserCancelDecision(
+		context.Background(), stateStore, "conv-stream-decision", historyID, runID,
+	); err != nil || !won {
+		t.Fatalf("claim cancellation: won=%v err=%v", won, err)
+	}
+	recorder := httptest.NewRecorder()
+	streamSingleAnswer(
+		context.Background(), context.Background(), recorder, recorder, db, stateStore,
+		server.URL, map[string]any{"query": "question", "run_id": runID},
+		"conv-stream-decision", "question", historyID,
+		chatPersistTarget{HistoryID: historyID, Seq: 1}, json.RawMessage(`{}`),
+	)
+
+	var history orm.ChatHistory
+	if err := db.Where("id = ?", historyID).Take(&history).Error; err != nil {
+		t.Fatalf("load cancelled history: %v", err)
+	}
+	terminal, err := parseRunTerminal(history.RunTerminal)
+	if err != nil {
+		t.Fatalf("parse cancelled terminal: %v", err)
+	}
+	if history.Result != "partial answer" || history.RunStatus != "cancelled" ||
+		terminal.Reason != "user_cancelled" || !terminal.PartialOutput {
+		t.Fatalf("unexpected cancelled history: history=%#v terminal=%#v", history, terminal)
+	}
+	if body := recorder.Body.String(); !strings.Contains(body, `"status":"cancelled"`) || strings.Contains(body, `"status":"failed"`) {
+		t.Fatalf("unexpected cancellation stream: %s", body)
+	}
+}
+
+func TestStreamSingleAnswerAcceptedModelFailureWinsOverLateStop(t *testing.T) {
+	db, stateStore := newRunDecisionStreamHarness(t)
+	const historyID = "history-failure-first"
+	const runID = "run-failure-first"
+	failureFrame := algorithmFrame(t, map[string]any{"runtime_event": map[string]any{
+		"schema_version": 1,
+		"event_id":       "evt-model-failure",
+		"run_id":         runID,
+		"type":           RuntimeEventRunFinished,
+		"data": map[string]any{
+			"status": "failed", "reason": "model_failure", "code": "rate_limited", "partial_output": false,
+		},
+	}})
+	server := streamServer(t, runID, failureFrame)
+	defer server.Close()
+
+	recorder := httptest.NewRecorder()
+	streamSingleAnswer(
+		context.Background(), context.Background(), recorder, recorder, db, stateStore,
+		server.URL, map[string]any{"query": "question", "run_id": runID},
+		"conv-stream-decision", "question", historyID,
+		chatPersistTarget{HistoryID: historyID, Seq: 1}, json.RawMessage(`{}`),
+	)
+	if won, err := claimUserCancelDecision(
+		context.Background(), stateStore, "conv-stream-decision", historyID, runID,
+	); err != nil || won {
+		t.Fatalf("late cancellation: won=%v err=%v", won, err)
+	}
+
+	var history orm.ChatHistory
+	if err := db.Where("id = ?", historyID).Take(&history).Error; err != nil {
+		t.Fatalf("load failed history: %v", err)
+	}
+	terminal, err := parseRunTerminal(history.RunTerminal)
+	if err != nil {
+		t.Fatalf("parse failed terminal: %v", err)
+	}
+	if history.RunStatus != "failed" || terminal.Reason != "model_failure" || terminal.Code != "rate_limited" {
+		t.Fatalf("late stop overwrote model failure: history=%#v terminal=%#v", history, terminal)
+	}
+	if body := recorder.Body.String(); !strings.Contains(body, `"status":"failed"`) || strings.Contains(body, `"status":"cancelled"`) {
+		t.Fatalf("unexpected failure stream: %s", body)
+	}
+}

--- a/backend/core/chat/run_decision_test.go
+++ b/backend/core/chat/run_decision_test.go
@@ -1,0 +1,163 @@
+package chat
+
+import (
+	"context"
+	"encoding/json"
+	"path/filepath"
+	"testing"
+
+	"lazymind/core/common/orm"
+	"lazymind/core/state"
+)
+
+func newRunDecisionTestStore(t *testing.T) state.Store {
+	t.Helper()
+	store, err := state.NewSQLiteStore(filepath.Join(t.TempDir(), "state.db"))
+	if err != nil {
+		t.Fatalf("create state store: %v", err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+	return store
+}
+
+func TestRunDecisionUserCancelWinsWhileRunIsActive(t *testing.T) {
+	ctx := context.Background()
+	store := newRunDecisionTestStore(t)
+	won, err := claimUserCancelDecision(ctx, store, "conv", "history", "run-1")
+	if err != nil || !won {
+		t.Fatalf("claim cancellation: won=%v err=%v", won, err)
+	}
+
+	terminal := resolveRunTerminal(ctx, store, "conv", "history", "run-1", &RunTerminal{
+		Status: "failed", Reason: "runtime_failure", Code: "upstream_stream_failed",
+		PartialOutput: true,
+	}, true, "upstream_terminal")
+
+	if terminal.Status != "cancelled" || terminal.Reason != "user_cancelled" || !terminal.PartialOutput || terminal.Code != "" {
+		t.Fatalf("unexpected cancellation terminal: %#v", terminal)
+	}
+}
+
+func TestRunDecisionAcceptedFailureIsNotOverwrittenByStop(t *testing.T) {
+	ctx := context.Background()
+	store := newRunDecisionTestStore(t)
+	failure := &RunTerminal{
+		Status: "failed", Reason: "model_failure", Code: "rate_limited",
+		PartialOutput: false,
+	}
+	accepted := resolveRunTerminal(
+		ctx, store, "conv", "history", "run-1", failure, false, "upstream_terminal",
+	)
+	if accepted.Status != "failed" || accepted.Reason != "model_failure" {
+		t.Fatalf("unexpected accepted terminal: %#v", accepted)
+	}
+
+	won, err := claimUserCancelDecision(ctx, store, "conv", "history", "run-1")
+	if err != nil {
+		t.Fatalf("claim late cancellation: %v", err)
+	}
+	if won {
+		t.Fatal("late cancellation overwrote accepted failure")
+	}
+
+	resolved := resolveRunTerminal(ctx, store, "conv", "history", "run-1", &RunTerminal{
+		Status: "cancelled", Reason: "user_cancelled", PartialOutput: true,
+	}, true, "late_terminal")
+	if *resolved != *failure {
+		t.Fatalf("accepted failure changed: got %#v want %#v", resolved, failure)
+	}
+}
+
+func TestRunDecisionRepeatedUserCancelIsIdempotent(t *testing.T) {
+	ctx := context.Background()
+	store := newRunDecisionTestStore(t)
+	for attempt := 0; attempt < 2; attempt++ {
+		won, err := claimUserCancelDecision(ctx, store, "conv", "history", "run-1")
+		if err != nil || !won {
+			t.Fatalf("claim cancellation attempt %d: won=%v err=%v", attempt+1, won, err)
+		}
+	}
+
+	terminal := resolveRunTerminal(ctx, store, "conv", "history", "run-1", &RunTerminal{
+		Status: "completed", Reason: "normal", PartialOutput: true,
+	}, true, "late_terminal")
+	if terminal.Status != "cancelled" || terminal.Reason != "user_cancelled" {
+		t.Fatalf("repeated cancellation changed the winning decision: %#v", terminal)
+	}
+}
+
+func TestRunDecisionIsIsolatedByRunID(t *testing.T) {
+	ctx := context.Background()
+	store := newRunDecisionTestStore(t)
+	if won, err := claimUserCancelDecision(ctx, store, "conv", "history", "run-1"); err != nil || !won {
+		t.Fatalf("claim first run cancellation: won=%v err=%v", won, err)
+	}
+
+	second := resolveRunTerminal(ctx, store, "conv", "history", "run-2", &RunTerminal{
+		Status: "failed", Reason: "runtime_failure", Code: "upstream_stream_failed",
+		PartialOutput: false,
+	}, false, "upstream_terminal")
+	if second.Status != "failed" || second.Reason != "runtime_failure" {
+		t.Fatalf("first run cancellation leaked into second run: %#v", second)
+	}
+}
+
+func TestResolveRuntimeChunkDecisionRewritesEventToWinningCancellation(t *testing.T) {
+	ctx := context.Background()
+	store := newRunDecisionTestStore(t)
+	if won, err := claimUserCancelDecision(ctx, store, "conv", "history", "run-1"); err != nil || !won {
+		t.Fatalf("claim cancellation: won=%v err=%v", won, err)
+	}
+	candidateEvent := failedRunEvent("run-1", "upstream_stream_failed", true)
+	candidate, _ := candidateEvent.Terminal()
+
+	decision := resolveRuntimeChunkDecision(
+		ctx, store, "conv", "history", "run-1",
+		runtimeChunkDecision{Event: candidateEvent, Terminal: candidate, Stop: true}, true,
+	)
+	terminal, err := decision.Event.Terminal()
+	if err != nil {
+		t.Fatalf("parse resolved event: %v", err)
+	}
+	if terminal.Status != "cancelled" || decision.Terminal.Status != "cancelled" || !decision.Stop {
+		t.Fatalf("unexpected resolved decision: %#v terminal=%#v", decision, terminal)
+	}
+}
+
+func TestExternalTerminalProjectionPersistsCoreDecision(t *testing.T) {
+	ctx := context.Background()
+	app, db := newExternalChatTestApplication(t)
+	createExternalChatTestRun(t, app, "run-external-decision")
+	job, err := app.claim(ctx, "user-1", ChatExecutorCodex, "host-1")
+	if err != nil || job == nil {
+		t.Fatalf("claim external run: job=%#v err=%v", job, err)
+	}
+	if _, err := app.appendEvent(
+		ctx, "user-1", job.RunID, "host-1", job.LeaseToken,
+		externalChatEvent{EventID: "failed-1", Type: "failed", Error: "provider failed"},
+	); err != nil {
+		t.Fatalf("append external failure: %v", err)
+	}
+
+	store := newRunDecisionTestStore(t)
+	if won, err := claimUserCancelDecision(
+		ctx, store, "conversation-1", "history-run-external-decision", job.RunID,
+	); err != nil || !won {
+		t.Fatalf("claim cancellation: won=%v err=%v", won, err)
+	}
+	if err := projectExternalChatRunStatus(ctx, db, store, "user-1", job.RunID); err != nil {
+		t.Fatalf("project external terminal: %v", err)
+	}
+
+	var history orm.ChatHistory
+	if err := db.Where("id = ?", "history-run-external-decision").Take(&history).Error; err != nil {
+		t.Fatalf("load projected history: %v", err)
+	}
+	var terminal RunTerminal
+	if err := json.Unmarshal(history.RunTerminal, &terminal); err != nil {
+		t.Fatalf("decode projected terminal: %v", err)
+	}
+	if history.RunStatus != "cancelled" || terminal.Status != "cancelled" || terminal.Reason != "user_cancelled" {
+		t.Fatalf("external history did not persist Core decision: history=%#v terminal=%#v", history, terminal)
+	}
+}

--- a/frontend/src/i18n/locales/en-US.ts
+++ b/frontend/src/i18n/locales/en-US.ts
@@ -1762,6 +1762,8 @@ const enUS = {
       completed: "Answer complete",
       interrupted: "Answer generation was interrupted",
       failed: "Model call failed",
+      modelFailed: "Model call failed",
+      runtimeFailed: "Runtime failed",
       cancelled: "Generation cancelled",
       partialOutput: "The partial output has been preserved.",
       noOutput: "No usable output was generated.",

--- a/frontend/src/i18n/locales/zh-CN.ts
+++ b/frontend/src/i18n/locales/zh-CN.ts
@@ -1715,6 +1715,8 @@ const zhCN = {
       completed: "回答已完成",
       interrupted: "回答未完整生成",
       failed: "模型调用失败",
+      modelFailed: "模型调用失败",
+      runtimeFailed: "运行失败",
       cancelled: "已取消生成",
       partialOutput: "已生成的部分内容已保留。",
       noOutput: "本次未生成可用内容。",

--- a/frontend/src/modules/chat/components/RunStatusCard/index.test.tsx
+++ b/frontend/src/modules/chat/components/RunStatusCard/index.test.tsx
@@ -24,6 +24,19 @@ describe("RunStatusCard", () => {
     expect(screen.getByText("chat.runStatus.partialOutput")).toBeInTheDocument();
   });
 
+  it("uses the cancellation reason as the presentation authority", () => {
+    render(<RunStatusCard terminal={{
+      status: "failed",
+      reason: "user_cancelled",
+      partial_output: false,
+    }} />);
+
+    const alert = screen.getByRole("alert");
+    expect(alert).toHaveClass("chat-run-status-card--cancelled");
+    expect(screen.getByText("chat.runStatus.cancelled")).toBeInTheDocument();
+    expect(screen.queryByText(/chat\.runStatus\.providerError/)).not.toBeInTheDocument();
+  });
+
   it.each([
     "usage_limit_exceeded",
     "concurrency_limited",
@@ -36,8 +49,34 @@ describe("RunStatusCard", () => {
       partial_output: false,
     }} />);
 
+    expect(screen.getByText("chat.runStatus.modelFailed")).toBeInTheDocument();
     expect(screen.getByText(new RegExp(`chat\\.runStatus\\.codes\\.${code}`))).toBeInTheDocument();
     expect(screen.getByText(/chat\.runStatus\.noOutput/)).toBeInTheDocument();
+  });
+
+  it("renders runtime failures with a runtime title and red alert", () => {
+    render(<RunStatusCard terminal={{
+      status: "failed",
+      reason: "runtime_failure",
+      code: "upstream_stream_failed",
+      partial_output: true,
+    }} />);
+
+    const alert = screen.getByRole("alert");
+    expect(alert).not.toHaveClass("chat-run-status-card--cancelled");
+    expect(screen.getByText("chat.runStatus.runtimeFailed")).toBeInTheDocument();
+    expect(screen.getByText(/chat\.runStatus\.runtimeError/)).toBeInTheDocument();
+  });
+
+  it("renders incomplete model output with the interrupted title", () => {
+    render(<RunStatusCard terminal={{
+      status: "interrupted",
+      reason: "model_incomplete",
+      code: "length",
+      partial_output: true,
+    }} />);
+
+    expect(screen.getByText("chat.runStatus.interrupted")).toBeInTheDocument();
   });
 
   it("renders a safe provider reason and partial-output state", () => {
@@ -48,7 +87,7 @@ describe("RunStatusCard", () => {
       partial_output: true,
     }} />);
 
-    expect(screen.getByText("chat.runStatus.interrupted")).toBeInTheDocument();
+    expect(screen.getByText("chat.runStatus.modelFailed")).toBeInTheDocument();
     expect(screen.getByText(/chat\.runStatus\.codes\.organization_spend_limit_exceeded/)).toBeInTheDocument();
     expect(screen.getByText(/chat\.runStatus\.partialOutput/)).toBeInTheDocument();
     expect(screen.queryByText(/HTTP/)).not.toBeInTheDocument();

--- a/frontend/src/modules/chat/components/RunStatusCard/index.tsx
+++ b/frontend/src/modules/chat/components/RunStatusCard/index.tsx
@@ -42,12 +42,16 @@ export interface RunTerminalView {
   partial_output: boolean;
 }
 
+function isUserCancelledTerminal(terminal: RunTerminalView): boolean {
+  return terminal.status === "cancelled" || terminal.reason === "user_cancelled";
+}
+
 export function runStatusDescription(
   terminal: RunTerminalView,
   t: TFunction,
 ): string {
   const parts: string[] = [];
-  if (terminal.status !== "cancelled") {
+  if (!isUserCancelledTerminal(terminal)) {
     const reasonKey = terminal.code && KNOWN_CODES.has(terminal.code)
       ? `chat.runStatus.codes.${terminal.code}`
       : terminal.reason === "model_incomplete"
@@ -65,6 +69,22 @@ export function runStatusDescription(
   return parts.join(" ");
 }
 
+export function runStatusTitleKey(terminal: RunTerminalView): string {
+  if (isUserCancelledTerminal(terminal)) {
+    return "chat.runStatus.cancelled";
+  }
+  if (terminal.reason === "model_failure") {
+    return "chat.runStatus.modelFailed";
+  }
+  if (terminal.reason === "model_incomplete") {
+    return "chat.runStatus.interrupted";
+  }
+  if (terminal.reason === "runtime_failure") {
+    return "chat.runStatus.runtimeFailed";
+  }
+  return `chat.runStatus.${terminal.status}`;
+}
+
 export default function RunStatusCard({
   terminal,
 }: {
@@ -75,7 +95,7 @@ export default function RunStatusCard({
     return null;
   }
   const description = runStatusDescription(terminal, t);
-  const isCancelled = terminal.status === "cancelled";
+  const isCancelled = isUserCancelledTerminal(terminal);
   const className = isCancelled
     ? "chat-run-status-card chat-run-status-card--cancelled"
     : "chat-run-status-card";
@@ -85,7 +105,7 @@ export default function RunStatusCard({
       type={isCancelled ? "warning" : "error"}
       showIcon
       icon={isCancelled ? <StopOutlined aria-hidden="true" /> : undefined}
-      message={t(`chat.runStatus.${terminal.status}`)}
+      message={t(runStatusTitleKey(terminal))}
       description={description}
     />
   );


### PR DESCRIPTION
## Summary

- add a run-scoped Core decision record keyed by conversation, history, and run, using atomic first-writer-wins semantics for user cancellation versus terminal outcomes
- route single-answer, dual-answer, disconnected drain, fallback, and external Agent terminal persistence through the shared Core resolver
- emit an explicit Python `cancelled/user_cancelled` terminal through `UserCancelledError` and `RunAccumulator`
- render cancellation in grey while keeping model failure, incomplete output, and runtime failure red with distinct titles
- keep the public stop API and `run_finished` protocol unchanged; no database migration is required

## Behavior

- when Core accepts a stop while the run is active, cancellation wins and later EOF, transport, tool, or subtask errors remain `cancelled/user_cancelled`
- when Core has already accepted a model or runtime failure, a later stop remains idempotent and does not overwrite the failure
- decisions are isolated by `run_id`, so regeneration and adjacent turns cannot inherit an earlier cancellation

## Tests

- `go test ./... -count=1` from `backend/core`
- focused Chat, State, SubAgent, and Workflow Go regression suites
- Redis integration coverage for first-writer ordering and run isolation
- controlled fake-provider stream tests for cancellation-first EOF and model-failure-first ordering
- Python cancellation and runtime terminal tests: 22 passed
- frontend RunStatusCard, AssistantMessage, and StreamManager tests: 18 passed
- frontend ESLint and TypeScript typecheck
- Python flake8 and `git diff --check`