### PR TITLE
fix(chat): make user cancellation terminal authoritative

### DIFF
--- a/algorithm/lazymind/chat/engine/agent_runtime/__init__.py
+++ b/algorithm/lazymind/chat/engine/agent_runtime/__init__.py
@@ -12,7 +12,7 @@ from .models import (
     ContextUsageItem,
     ContextUsageReport,
 )
-from .cancellation import make_cancel_stop_condition
+from .cancellation import UserCancelledError, make_cancel_stop_condition
 from .prompt_builder import PromptBuilder
 from .context_estimator import (
     estimate_context_usage,
@@ -42,4 +42,5 @@ __all__ = [
     'normalize_attachments',
     'render_attachment_content',
     'make_cancel_stop_condition',
+    'UserCancelledError',
 ]

--- a/algorithm/lazymind/chat/engine/agent_runtime/cancellation.py
+++ b/algorithm/lazymind/chat/engine/agent_runtime/cancellation.py
@@ -4,6 +4,10 @@ import json
 from asyncio import CancelledError
 
 
+class UserCancelledError(CancelledError):
+    """The active Agent run was explicitly stopped by the user."""
+
+
 def make_cancel_stop_condition():
     """Stop the current Agent when its sid-scoped cancel queue is signalled."""
     def _check(_output) -> bool:
@@ -13,10 +17,10 @@ def make_cancel_stop_condition():
             for raw in messages:
                 try:
                     if json.loads(raw).get('tag') == 'cancel':
-                        raise CancelledError('stopped by user')
+                        raise UserCancelledError('stopped by user')
                 except (ValueError, TypeError):
                     continue
-        except CancelledError:
+        except UserCancelledError:
             raise
         except Exception:
             pass

--- a/algorithm/lazymind/chat/engine/agent_runtime/tool_limit_control.py
+++ b/algorithm/lazymind/chat/engine/agent_runtime/tool_limit_control.py
@@ -4,7 +4,6 @@ import json
 import threading
 import time
 import uuid
-from asyncio import CancelledError
 from typing import Any, Optional
 
 import lazyllm
@@ -12,6 +11,8 @@ from lazyllm import FileSystemQueue
 from lazyllm.tools.agent.base import _write_agent_data
 
 from lazymind.config import config
+
+from .cancellation import UserCancelledError
 
 
 class ToolLimitDecisionCoordinator:
@@ -59,7 +60,7 @@ class ToolLimitDecisionCoordinator:
             for raw in FileSystemQueue(klass='cancel').dequeue() or []:
                 try:
                     if json.loads(raw).get('tag') == 'cancel':
-                        raise CancelledError('stopped by user')
+                        raise UserCancelledError('stopped by user')
                 except (TypeError, ValueError):
                     continue
             time.sleep(min(0.2, max(0.01, deadline - time.monotonic())))

--- a/algorithm/lazymind/chat/runtime_events.py
+++ b/algorithm/lazymind/chat/runtime_events.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from enum import Enum
 from typing import Any, Dict, Optional
 from uuid import uuid4
 
@@ -12,6 +13,12 @@ INCOMPLETE_MODEL_FINISHES = frozenset({
     'insufficient_system_resource',
     'unknown',
 })
+
+
+class RunOutcome(str, Enum):
+    SUCCEEDED = 'succeeded'
+    FAILED = 'failed'
+    CANCELLED = 'cancelled'
 
 
 def runtime_event(event_type: str, run_id: str, data: Dict[str, Any], *, event_id: Optional[str] = None) -> dict:
@@ -41,11 +48,11 @@ class RunAccumulator:
             self.last_model_terminal = data
             self.semantic_output = self.semantic_output or bool(data.get('has_semantic_output'))
 
-    def finish(self, *, succeeded: bool) -> dict:
+    def finish(self, *, outcome: RunOutcome) -> dict:
         if self.terminal_emitted:
             raise RuntimeError(f'run {self.run_id} already has a terminal')
         self.terminal_emitted = True
-        status, reason, code = self._terminal_fields(succeeded)
+        status, reason, code = self._terminal_fields(outcome)
         data: Dict[str, Any] = {
             'status': status,
             'reason': reason,
@@ -61,8 +68,10 @@ class RunAccumulator:
                 data['diagnostic_id'] = failure['diagnostic_id']
         return runtime_event('run_finished', self.run_id, data)
 
-    def _terminal_fields(self, succeeded: bool) -> tuple[str, str, str]:
-        if succeeded:
+    def _terminal_fields(self, outcome: RunOutcome) -> tuple[str, str, str]:
+        if outcome == RunOutcome.CANCELLED:
+            return 'cancelled', 'user_cancelled', ''
+        if outcome == RunOutcome.SUCCEEDED:
             return 'completed', 'awaiting_user_input' if self.ask_pending else 'normal', ''
         terminal = self.last_model_terminal or {}
         if terminal.get('kind') == 'finish':

--- a/algorithm/lazymind/chat/service/chat_service.py
+++ b/algorithm/lazymind/chat/service/chat_service.py
@@ -55,6 +55,7 @@ from lazymind.chat.engine.agent_runtime import (
     AgentExecutor,
     AgentRole,
     AgentRunPlan,
+    UserCancelledError,
     make_cancel_stop_condition,
     PromptBuilder,
     normalize_attachments,
@@ -1614,7 +1615,9 @@ async def _handle_chat_impl(
 
     async def event_stream() -> Any:
         final_result: Any = None
-        succeeded = False
+        from lazymind.chat.runtime_events import RunOutcome
+
+        outcome = RunOutcome.FAILED
 
         try:
             async with rag_sem:
@@ -1644,7 +1647,7 @@ async def _handle_chat_impl(
                 cost = round(time.time() - start_time, 3)
                 yield log_and_emit_frame(frame, cost, query, conversation.session_id, tag='FINISH')
 
-            succeeded = True
+            outcome = RunOutcome.SUCCEEDED
 
             if episode_results:
                 try:
@@ -1665,6 +1668,12 @@ async def _handle_chat_impl(
                         f'error_type={type(exc).__name__} error={exc}'
                     )
 
+        except UserCancelledError:
+            outcome = RunOutcome.CANCELLED
+            LOG.info(
+                f'[ChatServer] agent cancelled by user '
+                f'[conversation_id={conversation_id}] [run_id={translator.run.run_id}]'
+            )
         except Exception:
             LOG.exception('[ChatServer] agent failed')
         finally:
@@ -1673,7 +1682,7 @@ async def _handle_chat_impl(
                 _unregister_active_session(_conv_id_key, conversation.session_id)
 
         cost = round(time.time() - start_time, 3)
-        terminal_frame = translator.finish_run(succeeded=succeeded)
+        terminal_frame = translator.finish_run(outcome=outcome)
         terminal_frame['tool_call_turns'] = translator.tool_call_turns
         yield log_and_emit_frame(terminal_frame, cost, query, conversation.session_id, tag='RUN_FINISH')
 

--- a/algorithm/lazymind/chat/service/component/event_translator.py
+++ b/algorithm/lazymind/chat/service/component/event_translator.py
@@ -4,7 +4,7 @@ import re
 from typing import Any, Optional
 
 from lazymind.config import config as _cfg
-from lazymind.chat.runtime_events import RunAccumulator
+from lazymind.chat.runtime_events import RunAccumulator, RunOutcome
 from lazymind.chat.service.utils import (
     build_stream_citation_scanner,
     materialize_source_views,
@@ -166,6 +166,7 @@ class AgentEventFrameTranslator:
         if event_type == 'tool_results':
             tool_results = [tr for tr in (event.get('tool_results', []) or []) if isinstance(tr, dict)]
             if tool_results:
+                self.run.semantic_output = True
                 parts = [
                     _tool_result_frame_text(
                         tr,
@@ -179,12 +180,13 @@ class AgentEventFrameTranslator:
         if event_type == 'subagent_think':
             think = str(event.get('think') or '')
             if think:
+                self.run.semantic_output = True
                 frames.append(_stream_frame(think=think))
 
         return frames
 
-    def finish_run(self, *, succeeded: bool) -> dict[str, Any]:
-        return _stream_frame(extra={'runtime_event': self.run.finish(succeeded=succeeded)})
+    def finish_run(self, *, outcome: RunOutcome) -> dict[str, Any]:
+        return _stream_frame(extra={'runtime_event': self.run.finish(outcome=outcome)})
 
     def flush(self) -> list[dict[str, Any]]:
         frames: list[dict[str, Any]] = []

--- a/algorithm/tests/chat/test_cancellation.py
+++ b/algorithm/tests/chat/test_cancellation.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from lazymind.chat.engine.agent_runtime.cancellation import (
+    UserCancelledError,
+    make_cancel_stop_condition,
+)
+
+
+def test_user_cancel_signal_raises_domain_cancellation(monkeypatch):
+    from lazyllm.common import queue as queue_module
+
+    class FakeQueue:
+        def __init__(self, *, klass):
+            assert klass == 'cancel'
+
+        def dequeue(self):
+            return [json.dumps({'tag': 'cancel'})]
+
+    monkeypatch.setattr(queue_module, 'FileSystemQueue', FakeQueue)
+
+    with pytest.raises(UserCancelledError, match='stopped by user'):
+        make_cancel_stop_condition()(None)
+
+
+def test_non_user_queue_failure_does_not_cancel(monkeypatch):
+    from lazyllm.common import queue as queue_module
+
+    class BrokenQueue:
+        def __init__(self, *, klass):
+            assert klass == 'cancel'
+
+        def dequeue(self):
+            raise RuntimeError('state unavailable')
+
+    monkeypatch.setattr(queue_module, 'FileSystemQueue', BrokenQueue)
+
+    assert make_cancel_stop_condition()(None) is False
+
+
+def test_user_cancel_during_tool_limit_wait_uses_domain_cancellation(monkeypatch):
+    from lazymind.chat.engine.agent_runtime import tool_limit_control
+
+    class FakeQueue:
+        def __init__(self, *, klass):
+            self.klass = klass
+
+        def dequeue(self):
+            if self.klass == 'cancel':
+                return [json.dumps({'tag': 'cancel'})]
+            return []
+
+    monkeypatch.setattr(tool_limit_control, 'FileSystemQueue', FakeQueue)
+
+    with pytest.raises(UserCancelledError, match='stopped by user'):
+        tool_limit_control.ToolLimitDecisionCoordinator()._wait_for_action('decision-1', 0.2)

--- a/algorithm/tests/chat/test_runtime_events.py
+++ b/algorithm/tests/chat/test_runtime_events.py
@@ -6,7 +6,7 @@ import lazyllm
 import pytest
 
 from lazymind.chat.engine.agent_runtime.executor import AgentExecutor
-from lazymind.chat.runtime_events import RunAccumulator
+from lazymind.chat.runtime_events import RunAccumulator, RunOutcome
 from lazymind.chat.service.component.event_translator import AgentEventFrameTranslator
 
 
@@ -62,7 +62,7 @@ def test_translator_binds_model_event_to_run():
 ])
 def test_run_accumulator_maps_model_terminal(terminal, status, reason):
     accumulator = RunAccumulator(run_id='run-1', last_model_terminal=terminal)
-    event = accumulator.finish(succeeded=False)
+    event = accumulator.finish(outcome=RunOutcome.FAILED)
 
     assert event['type'] == 'run_finished'
     assert event['data']['status'] == status
@@ -77,7 +77,7 @@ def test_successful_model_terminal_does_not_mask_downstream_runtime_failure(fini
         'has_semantic_output': True,
     })
 
-    assert accumulator.finish(succeeded=False)['data']['code'] == 'runtime_failure'
+    assert accumulator.finish(outcome=RunOutcome.FAILED)['data']['code'] == 'runtime_failure'
 
 
 def test_run_accumulator_only_propagates_public_failure_fields():
@@ -94,7 +94,7 @@ def test_run_accumulator_only_propagates_public_failure_fields():
         },
     })
 
-    data = accumulator.finish(succeeded=False)['data']
+    data = accumulator.finish(outcome=RunOutcome.FAILED)['data']
 
     assert data == {
         'status': 'failed',
@@ -108,13 +108,50 @@ def test_run_accumulator_only_propagates_public_failure_fields():
 
 def test_run_accumulator_awaiting_user_input_is_completed():
     accumulator = RunAccumulator(run_id='run-1', ask_pending=True, semantic_output=True)
-    event = accumulator.finish(succeeded=True)
+    event = accumulator.finish(outcome=RunOutcome.SUCCEEDED)
 
     assert event['data'] == {
         'status': 'completed',
         'reason': 'awaiting_user_input',
         'partial_output': True,
     }
+
+
+def test_run_accumulator_user_cancel_is_an_explicit_terminal():
+    accumulator = RunAccumulator(
+        run_id='run-1',
+        semantic_output=True,
+        last_model_terminal={
+            'model_call_id': 'call-1',
+            'kind': 'finish',
+            'finish': 'tool_calls',
+            'has_semantic_output': True,
+        },
+    )
+
+    event = accumulator.finish(outcome=RunOutcome.CANCELLED)
+
+    assert event['data'] == {
+        'status': 'cancelled',
+        'reason': 'user_cancelled',
+        'partial_output': True,
+        'model_call_id': 'call-1',
+    }
+    with pytest.raises(RuntimeError, match='already has a terminal'):
+        accumulator.finish(outcome=RunOutcome.CANCELLED)
+
+
+@pytest.mark.parametrize('event', [
+    {'tag': 'tool_results', 'tool_results': [{'id': 'tool-1', 'name': 'search', 'content': 'result'}]},
+    {'tag': 'subagent_think', 'think': 'working'},
+])
+def test_cancelled_terminal_marks_rendered_runtime_output_as_partial(event):
+    translator = AgentEventFrameTranslator(query='test', run_id='run-1')
+
+    assert translator.feed(event)
+    terminal = translator.finish_run(outcome=RunOutcome.CANCELLED)['runtime_event']['data']
+
+    assert terminal['partial_output'] is True
 
 
 @pytest.mark.asyncio

--- a/backend/core/chat/conversation.go
+++ b/backend/core/chat/conversation.go
@@ -1039,23 +1039,58 @@ func StopChatGeneration(w http.ResponseWriter, r *http.Request) {
 	}
 
 	stateStore := store.State()
+	var stopSignalErr error
 	if stateStore != nil {
-		ids, _ := getGeneratingHistoryIDs(r.Context(), stateStore, convID)
+		ids, err := getGeneratingHistoryIDs(r.Context(), stateStore, convID)
+		if err != nil {
+			log.Logger.Warn().Err(err).Str("conversation_id", convID).
+				Msg("failed to load active chat runs before cancellation")
+			stopSignalErr = err
+		}
 		if len(ids) == 0 && historyID != "" {
 			ids = append(ids, historyID)
 		}
+		externalHistories := make(map[string]struct{})
+		if len(ids) > 0 {
+			var err error
+			externalHistories, err = activeExternalChatHistoryIDs(r.Context(), store.DB(), userID, convID, ids)
+			if err != nil {
+				log.Logger.Warn().Err(err).Str("conversation_id", convID).
+					Msg("failed to identify external chat runs before cancellation")
+				if stopSignalErr == nil {
+					stopSignalErr = err
+				}
+				ids = nil
+			}
+		}
 		for _, hid := range ids {
+			if _, external := externalHistories[hid]; external {
+				continue
+			}
 			if status, err := getChatStatus(r.Context(), stateStore, convID, hid); err == nil &&
 				status.Status == "generating" && strings.TrimSpace(status.RunID) != "" {
-				if _, err := claimUserCancelDecision(r.Context(), stateStore, convID, hid, status.RunID); err != nil {
+				cancelIsWinner, err := claimUserCancelDecision(r.Context(), stateStore, convID, hid, status.RunID)
+				if err != nil {
 					log.Logger.Warn().Err(err).
 						Str("conversation_id", convID).
 						Str("history_id", hid).
 						Str("run_id", status.RunID).
 						Msg("failed to record user cancellation decision")
+					if stopSignalErr == nil {
+						stopSignalErr = err
+					}
+				} else if !cancelIsWinner {
+					log.Logger.Info().Str("conversation_id", convID).Str("history_id", hid).
+						Str("run_id", status.RunID).Msg("user stop arrived after authoritative terminal")
 				}
 			}
-			_ = setChatCancelSignal(r.Context(), stateStore, convID, hid)
+			if err := setChatCancelSignal(r.Context(), stateStore, convID, hid); err != nil {
+				log.Logger.Warn().Err(err).Str("conversation_id", convID).Str("history_id", hid).
+					Msg("failed to publish chat cancellation wakeup")
+				if stopSignalErr == nil {
+					stopSignalErr = err
+				}
+			}
 		}
 	}
 
@@ -1084,7 +1119,19 @@ func StopChatGeneration(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Notify Python ChatAgent to cancel any active chat session for this conversation.
-	go workflow.NotifyChatCancel(convID)
+	notifyCtx, cancelNotify := terminalWriteContext(r.Context())
+	go func() {
+		defer cancelNotify()
+		if err := workflow.NotifyChatCancel(notifyCtx, convID); err != nil {
+			log.Logger.Warn().Err(err).Str("conversation_id", convID).
+				Msg("failed to notify Python chat cancellation")
+		}
+	}()
+
+	if stopSignalErr != nil {
+		common.ReplyErr(w, fmt.Sprintf("record chat cancellation failed: %v", stopSignalErr), http.StatusServiceUnavailable)
+		return
+	}
 
 	common.ReplyOK(w, nil)
 }

--- a/backend/core/chat/conversation.go
+++ b/backend/core/chat/conversation.go
@@ -20,6 +20,7 @@ import (
 	"lazymind/core/common"
 	"lazymind/core/common/orm"
 	"lazymind/core/evolution"
+	"lazymind/core/log"
 	"lazymind/core/modelconfig"
 	"lazymind/core/state"
 	"lazymind/core/store"
@@ -1044,6 +1045,16 @@ func StopChatGeneration(w http.ResponseWriter, r *http.Request) {
 			ids = append(ids, historyID)
 		}
 		for _, hid := range ids {
+			if status, err := getChatStatus(r.Context(), stateStore, convID, hid); err == nil &&
+				status.Status == "generating" && strings.TrimSpace(status.RunID) != "" {
+				if _, err := claimUserCancelDecision(r.Context(), stateStore, convID, hid, status.RunID); err != nil {
+					log.Logger.Warn().Err(err).
+						Str("conversation_id", convID).
+						Str("history_id", hid).
+						Str("run_id", status.RunID).
+						Msg("failed to record user cancellation decision")
+				}
+			}
 			_ = setChatCancelSignal(r.Context(), stateStore, convID, hid)
 		}
 	}

--- a/backend/core/chat/conversation_logic.go
+++ b/backend/core/chat/conversation_logic.go
@@ -1667,7 +1667,9 @@ func handleStreamChat(
 			_ = clearChatData(chatCtx, stateStore, convID, historyID)
 		}
 		_ = setChatInput(chatCtx, stateStore, convID, historyID, query, target.Seq, historyExt)
-		_ = setChatRuntimeStatus(chatCtx, stateStore, convID, historyID, "generating", "", primaryRunID, nil)
+		if requestUsesRunDecision(reqBody) {
+			_ = setChatRuntimeStatus(chatCtx, stateStore, convID, historyID, "generating", "", primaryRunID, nil)
+		}
 		if dualReply {
 			_ = setChatInput(chatCtx, stateStore, convID, secondaryHistoryID, query, target.Seq, historyExt)
 			_ = setChatRuntimeStatus(chatCtx, stateStore, convID, secondaryHistoryID, "generating", "", secondaryRunID, nil)
@@ -1722,21 +1724,50 @@ func consumeRuntimeChunk(chunk UpstreamStreamChunk, runID string, partialOutput 
 }
 
 func resolveRuntimeChunkDecision(
-	ctx context.Context,
+	parent context.Context,
 	stateStore state.Store,
 	convID, historyID, runID string,
 	decision runtimeChunkDecision,
 	partialOutput bool,
+	useRunDecision bool,
 ) runtimeChunkDecision {
 	if decision.Terminal == nil {
 		return decision
 	}
-	decision.Terminal = resolveRunTerminal(
-		ctx, stateStore, convID, historyID, runID,
-		decision.Terminal, partialOutput, "upstream_terminal",
-	)
+	normalized := *decision.Terminal
+	normalized.PartialOutput = partialOutput
+	decision.Terminal = &normalized
+	if useRunDecision {
+		ctx, cancel := terminalWriteContext(parent)
+		defer cancel()
+		decision.Terminal = resolveRunTerminal(
+			ctx, stateStore, convID, historyID, runID,
+			decision.Terminal, "upstream_terminal",
+		)
+	}
 	decision.Event = runFinishedEvent(runID, *decision.Terminal)
 	return decision
+}
+
+func requestUsesRunDecision(reqBody map[string]any) bool {
+	executor, _ := reqBody["_chat_executor"].(string)
+	return !isExternalChatProvider(executor)
+}
+
+func resolveCandidateRunTerminal(
+	parent context.Context,
+	stateStore state.Store,
+	convID, historyID, runID string,
+	candidate *RunTerminal,
+	source string,
+	useRunDecision bool,
+) *RunTerminal {
+	if !useRunDecision {
+		return candidate
+	}
+	ctx, cancel := terminalWriteContext(parent)
+	defer cancel()
+	return resolveRunTerminal(ctx, stateStore, convID, historyID, runID, candidate, source)
 }
 
 func publishRuntimeChunk(
@@ -1778,6 +1809,32 @@ func streamSingleAnswer(
 	historyExt = archiveRegeneratedTrafficAttempt(historyExt, target)
 	seq := target.Seq
 	runID, _ := reqBody["run_id"].(string)
+	if strings.TrimSpace(runID) == "" {
+		runID = newID("run_")
+		reqBody["run_id"] = runID
+	}
+	useRunDecision := requestUsesRunDecision(reqBody)
+	if target.IsRegeneration && useRunDecision {
+		if err := claimChatHistoryRun(chatCtx, db, historyID, runID); err != nil {
+			log.Logger.Error().Err(err).Str("conversation_id", convID).Str("history_id", historyID).
+				Str("run_id", runID).Msg("failed to claim regenerated history for run")
+			event := failedRunEvent(runID, "history_run_claim_failed", false)
+			terminal, _ := event.Terminal()
+			terminal = resolveCandidateRunTerminal(
+				chatCtx, stateStore, convID, historyID, runID, terminal, "history_run_claim", useRunDecision,
+			)
+			event = runFinishedEvent(runID, *terminal)
+			if stateStore != nil {
+				statusCtx, cancel := terminalWriteContext(chatCtx)
+				_ = setChatRuntimeStatus(statusCtx, stateStore, convID, historyID, terminal.Status, "", runID, terminal)
+				cancel()
+			}
+			writeSSEChunk(w, flusher, &ChatChunkResponse{
+				ConversationID: convID, Seq: int32(seq), HistoryID: historyID, RuntimeEvent: event,
+			})
+			return
+		}
+	}
 	ch, algorithmID, err := streamChatOutput(
 		chatCtx, db, baseURL, reqBody, convID, historyID, query,
 		target.Seq, historyExt, target.IsRegeneration,
@@ -1785,14 +1842,15 @@ func streamSingleAnswer(
 	if err != nil {
 		runEvent := failedRunEvent(runID, "upstream_request_failed", false)
 		terminal, _ := runEvent.Terminal()
-		terminal = resolveRunTerminal(
-			context.Background(), stateStore, convID, historyID, runID,
-			terminal, false, "upstream_request",
+		terminal = resolveCandidateRunTerminal(
+			chatCtx, stateStore, convID, historyID, runID, terminal, "upstream_request", useRunDecision,
 		)
 		runEvent = runFinishedEvent(runID, *terminal)
-		persistImmediateRunTerminal(db, convID, historyID, query, runID, target, historyExt, terminal)
-		if stateStore != nil {
-			_ = setChatRuntimeStatus(context.Background(), stateStore, convID, historyID, terminal.Status, "", runID, terminal)
+		persisted := persistImmediateRunTerminal(chatCtx, db, convID, historyID, query, runID, target, historyExt, terminal)
+		if stateStore != nil && persisted {
+			statusCtx, cancel := terminalWriteContext(chatCtx)
+			_ = setChatRuntimeStatus(statusCtx, stateStore, convID, historyID, terminal.Status, "", runID, terminal)
+			cancel()
 		}
 		writeSSEChunk(w, flusher, &ChatChunkResponse{
 			ConversationID: convID,
@@ -1801,6 +1859,12 @@ func streamSingleAnswer(
 			RuntimeEvent:   runEvent,
 		})
 		return
+	}
+	if !useRunDecision && stateStore != nil {
+		if err := setChatRuntimeStatus(chatCtx, stateStore, convID, historyID, "generating", "", runID, nil); err != nil {
+			log.Logger.Warn().Err(err).Str("conversation_id", convID).Str("history_id", historyID).
+				Str("run_id", runID).Msg("failed to project active external chat run to cache")
+		}
 	}
 	var fullText string
 	var pendingThink string
@@ -1832,7 +1896,7 @@ func streamSingleAnswer(
 			"update_time":         time.Now(),
 		}
 		if progressRowCreated {
-			if err := db.Model(&orm.ChatHistory{}).Where("id = ?", historyID).Updates(values).Error; err != nil {
+			if _, err := updateOwnedChatHistory(chatCtx, db, historyID, runID, values); err != nil {
 				log.Logger.Warn().Err(err).Str("history_id", historyID).Msg("failed to persist thinking progress")
 			}
 			return
@@ -1840,7 +1904,7 @@ func streamSingleAnswer(
 		now := time.Now()
 		if err := db.Create(&orm.ChatHistory{
 			ID: historyID, Seq: seq, ConversationID: convID, RawContent: query, Content: query, AlgorithmID: algorithmID,
-			Result: partialResult, ThinkingDurationS: thinkingDurationS, RunID: runID, Ext: historyExt,
+			Result: partialResult, ThinkingDurationS: thinkingDurationS, RunID: runID, RunStatus: "generating", Ext: historyExt,
 			TimeMixin: orm.TimeMixin{CreateTime: now, UpdateTime: now},
 		}).Error; err != nil {
 			log.Logger.Warn().Err(err).Str("history_id", historyID).Msg("failed to create thinking progress")
@@ -1864,8 +1928,8 @@ func streamSingleAnswer(
 		decision, handled := consumeRuntimeChunk(d, runID, partialOutput)
 		if handled {
 			decision = resolveRuntimeChunkDecision(
-				context.Background(), stateStore, convID, historyID, runID,
-				decision, partialOutput,
+				chatCtx, stateStore, convID, historyID, runID,
+				decision, partialOutput, useRunDecision,
 			)
 			if decision.Terminal != nil {
 				runTerminal = decision.Terminal
@@ -2080,9 +2144,8 @@ func streamSingleAnswer(
 			runEvent = failedRunEvent(runID, "missing_run_terminal", fullResult != "" || pendingThink != "")
 		}
 		runTerminal, _ = runEvent.Terminal()
-		runTerminal = resolveRunTerminal(
-			context.Background(), stateStore, convID, historyID, runID,
-			runTerminal, fullResult != "" || pendingThink != "", "core_fallback",
+		runTerminal = resolveCandidateRunTerminal(
+			chatCtx, stateStore, convID, historyID, runID, runTerminal, "core_fallback", useRunDecision,
 		)
 		runEvent = runFinishedEvent(runID, *runTerminal)
 		runtimeChunk := &ChatChunkResponse{ConversationID: convID, Seq: int32(seq), HistoryID: historyID, RuntimeEvent: runEvent}
@@ -2090,7 +2153,9 @@ func streamSingleAnswer(
 			writeSSEChunk(w, flusher, runtimeChunk)
 		}
 		if stateStore != nil {
-			_ = appendChatChunk(context.Background(), stateStore, convID, historyID, runtimeChunk)
+			storeCtx, cancel := terminalWriteContext(chatCtx)
+			_ = appendChatChunk(storeCtx, stateStore, convID, historyID, runtimeChunk)
+			cancel()
 		}
 	}
 	now := time.Now()
@@ -2110,16 +2175,11 @@ func streamSingleAnswer(
 	externalFinalized := strings.HasPrefix(algorithmID, "external:")
 	if externalFinalized {
 		var persistedHistory orm.ChatHistory
-		persisted = db.Where("id = ? AND conversation_id = ?", historyID, convID).Take(&persistedHistory).Error == nil
-		if persisted {
-			if err := persistResolvedExternalRunTerminal(context.Background(), db, historyID, runTerminal); err != nil {
-				log.Logger.Warn().Err(err).Str("conversation_id", convID).Str("history_id", historyID).
-					Msg("failed to persist resolved external run terminal")
-			}
-		}
+		persisted = db.Where("id = ? AND conversation_id = ? AND run_id = ?", historyID, convID, runID).
+			Take(&persistedHistory).Error == nil
 	}
 	if !externalFinalized && target.IsRegeneration && target.Existing != nil {
-		if err := db.Model(&orm.ChatHistory{}).Where("id = ?", historyID).Updates(map[string]any{
+		updated, err := updateOwnedChatHistory(chatCtx, db, historyID, runID, map[string]any{
 			"algorithm_id":        algorithmID,
 			"seq":                 seq,
 			"raw_content":         query,
@@ -2137,20 +2197,22 @@ func streamSingleAnswer(
 			"run_terminal":        terminalJSON(runTerminal),
 			"create_time":         now,
 			"update_time":         now,
-		}).Error; err != nil {
+		})
+		if err != nil {
 			log.Logger.Warn().Err(err).Str("conversation_id", convID).Str("history_id", historyID).Msg("failed to update stream chat history")
-		} else {
+		} else if updated {
 			persisted = true
 		}
 	} else if !externalFinalized && progressRowCreated {
-		if err := db.Model(&orm.ChatHistory{}).Where("id = ?", historyID).Updates(map[string]any{
+		updated, err := updateOwnedChatHistory(chatCtx, db, historyID, runID, map[string]any{
 			"algorithm_id": algorithmID, "seq": seq, "raw_content": query, "content": query, "result": fullResult,
 			"tool_call_turns": toolCallTurns, "thinking_duration_s": thinkingDurationS,
 			"retrieval_result": retrievalResult, "ext": historyExt, "update_time": now,
 			"run_id": runID, "run_status": runTerminal.Status, "run_terminal": terminalJSON(runTerminal),
-		}).Error; err != nil {
+		})
+		if err != nil {
 			log.Logger.Warn().Err(err).Str("conversation_id", convID).Str("history_id", historyID).Msg("failed to finalize stream chat history")
-		} else {
+		} else if updated {
 			persisted = true
 		}
 	} else if !externalFinalized {
@@ -2177,8 +2239,10 @@ func streamSingleAnswer(
 		}
 	}
 	finalStatus := runTerminal.Status
-	if stateStore != nil {
-		_ = setChatRuntimeStatus(context.Background(), stateStore, convID, historyID, finalStatus, stripToolTags(fullText), runID, runTerminal)
+	if stateStore != nil && persisted {
+		statusCtx, cancel := terminalWriteContext(chatCtx)
+		_ = setChatRuntimeStatus(statusCtx, stateStore, convID, historyID, finalStatus, stripToolTags(fullText), runID, runTerminal)
+		cancel()
 	}
 	if persisted && !externalFinalized {
 		db.Model(&orm.Conversation{}).Where("id = ?", convID).Update("updated_at", now)
@@ -2206,14 +2270,15 @@ func streamSingleAnswer(
 }
 
 func persistImmediateRunTerminal(
+	ctx context.Context,
 	db *gorm.DB,
 	convID, historyID, query, runID string,
 	target chatPersistTarget,
 	historyExt json.RawMessage,
 	terminal *RunTerminal,
-) {
+) bool {
 	if db == nil || terminal == nil {
-		return
+		return false
 	}
 	now := time.Now()
 	values := map[string]any{
@@ -2223,10 +2288,11 @@ func persistImmediateRunTerminal(
 	}
 	if target.IsRegeneration && target.Existing != nil {
 		values["create_time"] = now
-		if err := db.Model(&orm.ChatHistory{}).Where("id = ?", historyID).Updates(values).Error; err != nil {
+		updated, err := updateOwnedChatHistory(ctx, db, historyID, runID, values)
+		if err != nil {
 			log.Logger.Warn().Err(err).Str("history_id", historyID).Msg("failed to persist immediate run terminal")
 		}
-		return
+		return updated
 	}
 	history := orm.ChatHistory{
 		ID: historyID, Seq: target.Seq, ConversationID: convID, RawContent: query, Content: query,
@@ -2235,7 +2301,9 @@ func persistImmediateRunTerminal(
 	}
 	if err := db.Create(&history).Error; err != nil {
 		log.Logger.Warn().Err(err).Str("history_id", historyID).Msg("failed to persist immediate run terminal")
+		return false
 	}
+	return true
 }
 
 // persistAndPublishConversationArtifact is the shared main-Agent artifact path
@@ -2325,21 +2393,21 @@ func streamDualAnswer(
 	thinkStart := time.Now()
 	var primaryThinkingDurationS, secondaryThinkingDurationS int64
 	primaryProgressCreated, secondaryProgressCreated := false, false
-	persistProgress := func(id, result, pending string, duration int64, created *bool) {
+	persistProgress := func(id, runID, result, pending string, duration int64, created *bool) {
 		partialResult := result
 		if pending != "" {
 			partialResult += "<think>" + pending + "</think>"
 		}
 		if *created {
-			_ = db.Model(&orm.MultiAnswersChatHistory{}).Where("id = ?", id).Updates(map[string]any{
+			_, _ = updateOwnedMultiAnswerHistory(chatCtx, db, id, runID, map[string]any{
 				"result": partialResult, "thinking_duration_s": duration, "update_time": time.Now(),
-			}).Error
+			})
 			return
 		}
 		now := time.Now()
 		if err := db.Create(&orm.MultiAnswersChatHistory{
 			ID: id, Seq: seq, ConversationID: convID, RawContent: query, Content: query,
-			Result: partialResult, ThinkingDurationS: duration, Ext: historyExt,
+			Result: partialResult, ThinkingDurationS: duration, RunID: runID, RunStatus: "generating", Ext: historyExt,
 			TimeMixin: orm.TimeMixin{CreateTime: now, UpdateTime: now},
 		}).Error; err == nil {
 			*created = true
@@ -2354,7 +2422,7 @@ func streamDualAnswer(
 		if reasoning != "" {
 			primaryPendingThink += reasoning
 			primaryThinkingDurationS = int64(time.Since(thinkStart).Seconds())
-			persistProgress(historyID, primaryResult, primaryPendingThink, primaryThinkingDurationS, &primaryProgressCreated)
+			persistProgress(historyID, primaryRunID, primaryResult, primaryPendingThink, primaryThinkingDurationS, &primaryProgressCreated)
 			if reqCtx.Err() == nil {
 				writeSSEChunk(w, flusher, map[string]any{"conversation_id": convID, "seq": seq, "history_id": historyID, "thinking_duration_s": primaryThinkingDurationS})
 			}
@@ -2390,7 +2458,7 @@ func streamDualAnswer(
 		if reasoning != "" {
 			secondaryPendingThink += reasoning
 			secondaryThinkingDurationS = int64(time.Since(thinkStart).Seconds())
-			persistProgress(secondaryHistoryID, secondaryResult, secondaryPendingThink, secondaryThinkingDurationS, &secondaryProgressCreated)
+			persistProgress(secondaryHistoryID, secondaryRunID, secondaryResult, secondaryPendingThink, secondaryThinkingDurationS, &secondaryProgressCreated)
 			if reqCtx.Err() == nil {
 				writeSSEChunk(w, flusher, map[string]any{"conversation_id": convID, "seq": seq, "history_id": secondaryHistoryID, "thinking_duration_s": secondaryThinkingDurationS})
 			}
@@ -2430,8 +2498,8 @@ func streamDualAnswer(
 			partialOutput := primaryResult != "" || primaryPendingThink != ""
 			if decision, handled := consumeRuntimeChunk(d, primaryRunID, partialOutput); handled {
 				decision = resolveRuntimeChunkDecision(
-					context.Background(), stateStore, convID, historyID, primaryRunID,
-					decision, partialOutput,
+					chatCtx, stateStore, convID, historyID, primaryRunID,
+					decision, partialOutput, true,
 				)
 				if decision.Terminal != nil {
 					primaryTerminal = decision.Terminal
@@ -2463,8 +2531,8 @@ func streamDualAnswer(
 			partialOutput := secondaryResult != "" || secondaryPendingThink != ""
 			if decision, handled := consumeRuntimeChunk(d, secondaryRunID, partialOutput); handled {
 				decision = resolveRuntimeChunkDecision(
-					context.Background(), stateStore, convID, secondaryHistoryID, secondaryRunID,
-					decision, partialOutput,
+					chatCtx, stateStore, convID, secondaryHistoryID, secondaryRunID,
+					decision, partialOutput, true,
 				)
 				if decision.Terminal != nil {
 					secondaryTerminal = decision.Terminal
@@ -2488,7 +2556,7 @@ func streamDualAnswer(
 			}
 			appendSecondary(d.Text, d.ReasoningText, d.Sources)
 		case <-reqCtx.Done():
-			bg := context.Background()
+			bg := chatCtx
 			for !primaryDone || !secondaryDone {
 				select {
 				case d, ok := <-primaryCh:
@@ -2499,8 +2567,8 @@ func streamDualAnswer(
 						partialOutput := primaryResult != "" || primaryPendingThink != ""
 						if decision, handled := consumeRuntimeChunk(d, primaryRunID, partialOutput); handled {
 							decision = resolveRuntimeChunkDecision(
-								context.Background(), stateStore, convID, historyID, primaryRunID,
-								decision, partialOutput,
+								bg, stateStore, convID, historyID, primaryRunID,
+								decision, partialOutput, true,
 							)
 							if decision.Terminal != nil {
 								primaryTerminal = decision.Terminal
@@ -2528,7 +2596,7 @@ func streamDualAnswer(
 						if d.ReasoningText != "" {
 							primaryPendingThink += d.ReasoningText
 							primaryThinkingDurationS = int64(time.Since(thinkStart).Seconds())
-							persistProgress(historyID, primaryResult, primaryPendingThink, primaryThinkingDurationS, &primaryProgressCreated)
+							persistProgress(historyID, primaryRunID, primaryResult, primaryPendingThink, primaryThinkingDurationS, &primaryProgressCreated)
 							continue
 						}
 						if primaryPendingThink != "" {
@@ -2556,8 +2624,8 @@ func streamDualAnswer(
 						partialOutput := secondaryResult != "" || secondaryPendingThink != ""
 						if decision, handled := consumeRuntimeChunk(d, secondaryRunID, partialOutput); handled {
 							decision = resolveRuntimeChunkDecision(
-								context.Background(), stateStore, convID, secondaryHistoryID, secondaryRunID,
-								decision, partialOutput,
+								bg, stateStore, convID, secondaryHistoryID, secondaryRunID,
+								decision, partialOutput, true,
 							)
 							if decision.Terminal != nil {
 								secondaryTerminal = decision.Terminal
@@ -2585,7 +2653,7 @@ func streamDualAnswer(
 						if d.ReasoningText != "" {
 							secondaryPendingThink += d.ReasoningText
 							secondaryThinkingDurationS = int64(time.Since(thinkStart).Seconds())
-							persistProgress(secondaryHistoryID, secondaryResult, secondaryPendingThink, secondaryThinkingDurationS, &secondaryProgressCreated)
+							persistProgress(secondaryHistoryID, secondaryRunID, secondaryResult, secondaryPendingThink, secondaryThinkingDurationS, &secondaryProgressCreated)
 							continue
 						}
 						if secondaryPendingThink != "" {
@@ -2627,9 +2695,8 @@ dualPersist:
 			event = failedRunEvent(primaryRunID, "missing_run_terminal", partialOutput)
 		}
 		primaryTerminal, _ = event.Terminal()
-		primaryTerminal = resolveRunTerminal(
-			context.Background(), stateStore, convID, historyID, primaryRunID,
-			primaryTerminal, partialOutput, "core_fallback",
+		primaryTerminal = resolveCandidateRunTerminal(
+			chatCtx, stateStore, convID, historyID, primaryRunID, primaryTerminal, "core_fallback", true,
 		)
 		event = runFinishedEvent(primaryRunID, *primaryTerminal)
 		chunk := &ChatChunkResponse{ConversationID: convID, Seq: int32(seq), HistoryID: historyID, RuntimeEvent: event}
@@ -2637,7 +2704,9 @@ dualPersist:
 			writeSSEChunk(w, flusher, chunk)
 		}
 		if stateStore != nil {
-			_ = appendChatChunk(context.Background(), stateStore, convID, historyID, chunk)
+			storeCtx, cancel := terminalWriteContext(chatCtx)
+			_ = appendChatChunk(storeCtx, stateStore, convID, historyID, chunk)
+			cancel()
 		}
 	}
 	if secondaryTerminal == nil {
@@ -2649,9 +2718,8 @@ dualPersist:
 			event = failedRunEvent(secondaryRunID, "missing_run_terminal", partialOutput)
 		}
 		secondaryTerminal, _ = event.Terminal()
-		secondaryTerminal = resolveRunTerminal(
-			context.Background(), stateStore, convID, secondaryHistoryID, secondaryRunID,
-			secondaryTerminal, partialOutput, "core_fallback",
+		secondaryTerminal = resolveCandidateRunTerminal(
+			chatCtx, stateStore, convID, secondaryHistoryID, secondaryRunID, secondaryTerminal, "core_fallback", true,
 		)
 		event = runFinishedEvent(secondaryRunID, *secondaryTerminal)
 		chunk := &ChatChunkResponse{ConversationID: convID, Seq: int32(seq), HistoryID: secondaryHistoryID, RuntimeEvent: event}
@@ -2659,7 +2727,9 @@ dualPersist:
 			writeSSEChunk(w, flusher, chunk)
 		}
 		if stateStore != nil {
-			_ = appendChatChunk(context.Background(), stateStore, convID, secondaryHistoryID, chunk)
+			storeCtx, cancel := terminalWriteContext(chatCtx)
+			_ = appendChatChunk(storeCtx, stateStore, convID, secondaryHistoryID, chunk)
+			cancel()
 		}
 	}
 	primaryHistory := &orm.MultiAnswersChatHistory{
@@ -2669,10 +2739,11 @@ dualPersist:
 		RunID: primaryRunID, RunStatus: primaryTerminal.Status, RunTerminal: terminalJSON(primaryTerminal),
 		TimeMixin: orm.TimeMixin{CreateTime: now, UpdateTime: now},
 	}
+	primaryPersisted := false
 	if primaryProgressCreated {
-		_ = db.Model(primaryHistory).Where("id = ?", historyID).Updates(primaryHistory).Error
+		primaryPersisted, _ = updateOwnedMultiAnswerHistory(chatCtx, db, historyID, primaryRunID, primaryHistory)
 	} else {
-		_ = db.Create(primaryHistory).Error
+		primaryPersisted = db.Create(primaryHistory).Error == nil
 	}
 	secondaryHistory := &orm.MultiAnswersChatHistory{
 		ID: secondaryHistoryID, Seq: seq, ConversationID: convID, RawContent: query, Content: query, Result: secondaryResult,
@@ -2681,14 +2752,21 @@ dualPersist:
 		RunID: secondaryRunID, RunStatus: secondaryTerminal.Status, RunTerminal: terminalJSON(secondaryTerminal),
 		TimeMixin: orm.TimeMixin{CreateTime: now, UpdateTime: now},
 	}
+	secondaryPersisted := false
 	if secondaryProgressCreated {
-		_ = db.Model(secondaryHistory).Where("id = ?", secondaryHistoryID).Updates(secondaryHistory).Error
+		secondaryPersisted, _ = updateOwnedMultiAnswerHistory(chatCtx, db, secondaryHistoryID, secondaryRunID, secondaryHistory)
 	} else {
-		_ = db.Create(secondaryHistory).Error
+		secondaryPersisted = db.Create(secondaryHistory).Error == nil
 	}
 	if stateStore != nil {
-		_ = setChatRuntimeStatus(context.Background(), stateStore, convID, historyID, primaryTerminal.Status, stripToolTags(primaryText), primaryRunID, primaryTerminal)
-		_ = setChatRuntimeStatus(context.Background(), stateStore, convID, secondaryHistoryID, secondaryTerminal.Status, stripToolTags(secondaryText), secondaryRunID, secondaryTerminal)
+		statusCtx, cancel := terminalWriteContext(chatCtx)
+		defer cancel()
+		if primaryPersisted {
+			_ = setChatRuntimeStatus(statusCtx, stateStore, convID, historyID, primaryTerminal.Status, stripToolTags(primaryText), primaryRunID, primaryTerminal)
+		}
+		if secondaryPersisted {
+			_ = setChatRuntimeStatus(statusCtx, stateStore, convID, secondaryHistoryID, secondaryTerminal.Status, stripToolTags(secondaryText), secondaryRunID, secondaryTerminal)
+		}
 	}
 	db.Model(&orm.Conversation{}).Where("id = ?", convID).Update("updated_at", now)
 	if !target.IsRegeneration {

--- a/backend/core/chat/conversation_logic.go
+++ b/backend/core/chat/conversation_logic.go
@@ -1721,6 +1721,24 @@ func consumeRuntimeChunk(chunk UpstreamStreamChunk, runID string, partialOutput 
 	return decision, true
 }
 
+func resolveRuntimeChunkDecision(
+	ctx context.Context,
+	stateStore state.Store,
+	convID, historyID, runID string,
+	decision runtimeChunkDecision,
+	partialOutput bool,
+) runtimeChunkDecision {
+	if decision.Terminal == nil {
+		return decision
+	}
+	decision.Terminal = resolveRunTerminal(
+		ctx, stateStore, convID, historyID, runID,
+		decision.Terminal, partialOutput, "upstream_terminal",
+	)
+	decision.Event = runFinishedEvent(runID, *decision.Terminal)
+	return decision
+}
+
 func publishRuntimeChunk(
 	reqCtx, storeCtx context.Context,
 	w http.ResponseWriter,
@@ -1767,9 +1785,14 @@ func streamSingleAnswer(
 	if err != nil {
 		runEvent := failedRunEvent(runID, "upstream_request_failed", false)
 		terminal, _ := runEvent.Terminal()
+		terminal = resolveRunTerminal(
+			context.Background(), stateStore, convID, historyID, runID,
+			terminal, false, "upstream_request",
+		)
+		runEvent = runFinishedEvent(runID, *terminal)
 		persistImmediateRunTerminal(db, convID, historyID, query, runID, target, historyExt, terminal)
 		if stateStore != nil {
-			_ = setChatRuntimeStatus(chatCtx, stateStore, convID, historyID, terminal.Status, "", runID, terminal)
+			_ = setChatRuntimeStatus(context.Background(), stateStore, convID, historyID, terminal.Status, "", runID, terminal)
 		}
 		writeSSEChunk(w, flusher, &ChatChunkResponse{
 			ConversationID: convID,
@@ -1837,8 +1860,13 @@ func streamSingleAnswer(
 		ThinkingDurationS: 0,
 	})
 	for d := range ch {
-		decision, handled := consumeRuntimeChunk(d, runID, fullResult != "" || pendingThink != "")
+		partialOutput := fullResult != "" || pendingThink != ""
+		decision, handled := consumeRuntimeChunk(d, runID, partialOutput)
 		if handled {
+			decision = resolveRuntimeChunkDecision(
+				context.Background(), stateStore, convID, historyID, runID,
+				decision, partialOutput,
+			)
 			if decision.Terminal != nil {
 				runTerminal = decision.Terminal
 			}
@@ -2052,6 +2080,11 @@ func streamSingleAnswer(
 			runEvent = failedRunEvent(runID, "missing_run_terminal", fullResult != "" || pendingThink != "")
 		}
 		runTerminal, _ = runEvent.Terminal()
+		runTerminal = resolveRunTerminal(
+			context.Background(), stateStore, convID, historyID, runID,
+			runTerminal, fullResult != "" || pendingThink != "", "core_fallback",
+		)
+		runEvent = runFinishedEvent(runID, *runTerminal)
 		runtimeChunk := &ChatChunkResponse{ConversationID: convID, Seq: int32(seq), HistoryID: historyID, RuntimeEvent: runEvent}
 		if reqCtx.Err() == nil {
 			writeSSEChunk(w, flusher, runtimeChunk)
@@ -2078,6 +2111,12 @@ func streamSingleAnswer(
 	if externalFinalized {
 		var persistedHistory orm.ChatHistory
 		persisted = db.Where("id = ? AND conversation_id = ?", historyID, convID).Take(&persistedHistory).Error == nil
+		if persisted {
+			if err := persistResolvedExternalRunTerminal(context.Background(), db, historyID, runTerminal); err != nil {
+				log.Logger.Warn().Err(err).Str("conversation_id", convID).Str("history_id", historyID).
+					Msg("failed to persist resolved external run terminal")
+			}
+		}
 	}
 	if !externalFinalized && target.IsRegeneration && target.Existing != nil {
 		if err := db.Model(&orm.ChatHistory{}).Where("id = ?", historyID).Updates(map[string]any{
@@ -2388,7 +2427,12 @@ func streamDualAnswer(
 				primaryCh = nil
 				continue
 			}
-			if decision, handled := consumeRuntimeChunk(d, primaryRunID, primaryResult != "" || primaryPendingThink != ""); handled {
+			partialOutput := primaryResult != "" || primaryPendingThink != ""
+			if decision, handled := consumeRuntimeChunk(d, primaryRunID, partialOutput); handled {
+				decision = resolveRuntimeChunkDecision(
+					context.Background(), stateStore, convID, historyID, primaryRunID,
+					decision, partialOutput,
+				)
 				if decision.Terminal != nil {
 					primaryTerminal = decision.Terminal
 				}
@@ -2416,7 +2460,12 @@ func streamDualAnswer(
 				secondaryCh = nil
 				continue
 			}
-			if decision, handled := consumeRuntimeChunk(d, secondaryRunID, secondaryResult != "" || secondaryPendingThink != ""); handled {
+			partialOutput := secondaryResult != "" || secondaryPendingThink != ""
+			if decision, handled := consumeRuntimeChunk(d, secondaryRunID, partialOutput); handled {
+				decision = resolveRuntimeChunkDecision(
+					context.Background(), stateStore, convID, secondaryHistoryID, secondaryRunID,
+					decision, partialOutput,
+				)
 				if decision.Terminal != nil {
 					secondaryTerminal = decision.Terminal
 				}
@@ -2447,7 +2496,12 @@ func streamDualAnswer(
 						primaryDone = true
 						primaryCh = nil
 					} else {
-						if decision, handled := consumeRuntimeChunk(d, primaryRunID, primaryResult != "" || primaryPendingThink != ""); handled {
+						partialOutput := primaryResult != "" || primaryPendingThink != ""
+						if decision, handled := consumeRuntimeChunk(d, primaryRunID, partialOutput); handled {
+							decision = resolveRuntimeChunkDecision(
+								context.Background(), stateStore, convID, historyID, primaryRunID,
+								decision, partialOutput,
+							)
 							if decision.Terminal != nil {
 								primaryTerminal = decision.Terminal
 							}
@@ -2499,7 +2553,12 @@ func streamDualAnswer(
 						secondaryDone = true
 						secondaryCh = nil
 					} else {
-						if decision, handled := consumeRuntimeChunk(d, secondaryRunID, secondaryResult != "" || secondaryPendingThink != ""); handled {
+						partialOutput := secondaryResult != "" || secondaryPendingThink != ""
+						if decision, handled := consumeRuntimeChunk(d, secondaryRunID, partialOutput); handled {
+							decision = resolveRuntimeChunkDecision(
+								context.Background(), stateStore, convID, secondaryHistoryID, secondaryRunID,
+								decision, partialOutput,
+							)
 							if decision.Terminal != nil {
 								secondaryTerminal = decision.Terminal
 							}
@@ -2560,8 +2619,19 @@ dualPersist:
 		secondaryResult += "<think>" + secondaryPendingThink + "</think>"
 	}
 	if primaryTerminal == nil {
-		event := failedRunEvent(primaryRunID, "missing_run_terminal", primaryResult != "")
+		partialOutput := primaryResult != ""
+		var event *ChatRuntimeEvent
+		if chatCtx.Err() != nil {
+			event = cancelledRunEvent(primaryRunID, partialOutput)
+		} else {
+			event = failedRunEvent(primaryRunID, "missing_run_terminal", partialOutput)
+		}
 		primaryTerminal, _ = event.Terminal()
+		primaryTerminal = resolveRunTerminal(
+			context.Background(), stateStore, convID, historyID, primaryRunID,
+			primaryTerminal, partialOutput, "core_fallback",
+		)
+		event = runFinishedEvent(primaryRunID, *primaryTerminal)
 		chunk := &ChatChunkResponse{ConversationID: convID, Seq: int32(seq), HistoryID: historyID, RuntimeEvent: event}
 		if reqCtx.Err() == nil {
 			writeSSEChunk(w, flusher, chunk)
@@ -2571,8 +2641,19 @@ dualPersist:
 		}
 	}
 	if secondaryTerminal == nil {
-		event := failedRunEvent(secondaryRunID, "missing_run_terminal", secondaryResult != "")
+		partialOutput := secondaryResult != ""
+		var event *ChatRuntimeEvent
+		if chatCtx.Err() != nil {
+			event = cancelledRunEvent(secondaryRunID, partialOutput)
+		} else {
+			event = failedRunEvent(secondaryRunID, "missing_run_terminal", partialOutput)
+		}
 		secondaryTerminal, _ = event.Terminal()
+		secondaryTerminal = resolveRunTerminal(
+			context.Background(), stateStore, convID, secondaryHistoryID, secondaryRunID,
+			secondaryTerminal, partialOutput, "core_fallback",
+		)
+		event = runFinishedEvent(secondaryRunID, *secondaryTerminal)
 		chunk := &ChatChunkResponse{ConversationID: convID, Seq: int32(seq), HistoryID: secondaryHistoryID, RuntimeEvent: event}
 		if reqCtx.Err() == nil {
 			writeSSEChunk(w, flusher, chunk)

--- a/backend/core/chat/external_chat_http.go
+++ b/backend/core/chat/external_chat_http.go
@@ -14,6 +14,7 @@ import (
 	"lazymind/core/common"
 	"lazymind/core/common/orm"
 	"lazymind/core/externalcontext"
+	"lazymind/core/log"
 	"lazymind/core/store"
 )
 
@@ -341,7 +342,11 @@ func PublishExternalChatEvent(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if input.Type == "completed" || input.Type == "failed" {
-		_ = projectExternalChatRunStatus(r.Context(), store.DB(), store.State(), owner, mux.Vars(r)["run_id"])
+		runID := mux.Vars(r)["run_id"]
+		if err := projectExternalChatRunCache(r.Context(), store.DB(), store.State(), owner, runID); err != nil {
+			log.Logger.Warn().Err(err).Str("run_id", runID).
+				Msg("external chat terminal committed but cache projection failed")
+		}
 	}
 	common.ReplyOK(w, map[string]any{"sequence": sequence})
 }

--- a/backend/core/chat/external_chat_store.go
+++ b/backend/core/chat/external_chat_store.go
@@ -20,6 +20,7 @@ import (
 	"lazymind/core/agentinvocation"
 	"lazymind/core/common/orm"
 	"lazymind/core/externalcontext"
+	"lazymind/core/log"
 	"lazymind/core/workflow/artifactfile"
 )
 
@@ -112,7 +113,15 @@ func (a *externalChatApplication) createRun(ctx context.Context, run *orm.Extern
 	now := a.now()
 	run.Status = "pending"
 	run.CreatedAt, run.UpdatedAt = now, now
-	if err := a.db.WithContext(ctx).Create(run).Error; err != nil {
+	if err := a.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		if err := tx.Create(run).Error; err != nil {
+			return err
+		}
+		if run.Action == "regenerate" {
+			return claimChatHistoryRun(ctx, tx, run.HistoryID, run.ID)
+		}
+		return nil
+	}); err != nil {
 		return err
 	}
 	externalRunsAvailable.notify()
@@ -344,7 +353,8 @@ func (a *externalChatApplication) appendEvent(
 			} else {
 				run.Status, run.ErrorMessage = "failed", updates["error_message"].(string)
 			}
-			return finalizeExternalChatHistory(tx, &run, now)
+			_, err := finalizeExternalChatHistory(tx, &run, now)
+			return err
 		}
 		return nil
 	})
@@ -384,7 +394,7 @@ func (a *externalChatApplication) requestStop(ctx context.Context, owner, conver
 				return err
 			}
 			run.Status, run.StopRequested = "stopped", true
-			if err := finalizeExternalChatHistory(tx, run, now); err != nil {
+			if _, err := finalizeExternalChatHistory(tx, run, now); err != nil {
 				return err
 			}
 		}
@@ -392,21 +402,43 @@ func (a *externalChatApplication) requestStop(ctx context.Context, owner, conver
 	})
 }
 
-func finalizeExternalChatHistory(tx *gorm.DB, run *orm.ExternalChatRun, now time.Time) error {
+func activeExternalChatHistoryIDs(
+	ctx context.Context,
+	db *gorm.DB,
+	owner, conversationID string,
+	historyIDs []string,
+) (map[string]struct{}, error) {
+	out := make(map[string]struct{})
+	if db == nil || len(historyIDs) == 0 {
+		return out, nil
+	}
+	var runs []orm.ExternalChatRun
+	if err := db.WithContext(ctx).Select("history_id").
+		Where("actor_user_id = ? AND conversation_id = ? AND history_id IN ? AND status IN ?", owner, conversationID, historyIDs, []string{"pending", "running"}).
+		Find(&runs).Error; err != nil {
+		return nil, err
+	}
+	for _, run := range runs {
+		out[run.HistoryID] = struct{}{}
+	}
+	return out, nil
+}
+
+func finalizeExternalChatHistory(tx *gorm.DB, run *orm.ExternalChatRun, now time.Time) (bool, error) {
 	var events []orm.ExternalChatRunEvent
 	if err := tx.Where("run_id = ? AND type = ?", run.ID, "message").Order("sequence ASC").Find(&events).Error; err != nil {
-		return err
+		return false, err
 	}
 	var result strings.Builder
 	for index := range events {
 		normalized, err := rewriteExternalArtifactReferences(tx, *run, events[index].Text)
 		if err != nil {
-			return err
+			return false, err
 		}
 		if normalized != events[index].Text {
 			if err := tx.Model(&orm.ExternalChatRunEvent{}).Where("id = ?", events[index].ID).
 				Update("text", normalized).Error; err != nil {
-				return err
+				return false, err
 			}
 		}
 		result.WriteString(normalized)
@@ -420,26 +452,43 @@ func finalizeExternalChatHistory(tx *gorm.DB, run *orm.ExternalChatRun, now time
 		RunTerminal: terminalJSON(terminal), Ext: run.HistoryExt,
 		TimeMixin: orm.TimeMixin{CreateTime: now, UpdateTime: now},
 	}
-	if err := tx.Clauses(clause.OnConflict{
-		Columns: []clause.Column{{Name: "id"}},
-		DoUpdates: clause.Assignments(map[string]any{
+	var existing orm.ChatHistory
+	err := tx.Clauses(clause.Locking{Strength: "UPDATE"}).Where("id = ?", run.HistoryID).Take(&existing).Error
+	switch {
+	case errors.Is(err, gorm.ErrRecordNotFound):
+		if err := tx.Create(&history).Error; err != nil {
+			return false, err
+		}
+	case err != nil:
+		return false, err
+	case existing.RunID != run.ID:
+		log.Logger.Info().
+			Str("conversation_id", run.ConversationID).
+			Str("history_id", run.HistoryID).
+			Str("run_id", run.ID).
+			Str("current_run_id", existing.RunID).
+			Msg("ignored stale external chat history finalization")
+		return false, nil
+	default:
+		persisted, err := updateOwnedChatHistory(tx.Statement.Context, tx, run.HistoryID, run.ID, map[string]any{
 			"seq": history.Seq, "conversation_id": history.ConversationID,
 			"algorithm_id": history.AlgorithmID, "raw_content": history.RawContent,
-			"content": history.Content, "result": history.Result, "run_id": history.RunID,
+			"content": history.Content, "result": history.Result,
 			"run_status": history.RunStatus, "run_terminal": history.RunTerminal, "ext": history.Ext,
 			"update_time": now,
-		}),
-	}).Create(&history).Error; err != nil {
-		return err
+		})
+		if err != nil || !persisted {
+			return persisted, err
+		}
 	}
 	if err := tx.Model(&orm.Conversation{}).Where("id = ?", run.ConversationID).
 		Update("updated_at", now).Error; err != nil {
-		return err
+		return false, err
 	}
 	if run.Action != "regenerate" {
 		if err := tx.Model(&orm.Conversation{}).Where("id = ?", run.ConversationID).
 			UpdateColumn("chat_times", gorm.Expr("chat_times + ?", 1)).Error; err != nil {
-			return err
+			return false, err
 		}
 	}
 	taskStatus := "succeeded"
@@ -448,9 +497,10 @@ func finalizeExternalChatHistory(tx *gorm.DB, run *orm.ExternalChatRun, now time
 	} else if run.Status == "stopped" {
 		taskStatus = "canceled"
 	}
-	return tx.Model(&orm.TaskCenterTask{}).
+	err = tx.Model(&orm.TaskCenterTask{}).
 		Where("conversation_id = ? AND task_type = ? AND archived_at IS NULL AND status NOT IN ('succeeded','failed','canceled')", run.ConversationID, "background_chat").
 		Updates(map[string]any{"status": taskStatus, "finished_at": now, "updated_at": now}).Error
+	return err == nil, err
 }
 
 var markdownLinkDestination = regexp.MustCompile(`\]\(([^)\n]+)\)`)

--- a/backend/core/chat/external_chat_test.go
+++ b/backend/core/chat/external_chat_test.go
@@ -1147,6 +1147,10 @@ func TestExternalChatStopIsDurableAndPropagatesToLeaseOwner(t *testing.T) {
 	if err := app.requestStop(ctx, "user-1", "conversation-1", job.HistoryID); err != nil {
 		t.Fatalf("request stop: %v", err)
 	}
+	if _, err := app.appendEvent(ctx, "user-1", job.RunID, "host-1", job.LeaseToken,
+		externalChatEvent{EventID: "late-failure", Type: "failed", Error: "late failure"}); !errors.Is(err, errExternalChatLeaseLost) {
+		t.Fatalf("late failure after stop err=%v, want lease lost", err)
+	}
 	stop, err := app.heartbeat(ctx, "user-1", job.RunID, "host-1", job.LeaseToken)
 	if err != nil || !stop {
 		t.Fatalf("stopped heartbeat: stop=%v err=%v", stop, err)
@@ -1154,6 +1158,10 @@ func TestExternalChatStopIsDurableAndPropagatesToLeaseOwner(t *testing.T) {
 	var run orm.ExternalChatRun
 	if err := db.First(&run, "id = ?", job.RunID).Error; err != nil || run.Status != "stopped" || !run.StopRequested {
 		t.Fatalf("persisted stop: run=%#v err=%v", run, err)
+	}
+	var history orm.ChatHistory
+	if err := db.First(&history, "id = ?", job.HistoryID).Error; err != nil || history.RunStatus != "cancelled" {
+		t.Fatalf("persisted stopped history: history=%#v err=%v", history, err)
 	}
 }
 

--- a/backend/core/chat/history_run.go
+++ b/backend/core/chat/history_run.go
@@ -1,0 +1,58 @@
+package chat
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	"gorm.io/gorm"
+
+	"lazymind/core/common/orm"
+	"lazymind/core/log"
+)
+
+// claimChatHistoryRun transfers a reused history row to a new run before that
+// run can emit progress. Terminal/progress writers must then use the matching
+// run_id guard so a late previous run cannot overwrite the current owner.
+func claimChatHistoryRun(ctx context.Context, db *gorm.DB, historyID, runID string) error {
+	if db == nil || strings.TrimSpace(historyID) == "" || strings.TrimSpace(runID) == "" {
+		return nil
+	}
+	return db.WithContext(ctx).Model(&orm.ChatHistory{}).Where("id = ?", historyID).Updates(map[string]any{
+		"run_id": runID, "run_status": "generating", "run_terminal": nil, "update_time": time.Now(),
+	}).Error
+}
+
+func updateOwnedChatHistory(ctx context.Context, db *gorm.DB, historyID, runID string, values map[string]any) (bool, error) {
+	if db == nil || strings.TrimSpace(historyID) == "" || strings.TrimSpace(runID) == "" {
+		return false, nil
+	}
+	result := db.WithContext(ctx).Model(&orm.ChatHistory{}).
+		Where("id = ? AND run_id = ?", historyID, runID).Updates(values)
+	if result.Error != nil {
+		return false, result.Error
+	}
+	if result.RowsAffected == 0 {
+		log.Logger.Info().Str("history_id", historyID).Str("run_id", runID).
+			Msg("ignored stale chat history write")
+		return false, nil
+	}
+	return true, nil
+}
+
+func updateOwnedMultiAnswerHistory(ctx context.Context, db *gorm.DB, historyID, runID string, values any) (bool, error) {
+	if db == nil || strings.TrimSpace(historyID) == "" || strings.TrimSpace(runID) == "" {
+		return false, nil
+	}
+	result := db.WithContext(ctx).Model(&orm.MultiAnswersChatHistory{}).
+		Where("id = ? AND run_id = ?", historyID, runID).Updates(values)
+	if result.Error != nil {
+		return false, result.Error
+	}
+	if result.RowsAffected == 0 {
+		log.Logger.Info().Str("history_id", historyID).Str("run_id", runID).
+			Msg("ignored stale multi-answer history write")
+		return false, nil
+	}
+	return true, nil
+}

--- a/backend/core/chat/history_run_test.go
+++ b/backend/core/chat/history_run_test.go
@@ -1,0 +1,119 @@
+package chat
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"lazymind/core/common/orm"
+)
+
+func TestOwnedChatHistoryRejectsLateRunWrite(t *testing.T) {
+	_, db := newExternalChatTestApplication(t)
+	ctx := context.Background()
+	now := time.Now()
+	if err := db.Create(&orm.ChatHistory{
+		ID: "history-owned", ConversationID: "conversation-1", Seq: 1,
+		RunID: "run-old", RunStatus: "generating",
+		TimeMixin: orm.TimeMixin{CreateTime: now, UpdateTime: now},
+	}).Error; err != nil {
+		t.Fatalf("create history: %v", err)
+	}
+	if err := claimChatHistoryRun(ctx, db, "history-owned", "run-new"); err != nil {
+		t.Fatalf("claim new run: %v", err)
+	}
+	if updated, err := updateOwnedChatHistory(ctx, db, "history-owned", "run-old", map[string]any{
+		"run_status": "failed",
+	}); err != nil || updated {
+		t.Fatalf("late old run update: updated=%v err=%v", updated, err)
+	}
+	if updated, err := updateOwnedChatHistory(ctx, db, "history-owned", "run-new", map[string]any{
+		"run_status": "completed",
+	}); err != nil || !updated {
+		t.Fatalf("current run update: updated=%v err=%v", updated, err)
+	}
+	var history orm.ChatHistory
+	if err := db.First(&history, "id = ?", "history-owned").Error; err != nil {
+		t.Fatalf("load history: %v", err)
+	}
+	if history.RunID != "run-new" || history.RunStatus != "completed" {
+		t.Fatalf("history owner changed unexpectedly: %#v", history)
+	}
+}
+
+func TestChatStatusRejectsLateRunTerminal(t *testing.T) {
+	ctx := context.Background()
+	stateStore := newRunDecisionTestStore(t)
+	if err := setChatRuntimeStatus(ctx, stateStore, "conversation-1", "history-1", "generating", "", "run-new", nil); err != nil {
+		t.Fatalf("set current run: %v", err)
+	}
+	late := &RunTerminal{Status: "failed", Reason: "runtime_failure", Code: "transport_error"}
+	if err := setChatRuntimeStatus(ctx, stateStore, "conversation-1", "history-1", "failed", "old", "run-old", late); err != nil {
+		t.Fatalf("set stale terminal: %v", err)
+	}
+	status, err := getChatStatus(ctx, stateStore, "conversation-1", "history-1")
+	if err != nil {
+		t.Fatalf("get current status: %v", err)
+	}
+	if status.RunID != "run-new" || status.Status != "generating" || status.RunTerminal != nil {
+		t.Fatalf("stale terminal overwrote current status: %#v", status)
+	}
+}
+
+func TestExternalRegenerationOwnerRejectsLatePreviousTerminal(t *testing.T) {
+	app, db := newExternalChatTestApplication(t)
+	ctx := context.Background()
+	now := time.Now().UTC()
+	oldRun := &orm.ExternalChatRun{
+		ID: "external-old", RequestID: "external-old", ConversationID: "conversation-1",
+		HistoryID: "shared-history", Provider: ChatExecutorCodex, ActorUserID: "user-1",
+		Action: "start", Query: "old", Sequence: 1,
+	}
+	if err := app.createRun(ctx, oldRun); err != nil {
+		t.Fatalf("create old run: %v", err)
+	}
+	job, err := app.claim(ctx, "user-1", ChatExecutorCodex, "host-1")
+	if err != nil || job == nil || job.RunID != oldRun.ID {
+		t.Fatalf("claim old run: job=%#v err=%v", job, err)
+	}
+	if err := db.Create(&orm.ChatHistory{
+		ID: oldRun.HistoryID, ConversationID: oldRun.ConversationID, Seq: 1,
+		RunID: oldRun.ID, RunStatus: "generating",
+		TimeMixin: orm.TimeMixin{CreateTime: now, UpdateTime: now},
+	}).Error; err != nil {
+		t.Fatalf("create old history: %v", err)
+	}
+	newRun := &orm.ExternalChatRun{
+		ID: "external-new", RequestID: "external-new", ConversationID: "conversation-1",
+		HistoryID: oldRun.HistoryID, Provider: ChatExecutorCodex, ActorUserID: "user-1",
+		Action: "regenerate", Query: "new", Sequence: 1,
+	}
+	if err := app.createRun(ctx, newRun); err != nil {
+		t.Fatalf("create regenerated run: %v", err)
+	}
+	if _, err := app.appendEvent(ctx, "user-1", oldRun.ID, "host-1", job.LeaseToken,
+		externalChatEvent{EventID: "old-failed", Type: "failed", Error: "late failure"}); err != nil {
+		t.Fatalf("append late old terminal: %v", err)
+	}
+	var history orm.ChatHistory
+	if err := db.First(&history, "id = ?", oldRun.HistoryID).Error; err != nil {
+		t.Fatalf("load current history: %v", err)
+	}
+	if history.RunID != newRun.ID || history.RunStatus != "generating" {
+		t.Fatalf("late old terminal overwrote regeneration: %#v", history)
+	}
+	if err := app.requestStop(ctx, "user-1", "conversation-1", oldRun.HistoryID); err != nil {
+		t.Fatalf("stop current external run: %v", err)
+	}
+	if err := db.First(&history, "id = ?", oldRun.HistoryID).Error; err != nil {
+		t.Fatalf("reload current history: %v", err)
+	}
+	var terminal RunTerminal
+	if err := json.Unmarshal(history.RunTerminal, &terminal); err != nil {
+		t.Fatalf("decode current terminal: %v", err)
+	}
+	if history.RunID != newRun.ID || terminal.Status != "cancelled" || terminal.Reason != "user_cancelled" {
+		t.Fatalf("current external terminal mismatch: history=%#v terminal=%#v", history, terminal)
+	}
+}

--- a/backend/core/chat/redis_cache.go
+++ b/backend/core/chat/redis_cache.go
@@ -184,6 +184,13 @@ func reconcileGeneratingExternalChatStatuses(
 		}
 		terminalEvent := externalRunTerminalEvent(run.ID, run.Status, result != "")
 		terminal, _ := terminalEvent.Terminal()
+		terminal = resolveRunTerminal(
+			ctx, stateStore, run.ConversationID, run.HistoryID, run.ID,
+			terminal, result != "", "external_durable_terminal",
+		)
+		if err := persistResolvedExternalRunTerminal(ctx, db, run.HistoryID, terminal); err != nil {
+			return ids, err
+		}
 		if err := setChatRuntimeStatus(ctx, stateStore, conversationID, historyID, terminal.Status, result, run.ID, terminal); err != nil {
 			return ids, err
 		}
@@ -215,7 +222,23 @@ func projectExternalChatRunStatus(
 	}
 	terminalEvent := externalRunTerminalEvent(run.ID, run.Status, result != "")
 	terminal, _ := terminalEvent.Terminal()
+	terminal = resolveRunTerminal(
+		ctx, stateStore, run.ConversationID, run.HistoryID, run.ID,
+		terminal, result != "", "external_durable_terminal",
+	)
+	if err := persistResolvedExternalRunTerminal(ctx, db, run.HistoryID, terminal); err != nil {
+		return err
+	}
 	return setChatRuntimeStatus(ctx, stateStore, run.ConversationID, run.HistoryID, terminal.Status, result, run.ID, terminal)
+}
+
+func persistResolvedExternalRunTerminal(ctx context.Context, db *gorm.DB, historyID string, terminal *RunTerminal) error {
+	if db == nil || terminal == nil {
+		return nil
+	}
+	return db.WithContext(ctx).Model(&orm.ChatHistory{}).Where("id = ?", historyID).Updates(map[string]any{
+		"run_status": terminal.Status, "run_terminal": terminalJSON(terminal), "update_time": time.Now(),
+	}).Error
 }
 
 func getChatStatus(ctx context.Context, stateStore state.Store, conversationID, historyID string) (*ChatStatus, error) {

--- a/backend/core/chat/redis_cache.go
+++ b/backend/core/chat/redis_cache.go
@@ -3,6 +3,7 @@ package chat
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"time"
 
@@ -113,6 +114,15 @@ func setChatStatus(ctx context.Context, stateStore state.Store, conversationID, 
 }
 
 func setChatRuntimeStatus(ctx context.Context, stateStore state.Store, conversationID, historyID, status, currentResult, runID string, terminal *RunTerminal) error {
+	if status != "generating" && runID != "" {
+		if current, err := getChatStatus(ctx, stateStore, conversationID, historyID); err == nil &&
+			current.RunID != "" && current.RunID != runID {
+			log.Logger.Info().Str("conversation_id", conversationID).Str("history_id", historyID).
+				Str("run_id", runID).Str("current_run_id", current.RunID).
+				Msg("ignored stale chat status terminal")
+			return nil
+		}
+	}
 	key := chatStatusKey(conversationID)
 	totalChunks := int32(0)
 	chunks, _ := getChatChunks(ctx, stateStore, conversationID, historyID)
@@ -177,28 +187,18 @@ func reconcileGeneratingExternalChatStatuses(
 			remaining = append(remaining, historyID)
 			continue
 		}
-		result := ""
-		var history orm.ChatHistory
-		if err := db.WithContext(ctx).Select("result").Where("id = ?", historyID).Take(&history).Error; err == nil {
-			result = history.Result
-		}
-		terminalEvent := externalRunTerminalEvent(run.ID, run.Status, result != "")
-		terminal, _ := terminalEvent.Terminal()
-		terminal = resolveRunTerminal(
-			ctx, stateStore, run.ConversationID, run.HistoryID, run.ID,
-			terminal, result != "", "external_durable_terminal",
-		)
-		if err := persistResolvedExternalRunTerminal(ctx, db, run.HistoryID, terminal); err != nil {
+		projected, err := projectExternalChatRunCacheRecord(ctx, db, stateStore, run)
+		if err != nil {
 			return ids, err
 		}
-		if err := setChatRuntimeStatus(ctx, stateStore, conversationID, historyID, terminal.Status, result, run.ID, terminal); err != nil {
-			return ids, err
+		if !projected {
+			remaining = append(remaining, historyID)
 		}
 	}
 	return remaining, nil
 }
 
-func projectExternalChatRunStatus(
+func projectExternalChatRunCache(
 	ctx context.Context,
 	db *gorm.DB,
 	stateStore state.Store,
@@ -215,30 +215,30 @@ func projectExternalChatRunStatus(
 	if !externalRunTerminal(run.Status) {
 		return nil
 	}
-	result := ""
-	var history orm.ChatHistory
-	if err := db.WithContext(ctx).Select("result").Where("id = ?", run.HistoryID).Take(&history).Error; err == nil {
-		result = history.Result
-	}
-	terminalEvent := externalRunTerminalEvent(run.ID, run.Status, result != "")
-	terminal, _ := terminalEvent.Terminal()
-	terminal = resolveRunTerminal(
-		ctx, stateStore, run.ConversationID, run.HistoryID, run.ID,
-		terminal, result != "", "external_durable_terminal",
-	)
-	if err := persistResolvedExternalRunTerminal(ctx, db, run.HistoryID, terminal); err != nil {
-		return err
-	}
-	return setChatRuntimeStatus(ctx, stateStore, run.ConversationID, run.HistoryID, terminal.Status, result, run.ID, terminal)
+	_, err := projectExternalChatRunCacheRecord(ctx, db, stateStore, run)
+	return err
 }
 
-func persistResolvedExternalRunTerminal(ctx context.Context, db *gorm.DB, historyID string, terminal *RunTerminal) error {
-	if db == nil || terminal == nil {
-		return nil
+func projectExternalChatRunCacheRecord(
+	ctx context.Context,
+	db *gorm.DB,
+	stateStore state.Store,
+	run orm.ExternalChatRun,
+) (bool, error) {
+	var history orm.ChatHistory
+	if err := db.WithContext(ctx).Select("result", "run_id").
+		Where("id = ? AND run_id = ?", run.HistoryID, run.ID).Take(&history).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return false, nil
+		}
+		return false, err
 	}
-	return db.WithContext(ctx).Model(&orm.ChatHistory{}).Where("id = ?", historyID).Updates(map[string]any{
-		"run_status": terminal.Status, "run_terminal": terminalJSON(terminal), "update_time": time.Now(),
-	}).Error
+	terminalEvent := externalRunTerminalEvent(run.ID, run.Status, history.Result != "")
+	terminal, _ := terminalEvent.Terminal()
+	if err := setChatRuntimeStatus(ctx, stateStore, run.ConversationID, run.HistoryID, terminal.Status, history.Result, run.ID, terminal); err != nil {
+		return false, err
+	}
+	return true, nil
 }
 
 func getChatStatus(ctx context.Context, stateStore state.Store, conversationID, historyID string) (*ChatStatus, error) {

--- a/backend/core/chat/redis_cancel_integration_test.go
+++ b/backend/core/chat/redis_cancel_integration_test.go
@@ -142,7 +142,7 @@ func TestRedisCancelWatcherReleasesConnections(t *testing.T) {
 		}
 		cancelled := resolveRunTerminal(
 			decisionCtx, stateStore, conversationID, historyID, "cancel-first",
-			failure, false, "redis_integration_terminal",
+			failure, "redis_integration_terminal",
 		)
 		if cancelled.Status != "cancelled" || cancelled.Reason != "user_cancelled" {
 			t.Fatalf("cancel-first terminal=%#v", cancelled)
@@ -150,7 +150,7 @@ func TestRedisCancelWatcherReleasesConnections(t *testing.T) {
 
 		acceptedFailure := resolveRunTerminal(
 			decisionCtx, stateStore, conversationID, historyID, "failure-first",
-			failure, false, "redis_integration_terminal",
+			failure, "redis_integration_terminal",
 		)
 		if won, err := claimUserCancelDecision(decisionCtx, stateStore, conversationID, historyID, "failure-first"); err != nil || won {
 			t.Fatalf("late cancellation: won=%v err=%v", won, err)
@@ -161,11 +161,12 @@ func TestRedisCancelWatcherReleasesConnections(t *testing.T) {
 
 		nextRun := resolveRunTerminal(
 			decisionCtx, stateStore, conversationID, historyID, "next-run",
-			failure, false, "redis_integration_terminal",
+			failure, "redis_integration_terminal",
 		)
 		if nextRun.Status != "failed" || nextRun.Reason != "model_failure" {
 			t.Fatalf("previous run decision leaked into next run: %#v", nextRun)
 		}
+		assertConcurrentRunDecisionWinner(t, stateStore, prefix+":redis-concurrent")
 	})
 
 	assertRedisPoolIdle(t, client)

--- a/backend/core/chat/redis_cancel_integration_test.go
+++ b/backend/core/chat/redis_cancel_integration_test.go
@@ -127,6 +127,47 @@ func TestRedisCancelWatcherReleasesConnections(t *testing.T) {
 		}
 	})
 
+	t.Run("run decisions are atomic and run scoped", func(t *testing.T) {
+		decisionCtx := context.Background()
+		conversationID := prefix + ":decision"
+		historyID := "history"
+		failure := &RunTerminal{Status: "failed", Reason: "model_failure", Code: "rate_limited"}
+		for _, runID := range []string{"cancel-first", "failure-first", "next-run"} {
+			key := runDecisionKey(conversationID, historyID, runID)
+			t.Cleanup(func() { _ = client.Del(context.Background(), key).Err() })
+		}
+
+		if won, err := claimUserCancelDecision(decisionCtx, stateStore, conversationID, historyID, "cancel-first"); err != nil || !won {
+			t.Fatalf("claim cancellation: won=%v err=%v", won, err)
+		}
+		cancelled := resolveRunTerminal(
+			decisionCtx, stateStore, conversationID, historyID, "cancel-first",
+			failure, false, "redis_integration_terminal",
+		)
+		if cancelled.Status != "cancelled" || cancelled.Reason != "user_cancelled" {
+			t.Fatalf("cancel-first terminal=%#v", cancelled)
+		}
+
+		acceptedFailure := resolveRunTerminal(
+			decisionCtx, stateStore, conversationID, historyID, "failure-first",
+			failure, false, "redis_integration_terminal",
+		)
+		if won, err := claimUserCancelDecision(decisionCtx, stateStore, conversationID, historyID, "failure-first"); err != nil || won {
+			t.Fatalf("late cancellation: won=%v err=%v", won, err)
+		}
+		if acceptedFailure.Status != "failed" || acceptedFailure.Reason != "model_failure" {
+			t.Fatalf("failure-first terminal=%#v", acceptedFailure)
+		}
+
+		nextRun := resolveRunTerminal(
+			decisionCtx, stateStore, conversationID, historyID, "next-run",
+			failure, false, "redis_integration_terminal",
+		)
+		if nextRun.Status != "failed" || nextRun.Reason != "model_failure" {
+			t.Fatalf("previous run decision leaked into next run: %#v", nextRun)
+		}
+	})
+
 	assertRedisPoolIdle(t, client)
 	requestCtx, requestCancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
 	defer requestCancel()

--- a/backend/core/chat/run_decision.go
+++ b/backend/core/chat/run_decision.go
@@ -13,7 +13,8 @@ import (
 
 const (
 	runDecisionKeyPrefix = "rag/chat/run-decision:%s:%s:%s"
-	runDecisionTTL       = 15 * time.Minute
+	runDecisionTTL       = 24 * time.Hour
+	terminalWriteTimeout = 5 * time.Second
 
 	runDecisionUserCancel = "user_cancel"
 	runDecisionTerminal   = "terminal"
@@ -85,6 +86,9 @@ func logRunDecision(message, conversationID, historyID, runID string, winner run
 	event.Msg(message)
 }
 
+// claimUserCancelDecision records the stop intent when possible and returns
+// whether user cancellation is the authoritative winner, including retries
+// after an earlier user-cancel claim.
 func claimUserCancelDecision(
 	ctx context.Context,
 	stateStore state.Store,
@@ -97,18 +101,26 @@ func claimUserCancelDecision(
 	return err == nil && winner.Kind == runDecisionUserCancel, err
 }
 
+// terminalWriteContext lets terminal state survive a disconnected request while
+// keeping every detached write bounded. Callers must always invoke cancel.
+func terminalWriteContext(parent context.Context) (context.Context, context.CancelFunc) {
+	if parent == nil {
+		parent = context.Background()
+	}
+	return context.WithTimeout(context.WithoutCancel(parent), terminalWriteTimeout)
+}
+
 func resolveRunTerminal(
 	ctx context.Context,
 	stateStore state.Store,
 	conversationID, historyID, runID string,
 	candidate *RunTerminal,
-	partialOutput bool,
 	source string,
 ) *RunTerminal {
 	if candidate == nil {
 		fallback := RunTerminal{
 			Status: "failed", Reason: "runtime_failure", Code: "missing_run_terminal",
-			PartialOutput: partialOutput,
+			PartialOutput: false,
 		}
 		candidate = &fallback
 	}
@@ -128,7 +140,7 @@ func resolveRunTerminal(
 	}
 	if winner.Kind == runDecisionUserCancel {
 		return &RunTerminal{
-			Status: "cancelled", Reason: "user_cancelled", PartialOutput: partialOutput,
+			Status: "cancelled", Reason: "user_cancelled", PartialOutput: candidate.PartialOutput,
 		}
 	}
 	if winner.Kind == runDecisionTerminal && winner.Terminal != nil {

--- a/backend/core/chat/run_decision.go
+++ b/backend/core/chat/run_decision.go
@@ -1,0 +1,138 @@
+package chat
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	"lazymind/core/log"
+	"lazymind/core/state"
+)
+
+const (
+	runDecisionKeyPrefix = "rag/chat/run-decision:%s:%s:%s"
+	runDecisionTTL       = 15 * time.Minute
+
+	runDecisionUserCancel = "user_cancel"
+	runDecisionTerminal   = "terminal"
+)
+
+type runDecision struct {
+	Kind        string       `json:"kind"`
+	Terminal    *RunTerminal `json:"terminal,omitempty"`
+	Source      string       `json:"source"`
+	DecidedAtMS int64        `json:"decided_at_ms"`
+}
+
+func runDecisionKey(conversationID, historyID, runID string) string {
+	return fmt.Sprintf(runDecisionKeyPrefix, conversationID, historyID, runID)
+}
+
+func claimRunDecision(
+	ctx context.Context,
+	stateStore state.Store,
+	conversationID, historyID, runID string,
+	candidate runDecision,
+) (runDecision, bool, error) {
+	if stateStore == nil || strings.TrimSpace(conversationID) == "" ||
+		strings.TrimSpace(historyID) == "" || strings.TrimSpace(runID) == "" {
+		return candidate, true, nil
+	}
+	candidate.DecidedAtMS = time.Now().UnixMilli()
+	payload, err := json.Marshal(candidate)
+	if err != nil {
+		return runDecision{}, false, err
+	}
+	key := runDecisionKey(conversationID, historyID, runID)
+	won, err := stateStore.SetNX(ctx, key, payload, runDecisionTTL)
+	if err != nil {
+		return runDecision{}, false, err
+	}
+	if won {
+		logRunDecision("chat run decision accepted", conversationID, historyID, runID, candidate, "")
+		return candidate, true, nil
+	}
+	existingPayload, err := stateStore.Get(ctx, key)
+	if err != nil {
+		return runDecision{}, false, err
+	}
+	var existing runDecision
+	if err := json.Unmarshal(existingPayload, &existing); err != nil {
+		return runDecision{}, false, err
+	}
+	logRunDecision("chat run decision ignored", conversationID, historyID, runID, existing, candidate.Source)
+	return existing, false, nil
+}
+
+func logRunDecision(message, conversationID, historyID, runID string, winner runDecision, ignoredSource string) {
+	event := log.Logger.Info().
+		Str("conversation_id", conversationID).
+		Str("history_id", historyID).
+		Str("run_id", runID).
+		Str("decision_kind", winner.Kind).
+		Str("decision_source", winner.Source)
+	if winner.Terminal != nil {
+		event = event.
+			Str("terminal_status", winner.Terminal.Status).
+			Str("terminal_reason", winner.Terminal.Reason).
+			Str("terminal_code", winner.Terminal.Code)
+	}
+	if ignoredSource != "" {
+		event = event.Str("ignored_source", ignoredSource)
+	}
+	event.Msg(message)
+}
+
+func claimUserCancelDecision(
+	ctx context.Context,
+	stateStore state.Store,
+	conversationID, historyID, runID string,
+) (bool, error) {
+	winner, _, err := claimRunDecision(ctx, stateStore, conversationID, historyID, runID, runDecision{
+		Kind:   runDecisionUserCancel,
+		Source: "user_stop",
+	})
+	return err == nil && winner.Kind == runDecisionUserCancel, err
+}
+
+func resolveRunTerminal(
+	ctx context.Context,
+	stateStore state.Store,
+	conversationID, historyID, runID string,
+	candidate *RunTerminal,
+	partialOutput bool,
+	source string,
+) *RunTerminal {
+	if candidate == nil {
+		fallback := RunTerminal{
+			Status: "failed", Reason: "runtime_failure", Code: "missing_run_terminal",
+			PartialOutput: partialOutput,
+		}
+		candidate = &fallback
+	}
+	winner, _, err := claimRunDecision(ctx, stateStore, conversationID, historyID, runID, runDecision{
+		Kind:     runDecisionTerminal,
+		Terminal: candidate,
+		Source:   source,
+	})
+	if err != nil {
+		log.Logger.Warn().Err(err).
+			Str("conversation_id", conversationID).
+			Str("history_id", historyID).
+			Str("run_id", runID).
+			Str("decision_source", source).
+			Msg("chat run decision state unavailable; using candidate terminal")
+		return candidate
+	}
+	if winner.Kind == runDecisionUserCancel {
+		return &RunTerminal{
+			Status: "cancelled", Reason: "user_cancelled", PartialOutput: partialOutput,
+		}
+	}
+	if winner.Kind == runDecisionTerminal && winner.Terminal != nil {
+		return winner.Terminal
+	}
+	return candidate
+}

--- a/backend/core/chat/run_decision_stream_test.go
+++ b/backend/core/chat/run_decision_stream_test.go
@@ -1,0 +1,124 @@
+package chat
+
+import (
+	"context"
+	"encoding/json"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"gorm.io/gorm"
+
+	"lazymind/core/common/orm"
+	"lazymind/core/state"
+)
+
+func newRunDecisionStreamHarness(t *testing.T) (*gorm.DB, state.Store) {
+	t.Helper()
+	database, err := orm.Connect(orm.DriverSQLite, filepath.Join(t.TempDir(), "chat.db"))
+	if err != nil {
+		t.Fatalf("connect chat database: %v", err)
+	}
+	if err := database.AutoMigrate(&orm.Conversation{}, &orm.ChatHistory{}, &orm.TaskCenterTask{}); err != nil {
+		t.Fatalf("migrate chat database: %v", err)
+	}
+	now := time.Now().UTC()
+	if err := database.Create(&orm.Conversation{
+		ID: "conv-stream-decision",
+		BaseModel: orm.BaseModel{
+			CreateUserID: "user-1", CreateUserName: "user-1", CreatedAt: now, UpdatedAt: now,
+		},
+	}).Error; err != nil {
+		t.Fatalf("create conversation: %v", err)
+	}
+	stateStore, err := state.NewSQLiteStore(filepath.Join(t.TempDir(), "state.db"))
+	if err != nil {
+		t.Fatalf("create state store: %v", err)
+	}
+	t.Cleanup(func() { _ = stateStore.Close() })
+	return database.DB, stateStore
+}
+
+func TestStreamSingleAnswerUserCancelWinsOverCancellationEOF(t *testing.T) {
+	db, stateStore := newRunDecisionStreamHarness(t)
+	const historyID = "history-cancel-first"
+	const runID = "run-cancel-first"
+	server := streamServer(t, runID, algorithmFrame(t, map[string]any{"text": "partial answer"}))
+	defer server.Close()
+
+	if won, err := claimUserCancelDecision(
+		context.Background(), stateStore, "conv-stream-decision", historyID, runID,
+	); err != nil || !won {
+		t.Fatalf("claim cancellation: won=%v err=%v", won, err)
+	}
+	recorder := httptest.NewRecorder()
+	streamSingleAnswer(
+		context.Background(), context.Background(), recorder, recorder, db, stateStore,
+		server.URL, map[string]any{"query": "question", "run_id": runID},
+		"conv-stream-decision", "question", historyID,
+		chatPersistTarget{HistoryID: historyID, Seq: 1}, json.RawMessage(`{}`),
+	)
+
+	var history orm.ChatHistory
+	if err := db.Where("id = ?", historyID).Take(&history).Error; err != nil {
+		t.Fatalf("load cancelled history: %v", err)
+	}
+	terminal, err := parseRunTerminal(history.RunTerminal)
+	if err != nil {
+		t.Fatalf("parse cancelled terminal: %v", err)
+	}
+	if history.Result != "partial answer" || history.RunStatus != "cancelled" ||
+		terminal.Reason != "user_cancelled" || !terminal.PartialOutput {
+		t.Fatalf("unexpected cancelled history: history=%#v terminal=%#v", history, terminal)
+	}
+	if body := recorder.Body.String(); !strings.Contains(body, `"status":"cancelled"`) || strings.Contains(body, `"status":"failed"`) {
+		t.Fatalf("unexpected cancellation stream: %s", body)
+	}
+}
+
+func TestStreamSingleAnswerAcceptedModelFailureWinsOverLateStop(t *testing.T) {
+	db, stateStore := newRunDecisionStreamHarness(t)
+	const historyID = "history-failure-first"
+	const runID = "run-failure-first"
+	failureFrame := algorithmFrame(t, map[string]any{"runtime_event": map[string]any{
+		"schema_version": 1,
+		"event_id":       "evt-model-failure",
+		"run_id":         runID,
+		"type":           RuntimeEventRunFinished,
+		"data": map[string]any{
+			"status": "failed", "reason": "model_failure", "code": "rate_limited", "partial_output": false,
+		},
+	}})
+	server := streamServer(t, runID, failureFrame)
+	defer server.Close()
+
+	recorder := httptest.NewRecorder()
+	streamSingleAnswer(
+		context.Background(), context.Background(), recorder, recorder, db, stateStore,
+		server.URL, map[string]any{"query": "question", "run_id": runID},
+		"conv-stream-decision", "question", historyID,
+		chatPersistTarget{HistoryID: historyID, Seq: 1}, json.RawMessage(`{}`),
+	)
+	if won, err := claimUserCancelDecision(
+		context.Background(), stateStore, "conv-stream-decision", historyID, runID,
+	); err != nil || won {
+		t.Fatalf("late cancellation: won=%v err=%v", won, err)
+	}
+
+	var history orm.ChatHistory
+	if err := db.Where("id = ?", historyID).Take(&history).Error; err != nil {
+		t.Fatalf("load failed history: %v", err)
+	}
+	terminal, err := parseRunTerminal(history.RunTerminal)
+	if err != nil {
+		t.Fatalf("parse failed terminal: %v", err)
+	}
+	if history.RunStatus != "failed" || terminal.Reason != "model_failure" || terminal.Code != "rate_limited" {
+		t.Fatalf("late stop overwrote model failure: history=%#v terminal=%#v", history, terminal)
+	}
+	if body := recorder.Body.String(); !strings.Contains(body, `"status":"failed"`) || strings.Contains(body, `"status":"cancelled"`) {
+		t.Fatalf("unexpected failure stream: %s", body)
+	}
+}

--- a/backend/core/chat/run_decision_test.go
+++ b/backend/core/chat/run_decision_test.go
@@ -1,0 +1,163 @@
+package chat
+
+import (
+	"context"
+	"encoding/json"
+	"path/filepath"
+	"testing"
+
+	"lazymind/core/common/orm"
+	"lazymind/core/state"
+)
+
+func newRunDecisionTestStore(t *testing.T) state.Store {
+	t.Helper()
+	store, err := state.NewSQLiteStore(filepath.Join(t.TempDir(), "state.db"))
+	if err != nil {
+		t.Fatalf("create state store: %v", err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+	return store
+}
+
+func TestRunDecisionUserCancelWinsWhileRunIsActive(t *testing.T) {
+	ctx := context.Background()
+	store := newRunDecisionTestStore(t)
+	won, err := claimUserCancelDecision(ctx, store, "conv", "history", "run-1")
+	if err != nil || !won {
+		t.Fatalf("claim cancellation: won=%v err=%v", won, err)
+	}
+
+	terminal := resolveRunTerminal(ctx, store, "conv", "history", "run-1", &RunTerminal{
+		Status: "failed", Reason: "runtime_failure", Code: "upstream_stream_failed",
+		PartialOutput: true,
+	}, true, "upstream_terminal")
+
+	if terminal.Status != "cancelled" || terminal.Reason != "user_cancelled" || !terminal.PartialOutput || terminal.Code != "" {
+		t.Fatalf("unexpected cancellation terminal: %#v", terminal)
+	}
+}
+
+func TestRunDecisionAcceptedFailureIsNotOverwrittenByStop(t *testing.T) {
+	ctx := context.Background()
+	store := newRunDecisionTestStore(t)
+	failure := &RunTerminal{
+		Status: "failed", Reason: "model_failure", Code: "rate_limited",
+		PartialOutput: false,
+	}
+	accepted := resolveRunTerminal(
+		ctx, store, "conv", "history", "run-1", failure, false, "upstream_terminal",
+	)
+	if accepted.Status != "failed" || accepted.Reason != "model_failure" {
+		t.Fatalf("unexpected accepted terminal: %#v", accepted)
+	}
+
+	won, err := claimUserCancelDecision(ctx, store, "conv", "history", "run-1")
+	if err != nil {
+		t.Fatalf("claim late cancellation: %v", err)
+	}
+	if won {
+		t.Fatal("late cancellation overwrote accepted failure")
+	}
+
+	resolved := resolveRunTerminal(ctx, store, "conv", "history", "run-1", &RunTerminal{
+		Status: "cancelled", Reason: "user_cancelled", PartialOutput: true,
+	}, true, "late_terminal")
+	if *resolved != *failure {
+		t.Fatalf("accepted failure changed: got %#v want %#v", resolved, failure)
+	}
+}
+
+func TestRunDecisionRepeatedUserCancelIsIdempotent(t *testing.T) {
+	ctx := context.Background()
+	store := newRunDecisionTestStore(t)
+	for attempt := 0; attempt < 2; attempt++ {
+		won, err := claimUserCancelDecision(ctx, store, "conv", "history", "run-1")
+		if err != nil || !won {
+			t.Fatalf("claim cancellation attempt %d: won=%v err=%v", attempt+1, won, err)
+		}
+	}
+
+	terminal := resolveRunTerminal(ctx, store, "conv", "history", "run-1", &RunTerminal{
+		Status: "completed", Reason: "normal", PartialOutput: true,
+	}, true, "late_terminal")
+	if terminal.Status != "cancelled" || terminal.Reason != "user_cancelled" {
+		t.Fatalf("repeated cancellation changed the winning decision: %#v", terminal)
+	}
+}
+
+func TestRunDecisionIsIsolatedByRunID(t *testing.T) {
+	ctx := context.Background()
+	store := newRunDecisionTestStore(t)
+	if won, err := claimUserCancelDecision(ctx, store, "conv", "history", "run-1"); err != nil || !won {
+		t.Fatalf("claim first run cancellation: won=%v err=%v", won, err)
+	}
+
+	second := resolveRunTerminal(ctx, store, "conv", "history", "run-2", &RunTerminal{
+		Status: "failed", Reason: "runtime_failure", Code: "upstream_stream_failed",
+		PartialOutput: false,
+	}, false, "upstream_terminal")
+	if second.Status != "failed" || second.Reason != "runtime_failure" {
+		t.Fatalf("first run cancellation leaked into second run: %#v", second)
+	}
+}
+
+func TestResolveRuntimeChunkDecisionRewritesEventToWinningCancellation(t *testing.T) {
+	ctx := context.Background()
+	store := newRunDecisionTestStore(t)
+	if won, err := claimUserCancelDecision(ctx, store, "conv", "history", "run-1"); err != nil || !won {
+		t.Fatalf("claim cancellation: won=%v err=%v", won, err)
+	}
+	candidateEvent := failedRunEvent("run-1", "upstream_stream_failed", true)
+	candidate, _ := candidateEvent.Terminal()
+
+	decision := resolveRuntimeChunkDecision(
+		ctx, store, "conv", "history", "run-1",
+		runtimeChunkDecision{Event: candidateEvent, Terminal: candidate, Stop: true}, true,
+	)
+	terminal, err := decision.Event.Terminal()
+	if err != nil {
+		t.Fatalf("parse resolved event: %v", err)
+	}
+	if terminal.Status != "cancelled" || decision.Terminal.Status != "cancelled" || !decision.Stop {
+		t.Fatalf("unexpected resolved decision: %#v terminal=%#v", decision, terminal)
+	}
+}
+
+func TestExternalTerminalProjectionPersistsCoreDecision(t *testing.T) {
+	ctx := context.Background()
+	app, db := newExternalChatTestApplication(t)
+	createExternalChatTestRun(t, app, "run-external-decision")
+	job, err := app.claim(ctx, "user-1", ChatExecutorCodex, "host-1")
+	if err != nil || job == nil {
+		t.Fatalf("claim external run: job=%#v err=%v", job, err)
+	}
+	if _, err := app.appendEvent(
+		ctx, "user-1", job.RunID, "host-1", job.LeaseToken,
+		externalChatEvent{EventID: "failed-1", Type: "failed", Error: "provider failed"},
+	); err != nil {
+		t.Fatalf("append external failure: %v", err)
+	}
+
+	store := newRunDecisionTestStore(t)
+	if won, err := claimUserCancelDecision(
+		ctx, store, "conversation-1", "history-run-external-decision", job.RunID,
+	); err != nil || !won {
+		t.Fatalf("claim cancellation: won=%v err=%v", won, err)
+	}
+	if err := projectExternalChatRunStatus(ctx, db, store, "user-1", job.RunID); err != nil {
+		t.Fatalf("project external terminal: %v", err)
+	}
+
+	var history orm.ChatHistory
+	if err := db.Where("id = ?", "history-run-external-decision").Take(&history).Error; err != nil {
+		t.Fatalf("load projected history: %v", err)
+	}
+	var terminal RunTerminal
+	if err := json.Unmarshal(history.RunTerminal, &terminal); err != nil {
+		t.Fatalf("decode projected terminal: %v", err)
+	}
+	if history.RunStatus != "cancelled" || terminal.Status != "cancelled" || terminal.Reason != "user_cancelled" {
+		t.Fatalf("external history did not persist Core decision: history=%#v terminal=%#v", history, terminal)
+	}
+}

--- a/backend/core/chat/run_decision_test.go
+++ b/backend/core/chat/run_decision_test.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"encoding/json"
 	"path/filepath"
+	"sync"
 	"testing"
+	"time"
 
 	"lazymind/core/common/orm"
 	"lazymind/core/state"
@@ -31,7 +33,7 @@ func TestRunDecisionUserCancelWinsWhileRunIsActive(t *testing.T) {
 	terminal := resolveRunTerminal(ctx, store, "conv", "history", "run-1", &RunTerminal{
 		Status: "failed", Reason: "runtime_failure", Code: "upstream_stream_failed",
 		PartialOutput: true,
-	}, true, "upstream_terminal")
+	}, "upstream_terminal")
 
 	if terminal.Status != "cancelled" || terminal.Reason != "user_cancelled" || !terminal.PartialOutput || terminal.Code != "" {
 		t.Fatalf("unexpected cancellation terminal: %#v", terminal)
@@ -46,7 +48,7 @@ func TestRunDecisionAcceptedFailureIsNotOverwrittenByStop(t *testing.T) {
 		PartialOutput: false,
 	}
 	accepted := resolveRunTerminal(
-		ctx, store, "conv", "history", "run-1", failure, false, "upstream_terminal",
+		ctx, store, "conv", "history", "run-1", failure, "upstream_terminal",
 	)
 	if accepted.Status != "failed" || accepted.Reason != "model_failure" {
 		t.Fatalf("unexpected accepted terminal: %#v", accepted)
@@ -62,7 +64,7 @@ func TestRunDecisionAcceptedFailureIsNotOverwrittenByStop(t *testing.T) {
 
 	resolved := resolveRunTerminal(ctx, store, "conv", "history", "run-1", &RunTerminal{
 		Status: "cancelled", Reason: "user_cancelled", PartialOutput: true,
-	}, true, "late_terminal")
+	}, "late_terminal")
 	if *resolved != *failure {
 		t.Fatalf("accepted failure changed: got %#v want %#v", resolved, failure)
 	}
@@ -80,7 +82,7 @@ func TestRunDecisionRepeatedUserCancelIsIdempotent(t *testing.T) {
 
 	terminal := resolveRunTerminal(ctx, store, "conv", "history", "run-1", &RunTerminal{
 		Status: "completed", Reason: "normal", PartialOutput: true,
-	}, true, "late_terminal")
+	}, "late_terminal")
 	if terminal.Status != "cancelled" || terminal.Reason != "user_cancelled" {
 		t.Fatalf("repeated cancellation changed the winning decision: %#v", terminal)
 	}
@@ -96,7 +98,7 @@ func TestRunDecisionIsIsolatedByRunID(t *testing.T) {
 	second := resolveRunTerminal(ctx, store, "conv", "history", "run-2", &RunTerminal{
 		Status: "failed", Reason: "runtime_failure", Code: "upstream_stream_failed",
 		PartialOutput: false,
-	}, false, "upstream_terminal")
+	}, "upstream_terminal")
 	if second.Status != "failed" || second.Reason != "runtime_failure" {
 		t.Fatalf("first run cancellation leaked into second run: %#v", second)
 	}
@@ -113,7 +115,7 @@ func TestResolveRuntimeChunkDecisionRewritesEventToWinningCancellation(t *testin
 
 	decision := resolveRuntimeChunkDecision(
 		ctx, store, "conv", "history", "run-1",
-		runtimeChunkDecision{Event: candidateEvent, Terminal: candidate, Stop: true}, true,
+		runtimeChunkDecision{Event: candidateEvent, Terminal: candidate, Stop: true}, true, true,
 	)
 	terminal, err := decision.Event.Terminal()
 	if err != nil {
@@ -124,7 +126,24 @@ func TestResolveRuntimeChunkDecisionRewritesEventToWinningCancellation(t *testin
 	}
 }
 
-func TestExternalTerminalProjectionPersistsCoreDecision(t *testing.T) {
+func TestExternalRuntimeChunkUsesDurableTerminalWithoutSharedDecision(t *testing.T) {
+	ctx := context.Background()
+	stateStore := newRunDecisionTestStore(t)
+	if cancelIsWinner, err := claimUserCancelDecision(ctx, stateStore, "conv", "history", "external-run"); err != nil || !cancelIsWinner {
+		t.Fatalf("seed unrelated shared cancellation: winner=%v err=%v", cancelIsWinner, err)
+	}
+	event := failedRunEvent("external-run", "external_agent_failed", false)
+	terminal, _ := event.Terminal()
+	decision := resolveRuntimeChunkDecision(
+		ctx, stateStore, "conv", "history", "external-run",
+		runtimeChunkDecision{Event: event, Terminal: terminal, Stop: true}, false, false,
+	)
+	if decision.Terminal.Status != "failed" || decision.Terminal.Reason != "runtime_failure" {
+		t.Fatalf("shared decision changed external terminal: %#v", decision.Terminal)
+	}
+}
+
+func TestExternalTerminalProjectionIgnoresSharedRunDecision(t *testing.T) {
 	ctx := context.Background()
 	app, db := newExternalChatTestApplication(t)
 	createExternalChatTestRun(t, app, "run-external-decision")
@@ -145,7 +164,7 @@ func TestExternalTerminalProjectionPersistsCoreDecision(t *testing.T) {
 	); err != nil || !won {
 		t.Fatalf("claim cancellation: won=%v err=%v", won, err)
 	}
-	if err := projectExternalChatRunStatus(ctx, db, store, "user-1", job.RunID); err != nil {
+	if err := projectExternalChatRunCache(ctx, db, store, "user-1", job.RunID); err != nil {
 		t.Fatalf("project external terminal: %v", err)
 	}
 
@@ -157,7 +176,84 @@ func TestExternalTerminalProjectionPersistsCoreDecision(t *testing.T) {
 	if err := json.Unmarshal(history.RunTerminal, &terminal); err != nil {
 		t.Fatalf("decode projected terminal: %v", err)
 	}
-	if history.RunStatus != "cancelled" || terminal.Status != "cancelled" || terminal.Reason != "user_cancelled" {
-		t.Fatalf("external history did not persist Core decision: history=%#v terminal=%#v", history, terminal)
+	if history.RunStatus != "failed" || terminal.Status != "failed" || terminal.Reason != "runtime_failure" {
+		t.Fatalf("external history did not preserve durable terminal: history=%#v terminal=%#v", history, terminal)
+	}
+	if err := store.Close(); err != nil {
+		t.Fatalf("close cache store: %v", err)
+	}
+	if err := projectExternalChatRunCache(ctx, db, store, "user-1", job.RunID); err == nil {
+		t.Fatal("expected closed cache projection to fail")
+	}
+	var durable orm.ChatHistory
+	if err := db.Where("id = ?", history.ID).Take(&durable).Error; err != nil {
+		t.Fatalf("reload durable history: %v", err)
+	}
+	if durable.RunStatus != "failed" || string(durable.RunTerminal) != string(history.RunTerminal) {
+		t.Fatalf("cache failure changed durable terminal: before=%#v after=%#v", history, durable)
+	}
+}
+
+func TestRunDecisionConcurrentCandidatesHaveOneWinner(t *testing.T) {
+	assertConcurrentRunDecisionWinner(t, newRunDecisionTestStore(t), "sqlite-concurrent")
+}
+
+func assertConcurrentRunDecisionWinner(t *testing.T, store state.Store, runID string) {
+	t.Helper()
+	ctx := context.Background()
+	candidates := []runDecision{
+		{Kind: runDecisionUserCancel, Source: "user_stop"},
+		{Kind: runDecisionTerminal, Source: "model", Terminal: &RunTerminal{Status: "failed", Reason: "model_failure", Code: "rate_limited"}},
+		{Kind: runDecisionTerminal, Source: "runtime", Terminal: &RunTerminal{Status: "failed", Reason: "runtime_failure", Code: "transport_error"}},
+	}
+	start := make(chan struct{})
+	accepted := make(chan bool, len(candidates))
+	errs := make(chan error, len(candidates))
+	var wait sync.WaitGroup
+	for _, candidate := range candidates {
+		candidate := candidate
+		wait.Add(1)
+		go func() {
+			defer wait.Done()
+			<-start
+			_, won, err := claimRunDecision(ctx, store, "conv", "history", runID, candidate)
+			accepted <- won
+			errs <- err
+		}()
+	}
+	close(start)
+	wait.Wait()
+	close(accepted)
+	close(errs)
+	for err := range errs {
+		if err != nil {
+			t.Fatalf("concurrent decision: %v", err)
+		}
+	}
+	winners := 0
+	for won := range accepted {
+		if won {
+			winners++
+		}
+	}
+	if winners != 1 {
+		t.Fatalf("accepted winners=%d, want 1", winners)
+	}
+	payload, err := store.Get(ctx, runDecisionKey("conv", "history", runID))
+	if err != nil {
+		t.Fatalf("load winner: %v", err)
+	}
+	var winner runDecision
+	if err := json.Unmarshal(payload, &winner); err != nil {
+		t.Fatalf("decode winner: %v", err)
+	}
+	if winner.Kind != runDecisionUserCancel && winner.Kind != runDecisionTerminal {
+		t.Fatalf("invalid winner: %#v", winner)
+	}
+}
+
+func TestRunDecisionTTLRejectsLateCandidatesForOneDay(t *testing.T) {
+	if runDecisionTTL != 24*time.Hour {
+		t.Fatalf("runDecisionTTL=%v, want 24h", runDecisionTTL)
 	}
 }

--- a/backend/core/common/error_catalog_internal.go
+++ b/backend/core/common/error_catalog_internal.go
@@ -545,6 +545,7 @@ func init() {
 		registerAdditionalErrorAlias(source, "Upstream service error", http.StatusBadGateway, 2000110)
 	}
 	registerAdditionalErrorPattern("chat service returned status %d", "Upstream service error", http.StatusBadGateway, 2000110)
+	registerAdditionalErrorAlias("record chat cancellation failed", "Upstream service error", http.StatusServiceUnavailable, 2000110)
 	registerAdditionalErrorPattern("migrate model provider credential %s", "Internal server error", http.StatusInternalServerError, 2000000)
 	registerAdditionalErrorPattern("load workflow head revision %s", "Internal server error", http.StatusInternalServerError, 2000000)
 	registerAdditionalErrorPattern("session_ids must belong to user %q and must not contain plugin conversations", "Invalid request", http.StatusBadRequest, 2000103)

--- a/backend/core/workflow/hooks.go
+++ b/backend/core/workflow/hooks.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"time"
 
 	"gorm.io/gorm"
 
@@ -16,6 +17,8 @@ import (
 	"lazymind/core/subagent"
 	"lazymind/core/taskcenter"
 )
+
+var chatCancelHTTPClient = &http.Client{Timeout: 5 * time.Second}
 
 // RegisterSubAgentHooks wires plugin lifecycle hooks into the subagent EventHooks.
 // Must be called once at application startup (after store is initialized).
@@ -30,7 +33,13 @@ func RegisterSubAgentHooks() {
 		if db != nil {
 			StopActiveWorkflowSession(ctx, db, stateStore, convID)
 		}
-		go NotifyChatCancel(convID)
+		go func() {
+			cancelCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 5*time.Second)
+			defer cancel()
+			if err := NotifyChatCancel(cancelCtx, convID); err != nil {
+				fmt.Printf("[plugin] NotifyChatCancel: %v\n", err)
+			}
+		}()
 	}
 }
 
@@ -258,16 +267,24 @@ func notifyTaskCancel(taskID string) {
 
 // NotifyChatCancel posts a cancel signal to the Python chat service so that
 // the active ChatAgent session for the given conversation terminates.
-// Called by StopChatGeneration in a goroutine; errors are logged and suppressed.
-func NotifyChatCancel(convID string) {
+// Callers own retry/logging policy; the request itself is always bounded.
+func NotifyChatCancel(ctx context.Context, convID string) error {
 	body, _ := json.Marshal(map[string]string{
 		"conversation_id": convID,
 	})
 	url := common.JoinURL(common.ChatServiceEndpoint(), "/api/workflow/task-cancel")
-	resp, err := http.Post(url, "application/json", bytes.NewReader(body)) //nolint:noctx
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
 	if err != nil {
-		fmt.Printf("[plugin] NotifyChatCancel: %v\n", err)
-		return
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := chatCancelHTTPClient.Do(req)
+	if err != nil {
+		return err
 	}
 	_ = resp.Body.Close()
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		return fmt.Errorf("chat cancel returned HTTP %d", resp.StatusCode)
+	}
+	return nil
 }

--- a/backend/core/workflow/hooks.go
+++ b/backend/core/workflow/hooks.go
@@ -284,7 +284,7 @@ func NotifyChatCancel(ctx context.Context, convID string) error {
 	}
 	_ = resp.Body.Close()
 	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
-		return fmt.Errorf("chat cancel returned HTTP %d", resp.StatusCode)
+		return fmt.Errorf("chat service returned status %d", resp.StatusCode)
 	}
 	return nil
 }

--- a/frontend/src/i18n/locales/en-US.ts
+++ b/frontend/src/i18n/locales/en-US.ts
@@ -1762,7 +1762,6 @@ const enUS = {
       completed: "Answer complete",
       interrupted: "Answer generation was interrupted",
       failed: "Model call failed",
-      modelFailed: "Model call failed",
       runtimeFailed: "Runtime failed",
       cancelled: "Generation cancelled",
       partialOutput: "The partial output has been preserved.",

--- a/frontend/src/i18n/locales/en-US.ts
+++ b/frontend/src/i18n/locales/en-US.ts
@@ -1762,6 +1762,8 @@ const enUS = {
       completed: "Answer complete",
       interrupted: "Answer generation was interrupted",
       failed: "Model call failed",
+      modelFailed: "Model call failed",
+      runtimeFailed: "Runtime failed",
       cancelled: "Generation cancelled",
       partialOutput: "The partial output has been preserved.",
       noOutput: "No usable output was generated.",

--- a/frontend/src/i18n/locales/zh-CN.ts
+++ b/frontend/src/i18n/locales/zh-CN.ts
@@ -1715,6 +1715,8 @@ const zhCN = {
       completed: "回答已完成",
       interrupted: "回答未完整生成",
       failed: "模型调用失败",
+      modelFailed: "模型调用失败",
+      runtimeFailed: "运行失败",
       cancelled: "已取消生成",
       partialOutput: "已生成的部分内容已保留。",
       noOutput: "本次未生成可用内容。",

--- a/frontend/src/i18n/locales/zh-CN.ts
+++ b/frontend/src/i18n/locales/zh-CN.ts
@@ -1715,7 +1715,6 @@ const zhCN = {
       completed: "回答已完成",
       interrupted: "回答未完整生成",
       failed: "模型调用失败",
-      modelFailed: "模型调用失败",
       runtimeFailed: "运行失败",
       cancelled: "已取消生成",
       partialOutput: "已生成的部分内容已保留。",

--- a/frontend/src/modules/chat/components/RunStatusCard/index.test.tsx
+++ b/frontend/src/modules/chat/components/RunStatusCard/index.test.tsx
@@ -24,6 +24,19 @@ describe("RunStatusCard", () => {
     expect(screen.getByText("chat.runStatus.partialOutput")).toBeInTheDocument();
   });
 
+  it("uses the cancellation reason as the presentation authority", () => {
+    render(<RunStatusCard terminal={{
+      status: "failed",
+      reason: "user_cancelled",
+      partial_output: false,
+    }} />);
+
+    const alert = screen.getByRole("alert");
+    expect(alert).toHaveClass("chat-run-status-card--cancelled");
+    expect(screen.getByText("chat.runStatus.cancelled")).toBeInTheDocument();
+    expect(screen.queryByText(/chat\.runStatus\.providerError/)).not.toBeInTheDocument();
+  });
+
   it.each([
     "usage_limit_exceeded",
     "concurrency_limited",
@@ -36,8 +49,34 @@ describe("RunStatusCard", () => {
       partial_output: false,
     }} />);
 
+    expect(screen.getByText("chat.runStatus.modelFailed")).toBeInTheDocument();
     expect(screen.getByText(new RegExp(`chat\\.runStatus\\.codes\\.${code}`))).toBeInTheDocument();
     expect(screen.getByText(/chat\.runStatus\.noOutput/)).toBeInTheDocument();
+  });
+
+  it("renders runtime failures with a runtime title and red alert", () => {
+    render(<RunStatusCard terminal={{
+      status: "failed",
+      reason: "runtime_failure",
+      code: "upstream_stream_failed",
+      partial_output: true,
+    }} />);
+
+    const alert = screen.getByRole("alert");
+    expect(alert).not.toHaveClass("chat-run-status-card--cancelled");
+    expect(screen.getByText("chat.runStatus.runtimeFailed")).toBeInTheDocument();
+    expect(screen.getByText(/chat\.runStatus\.runtimeError/)).toBeInTheDocument();
+  });
+
+  it("renders incomplete model output with the interrupted title", () => {
+    render(<RunStatusCard terminal={{
+      status: "interrupted",
+      reason: "model_incomplete",
+      code: "length",
+      partial_output: true,
+    }} />);
+
+    expect(screen.getByText("chat.runStatus.interrupted")).toBeInTheDocument();
   });
 
   it("renders a safe provider reason and partial-output state", () => {
@@ -48,7 +87,7 @@ describe("RunStatusCard", () => {
       partial_output: true,
     }} />);
 
-    expect(screen.getByText("chat.runStatus.interrupted")).toBeInTheDocument();
+    expect(screen.getByText("chat.runStatus.modelFailed")).toBeInTheDocument();
     expect(screen.getByText(/chat\.runStatus\.codes\.organization_spend_limit_exceeded/)).toBeInTheDocument();
     expect(screen.getByText(/chat\.runStatus\.partialOutput/)).toBeInTheDocument();
     expect(screen.queryByText(/HTTP/)).not.toBeInTheDocument();

--- a/frontend/src/modules/chat/components/RunStatusCard/index.test.tsx
+++ b/frontend/src/modules/chat/components/RunStatusCard/index.test.tsx
@@ -24,7 +24,7 @@ describe("RunStatusCard", () => {
     expect(screen.getByText("chat.runStatus.partialOutput")).toBeInTheDocument();
   });
 
-  it("uses the cancellation reason as the presentation authority", () => {
+  it("does not let an invalid cancellation reason override failed status", () => {
     render(<RunStatusCard terminal={{
       status: "failed",
       reason: "user_cancelled",
@@ -32,9 +32,9 @@ describe("RunStatusCard", () => {
     }} />);
 
     const alert = screen.getByRole("alert");
-    expect(alert).toHaveClass("chat-run-status-card--cancelled");
-    expect(screen.getByText("chat.runStatus.cancelled")).toBeInTheDocument();
-    expect(screen.queryByText(/chat\.runStatus\.providerError/)).not.toBeInTheDocument();
+    expect(alert).not.toHaveClass("chat-run-status-card--cancelled");
+    expect(screen.getByText("chat.runStatus.failed")).toBeInTheDocument();
+    expect(screen.getByText(/chat\.runStatus\.providerError/)).toBeInTheDocument();
   });
 
   it.each([
@@ -49,7 +49,7 @@ describe("RunStatusCard", () => {
       partial_output: false,
     }} />);
 
-    expect(screen.getByText("chat.runStatus.modelFailed")).toBeInTheDocument();
+    expect(screen.getByText("chat.runStatus.failed")).toBeInTheDocument();
     expect(screen.getByText(new RegExp(`chat\\.runStatus\\.codes\\.${code}`))).toBeInTheDocument();
     expect(screen.getByText(/chat\.runStatus\.noOutput/)).toBeInTheDocument();
   });
@@ -87,7 +87,7 @@ describe("RunStatusCard", () => {
       partial_output: true,
     }} />);
 
-    expect(screen.getByText("chat.runStatus.modelFailed")).toBeInTheDocument();
+    expect(screen.getByText("chat.runStatus.failed")).toBeInTheDocument();
     expect(screen.getByText(/chat\.runStatus\.codes\.organization_spend_limit_exceeded/)).toBeInTheDocument();
     expect(screen.getByText(/chat\.runStatus\.partialOutput/)).toBeInTheDocument();
     expect(screen.queryByText(/HTTP/)).not.toBeInTheDocument();

--- a/frontend/src/modules/chat/components/RunStatusCard/index.tsx
+++ b/frontend/src/modules/chat/components/RunStatusCard/index.tsx
@@ -42,12 +42,16 @@ export interface RunTerminalView {
   partial_output: boolean;
 }
 
+function isUserCancelledTerminal(terminal: RunTerminalView): boolean {
+  return terminal.status === "cancelled" || terminal.reason === "user_cancelled";
+}
+
 export function runStatusDescription(
   terminal: RunTerminalView,
   t: TFunction,
 ): string {
   const parts: string[] = [];
-  if (terminal.status !== "cancelled") {
+  if (!isUserCancelledTerminal(terminal)) {
     const reasonKey = terminal.code && KNOWN_CODES.has(terminal.code)
       ? `chat.runStatus.codes.${terminal.code}`
       : terminal.reason === "model_incomplete"
@@ -65,6 +69,22 @@ export function runStatusDescription(
   return parts.join(" ");
 }
 
+export function runStatusTitleKey(terminal: RunTerminalView): string {
+  if (isUserCancelledTerminal(terminal)) {
+    return "chat.runStatus.cancelled";
+  }
+  if (terminal.reason === "model_failure") {
+    return "chat.runStatus.modelFailed";
+  }
+  if (terminal.reason === "model_incomplete") {
+    return "chat.runStatus.interrupted";
+  }
+  if (terminal.reason === "runtime_failure") {
+    return "chat.runStatus.runtimeFailed";
+  }
+  return `chat.runStatus.${terminal.status}`;
+}
+
 export default function RunStatusCard({
   terminal,
 }: {
@@ -75,7 +95,7 @@ export default function RunStatusCard({
     return null;
   }
   const description = runStatusDescription(terminal, t);
-  const isCancelled = terminal.status === "cancelled";
+  const isCancelled = isUserCancelledTerminal(terminal);
   const className = isCancelled
     ? "chat-run-status-card chat-run-status-card--cancelled"
     : "chat-run-status-card";
@@ -85,7 +105,7 @@ export default function RunStatusCard({
       type={isCancelled ? "warning" : "error"}
       showIcon
       icon={isCancelled ? <StopOutlined aria-hidden="true" /> : undefined}
-      message={t(`chat.runStatus.${terminal.status}`)}
+      message={t(runStatusTitleKey(terminal))}
       description={description}
     />
   );

--- a/frontend/src/modules/chat/components/RunStatusCard/index.tsx
+++ b/frontend/src/modules/chat/components/RunStatusCard/index.tsx
@@ -43,7 +43,7 @@ export interface RunTerminalView {
 }
 
 function isUserCancelledTerminal(terminal: RunTerminalView): boolean {
-  return terminal.status === "cancelled" || terminal.reason === "user_cancelled";
+  return terminal.status === "cancelled";
 }
 
 export function runStatusDescription(
@@ -74,7 +74,7 @@ export function runStatusTitleKey(terminal: RunTerminalView): string {
     return "chat.runStatus.cancelled";
   }
   if (terminal.reason === "model_failure") {
-    return "chat.runStatus.modelFailed";
+    return "chat.runStatus.failed";
   }
   if (terminal.reason === "model_incomplete") {
     return "chat.runStatus.interrupted";


### PR DESCRIPTION
## Summary

- keep a run-scoped Core decision record for LazyMind Chat, Workflow, and SubAgent runs, using atomic first-writer-wins semantics for user cancellation versus terminal outcomes
- use the existing ExternalChatRun row-lock transaction as the only terminal authority for External Agent runs; Redis projection is cache-only and never rewrites durable history
- guard regenerated history and derived cache terminals by history_id plus run_id so late runs cannot overwrite the current run
- emit an explicit Python cancelled/user_cancelled terminal through UserCancelledError and the shared RunAccumulator
- render only status=cancelled in grey; model failure, incomplete output, and runtime failure remain red with distinct titles
- keep the public stop API and run_finished protocol unchanged; no database migration is required

## Behavior

- when Core accepts a stop while an internal run is active, cancellation wins and later EOF, transport, tool, or subtask errors remain cancelled/user_cancelled
- when Core has already accepted a model or runtime failure, a later stop remains idempotent and does not overwrite the failure
- External Agent stop, failure, and completion compete in one durable database transaction; active streaming and resume read that committed result
- decisions and history writes are isolated by run_id, so regeneration and adjacent turns cannot inherit or overwrite an earlier terminal
- cancellation wakeup and Python notification errors are bounded, logged with identifiers, and surfaced by the existing stop endpoint failure response

## Tests

- go test ./chat ./workflow ./state ./subagent -count=1
- go vet ./chat ./workflow ./state ./subagent
- real temporary Redis: TestRedisCancelWatcherReleasesConnections, including concurrent SetNX candidates and pool recovery
- Python cancellation and runtime terminal tests: 22 passed
- frontend RunStatusCard tests: 9 passed
- scoped frontend ESLint passed
- git diff --check passed

## Local validation notes

- the repository-wide frontend Vitest command is currently affected by localStorage and matchMedia environment failures in unrelated suites; the touched RunStatusCard suite passes independently
- repository-wide tsc --noEmit still reports existing generated-client and unrelated module errors; no error points to the touched RunStatusCard or locale files