### PR TITLE
fix codex history bug

### DIFF
--- a/backend/core/chat/conversation.go
+++ b/backend/core/chat/conversation.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"regexp"
 	"sort"
 	"strconv"
 	"strings"
@@ -26,6 +27,11 @@ import (
 	"lazymind/core/subagent"
 	"lazymind/core/taskcenter"
 	"lazymind/core/workflow"
+)
+
+var (
+	codexRequestMarkerPattern = regexp.MustCompile(`(?im)^#+\s*My request for Codex:\s*$`)
+	codexImageTagPattern      = regexp.MustCompile(`(?i)</?image\b[^>]*>`)
 )
 
 func writeConversationJSON(w http.ResponseWriter, status int, v any) {
@@ -1389,6 +1395,9 @@ func chatHistoryToResponseItem(h orm.ChatHistory) map[string]any {
 }
 
 func displayChatHistoryContent(raw string) string {
+	if marker := codexRequestMarkerPattern.FindStringIndex(raw); marker != nil {
+		return strings.TrimSpace(codexImageTagPattern.ReplaceAllString(raw[marker[1]:], ""))
+	}
 	const openTag = "<current-task-request>"
 	const closeTag = "</current-task-request>"
 	start := strings.LastIndex(raw, openTag)
@@ -1884,6 +1893,34 @@ func ListConversations(w http.ResponseWriter, r *http.Request) {
 			q = q.Where("NOT EXISTS (?)", externalBinding)
 		} else {
 			q = q.Where("EXISTS (?)", validatedExternalBinding.Where("validated_bindings.provider = ?", assistantFilter))
+		}
+	}
+	assistantsFilter := strings.ToLower(strings.TrimSpace(r.URL.Query().Get("assistants")))
+	if assistantsFilter != "" {
+		requested := strings.Split(assistantsFilter, ",")
+		providers := make([]string, 0, len(requested))
+		includeLazyMind := false
+		for _, candidate := range requested {
+			candidate = strings.TrimSpace(candidate)
+			normalized, valid := normalizeChatExecutor(candidate)
+			if !valid || normalized != candidate {
+				common.ReplyErr(w, "assistants contains an unsupported chat executor", http.StatusBadRequest)
+				return
+			}
+			if normalized == ChatExecutorLazyMind {
+				includeLazyMind = true
+			} else {
+				providers = append(providers, normalized)
+			}
+		}
+		switch {
+		case includeLazyMind && len(providers) > 0:
+			q = q.Where("NOT EXISTS (?) OR EXISTS (?)", externalBinding,
+				validatedExternalBinding.Where("validated_bindings.provider IN ?", providers))
+		case includeLazyMind:
+			q = q.Where("NOT EXISTS (?)", externalBinding)
+		case len(providers) > 0:
+			q = q.Where("EXISTS (?)", validatedExternalBinding.Where("validated_bindings.provider IN ?", providers))
 		}
 	}
 	if keyword != "" {

--- a/backend/core/chat/conversation_utils_test.go
+++ b/backend/core/chat/conversation_utils_test.go
@@ -179,6 +179,13 @@ func TestDisplayChatHistoryContent_Passthrough(t *testing.T) {
 	}
 }
 
+func TestDisplayChatHistoryContent_NormalizesImportedCodexEnvelope(t *testing.T) {
+	raw := "# Files mentioned by the user:\n\n## image.png: /tmp/image.png\n\n## My request for Codex:\n修复界面\n<image path=\"/tmp/image.png\"></image>"
+	if got, want := displayChatHistoryContent(raw), "修复界面"; got != want {
+		t.Fatalf("got %q, want %q", got, want)
+	}
+}
+
 // TestDisplayChatHistoryContent_ExtractsTaskRequestContent extracts text between tags.
 func TestDisplayChatHistoryContent_ExtractsTaskRequestContent(t *testing.T) {
 	raw := "prefix <current-task-request>do this</current-task-request> suffix"

--- a/backend/core/chat/external_chat.go
+++ b/backend/core/chat/external_chat.go
@@ -65,6 +65,7 @@ type chatExecutorStatus struct {
 	Installed         bool   `json:"installed"`
 	HostOnline        bool   `json:"host_online"`
 	Available         bool   `json:"available"`
+	Connected         bool   `json:"connected"`
 	UnavailableReason string `json:"unavailable_reason,omitempty"`
 }
 

--- a/backend/core/chat/external_chat_http.go
+++ b/backend/core/chat/external_chat_http.go
@@ -39,6 +39,14 @@ func ListChatExecutors(w http.ResponseWriter, r *http.Request) {
 			}
 			status.Installed, status.HostOnline, status.Available = host.Installed, host.HostOnline, host.Available
 			status.UnavailableReason = host.UnavailableReason
+			var connectedSessions int64
+			if err := store.DB().WithContext(r.Context()).Model(&orm.ExternalAgentSession{}).
+				Where("owner_user_id = ? AND provider = ? AND active = ?", owner, definition.ID, true).
+				Count(&connectedSessions).Error; err != nil {
+				common.ReplyErr(w, err.Error(), http.StatusServiceUnavailable)
+				return
+			}
+			status.Connected = connectedSessions > 0
 		}
 		executors = append(executors, status)
 	}

