### PR TITLE
[Bugfix]: launch native Windows Assistant Bridge from WSL

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,11 @@ LOCAL_BUILD_DIR := $(CURDIR)/local/build
 override export LAZYMIND_LOCAL_BUILD_ROOT := $(LOCAL_BUILD_DIR)
 override LOCAL_RUNTIME_MANAGER_BIN := $(LOCAL_BUILD_DIR)/bin/local-runtime-manager
 override LOCAL_RUNTIME_MANAGER_WIN_BIN := $(LOCAL_BUILD_DIR)/bin/local-runtime-manager.exe
+HOST_UNAME_S := $(shell uname -s 2>/dev/null)
+HOST_UNAME_M := $(shell uname -m 2>/dev/null)
+HOST_UNAME_GOARCH := $(if $(filter arm64 aarch64,$(HOST_UNAME_M)),arm64,$(if $(filter x86_64 amd64,$(HOST_UNAME_M)),amd64,unsupported))
+HOST_IS_WSL := $(if $(and $(filter Linux,$(HOST_UNAME_S)),$(or $(WSL_INTEROP),$(WSL_DISTRO_NAME))),1,0)
+_HOST_GO_BUILD := $(GO)
 ifeq ($(OS),Windows_NT)
 LAZYMIND_CLI_FILENAME := lazymind.exe
 HOST_GOOS := windows
