### PR TITLE
fix(test-workflow): declare metadata_json as json

### DIFF
--- a/workflows/test-workflow/workflow.yaml
+++ b/workflows/test-workflow/workflow.yaml
@@ -40,7 +40,7 @@ slots:
     cardinality: single
   - id: metadata_json
     label: JSON Metadata
-    type: text
+    type: json
     cardinality: single
   - id: text_attachment
     label: Text Attachment


### PR DESCRIPTION
fix(test-workflow): declare metadata_json as json

## 问题现象

0.3.0 `test-workflow` 的 `script` 步产物 `metadata_json` 定义不一致：

- `workflow.yaml`：`type: text`
- `scenario/state.yml` prompt：要求把 `build_test_metadata` 的返回对象按 `content_type="json"` 写入

Agent 按 prompt 提交 `json`，hosted submit 按 YAML 校验类型，`json != text`，报错 `ARTIFACT_WRITE_FAILED`。

## 解决方案

将 `workflows/test-workflow/workflow.yaml` 中 `metadata_json` 改为 `type: json`，与 prompt 对齐。不改 prompt：该 slot 本身就是 JSON 对象。

## 测试平台

已在以下环境验证 script 步可正常提交，不再出现 `ARTIFACT_WRITE_FAILED`：

- Codex
- 0.3.0 Mac Desktop
- 0.3.0 Docker

---

## Symptom

In 0.3.0 `test-workflow`, the `script` step slot `metadata_json` was inconsistent:

- `workflow.yaml`: `type: text`
- `scenario/state.yml` prompt: save `build_test_metadata`'s return value with `content_type="json"`

The agent submitted `json`. Hosted submit validates against YAML, `json != text`, and failed with `ARTIFACT_WRITE_FAILED`.

## Fix

Set `metadata_json` in `workflows/test-workflow/workflow.yaml` to `type: json` so it matches the prompt. Leave the prompt unchanged; this slot is a JSON object.

## Test platforms

Verified the script step submits successfully with no `ARTIFACT_WRITE_FAILED` on:

- Codex
- 0.3.0 Mac Desktop
- 0.3.0 Docker