--- a/backend/core/common/error_catalog_additional.go
+++ b/backend/core/common/error_catalog_additional.go
@@ -323,6 +323,7 @@ func init() {
 	registerAdditionalError("task is terminal", http.StatusConflict, 2002049)
 	registerAdditionalError("chat_executor must be 'lazymind', 'codex', 'cursor', or 'workbuddy'", http.StatusBadRequest, 2002050)
 	registerAdditionalErrorAlias("assistant must be 'lazymind', 'codex', 'cursor', or 'workbuddy'", "chat_executor must be 'lazymind', 'codex', 'cursor', or 'workbuddy'", http.StatusBadRequest, 2002050)
+	registerAdditionalErrorAlias("assistants contains an unsupported chat executor", "chat_executor must be 'lazymind', 'codex', 'cursor', or 'workbuddy'", http.StatusBadRequest, 2002050)
 	registerAdditionalError("conversation has an unsupported chat executor", http.StatusConflict, 2002051)
 	registerAdditionalError("external chat executors require streaming", http.StatusConflict, 2002052)
 	registerAdditionalError("unsupported external chat provider", http.StatusBadRequest, 2002053)

--- a/backend/core/externalcontext/service.go
+++ b/backend/core/externalcontext/service.go
@@ -4,10 +4,16 @@
 package externalcontext
 
 import (
+	"bytes"
 	"context"
 	"database/sql"
+	"encoding/base64"
 	"encoding/json"
 	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"regexp"
 	"strings"
 	"time"
 	"unicode"
@@ -17,8 +23,85 @@ import (
 	"gorm.io/gorm/clause"
 
 	"lazymind/core/common/orm"
+	"lazymind/core/doc"
 	"lazymind/core/settings"
 )
+
+var (
+	codexRequestMarker = regexp.MustCompile(`(?im)^#+\s*My request for Codex:\s*$`)
+	codexImageTag      = regexp.MustCompile(`(?i)<image\b[^>]*\bpath="([^"]+)"[^>]*>`)
+	codexAnyImageTag   = regexp.MustCompile(`(?i)</?image\b[^>]*>`)
+)
+
+func normalizeCodexUserMessage(owner, historyID, raw string, transferred []NativeImage) (string, []map[string]any) {
+	const maxImportedImageBytes = 25 << 20
+	marker := codexRequestMarker.FindStringIndex(raw)
+	if marker == nil {
+		return raw, nil
+	}
+	request := strings.TrimSpace(raw[marker[1]:])
+	inputs := []map[string]any{{"input_type": "text", "text": strings.TrimSpace(codexAnyImageTag.ReplaceAllString(request, ""))}}
+	attachmentRoot := filepath.Join(doc.UploadRoot(), "external-agent-attachments", deterministicID("owner", owner), historyID)
+	transferredByName := make(map[string]string, len(transferred))
+	for _, image := range transferred {
+		if name := filepath.Base(strings.TrimSpace(image.Name)); name != "." && name != "" {
+			transferredByName[name] = image.Base64
+		}
+	}
+	for _, match := range codexImageTag.FindAllStringSubmatch(request, -1) {
+		if len(match) < 2 {
+			continue
+		}
+		sourcePath := filepath.Clean(strings.TrimSpace(match[1]))
+		switch strings.ToLower(filepath.Ext(sourcePath)) {
+		case ".png", ".jpg", ".jpeg", ".gif", ".webp", ".bmp":
+		default:
+			continue
+		}
+		filename := filepath.Base(sourcePath)
+		var source io.Reader
+		closeSource := func() {}
+		if encoded := transferredByName[filename]; encoded != "" {
+			content, decodeErr := base64.StdEncoding.DecodeString(encoded)
+			if decodeErr != nil || len(content) > maxImportedImageBytes {
+				continue
+			}
+			source = bytes.NewReader(content)
+		} else {
+			local, openErr := os.Open(sourcePath)
+			if openErr != nil {
+				continue
+			}
+			info, statErr := local.Stat()
+			if statErr != nil || !info.Mode().IsRegular() || info.Size() > maxImportedImageBytes {
+				local.Close()
+				continue
+			}
+			source = local
+			closeSource = func() { _ = local.Close() }
+		}
+		if mkdirErr := os.MkdirAll(attachmentRoot, 0o700); mkdirErr != nil {
+			closeSource()
+			continue
+		}
+		targetPath := filepath.Join(attachmentRoot, filename)
+		target, createErr := os.OpenFile(targetPath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o600)
+		if createErr == nil {
+			_, createErr = io.Copy(target, source)
+			target.Close()
+		}
+		closeSource()
+		if createErr != nil {
+			continue
+		}
+		if reference := doc.StaticFileReferenceFromAnyStoragePath(targetPath); reference != "" {
+			inputs = append(inputs, map[string]any{
+				"input_type": "image", "uri": reference, "file_id": filename,
+			})
+		}
+	}
+	return inputs[0]["text"].(string), inputs
+}
 
 var (
 	ErrInvalidSource = errors.New("invalid external Agent source")
@@ -51,11 +134,17 @@ type NativeSession struct {
 }
 
 type NativeTurn struct {
-	ID        string    `json:"turn_id"`
-	User      string    `json:"user"`
-	Assistant string    `json:"assistant"`
-	CreatedAt time.Time `json:"created_at"`
-	Managed   bool      `json:"managed,omitempty"`
+	ID        string        `json:"turn_id"`
+	User      string        `json:"user"`
+	Assistant string        `json:"assistant"`
+	CreatedAt time.Time     `json:"created_at"`
+	Managed   bool          `json:"managed,omitempty"`
+	Images    []NativeImage `json:"images,omitempty"`
+}
+
+type NativeImage struct {
+	Name   string `json:"name"`
+	Base64 string `json:"base64"`
 }
 
 // Link is the resolved LazyMind authority for one provider-native turn.
@@ -357,6 +446,17 @@ func (s *Service) SyncSessionCatalog(
 				len([]rune(turn.User)) > 1<<20 || len([]rune(turn.Assistant)) > 1<<20 {
 				continue
 			}
+			if len(turn.Images) > 4 {
+				turn.Images = turn.Images[:4]
+			}
+			validImages := make([]NativeImage, 0, len(turn.Images))
+			for _, image := range turn.Images {
+				image.Name = filepath.Base(strings.TrimSpace(image.Name))
+				if validIdentity(image.Name, 255) && len(image.Base64) <= 7<<20 {
+					validImages = append(validImages, image)
+				}
+			}
+			turn.Images = validImages
 			validTurns = append(validTurns, turn)
 		}
 		session.Turns = validTurns
@@ -516,6 +616,11 @@ func (s *Service) importNativeSession(
 		}
 		identity := owner + "\x00" + provider + "\x00" + hostID + "\x00" + session.ThreadID + "\x00" + turn.ID
 		historyID := deterministicID("mcp-history", identity)
+		userContent := turn.User
+		var importedInputs []map[string]any
+		if provider == "codex" {
+			userContent, importedInputs = normalizeCodexUserMessage(owner, historyID, turn.User, turn.Images)
+		}
 		managedHistoryID, err := s.managedHistoryID(ctx, owner, provider, session.ThreadID, binding.ConversationID, turn, createdAt)
 		if err != nil {
 			return err
@@ -524,7 +629,7 @@ func (s *Service) importNativeSession(
 			if err := s.db.WithContext(ctx).Model(&orm.ChatHistory{}).
 				Where("id = ? AND conversation_id = ?", managedHistoryID, binding.ConversationID).
 				Updates(map[string]any{
-					"raw_content": turn.User, "content": turn.User, "result": turn.Assistant,
+					"raw_content": userContent, "content": userContent, "result": turn.Assistant,
 					"update_time": createdAt,
 				}).Error; err != nil {
 				return err
@@ -548,26 +653,43 @@ func (s *Service) importNativeSession(
 		}
 		if existing == 0 {
 			maxSequence++
-			ext, _ := json.Marshal(map[string]any{"external_agent_activity": map[string]any{
+			extPayload := map[string]any{"external_agent_activity": map[string]any{
 				"provider": provider, "host_id": hostID,
 				"thread_id": session.ThreadID, "turn_id": turn.ID,
 				"source": "native_transcript",
-			}})
+			}}
+			if len(importedInputs) > 0 {
+				extPayload["input"] = importedInputs
+			}
+			ext, _ := json.Marshal(extPayload)
 			history := orm.ChatHistory{
 				ID: historyID, Seq: maxSequence, ConversationID: binding.ConversationID,
-				AlgorithmID: "external:" + provider, RawContent: turn.User, Content: turn.User,
+				AlgorithmID: "external:" + provider, RawContent: userContent, Content: userContent,
 				Result: turn.Assistant, Ext: ext,
 				TimeMixin: orm.TimeMixin{CreateTime: createdAt, UpdateTime: createdAt},
 			}
 			if err := s.db.WithContext(ctx).Create(&history).Error; err != nil {
 				return err
 			}
-		} else if err := s.db.WithContext(ctx).Model(&orm.ChatHistory{}).Where("id = ?", historyID).
-			Updates(map[string]any{
-				"raw_content": turn.User, "content": turn.User, "result": turn.Assistant,
+		} else {
+			updates := map[string]any{
+				"raw_content": userContent, "content": userContent, "result": turn.Assistant,
 				"update_time": createdAt,
-			}).Error; err != nil {
-			return err
+			}
+			if len(importedInputs) > 0 {
+				ext, _ := json.Marshal(map[string]any{
+					"external_agent_activity": map[string]any{
+						"provider": provider, "host_id": hostID, "thread_id": session.ThreadID,
+						"turn_id": turn.ID, "source": "native_transcript",
+					},
+					"input": importedInputs,
+				})
+				updates["ext"] = ext
+			}
+			if err := s.db.WithContext(ctx).Model(&orm.ChatHistory{}).Where("id = ?", historyID).
+				Updates(updates).Error; err != nil {
+				return err
+			}
 		}
 	}
 	var historyCount int64

--- a/backend/core/externalcontext/service_test.go
+++ b/backend/core/externalcontext/service_test.go
@@ -1,0 +1,49 @@
+package externalcontext
+
+import (
+	"encoding/base64"
+	"strings"
+	"testing"
+)
+
+func TestNormalizeCodexUserMessageStripsTransportEnvelope(t *testing.T) {
+	raw := `# Files mentioned by the user:
+
+## screenshot.png: /missing/screenshot.png
+
+# My request for Codex:
+
+请修复图片展示
+<image name="Image #1" path="/missing/screenshot.png">`
+
+	text, inputs := normalizeCodexUserMessage("user-1", "history-1", raw, nil)
+	if text != "请修复图片展示" {
+		t.Fatalf("text = %q, want request body only", text)
+	}
+	if len(inputs) != 1 || inputs[0]["input_type"] != "text" || inputs[0]["text"] != text {
+		t.Fatalf("inputs = %#v, want normalized text input", inputs)
+	}
+}
+
+func TestNormalizeCodexUserMessageLeavesRegularTextUntouched(t *testing.T) {
+	raw := "普通 Codex 用户消息"
+	text, inputs := normalizeCodexUserMessage("user-1", "history-1", raw, nil)
+	if text != raw || inputs != nil {
+		t.Fatalf("text=%q inputs=%#v", text, inputs)
+	}
+}
+
+func TestNormalizeCodexUserMessageStoresTransferredImage(t *testing.T) {
+	t.Setenv("LAZYMIND_UPLOAD_ROOT", t.TempDir())
+	raw := "## My request for Codex:\n查看截图\n<image path=\"/var/folders/example/clipboard.png\"></image>"
+	text, inputs := normalizeCodexUserMessage("user-1", "history-image", raw, []NativeImage{{
+		Name: "clipboard.png", Base64: base64.StdEncoding.EncodeToString([]byte("image-content")),
+	}})
+	if text != "查看截图" || len(inputs) != 2 {
+		t.Fatalf("text=%q inputs=%#v", text, inputs)
+	}
+	uri, _ := inputs[1]["uri"].(string)
+	if !strings.HasPrefix(uri, "/static-files/external-agent-attachments/") {
+		t.Fatalf("image uri = %q", uri)
+	}
+}

--- a/frontend/src/modules/chat/components/AskCard/index.scss
+++ b/frontend/src/modules/chat/components/AskCard/index.scss
@@ -9,7 +9,6 @@
 
   &--disabled {
     opacity: 0.75;
-    pointer-events: none;
   }
 
   // ── Header ──────────────────────────────────────────────

--- a/frontend/src/modules/chat/components/AskCard/index.test.tsx
+++ b/frontend/src/modules/chat/components/AskCard/index.test.tsx
@@ -1,0 +1,48 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import AskCard from "./index";
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+describe("AskCard read-only history", () => {
+  it("keeps answers immutable while allowing previous, next, and direct page navigation", () => {
+    const onSubmit = vi.fn();
+    const onAnswerChange = vi.fn();
+    render(
+      <AskCard
+        askPending={{
+          ask_id: "ask-history",
+          questions: [
+            { text: "第一题", type: "single", choices: ["答案 A", "答案 B"] },
+            { text: "第二题", type: "text" },
+          ],
+        }}
+        disabled
+        savedAnswers={{
+          0: { type: "single", value: "答案 A", otherText: "" },
+          1: { type: "text", value: "已保存答案" },
+        }}
+        onSubmit={onSubmit}
+        onAnswerChange={onAnswerChange}
+      />,
+    );
+
+    expect(screen.getByRole("radio", { name: "答案 A" })).toBeDisabled();
+    fireEvent.click(screen.getByRole("button", { name: /chat\.askCardNext/ }));
+    expect(screen.getByText("第二题")).toBeInTheDocument();
+    expect(screen.getByDisplayValue("已保存答案")).toBeDisabled();
+
+    fireEvent.click(screen.getByRole("button", { name: "Go to question 1" }));
+    expect(screen.getByText("第一题")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Go to question 2" }));
+    fireEvent.click(screen.getByRole("button", { name: /chat\.askCardPrev/ }));
+    expect(screen.getByText("第一题")).toBeInTheDocument();
+    expect(onAnswerChange).not.toHaveBeenCalled();
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/modules/chat/components/ChatImages/index.tsx
+++ b/frontend/src/modules/chat/components/ChatImages/index.tsx
@@ -1,5 +1,7 @@
 import { Image } from "antd";
+import { useEffect, useState } from "react";
 import { CloseCircleFilled } from "@ant-design/icons";
+import { resolveMarkdownImageUrlAsync } from "@/modules/knowledge/utils/imageUrl";
 
 import "./index.scss";
 
@@ -21,7 +23,7 @@ const ChatImages = (props: Props) => {
       {images.map((item, index) => {
         return (
           <div className="chat-images-item" key={`img-${index}`}>
-            <Image src={item.base64} height={52} />
+            <ResolvedChatImage src={item.base64} />
             {onRemove && (
               <div
                 className="chat-images-remove"
@@ -36,5 +38,17 @@ const ChatImages = (props: Props) => {
     </div>
   );
 };
+
+function ResolvedChatImage({ src }: { src: string }) {
+  const [resolvedSrc, setResolvedSrc] = useState(src);
+  useEffect(() => {
+    let active = true;
+    void resolveMarkdownImageUrlAsync(src).then((value) => {
+      if (active) setResolvedSrc(value);
+    });
+    return () => { active = false; };
+  }, [src]);
+  return <Image src={resolvedSrc} height={52} />;
+}
 
 export default ChatImages;

--- a/frontend/src/modules/chat/components/RecordList/index.test.tsx
+++ b/frontend/src/modules/chat/components/RecordList/index.test.tsx
@@ -8,6 +8,7 @@ const mocks = vi.hoisted(() => ({
   listConversations: vi.fn(),
   setPinned: vi.fn(),
   deleteConversation: vi.fn(),
+  listChatExecutors: vi.fn(),
   messageSuccess: vi.fn(),
   messageError: vi.fn(),
 }));
@@ -51,6 +52,9 @@ vi.mock("@/modules/chat/utils/request", () => ({
     conversationServiceListConversations: mocks.listConversations,
     conversationServiceSetPinned: mocks.setPinned,
     conversationServiceDeleteConversation: mocks.deleteConversation,
+  }),
+  ConversationSettingsApi: () => ({
+    listChatExecutors: mocks.listChatExecutors,
   }),
 }));
 
@@ -135,6 +139,9 @@ describe("RecordList conversation pinning", () => {
         conversations: [newerConversation, olderConversation],
         next_page_token: "",
       },
+    });
+    mocks.listChatExecutors.mockResolvedValue({
+      data: { data: { executors: [] } },
     });
   });
 

--- a/frontend/src/modules/chat/components/RecordList/index.tsx
+++ b/frontend/src/modules/chat/components/RecordList/index.tsx
@@ -47,7 +47,11 @@ import { useChatNewMessageStore } from "@/modules/chat/store/chatNewMessage";
 
 import dayjs from "dayjs";
 
-import { ChatServiceApi } from "@/modules/chat/utils/request";
+import {
+  ChatServiceApi,
+  ConversationSettingsApi,
+  type ChatExecutorDescriptor,
+} from "@/modules/chat/utils/request";
 import {
   bumpConversationToTop,
 } from "@/modules/chat/utils/conversationActivity";
@@ -189,13 +193,17 @@ const RecordList = forwardRef<RecordListImperativeProps, IRecordList>(
     // Values: 'normal' = non-task, 'task' = task. Multiple values allowed.
     const [convTypeFilter, setConvTypeFilter] = useState<string[]>(() => {
       try {
-        return sessionStorage.getItem(CHAT_CONVERSATION_FILTER_KEY) === "task"
-          ? ["task"]
-          : ["normal"];
+        const stored = sessionStorage.getItem(CHAT_CONVERSATION_FILTER_KEY);
+        if (stored?.startsWith("[")) {
+          const parsed = JSON.parse(stored);
+          if (Array.isArray(parsed) && parsed.length > 0) return parsed;
+        }
+        return stored === "task" ? ["task"] : ["normal"];
       } catch {
         return ["normal"];
       }
     });
+    const [connectedAgents, setConnectedAgents] = useState<ChatExecutorDescriptor[]>([]);
     const [filterPopoverOpen, setFilterPopoverOpen] = useState(false);
     const scrollableTargetId = compact
       ? "sidebarConversationScrollableDiv"
@@ -206,6 +214,21 @@ const RecordList = forwardRef<RecordListImperativeProps, IRecordList>(
     const pinningConversationRef = useRef(false);
     const { setThink } = useChatThinkStore();
     const { setNewMessage } = useChatNewMessageStore();
+
+    useEffect(() => {
+      let active = true;
+      ConversationSettingsApi().listChatExecutors().then((response) => {
+        if (!active) return;
+        setConnectedAgents(
+          response.data.data.executors.filter(
+            (executor) => executor.kind === "external" && executor.connected,
+          ),
+        );
+      }).catch(() => {
+        // The regular/task filters remain usable if host discovery is unavailable.
+      });
+      return () => { active = false; };
+    }, []);
 
     useEffect(() => {
       const handleFilterChange = (event: Event) => {
@@ -353,6 +376,8 @@ const RecordList = forwardRef<RecordListImperativeProps, IRecordList>(
       // 'normal' only → is_task_conv=false, 'task' only → is_task_conv=true, both → no filter.
       const hasNormal = activeFilter.includes('normal');
       const hasTask = activeFilter.includes('task');
+      const selectedAgents = activeFilter.filter((value) => value.startsWith('agent:'))
+        .map((value) => value.slice('agent:'.length));
       let isTaskConvParam: string | undefined;
       if (hasNormal && !hasTask) {
         isTaskConvParam = 'false';
@@ -367,9 +392,13 @@ const RecordList = forwardRef<RecordListImperativeProps, IRecordList>(
             pageToken: isFirst ? "" : pageToken,
             pageSize: 50,
           },
-          isTaskConvParam !== undefined
-            ? { params: { is_task_conv: isTaskConvParam } }
-            : undefined,
+          { params: {
+            ...(isTaskConvParam !== undefined ? { is_task_conv: isTaskConvParam } : {}),
+            assistants: [
+              ...(hasNormal || hasTask ? ['lazymind'] : []),
+              ...selectedAgents,
+            ].join(','),
+          } },
         )
         .then((res) => {
           const conversations: SidebarConversation[] =
@@ -809,7 +838,7 @@ const RecordList = forwardRef<RecordListImperativeProps, IRecordList>(
                                   try {
                                     sessionStorage.setItem(
                                       CHAT_CONVERSATION_FILTER_KEY,
-                                      next.length === 1 ? next[0] : "all",
+                                      JSON.stringify(next),
                                     );
                                   } catch {
                                     // Ignore storage errors.
@@ -820,6 +849,11 @@ const RecordList = forwardRef<RecordListImperativeProps, IRecordList>(
                               >
                                 <Checkbox value="normal">{t("chat.normalConversation")}</Checkbox>
                                 <Checkbox value="task">{t("chat.taskConversation")}</Checkbox>
+                                {connectedAgents.map((agent) => (
+                                  <Checkbox key={agent.id} value={`agent:${agent.id}`}>
+                                    {agent.display_name}
+                                  </Checkbox>
+                                ))}
                               </Checkbox.Group>
                             </div>
                           }

--- a/frontend/src/modules/chat/utils/message.test.ts
+++ b/frontend/src/modules/chat/utils/message.test.ts
@@ -10,9 +10,22 @@ import {
   mergeChatMessageLists,
   mergeConversationTrailIntoMessageList,
   normalizeMessageInputs,
+  normalizeImportedUserText,
   stripAskUserReceipt,
   stripCitationFromText,
 } from "./message";
+
+describe("normalizeImportedUserText", () => {
+  it("shows only the request body from an existing Codex transport envelope", () => {
+    expect(normalizeImportedUserText(`# Files mentioned by the user:
+
+## image.png: /tmp/image.png
+
+## My request for Codex:
+修复界面
+<image name="Image #1" path="/tmp/image.png"></image>`)).toBe("修复界面");
+  });
+});
 
 describe("isAskPendingReadOnly", () => {
   it("keeps the latest unanswered Ask interactive after history reload", () => {
@@ -125,6 +138,22 @@ describe("citation helpers", () => {
 });
 
 describe("buildChatMessageListFromHistory", () => {
+  it("uses a persisted image URI when imported history has no base64 payload", () => {
+    const list = buildChatMessageListFromHistory([
+      {
+        id: "history-1",
+        query: "hello",
+        input: [
+          { input_type: "text", text: "hello" },
+          { input_type: "image", uri: "/static-files/imported/image.png", file_id: "image.png" },
+        ],
+      },
+    ], { reverseHistory: false });
+
+    expect(list[0].images).toEqual([
+      { base64: "/static-files/imported/image.png", uid: "image.png" },
+    ]);
+  });
   it("returns an empty list for null/undefined history", () => {
     expect(buildChatMessageListFromHistory(null)).toEqual([]);
     expect(buildChatMessageListFromHistory(undefined)).toEqual([]);

--- a/frontend/src/modules/chat/utils/message.ts
+++ b/frontend/src/modules/chat/utils/message.ts
@@ -17,6 +17,18 @@ const CITE_MESSAGE_GLOBAL_PATTERN =
   /<cite_message>([\s\S]*?)<\/cite_message>\s*/gi;
 const ASK_USER_RECEIPT_PATTERN =
   /^Question sent to user \(ask_id=[^)]+\)\.\s*Waiting for answer on next turn\.?$/i;
+const CODEX_REQUEST_MARKER_PATTERN = /^#+\s*My request for Codex:\s*$/im;
+const CODEX_IMAGE_TAG_PATTERN = /<\/?image\b[^>]*>/gi;
+
+export function normalizeImportedUserText(text: string | undefined) {
+  const value = text || "";
+  const marker = CODEX_REQUEST_MARKER_PATTERN.exec(value);
+  if (!marker) return value;
+  return value
+    .slice(marker.index + marker[0].length)
+    .replace(CODEX_IMAGE_TAG_PATTERN, "")
+    .trim();
+}
 
 export function stripAskUserReceipt(
   text: string | undefined,
@@ -197,7 +209,7 @@ export function buildChatMessageListFromHistory(
       const inputType = input.input_type || "text";
       return inputType === "text" && !!input.text;
     });
-    const rawQuery = record.query || textInput?.text || "";
+    const rawQuery = normalizeImportedUserText(record.query || textInput?.text || "");
     const citeMessages = getCitationsFromText(rawQuery);
     const displayQuery = stripCitations
       ? stripCitationFromText(rawQuery)
@@ -214,7 +226,7 @@ export function buildChatMessageListFromHistory(
       images: normalizedInputs
         ?.filter((input) => input.input_type === "image")
         .map((image) => ({
-          base64: image?.input_base64,
+          base64: image?.input_base64 || image?.uri,
           uid: image.file_id,
         })),
       files: normalizedInputs

--- a/frontend/src/modules/chat/utils/request.ts
+++ b/frontend/src/modules/chat/utils/request.ts
@@ -1083,6 +1083,7 @@ export interface ChatExecutorDescriptor {
   installed: boolean;
   host_online: boolean;
   available: boolean;
+  connected?: boolean;
   unavailable_reason?: string;
 }
 

--- a/local/lazymind-cli/internal/agentcatalog/catalog_test.go
+++ b/local/lazymind-cli/internal/agentcatalog/catalog_test.go
@@ -20,6 +20,38 @@ func TestProjectPathNormalizesEquivalentNativePaths(t *testing.T) {
 	}
 }
 
+func TestTranscriptTurnsKeepsCodexCommentaryAndCollapsesRollbackDuplicate(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "rollout.jsonl")
+	content := strings.Join([]string{
+		`{"timestamp":"2026-08-31T01:00:00Z","type":"response_item","payload":{"type":"message","id":"first","role":"user","content":[{"type":"input_text","text":"# Files mentioned by the user:\n\n## image.png: /tmp/image.png\n\n## My request for Codex:\n修复界面\n<image path=\"/tmp/image.png\"></image>"}]}}`,
+		`{"timestamp":"2026-08-31T01:00:01Z","type":"response_item","payload":{"type":"message","id":"retry","role":"user","content":[{"type":"input_text","text":"# Files mentioned by the user:\n## image.png: /tmp/image.png\n## My request for Codex:\n修复界面"}]}}`,
+		`{"timestamp":"2026-08-31T01:00:02Z","type":"response_item","payload":{"type":"message","role":"assistant","phase":"commentary","content":[{"type":"output_text","text":"正在处理"}]}}`,
+		`{"timestamp":"2026-08-31T01:00:03Z","type":"response_item","payload":{"type":"message","role":"assistant","phase":"final_answer","content":[{"type":"output_text","text":"处理完成"}]}}`,
+	}, "\n")
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	turns := transcriptTurns(path, "codex")
+	if len(turns) != 1 || turns[0].ID != "first" || turns[0].Assistant != "正在处理\n处理完成" {
+		t.Fatalf("turns = %#v", turns)
+	}
+}
+
+func TestCodexUserImagesTransfersReferencedClipboardImage(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "clipboard.png")
+	content := []byte("png-test-content")
+	if err := os.WriteFile(path, content, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	images := codexUserImages(`<image name="Image #1" path="` + path + `"></image>`)
+	if len(images) != 1 || images[0].Name != "clipboard.png" {
+		t.Fatalf("images = %#v", images)
+	}
+	if images[0].Base64 == "" {
+		t.Fatal("expected encoded image content")
+	}
+}
+
 func TestCodexSessionsUseRolloutProjectAuthority(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("CODEX_HOME", home)

--- a/local/lazymind-cli/internal/agentcatalog/catalog_test.go
+++ b/local/lazymind-cli/internal/agentcatalog/catalog_test.go
@@ -37,6 +37,22 @@ func TestTranscriptTurnsKeepsCodexCommentaryAndCollapsesRollbackDuplicate(t *tes
 	}
 }
 
+func TestTranscriptTurnsDoesNotMarkOrdinaryCodexUserMessageAsManaged(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "rollout.jsonl")
+	content := strings.Join([]string{
+		`{"timestamp":"2026-08-31T01:00:00Z","type":"response_item","payload":{"type":"message","id":"response-user","role":"user","content":[{"type":"input_text","text":"检查这个 PR"}]}}`,
+		`{"timestamp":"2026-08-31T01:00:01Z","type":"event_msg","payload":{"type":"user_message","client_id":"desktop-user","message":"检查这个 PR"}}`,
+		`{"timestamp":"2026-08-31T01:00:02Z","type":"response_item","payload":{"type":"message","role":"assistant","phase":"final_answer","content":[{"type":"output_text","text":"发现一个问题"}]}}`,
+	}, "\n")
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	turns := transcriptTurns(path, "codex")
+	if len(turns) != 1 || turns[0].ID != "desktop-user" || turns[0].Managed {
+		t.Fatalf("turns = %#v", turns)
+	}
+}
+
 func TestCodexUserImagesTransfersReferencedClipboardImage(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "clipboard.png")
 	content := []byte("png-test-content")

--- a/local/lazymind-cli/internal/agentcatalog/native_sessions.go
+++ b/local/lazymind-cli/internal/agentcatalog/native_sessions.go
@@ -380,7 +380,10 @@ func transcriptTurns(path, provider string) []chatagent.NativeTurn {
 			current = &chatagent.NativeTurn{ID: turnID, User: text, CreatedAt: message.timestamp, Managed: managed}
 		case "identity":
 			if current != nil && message.id != "" && cleanUserText(message.text) == current.User {
-				current.ID, current.Managed = message.id, true
+				// Codex emits user_message for ordinary Desktop turns too.  It is
+				// useful as the stable turn identity, but it does not mean that the
+				// turn was launched and persisted by LazyMind.
+				current.ID = message.id
 			}
 		case "assistant":
 			if current != nil && message.text != "" {

--- a/local/lazymind-cli/internal/agentcatalog/native_sessions.go
+++ b/local/lazymind-cli/internal/agentcatalog/native_sessions.go
@@ -5,11 +5,13 @@ import (
 	"bytes"
 	"context"
 	"crypto/sha256"
+	"encoding/base64"
 	"encoding/hex"
 	"encoding/json"
 	"io/fs"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strconv"
 	"strings"
 	"sync"
@@ -22,6 +24,8 @@ const (
 	maxTranscriptLine = 16 << 20
 	maxTurnRunes      = 1 << 20
 )
+
+var codexImagePathPattern = regexp.MustCompile(`(?i)<image\b[^>]*\bpath="([^"]+)"[^>]*>`)
 
 type cachedSession struct {
 	modTime time.Time
@@ -345,6 +349,9 @@ func transcriptTurns(path, provider string) []chatagent.NativeTurn {
 		}
 		current.User = compactText(current.User, maxTurnRunes)
 		current.Assistant = compactText(current.Assistant, maxTurnRunes)
+		if provider == "codex" {
+			current.Images = codexUserImages(current.User)
+		}
 		turns = append(turns, *current)
 		current = nil
 	}
@@ -356,6 +363,13 @@ func transcriptTurns(path, provider string) []chatagent.NativeTurn {
 			managed := managedUserText(message.text) || strings.HasPrefix(message.id, "h_")
 			text := cleanUserText(message.text)
 			if text == "" {
+				continue
+			}
+			if current != nil && current.Assistant == "" && equivalentCodexUserText(current.User, text) {
+				current.User = text
+				if !message.timestamp.IsZero() {
+					current.CreatedAt = message.timestamp
+				}
 				continue
 			}
 			flush()
@@ -383,6 +397,34 @@ func transcriptTurns(path, provider string) []chatagent.NativeTurn {
 	}
 	flush()
 	return turns
+}
+
+func codexUserImages(text string) []chatagent.NativeImage {
+	const maxImageBytes = 5 << 20
+	images := make([]chatagent.NativeImage, 0)
+	for _, match := range codexImagePathPattern.FindAllStringSubmatch(text, 4) {
+		if len(match) < 2 {
+			continue
+		}
+		path := filepath.Clean(strings.TrimSpace(match[1]))
+		switch strings.ToLower(filepath.Ext(path)) {
+		case ".png", ".jpg", ".jpeg", ".gif", ".webp", ".bmp":
+		default:
+			continue
+		}
+		info, err := os.Stat(path)
+		if err != nil || !info.Mode().IsRegular() || info.Size() > maxImageBytes {
+			continue
+		}
+		content, err := os.ReadFile(path)
+		if err != nil {
+			continue
+		}
+		images = append(images, chatagent.NativeImage{
+			Name: filepath.Base(path), Base64: base64.StdEncoding.EncodeToString(content),
+		})
+	}
+	return images
 }
 
 func transcriptTitle(path, provider string) string {
@@ -432,9 +474,6 @@ func decodeTranscriptMessage(line []byte, provider string) transcriptMessage {
 			return transcriptMessage{}
 		}
 		role := stringValue(payload["role"])
-		if phase := stringValue(payload["phase"]); role == "assistant" && phase != "" && phase != "final_answer" {
-			return transcriptMessage{}
-		}
 		id := stringValue(payload["clientId"])
 		if id == "" {
 			id = stringValue(payload["id"])
@@ -468,6 +507,19 @@ func decodeTranscriptMessage(line []byte, provider string) transcriptMessage {
 		}
 	}
 	return transcriptMessage{}
+}
+
+func equivalentCodexUserText(left, right string) bool {
+	canonical := func(value string) string {
+		if marker := strings.LastIndex(strings.ToLower(value), "my request for codex:"); marker >= 0 {
+			value = value[marker+len("my request for codex:"):]
+		}
+		if image := strings.Index(strings.ToLower(value), "<image"); image >= 0 {
+			value = value[:image]
+		}
+		return strings.Join(strings.Fields(value), " ")
+	}
+	return canonical(left) != "" && canonical(left) == canonical(right)
 }
 
 func contentText(value any) string {

--- a/local/lazymind-cli/internal/chatagent/host.go
+++ b/local/lazymind-cli/internal/chatagent/host.go
@@ -72,11 +72,17 @@ type NativeSession struct {
 }
 
 type NativeTurn struct {
-	ID        string    `json:"turn_id"`
-	User      string    `json:"user"`
-	Assistant string    `json:"assistant"`
-	CreatedAt time.Time `json:"created_at"`
-	Managed   bool      `json:"managed,omitempty"`
+	ID        string        `json:"turn_id"`
+	User      string        `json:"user"`
+	Assistant string        `json:"assistant"`
+	CreatedAt time.Time     `json:"created_at"`
+	Managed   bool          `json:"managed,omitempty"`
+	Images    []NativeImage `json:"images,omitempty"`
+}
+
+type NativeImage struct {
+	Name   string `json:"name"`
+	Base64 string `json:"base64"`
 }
 
 type syncSessionCatalogResponse struct {


### PR DESCRIPTION
## 背景

LazyMind 导入 Codex 等外部 Agent 的历史对话时，存在筛选入口缺失、Codex 用户消息格式异常、引用图片无法显示、部分回复或整段历史为空，以及历史 Ask Panel 无法翻页等问题。

## 主要改动

- 在对话筛选中按已连接的 Agent 动态展示独立类别（如 Codex、Cursor、WorkBuddy），默认不勾选。
- 兼容 Codex Desktop transcript 的用户消息结构，清理注入的文件说明和 `<image>` 标记，合并回滚产生的重复用户消息。
- 保留 Codex commentary 与 final answer，避免模型回复丢失。
- 修正普通 Codex `user_message` 被误判为 LazyMind 托管执行消息的问题，避免有标题但历史内容为空。
- 由本机 Connector 读取用户引用图片并传给 Core，Core 落盘到受控静态资源目录后供前端展示，解决容器无法访问 macOS 临时路径的问题。
- 移除分批同步时会误删其他批次历史记录的清理行为。
- 历史 Ask Panel 保持答案只读，同时允许上一项、下一项和页码跳转。
- 补充 Core、Connector 与前端回归测试。

## 验证

- `make lint`
- `go -C backend/core test ./externalcontext ./chat`
- `go -C local/lazymind-cli test ./internal/agentcatalog ./internal/chatagent`
- 前端 TypeScript 类型检查与相关组件测试
- `make up-build SERVICES=frontend,core PIP_INDEX_URL=https://pypi.org/simple`
- 浏览器实际验证：
  - Codex CLI 筛选项默认未选，勾选后正常显示历史对话；
  - 用户输入引用的 6 张图片均成功加载且尺寸有效；
  - 原先为空的“审查 PR 663 是否有问题”对话已恢复完整用户输入与模型回复；
  - 页面控制台无相关错误。