@@ -31,16 +36,25 @@ HOST_WINDOWS_ARCH := $(strip $(if $(PROCESSOR_ARCHITEW6432),$(PROCESSOR_ARCHITEW
 HOST_GOARCH := $(if $(filter AMD64 amd64 x86_64,$(HOST_WINDOWS_ARCH)),amd64,$(if $(filter ARM64 arm64 aarch64,$(HOST_WINDOWS_ARCH)),arm64,unsupported))
 _HOST_DOCKER_USER_FLAG :=
 _HOST_DOCKER_PREFIX := MSYS_NO_PATHCONV=1
+else ifeq ($(HOST_IS_WSL),1)
+LAZYMIND_CLI_FILENAME := lazymind.exe
+HOST_GOOS := windows
+HOST_GOARCH := $(HOST_UNAME_GOARCH)
+_HOST_DOCKER_USER_FLAG := --user "$$(id -u):$$(id -g)"
+_HOST_DOCKER_PREFIX :=
+_HOST_GO_BUILD := CGO_ENABLED=0 GOOS="$(HOST_GOOS)" GOARCH="$(HOST_GOARCH)" $(GO)
 else
 LAZYMIND_CLI_FILENAME := lazymind
-HOST_UNAME_S := $(shell uname -s 2>/dev/null)
-HOST_UNAME_M := $(shell uname -m 2>/dev/null)
 HOST_GOOS := $(if $(filter Darwin,$(HOST_UNAME_S)),darwin,$(if $(filter Linux,$(HOST_UNAME_S)),linux,unsupported))
-HOST_GOARCH := $(if $(filter arm64 aarch64,$(HOST_UNAME_M)),arm64,$(if $(filter x86_64 amd64,$(HOST_UNAME_M)),amd64,unsupported))
+HOST_GOARCH := $(HOST_UNAME_GOARCH)
 _HOST_DOCKER_USER_FLAG := --user "$$(id -u):$$(id -g)"
 _HOST_DOCKER_PREFIX :=
 endif
 override LAZYMIND_CLI_BIN := $(LOCAL_BUILD_DIR)/bin/$(LAZYMIND_CLI_FILENAME)
+ifeq ($(HOST_IS_WSL),1)
+_WSL_ASSISTANT_BRIDGE_SCRIPT := $(shell wslpath -w "$(CURDIR)/local/scripts/assistant-bridge-win.ps1" 2>/dev/null)
+_WSL_ASSISTANT_BRIDGE_SOURCE := $(shell wslpath -w "$(LAZYMIND_CLI_BIN)" 2>/dev/null)
+endif
 LOCAL_WIN_SCRIPT := $(CURDIR)/local/scripts/local-win.ps1
 DESKTOP_WIN_SCRIPT := $(CURDIR)/desktop/scripts/build-windows-x64.ps1
 LAZYMIND_LOCAL_DOWN_TIMEOUT ?= 150s
@@ -502,7 +516,7 @@ local-runtime-manager-build:
 lazymind-cli-build:
 	@mkdir -p "$(dir $(LAZYMIND_CLI_BIN))"
 	@if command -v "$(GO)" >/dev/null 2>&1; then \
-		cd local/lazymind-cli && $(GO) build -buildvcs=false -o "$(LAZYMIND_CLI_BIN)" ./cmd/lazymind; \
+		cd local/lazymind-cli && $(_HOST_GO_BUILD) build -buildvcs=false -o "$(LAZYMIND_CLI_BIN)" ./cmd/lazymind; \
 	elif [ "$(HOST_GOOS)" != "unsupported" ] && [ "$(HOST_GOARCH)" != "unsupported" ]; then \
 		echo "🔨 Building the host Assistant Bridge with Docker ($(HOST_GOOS)/$(HOST_GOARCH))..."; \
 		$(_HOST_DOCKER_PREFIX) docker run --rm \
@@ -519,15 +533,32 @@ lazymind-cli-build:
 	fi
 
 assistant-bridge-start: lazymind-cli-build
+ifeq ($(HOST_IS_WSL),1)
+	@if ! command -v powershell.exe >/dev/null 2>&1; then \
+		echo "❌ WSL interoperability is unavailable; enable Windows executable interop before starting the native Assistant Bridge."; \
+		exit 1; \
+	fi
+	@powershell.exe -NoProfile -NonInteractive -ExecutionPolicy Bypass \
+		-File "$(_WSL_ASSISTANT_BRIDGE_SCRIPT)" start "$(_WSL_ASSISTANT_BRIDGE_SOURCE)"
+	@rm -f "$(LOCAL_BUILD_DIR)/bin/lazymind"
+else
 	@"$(LAZYMIND_CLI_BIN)" assistant stop >/dev/null
 	@if [ "$(LAZYMIND_CLI_FILENAME)" = "lazymind.exe" ]; then rm -f "$(LOCAL_BUILD_DIR)/bin/lazymind"; fi
 	@"$(LAZYMIND_CLI_BIN)" assistant start >/dev/null
+endif
 	@echo "✅ LazyMind 助理桥接器已启动；可在设置 → 外部 Agent 集成中启用本机能力"
 
 assistant-bridge-stop:
+ifeq ($(HOST_IS_WSL),1)
+	@if command -v powershell.exe >/dev/null 2>&1; then \
+		powershell.exe -NoProfile -NonInteractive -ExecutionPolicy Bypass \
+			-File "$(_WSL_ASSISTANT_BRIDGE_SCRIPT)" stop "$(_WSL_ASSISTANT_BRIDGE_SOURCE)" || true; \
+	fi
+else
 	@if [ -x "$(LAZYMIND_CLI_BIN)" ]; then \
 		"$(LAZYMIND_CLI_BIN)" assistant stop >/dev/null || true; \
 	fi
+endif
 
 desktop-darwin-arm64:
 	@bash desktop/scripts/build-darwin-arm64.sh

--- a/desktop/scripts/desktop-build.test.mjs
+++ b/desktop/scripts/desktop-build.test.mjs
@@ -37,6 +37,14 @@ const desktopReleaseWorkflow = path.join(
 const coreDockerfile = path.join(scriptsDir, "..", "..", "backend", "core", "Dockerfile");
 const dockerCompose = path.join(scriptsDir, "..", "..", "docker-compose.yml");
 const rootMakefile = path.join(scriptsDir, "..", "..", "Makefile");
+const windowsAssistantBridgeScript = path.join(
+  scriptsDir,
+  "..",
+  "..",
+  "local",
+  "scripts",
+  "assistant-bridge-win.ps1",
+);
 
 function nsisMacro(source, name) {
   const match = source.match(new RegExp(`!macro ${name}\\b([\\s\\S]*?)!macroend`));
@@ -197,6 +205,22 @@ test("Docker startup builds a native Windows Assistant Bridge", () => {
   assert.match(source, /_HOST_DOCKER_PREFIX := MSYS_NO_PATHCONV=1/);
   assert.match(source, /\$\(_HOST_DOCKER_USER_FLAG\)[\s\S]*GOOS="\$\(HOST_GOOS\)"/);
   assert.match(source, /local\/build\/bin\/\$\(LAZYMIND_CLI_FILENAME\)/);
+});
+
+test("WSL Docker startup launches a native Windows Assistant Bridge", () => {
+  const source = readFileSync(rootMakefile, "utf8");
+  const launcher = readFileSync(windowsAssistantBridgeScript, "utf8");
+
+  assert.match(source, /HOST_IS_WSL[\s\S]*WSL_INTEROP[\s\S]*WSL_DISTRO_NAME/);
+  assert.match(source, /else ifeq \(\$\(HOST_IS_WSL\),1\)[\s\S]*LAZYMIND_CLI_FILENAME := lazymind\.exe/);
+  assert.match(source, /else ifeq \(\$\(HOST_IS_WSL\),1\)[\s\S]*HOST_GOOS := windows/);
+  assert.match(source, /_HOST_GO_BUILD := CGO_ENABLED=0 GOOS="\$\(HOST_GOOS\)" GOARCH="\$\(HOST_GOARCH\)" \$\(GO\)/);
+  assert.match(source, /\$\(_HOST_GO_BUILD\) build/);
+  assert.match(source, /wslpath -w[\s\S]*assistant-bridge-win\.ps1/);
+  assert.match(source, /HOST_IS_WSL[\s\S]*command -v powershell\.exe/);
+  assert.match(launcher, /LOCALAPPDATA[\s\S]*LazyMind\\assistant-bridge/);
+  assert.match(launcher, /Copy-Item[\s\S]*Move-Item[\s\S]*assistant', 'start/);
+  assert.match(launcher, /Remove-Item Env:LAZYMIND_HOME/);
 });
 
 test("generates a multi-resolution Windows ICO from the macOS icon", () => {

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -666,9 +666,9 @@ tests/test_cli.py
 
 桥接器只监听 `127.0.0.1`，只接受本机 LazyMind 页面来源。Desktop 通过 Electron IPC 和 connector 标准输入同步当前会话，令牌不会进入命令行参数；标准 Docker 网页通过同源回环接口同步。两种入口都会把会话写入 `0600` 凭证文件，并在退出时清除。同步接口拒绝与页面 Origin 不一致的服务地址。Host 遇到被拒绝的 access token 时会刷新令牌，本地 refresh token 失效时会尝试从当前本地 Runtime 重建会话；仍无法恢复时，“助理”页会明确显示 LazyMind 登录失效或本机连接失败，不再无限显示“正在连接”。写入外部 Agent 配置的内容始终只有 connector 绝对路径、`mcp proxy` 参数以及可选的 `LAZYMIND_HOME`，不会把 access token 或 refresh token 写入任何 Agent 配置。
 
-直接执行裸 `docker compose up` 无法启动宿主机进程，因此标准用户入口是 `make up`。Windows 必须从 Git Bash 执行该入口；构建会生成原生 `lazymind.exe`，且不会把 Unix 用户参数传给 Docker Desktop。已经用裸 compose 启动服务时，可在仓库根目录补充运行 `make assistant-bridge-start`。
+直接执行裸 `docker compose up` 无法启动宿主机进程，因此标准用户入口是 `make up`。Windows 可从 Git Bash 或启用了 Windows 可执行文件互操作的 WSL 执行该入口；两种方式都会生成并启动原生 `lazymind.exe`，不会把 Linux Bridge 路径写入 Windows Agent。已经用裸 compose 启动服务时，可在同一环境补充运行 `make assistant-bridge-start`。
 
-Windows 浏览器必须连接 Windows 原生 Assistant Bridge；WSL/Linux Bridge 中的 `lazymind` 是 Linux 可执行文件，不能通过路径格式转换交给 Windows 桌面 Agent。网页与 Bridge 平台不一致时，集成页会拒绝生成 MCP 安装配置，并提示先停止 WSL/Linux Bridge、再从 Windows Git Bash 启动原生 Bridge。
+Windows 浏览器必须连接 Windows 原生 Assistant Bridge。WSL 启动流程会识别宿主平台并通过 WSL 互操作运行 `lazymind.exe`；若互操作不可用则启动命令会直接失败并给出提示。网页与 Bridge 平台仍不一致时，所有助理配置和凭证同步接口都会拒绝请求，集成页会显示平台错配，而不会误报桥接器未运行。
 
 ### 16.1 Codex Desktop 与 Codex CLI
 

--- a/frontend/src/i18n/locales/en-US.ts
+++ b/frontend/src/i18n/locales/en-US.ts
@@ -985,6 +985,7 @@ const enUS = {
     disconnectSuccess: "Removed the {{agent}} MCP configuration managed by LazyMind",
     operationFailed: "The operation did not complete",
     bridgeUnavailable: "The local Assistant Bridge is not running. Start Docker with make up from the repository root. If you used bare docker compose, run make assistant-bridge-start.",
+    bridgePlatformMismatch: "This page and the Assistant Bridge are running on different operating systems. For Windows with WSL/Docker, stop the WSL/Linux Bridge and start the native Windows Bridge.",
     executorDetectionReady: "Local detection service is ready",
     executorConnecting: "Connecting",
     executorSessionExpired: "Your LazyMind session expired. Sign in again.",

--- a/frontend/src/i18n/locales/zh-CN.ts
+++ b/frontend/src/i18n/locales/zh-CN.ts
@@ -958,6 +958,7 @@ const zhCN = {
     disconnectSuccess: "已移除由 LazyMind 管理的 {{agent}} MCP 配置",
     operationFailed: "操作未完成",
     bridgeUnavailable: "本机助理桥接器未运行。请在仓库根目录使用 make up 启动 Docker；如果已经使用裸 docker compose 启动，请运行 make assistant-bridge-start。",
+    bridgePlatformMismatch: "当前页面与助理桥接器运行在不同操作系统中。Windows + WSL/Docker 场景请停止 WSL/Linux 桥接器，并启动 Windows 原生桥接器。",
     executorDetectionReady: "本机检测服务已就绪",
     executorConnecting: "正在连接",
     executorSessionExpired: "LazyMind 登录已失效，请重新登录",

--- a/frontend/src/modules/agentIntegration/AgentIntegrationPage.test.tsx
+++ b/frontend/src/modules/agentIntegration/AgentIntegrationPage.test.tsx
@@ -71,6 +71,7 @@ vi.mock("react-i18next", () => ({
         "agentIntegration.configurationIncomplete": "配置未完成",
         "agentIntegration.configurationIssue": "配置异常",
         "agentIntegration.bridgeUnavailable": "本机助理桥接器未运行",
+        "agentIntegration.bridgePlatformMismatch": "当前检测到的是 WSL/Linux 助理桥接器，请启动 Windows 原生桥接器。",
         "agentIntegration.sessionPrivacyNotice": `启用后，LazyMind 会读取 ${agent} 的本机会话信息；关闭后停止读取。`,
         "agentIntegration.guideFooter": "完成后重新检测",
         "agentIntegration.checkAgain": "重新检测",
@@ -365,6 +366,20 @@ describe("AgentIntegrationPage", () => {
 
     await waitFor(() => expect(mocks.statuses).toHaveBeenCalledTimes(2));
     expect(screen.queryByText("本机助理桥接器未运行")).not.toBeInTheDocument();
+  });
+
+  it("reports a platform mismatch without calling the Bridge unavailable", async () => {
+    mocks.statuses.mockResolvedValue({
+      ok: false,
+      reason: "platform_mismatch",
+      error: new Error("LazyMind is open on windows, but Assistant Bridge is running on linux."),
+    });
+
+    render(<AgentIntegrationPage />);
+
+    expect(await screen.findByText(/WSL\/Linux 助理桥接器/)).toBeInTheDocument();
+    expect(screen.queryByText("本机助理桥接器未运行")).not.toBeInTheDocument();
+    expect(mocks.statuses).toHaveBeenCalledOnce();
   });
 
   it("shows refresh progress and coalesces repeated refresh clicks", async () => {

--- a/frontend/src/modules/agentIntegration/AgentIntegrationPage.tsx
+++ b/frontend/src/modules/agentIntegration/AgentIntegrationPage.tsx
@@ -13,6 +13,7 @@ import {
 } from "@ant-design/icons";
 import { useTranslation } from "react-i18next";
 import type { TFunction } from "i18next";
+import { ASSISTANT_BRIDGE_PLATFORM_MISMATCH } from "@/runtime/assistantSession";
 import {
   agentIntegrationAction,
   agentIntegrationStatuses,
@@ -96,10 +97,10 @@ type StatusMap = Partial<Record<DesktopAgent, DesktopAgentIntegrationStatus>>;
 type ExecutorPolicyMap = Partial<Record<DesktopExecutorProvider, DesktopExecutorPolicy>>;
 type BindingMap = Partial<Record<DesktopAgentBindingTarget, string>>;
 
-async function retryBridgeResult<T extends { ok: boolean }>(call: () => Promise<T>): Promise<T> {
+async function retryBridgeResult<T extends { ok: boolean; reason?: string }>(call: () => Promise<T>): Promise<T> {
   let result = await call();
   for (const delay of BRIDGE_RETRY_DELAYS_MS) {
-    if (result.ok) return result;
+    if (result.ok || result.reason === ASSISTANT_BRIDGE_PLATFORM_MISMATCH) return result;
     await new Promise((resolve) => window.setTimeout(resolve, delay));
     result = await call();
   }
@@ -135,6 +136,7 @@ export default function AgentIntegrationPage() {
   const [action, setAction] = useState("");
   const [error, setError] = useState("");
   const [bridgeUnavailable, setBridgeUnavailable] = useState(false);
+  const [bridgePlatformMismatch, setBridgePlatformMismatch] = useState(false);
   const [manualBindingTarget, setManualBindingTarget] = useState<DesktopAgentBindingTarget | null>(null);
   const [manualBindingPath, setManualBindingPath] = useState("");
   const [externalConfigurationAgent, setExternalConfigurationAgent] = useState<DesktopAgent | null>(null);
@@ -150,12 +152,17 @@ export default function AgentIntegrationPage() {
       setRefreshing(true);
       let nextError = "";
       let localBridgeUnavailable = false;
+      let localBridgePlatformMismatch = false;
       let currentPolicies: ExecutorPolicyMap = {};
+      const recordBridgeFailure = (reason?: string) => {
+        if (reason === ASSISTANT_BRIDGE_PLATFORM_MISMATCH) localBridgePlatformMismatch = true;
+        else localBridgeUnavailable = true;
+      };
       try {
         const result = await retryBridgeResult(agentIntegrationStatuses);
         if (!isCurrent()) return;
         if (result.ok) setStatuses(result.data);
-        else localBridgeUnavailable = true;
+        else recordBridgeFailure(result.reason);
 
         const [policyResult, bindingResult] = await Promise.all([
           retryBridgeResult(executorIntegrationPolicies),
@@ -166,10 +173,10 @@ export default function AgentIntegrationPage() {
           currentPolicies = policyResult.data;
           setExecutorPolicies(policyResult.data);
         }
-        else localBridgeUnavailable = true;
+        else recordBridgeFailure(policyResult.reason);
 
         if (bindingResult.ok) setBindings(bindingResult.data);
-        else localBridgeUnavailable = true;
+        else recordBridgeFailure(bindingResult.reason);
 
         try {
           let values: ChatExecutorDescriptor[] = [];
@@ -197,6 +204,7 @@ export default function AgentIntegrationPage() {
         if (isCurrent()) {
           setError(nextError);
           setBridgeUnavailable(localBridgeUnavailable);
+          setBridgePlatformMismatch(localBridgePlatformMismatch);
           setLoading(false);
           setRefreshing(false);
         }
@@ -345,7 +353,7 @@ export default function AgentIntegrationPage() {
         </Button>
       </div>
 
-      {(error || bridgeUnavailable) && (
+      {(error || bridgeUnavailable || bridgePlatformMismatch) && (
         <Alert
           type="error"
           showIcon
@@ -353,6 +361,8 @@ export default function AgentIntegrationPage() {
           message={t("agentIntegration.operationFailed")}
           description={(
             <span className="agent-integration-error">
+              {bridgePlatformMismatch && <span>{t("agentIntegration.bridgePlatformMismatch")}</span>}
+              {bridgePlatformMismatch && (bridgeUnavailable || error) && <br />}
               {bridgeUnavailable && <span>{t("agentIntegration.bridgeUnavailable")}</span>}
               {bridgeUnavailable && error && <br />}
               {error}
@@ -361,6 +371,7 @@ export default function AgentIntegrationPage() {
           onClose={() => {
             setError("");
             setBridgeUnavailable(false);
+            setBridgePlatformMismatch(false);
           }}
         />
       )}

--- a/frontend/src/runtime/assistantSession.ts
+++ b/frontend/src/runtime/assistantSession.ts
@@ -1,5 +1,22 @@
 export const LOCAL_ASSISTANT_BRIDGE = "http://127.0.0.1:19091/v1";
 const CLIENT_PLATFORM_HEADER = "X-LazyMind-Client-Platform";
+export const ASSISTANT_BRIDGE_PLATFORM_MISMATCH = "platform_mismatch";
+
+export class AssistantBridgeRequestError extends Error {
+  constructor(
+    message: string,
+    public readonly code = "",
+    public readonly clientPlatform = "",
+    public readonly bridgePlatform = "",
+  ) {
+    super(message);
+    this.name = "AssistantBridgeRequestError";
+  }
+}
+
+export function isAssistantBridgePlatformMismatch(error: unknown): boolean {
+  return error instanceof AssistantBridgeRequestError && error.code === ASSISTANT_BRIDGE_PLATFORM_MISMATCH;
+}
 
 export function browserClientPlatform(): "windows" | "darwin" | "linux" | "" {
   if (typeof navigator === "undefined") return "";
@@ -62,6 +79,29 @@ export async function assistantBridgeFetch(
   }
 }
 
+export async function assistantBridgeJSON<T>(
+  path: string,
+  init: RequestInit | undefined,
+  timeoutMs: number,
+): Promise<T> {
+  const response = await assistantBridgeFetch(path, init, timeoutMs);
+  const payload = await response.json().catch(() => ({})) as T & {
+    code?: string;
+    error?: string;
+    client_platform?: string;
+    bridge_platform?: string;
+  };
+  if (!response.ok) {
+    throw new AssistantBridgeRequestError(
+      payload.error || `Assistant Bridge returned HTTP ${response.status}`,
+      payload.code,
+      payload.client_platform,
+      payload.bridge_platform,
+    );
+  }
+  return payload;
+}
+
 export async function syncLocalAssistantSession(
   user: SessionUser | null,
   serverURL: string,
@@ -84,7 +124,7 @@ export async function syncLocalAssistantSession(
     await desktopBridge.assistantSessionSet(session);
     return;
   }
-  const response = await assistantBridgeFetch(
+  await assistantBridgeJSON(
     "/session",
     {
       method: "POST",
@@ -93,7 +133,6 @@ export async function syncLocalAssistantSession(
     },
     timeoutMs,
   );
-  if (!response.ok) throw new Error(`Assistant Bridge returned HTTP ${response.status}`);
 }
 
 export async function clearLocalAssistantSession(timeoutMs = 15_000): Promise<void> {
@@ -103,6 +142,5 @@ export async function clearLocalAssistantSession(timeoutMs = 15_000): Promise<vo
     await desktopBridge.assistantSessionClear();
     return;
   }
-  const response = await assistantBridgeFetch("/session", { method: "DELETE" }, timeoutMs);
-  if (!response.ok) throw new Error(`Assistant Bridge returned HTTP ${response.status}`);
+  await assistantBridgeJSON("/session", { method: "DELETE" }, timeoutMs);
 }

--- a/frontend/src/runtime/desktopBridge.test.ts
+++ b/frontend/src/runtime/desktopBridge.test.ts
@@ -127,6 +127,44 @@ describe("browser Assistant Bridge session synchronization", () => {
     expect(fetchMock.mock.calls[0][0]).toBe("http://127.0.0.1:19091/v1/executors");
   });
 
+  it("preserves a structured platform mismatch from the local Bridge", async () => {
+    mocks.user.mockReturnValue(null);
+    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(new Response(JSON.stringify({
+      code: "platform_mismatch",
+      error: "LazyMind is open on windows, but Assistant Bridge is running on linux.",
+      client_platform: "windows",
+      bridge_platform: "linux",
+    }), { status: 409 }));
+
+    const result = await executorIntegrationPolicies();
+
+    expect(result).toMatchObject({
+      ok: false,
+      reason: "platform_mismatch",
+      error: {
+        message: "LazyMind is open on windows, but Assistant Bridge is running on linux.",
+        code: "platform_mismatch",
+        clientPlatform: "windows",
+        bridgePlatform: "linux",
+      },
+    });
+  });
+
+  it("does not synchronize credentials into a mismatched Bridge", async () => {
+    mocks.user.mockReturnValue({ token: "access", refreshToken: "refresh" });
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(new Response(JSON.stringify({
+      code: "platform_mismatch",
+      error: "Assistant Bridge platform mismatch",
+      client_platform: "windows",
+      bridge_platform: "linux",
+    }), { status: 409 }));
+
+    const result = await agentIntegrationStatuses();
+
+    expect(result).toMatchObject({ ok: false, reason: "platform_mismatch" });
+    expect(fetchMock).toHaveBeenCalledOnce();
+  });
+
   it("changes one executor permission through the local Bridge", async () => {
     mocks.user.mockReturnValue(null);
     const fetchMock = vi.spyOn(globalThis, "fetch")

--- a/frontend/src/runtime/desktopBridge.ts
+++ b/frontend/src/runtime/desktopBridge.ts
@@ -1,10 +1,15 @@
 import {
-  assistantBridgeFetch,
+  ASSISTANT_BRIDGE_PLATFORM_MISMATCH,
+  assistantBridgeJSON,
+  isAssistantBridgePlatformMismatch,
   syncLocalAssistantSession,
   type LocalAssistantSession,
 } from "./assistantSession";
 
-export type DesktopBridgeUnavailableReason = "unavailable" | "failed";
+export type DesktopBridgeUnavailableReason =
+  | "unavailable"
+  | "failed"
+  | typeof ASSISTANT_BRIDGE_PLATFORM_MISMATCH;
 
 export type DesktopBridgeResult =
   | { ok: true }
@@ -194,6 +199,14 @@ function getDesktopBridge(): LazyMindDesktopBridge | undefined {
     .lazymindDesktop;
 }
 
+function localBridgeFailure(error: unknown, fallback: "unavailable" | "failed" = "unavailable") {
+  return {
+    ok: false as const,
+    reason: isAssistantBridgePlatformMismatch(error) ? ASSISTANT_BRIDGE_PLATFORM_MISMATCH : fallback,
+    error,
+  };
+}
+
 export function hasDesktopFileBridge(): boolean {
   const bridge = getDesktopBridge();
   return Boolean(bridge?.showItemInFolder && bridge?.saveFileAs && bridge?.downloadFile);
@@ -278,15 +291,12 @@ export async function agentIntegrationStatuses(): Promise<DesktopAgentIntegratio
       };
       return { ok: true, data: payload?.agents || {} };
     }
-    const response = await assistantBridgeFetch("/agents", undefined, STATUS_TIMEOUT_MS);
-    const payload = await response.json().catch(() => ({})) as {
+    const payload = await assistantBridgeJSON<{
       agents?: Partial<Record<DesktopAgent, DesktopAgentIntegrationStatus>>;
-      error?: string;
-    };
-    if (!response.ok) throw new Error(payload.error || `Assistant Bridge returned HTTP ${response.status}`);
+    }>("/agents", undefined, STATUS_TIMEOUT_MS);
     return { ok: true, data: payload.agents || {} };
   } catch (error) {
-    return { ok: false, reason: "unavailable", error };
+    return localBridgeFailure(error);
   }
 }
 
@@ -303,7 +313,7 @@ export async function agentIntegrationAction(agent: DesktopAgent, action: Deskto
       action === "login" ? LOGIN_TIMEOUT_MS : ACTION_TIMEOUT_MS,
     );
   } catch (error) {
-    return { ok: false, reason: "unavailable", error };
+    return localBridgeFailure(error);
   }
 }
 
@@ -316,15 +326,12 @@ export async function executorIntegrationPolicies(): Promise<DesktopExecutorPoli
       };
       return { ok: true, data: payload.executors || {} };
     }
-    const response = await assistantBridgeFetch("/executors", undefined, ACTION_TIMEOUT_MS);
-    const payload = await response.json().catch(() => ({})) as {
+    const payload = await assistantBridgeJSON<{
       executors?: Partial<Record<DesktopExecutorProvider, DesktopExecutorPolicy>>;
-      error?: string;
-    };
-    if (!response.ok) throw new Error(payload.error || `Assistant Bridge returned HTTP ${response.status}`);
+    }>("/executors", undefined, ACTION_TIMEOUT_MS);
     return { ok: true, data: payload.executors || {} };
   } catch (error) {
-    return { ok: false, reason: "unavailable", error };
+    return localBridgeFailure(error);
   }
 }
 
@@ -339,20 +346,15 @@ export async function executorIntegrationAction(
     if (bridge?.executorIntegrationAction) {
       payload = await bridge.executorIntegrationAction(provider, action);
     } else {
-      const response = await assistantBridgeFetch(
+      payload = await assistantBridgeJSON(
         `/executors/${encodeURIComponent(provider)}/${action}`,
         { method: "POST" },
         ACTION_TIMEOUT_MS,
       );
-      payload = await response.json().catch(() => ({}));
-      if (!response.ok) {
-        const error = (payload as { error?: string }).error;
-        throw new Error(error || `Assistant Bridge returned HTTP ${response.status}`);
-      }
     }
     return { ok: true, data: payload as DesktopExecutorPolicy };
   } catch (error) {
-    return { ok: false, reason: "unavailable", error };
+    return localBridgeFailure(error);
   }
 }
 
@@ -363,16 +365,14 @@ export async function agentExecutableBindings(): Promise<DesktopAgentExecutableB
     if (bridge?.agentExecutableBindings) {
       payload = await bridge.agentExecutableBindings();
     } else {
-      const response = await assistantBridgeFetch("/bindings", undefined, ACTION_TIMEOUT_MS);
-      payload = await response.json().catch(() => ({}));
-      if (!response.ok) throw new Error(`Assistant Bridge returned HTTP ${response.status}`);
+      payload = await assistantBridgeJSON("/bindings", undefined, ACTION_TIMEOUT_MS);
     }
     const bindings = (payload as {
       bindings?: Partial<Record<DesktopAgentBindingTarget, string>>;
     }).bindings;
     return { ok: true, data: bindings || {} };
   } catch (error) {
-    return { ok: false, reason: "unavailable", error };
+    return localBridgeFailure(error);
   }
 }
 
@@ -401,7 +401,7 @@ async function changeAgentExecutable(
     } else if (path === undefined && bridge?.agentExecutableClear) {
       payload = await bridge.agentExecutableClear(target);
     } else {
-      const response = await assistantBridgeFetch(
+      payload = await assistantBridgeJSON(
         `/bindings/${encodeURIComponent(target)}`,
         path === undefined
           ? { method: "DELETE" }
@@ -412,12 +412,10 @@ async function changeAgentExecutable(
           },
         BINDING_TIMEOUT_MS,
       );
-      payload = await response.json().catch(() => ({}));
-      if (!response.ok) throw new Error((payload as { error?: string }).error || `Assistant Bridge returned HTTP ${response.status}`);
     }
     return { ok: true, data: payload as DesktopAgentExecutableBinding };
   } catch (error) {
-    return { ok: false, reason: "failed", error };
+    return localBridgeFailure(error, "failed");
   }
 }
 
@@ -432,12 +430,10 @@ async function callLocalAssistantBridge(
   timeoutMs = ACTION_TIMEOUT_MS,
 ): Promise<DesktopAgentIntegrationResult> {
   try {
-    const response = await assistantBridgeFetch(path, init, timeoutMs);
-    const payload = await response.json().catch(() => ({})) as DesktopAgentIntegrationStatus & { error?: string };
-    if (!response.ok) throw new Error(payload.error || `Assistant Bridge returned HTTP ${response.status}`);
+    const payload = await assistantBridgeJSON<DesktopAgentIntegrationStatus>(path, init, timeoutMs);
     return { ok: true, data: payload };
   } catch (error) {
-    return { ok: false, reason: "unavailable", error };
+    return localBridgeFailure(error);
   }
 }
 

--- a/local/lazymind-cli/internal/assistantbridge/server.go
+++ b/local/lazymind-cli/internal/assistantbridge/server.go
@@ -32,6 +32,7 @@ const (
 	agentLoginTimeout    = 2 * time.Minute
 	bridgeProbeTimeout   = 5 * time.Second
 	clientPlatformHeader = "X-LazyMind-Client-Platform"
+	platformMismatchCode = "platform_mismatch"
 )
 
 type Server struct {
@@ -77,12 +78,15 @@ func New(address string, bridge *mcpbridge.Bridge, store *credentials.Store, pol
 }
 
 func Start(ctx context.Context, address string) (map[string]any, error) {
-	if status, err := Health(ctx, address); err == nil {
-		return status, nil
-	}
 	self, err := os.Executable()
 	if err != nil {
 		return nil, err
+	}
+	if status, healthErr := Health(ctx, address); healthErr == nil {
+		if err := validateBridgeIdentity(status, self); err != nil {
+			return nil, err
+		}
+		return status, nil
 	}
 	home, err := assistantHome()
 	if err != nil {
@@ -111,11 +115,34 @@ func Start(ctx context.Context, address string) (map[string]any, error) {
 	for time.Now().Before(deadline) {
 		status, healthErr := Health(ctx, address)
 		if healthErr == nil {
+			if err := validateBridgeIdentity(status, self); err != nil {
+				return nil, err
+			}
 			return status, nil
 		}
 		time.Sleep(100 * time.Millisecond)
 	}
 	return nil, fmt.Errorf("Assistant Bridge did not start; inspect %s", logPath)
+}
+
+func validateBridgeIdentity(status map[string]any, expectedExecutable string) error {
+	platform, _ := status["platform"].(string)
+	platform = strings.ToLower(strings.TrimSpace(platform))
+	if platform == "" {
+		return errors.New("the running Assistant Bridge does not report its platform; stop it before starting this version")
+	}
+	if platform != runtime.GOOS {
+		return fmt.Errorf(
+			"Assistant Bridge is already running on %s; stop it before starting the native %s bridge",
+			platform, runtime.GOOS,
+		)
+	}
+	executable, _ := status["executable"].(string)
+	executable = strings.TrimSpace(executable)
+	if executable == "" || !agentexec.SameExecutable(executable, expectedExecutable) {
+		return errors.New("the running Assistant Bridge belongs to another LazyMind executable; stop it before starting this version")
+	}
+	return nil
 }
 
 func Stop(ctx context.Context, address string) error {
@@ -225,7 +252,11 @@ func (s *Server) cancelAgentLogins() {
 func (s *Server) routes() http.Handler {
 	mux := http.NewServeMux()
 	mux.HandleFunc("GET /v1/health", func(writer http.ResponseWriter, _ *http.Request) {
-		writeJSON(writer, http.StatusOK, map[string]any{"ok": true, "pid": os.Getpid(), "version": "v1"})
+		executable, _ := os.Executable()
+		writeJSON(writer, http.StatusOK, map[string]any{
+			"ok": true, "pid": os.Getpid(), "version": "v1",
+			"platform": runtime.GOOS, "executable": executable,
+		})
 	})
 	mux.HandleFunc("GET /v1/agents", s.handleAgentStatuses)
 	mux.HandleFunc("GET /v1/agents/{agent}", s.handleAgentStatus)
@@ -561,11 +592,14 @@ func (s *Server) allowLocalBrowser(next http.Handler) http.Handler {
 			writer.WriteHeader(http.StatusNoContent)
 			return
 		}
-		if strings.HasPrefix(request.URL.Path, "/v1/agents") && clientPlatformMismatch(request) {
+		if request.URL.Path != "/v1/health" && clientPlatformMismatch(request) {
 			clientPlatform := strings.ToLower(strings.TrimSpace(request.Header.Get(clientPlatformHeader)))
 			writeJSON(writer, http.StatusConflict, map[string]string{
+				"code":            platformMismatchCode,
+				"client_platform": clientPlatform,
+				"bridge_platform": runtime.GOOS,
 				"error": fmt.Sprintf(
-					"LazyMind is open on %s, but Assistant Bridge is running on %s. Stop the Linux/WSL bridge and start the native %s Assistant Bridge; cross-platform desktop MCP paths are not executable.",
+					"LazyMind is open on %s, but Assistant Bridge is running on %s. Stop the current bridge and start the native %s Assistant Bridge; cross-platform desktop MCP paths are not executable.",
 					clientPlatform, runtime.GOOS, clientPlatform,
 				),
 			})

--- a/local/lazymind-cli/internal/assistantbridge/server_test.go
+++ b/local/lazymind-cli/internal/assistantbridge/server_test.go
@@ -3,7 +3,9 @@ package assistantbridge
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -221,18 +223,98 @@ func TestBrowserSessionRejectsAnotherServerOrigin(t *testing.T) {
 	}
 }
 
-func TestBrowserAgentRoutesRejectAnotherHostPlatform(t *testing.T) {
+func TestBrowserAssistantRoutesRejectAnotherHostPlatform(t *testing.T) {
 	server := newTestServer(t, t.TempDir())
 	clientPlatform := "windows"
 	if runtime.GOOS == "windows" {
 		clientPlatform = "linux"
 	}
-	request := httptest.NewRequest(http.MethodGet, "/v1/agents", nil)
-	request.Header.Set("X-LazyMind-Client-Platform", clientPlatform)
+	for _, test := range []struct {
+		method string
+		path   string
+	}{
+		{http.MethodPost, "/v1/session"},
+		{http.MethodGet, "/v1/agents"},
+		{http.MethodGet, "/v1/executors"},
+		{http.MethodGet, "/v1/bindings"},
+	} {
+		t.Run(test.path, func(t *testing.T) {
+			request := httptest.NewRequest(test.method, test.path, nil)
+			request.Header.Set(clientPlatformHeader, clientPlatform)
+			response := httptest.NewRecorder()
+			server.routes().ServeHTTP(response, request)
+			if response.Code != http.StatusConflict {
+				t.Fatalf("status=%d body=%s", response.Code, response.Body.String())
+			}
+			var payload map[string]string
+			if err := json.Unmarshal(response.Body.Bytes(), &payload); err != nil {
+				t.Fatal(err)
+			}
+			if payload["code"] != platformMismatchCode || payload["client_platform"] != clientPlatform ||
+				payload["bridge_platform"] != runtime.GOOS || !strings.Contains(payload["error"], "native") {
+				t.Fatalf("payload=%#v", payload)
+			}
+		})
+	}
+}
+
+func TestBrowserHealthReportsBridgeIdentityAcrossPlatforms(t *testing.T) {
+	server := newTestServer(t, t.TempDir())
+	clientPlatform := "windows"
+	if runtime.GOOS == "windows" {
+		clientPlatform = "linux"
+	}
+	request := httptest.NewRequest(http.MethodGet, "/v1/health", nil)
+	request.Header.Set(clientPlatformHeader, clientPlatform)
 	response := httptest.NewRecorder()
 	server.routes().ServeHTTP(response, request)
-	if response.Code != http.StatusConflict || !strings.Contains(response.Body.String(), "native") {
+	if response.Code != http.StatusOK {
 		t.Fatalf("status=%d body=%s", response.Code, response.Body.String())
+	}
+	var payload map[string]any
+	if err := json.Unmarshal(response.Body.Bytes(), &payload); err != nil {
+		t.Fatal(err)
+	}
+	if payload["platform"] != runtime.GOOS || strings.TrimSpace(fmt.Sprint(payload["executable"])) == "" {
+		t.Fatalf("payload=%#v", payload)
+	}
+}
+
+func TestValidateBridgeIdentityRequiresMatchingPlatformAndExecutable(t *testing.T) {
+	root := t.TempDir()
+	expected := filepath.Join(root, "lazymind")
+	foreign := filepath.Join(root, "other-lazymind")
+	if runtime.GOOS == "windows" {
+		expected += ".exe"
+		foreign += ".exe"
+	}
+	for _, path := range []string{expected, foreign} {
+		if err := os.WriteFile(path, []byte("fixture"), 0o700); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := validateBridgeIdentity(map[string]any{
+		"platform": runtime.GOOS, "executable": expected,
+	}, expected); err != nil {
+		t.Fatalf("matching identity: %v", err)
+	}
+	if err := validateBridgeIdentity(map[string]any{
+		"platform": runtime.GOOS, "executable": foreign,
+	}, expected); err == nil || !strings.Contains(err.Error(), "another LazyMind executable") {
+		t.Fatalf("foreign executable error=%v", err)
+	}
+	otherPlatform := "windows"
+	if runtime.GOOS == "windows" {
+		otherPlatform = "linux"
+	}
+	if err := validateBridgeIdentity(map[string]any{
+		"platform": otherPlatform, "executable": expected,
+	}, expected); err == nil || !strings.Contains(err.Error(), "already running on") {
+		t.Fatalf("platform mismatch error=%v", err)
+	}
+	if err := validateBridgeIdentity(map[string]any{}, expected); err == nil ||
+		!strings.Contains(err.Error(), "does not report its platform") {
+		t.Fatalf("missing identity error=%v", err)
 	}
 }
 

--- a/local/scripts/assistant-bridge-win.ps1
+++ b/local/scripts/assistant-bridge-win.ps1
@@ -1,0 +1,60 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true, Position = 0)]
+    [ValidateSet('start', 'stop')]
+    [string]$Action,
+
+    [Parameter(Mandatory = $true, Position = 1)]
+    [string]$SourcePath
+)
+
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version 2.0
+
+if (-not $env:LOCALAPPDATA) {
+    throw 'LOCALAPPDATA is unavailable; cannot stage the native Windows Assistant Bridge.'
+}
+
+$installDir = Join-Path $env:LOCALAPPDATA 'LazyMind\assistant-bridge'
+$installedBinary = Join-Path $installDir 'lazymind.exe'
+
+function Invoke-Bridge([string]$Path, [string[]]$Arguments) {
+    & $Path @Arguments | Out-Null
+    if ($LASTEXITCODE -ne 0) {
+        throw "Assistant Bridge command failed with exit code $LASTEXITCODE"
+    }
+}
+
+# WSL environment paths are not valid Windows runtime roots. The native
+# process must resolve its home and data paths from the active Windows user.
+Remove-Item Env:LAZYMIND_HOME -ErrorAction SilentlyContinue
+Remove-Item Env:LAZYMIND_LOCAL_BUILD_ROOT -ErrorAction SilentlyContinue
+
+if ($Action -eq 'stop') {
+    $binary = if (Test-Path -LiteralPath $installedBinary -PathType Leaf) {
+        $installedBinary
+    } elseif (Test-Path -LiteralPath $SourcePath -PathType Leaf) {
+        $SourcePath
+    } else {
+        $null
+    }
+    if ($binary) { Invoke-Bridge $binary @('assistant', 'stop') }
+    exit 0
+}
+
+if (-not (Test-Path -LiteralPath $SourcePath -PathType Leaf)) {
+    throw "Windows Assistant Bridge build was not found: $SourcePath"
+}
+
+# Stop either an existing native Bridge or a stale WSL-forwarded Bridge before
+# replacing the executable. The CLI waits until the loopback listener closes.
+Invoke-Bridge $SourcePath @('assistant', 'stop')
+New-Item -ItemType Directory -Force -Path $installDir | Out-Null
+$temporary = "$installedBinary.$PID.tmp"
+try {
+    Copy-Item -LiteralPath $SourcePath -Destination $temporary -Force
+    Move-Item -LiteralPath $temporary -Destination $installedBinary -Force
+} finally {
+    Remove-Item -LiteralPath $temporary -Force -ErrorAction SilentlyContinue
+}
+Invoke-Bridge $installedBinary @('assistant', 'start')


### PR DESCRIPTION
## 背景

Windows 用户通过 WSL 启动 LazyMind Docker 服务时，原有启动流程会根据 WSL 的 Linux 内核构建并启动 Linux 版 Assistant Bridge。

由于 LazyMind 页面运行在 Windows 浏览器中，页面上报的平台为 Windows，而 Bridge 上报的平台为 Linux，最终触发跨平台保护，导致外部 Agent 无法检测、配置或连接。同时，页面会将平台错配误报为“本机助理桥接器未运行”。

## 修改内容

### WSL 自动启动 Windows 原生 Bridge

- 自动识别 WSL 环境，无需用户配置额外参数。
- WSL 下自动选择 Windows 和当前机器架构作为编译目标。
- 本机存在 Go 时直接交叉编译；不存在时继续使用 Docker Go 工具链构建。
- 自动通过 `wslpath` 转换 Windows 可访问路径。
- 使用 PowerShell 将 `lazymind.exe` 原子部署到：
  `%LOCALAPPDATA%\LazyMind\assistant-bridge`
- 启动前自动停止已有的 Windows Bridge 或旧版 WSL/Linux Bridge。
- 清除从 WSL 继承的 Linux 路径变量，确保 Bridge 使用 Windows 用户目录。
- `make up`、`make up-build`、`make assistant-bridge-start` 和 `make down` 均可直接使用，无需额外参数。

### Bridge 平台与实例校验

- `/v1/health` 增加 Bridge 平台和可执行文件身份。
- 启动时校验现有 Bridge 是否属于当前平台和当前 LazyMind 可执行文件。
- 不再将错误平台或其他 LazyMind 安装启动的 Bridge 误认为当前实例。

### 统一平台错配处理

- 对以下接口统一执行平台校验：
  - 会话同步
  - Agent 检测与配置
  - 执行器状态与开关
  - 本机程序绑定
- 平台错配统一返回结构化 `platform_mismatch` 错误。
- 防止登录凭证被同步到错误平台的 Bridge。
- 平台错配不再触发无意义的重复请求。

### 前端提示修复

- 区分“Bridge 未运行”和“Bridge 平台不匹配”。
- Windows + WSL/Docker 场景显示明确的原生 Windows Bridge 引导。
- 不再将已运行但平台错误的 Bridge 误报为未启动。

## 兼容性

- 普通 macOS、Linux 和原生 Windows 的原有构建方式保持不变。
- 只有自动检测到 WSL 时才启用 Windows 交叉编译和原生部署流程。
- 不要求用户设置 `GOOS`、`GOARCH`、Bridge 地址、Windows 路径或 `LOCALAPPDATA`。
- WSL 使用系统默认提供的 Windows 可执行文件互操作能力。